### PR TITLE
Fix off-by-one in equals (`=`)

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -90,11 +90,13 @@ func installLangNS() {
 	})
 
 	equals, err := vm.NativeFnType.Wrap(func(vs []vm.Value) vm.Value {
-		if len(vs) < 1 {
+		length := len(vs)
+		if length < 1 {
 			// FIXME error out
 			return vm.NIL
 		}
-		for i := range vs[1:] {
+
+		for i := 1; i < length; i++ {
 			if vs[0] != vs[i] {
 				return vm.FALSE
 			}


### PR DESCRIPTION
This would lead to `(= :whatever :something-else)` being `true`.
Also would lead to pretty much all tests passing regardless of correctness :P