### PR TITLE
fix(require): match value-receiver vm.ArrayVector (#13)

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3401,7 +3401,7 @@ func installLangNS() {
 			switch arg := v.(type) {
 			case vm.Symbol:
 				NS(string(arg)) // triggers autoloading
-			case *vm.ArrayVector:
+			case vm.ArrayVector:
 				// Vector form: [ns-name :as alias] or [ns-name :refer [syms...]]
 				if arg.RawCount() < 1 {
 					return vm.NIL, fmt.Errorf("require: empty vector")
@@ -3423,7 +3423,7 @@ func installLangNS() {
 					case vm.Keyword("refer"):
 						if val == vm.Keyword("all") {
 							cns.Refer(target, "", true)
-						} else if vec, ok := val.(*vm.ArrayVector); ok {
+						} else if vec, ok := val.(vm.ArrayVector); ok {
 							syms := make([]vm.Symbol, vec.RawCount())
 							for j := 0; j < vec.RawCount(); j++ {
 								syms[j] = vec.ValueAt(vm.Int(int64(j))).(vm.Symbol)

--- a/test/bugfix_test.lg
+++ b/test/bugfix_test.lg
@@ -43,3 +43,14 @@
       (doseq [x [1 2 3]]
         (swap! result conj x))
       (is (= [1 2 3] @result)))))
+
+;; Bug #13: vector form of (require ...) failed at runtime
+(deftest require-vector-form
+  (testing "symbol form still loads namespace"
+    (is (= nil (require (quote clojure.string)))))
+
+  (testing "vector form with :as does not throw"
+    (is (= nil (require (quote [clojure.string :as bug13-str])))))
+
+  (testing "vector form with :refer does not throw"
+    (is (= nil (require (quote [clojure.string :refer [trim]]))))))


### PR DESCRIPTION
Fixes #13. The `require` runtime function type-switched on `*vm.ArrayVector` but the reader produces a value-receiver `vm.ArrayVector` (`type ArrayVector []Value`), so every vector form fell through to the `default` branch and returned `require expected Symbol or Vector, got let-go.lang.ArrayVector`.

Per @nooga in https://github.com/nooga/let-go/issues/13#issuecomment-4435057291 ("The fix looks good ... Happy to accept a PR for this one"), this PR drops the pointer cases and adds a regression test in `test/bugfix_test.lg`.