### PR TITLE
fix(bytecode): serialize #uuid constants for AOT compilation

### DIFF
--- a/pkg/bytecode/bytecode_test.go
+++ b/pkg/bytecode/bytecode_test.go
@@ -267,6 +267,43 @@ func TestVoidRoundtrip(t *testing.T) {
 	}
 }
 
+func TestUUIDRoundtrip(t *testing.T) {
+	cases := []string{
+		"550e8400-e29b-41d4-a716-446655440000",
+		"00000000-0000-0000-0000-000000000000",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff",
+	}
+	for _, tc := range cases {
+		u := vm.NewUUID(tc)
+		got := roundtripValue(t, u)
+		gu, ok := got.(*vm.UUID)
+		if !ok {
+			t.Fatalf("expected *UUID, got %T", got)
+		}
+		if s := gu.Unbox().(string); s != tc {
+			t.Errorf("UUID roundtrip: got %q, want %q", s, tc)
+		}
+	}
+}
+
+// Uppercase input must canonicalise to lowercase through the reader (ParseUUID),
+// and that lowercase form must survive the bytecode round-trip unchanged.
+func TestUUIDRoundtripCanonicalisesUppercase(t *testing.T) {
+	u := vm.ParseUUID("550E8400-E29B-41D4-A716-446655440000")
+	if u == nil {
+		t.Fatal("ParseUUID returned nil for uppercase input")
+	}
+	got := roundtripValue(t, u)
+	gu, ok := got.(*vm.UUID)
+	if !ok {
+		t.Fatalf("expected *UUID, got %T", got)
+	}
+	want := "550e8400-e29b-41d4-a716-446655440000"
+	if s := gu.Unbox().(string); s != want {
+		t.Errorf("UUID canonicalisation: got %q, want %q", s, want)
+	}
+}
+
 func TestEmptyListRoundtrip(t *testing.T) {
 	got := roundtripValue(t, vm.EmptyList)
 	if got != vm.EmptyList {

--- a/pkg/bytecode/decoder.go
+++ b/pkg/bytecode/decoder.go
@@ -463,6 +463,16 @@ func (d *decoder) readValue() (vm.Value, error) {
 		return vm.NewBigInt(bi), nil
 	case TagVoid:
 		return vm.VOID, nil
+	case TagUUID:
+		s, err := d.readStringRef()
+		if err != nil {
+			return nil, err
+		}
+		u := vm.ParseUUID(s)
+		if u == nil {
+			return nil, fmt.Errorf("invalid UUID in bytecode: %q", s)
+		}
+		return u, nil
 	case TagFunc:
 		chunkIdx, err := d.r.ReadVarint()
 		if err != nil {

--- a/pkg/bytecode/encoder.go
+++ b/pkg/bytecode/encoder.go
@@ -191,6 +191,8 @@ func (b *ModuleBuilder) internStringsForValue(v vm.Value) {
 		}
 	case *vm.Regex:
 		b.internString(val.Pattern())
+	case *vm.UUID:
+		b.internString(val.Unbox().(string))
 	case *vm.List:
 		var s vm.Seq = val
 		for s != nil && s != vm.EmptyList {
@@ -438,6 +440,11 @@ func (e *encoder) writeValue(v vm.Value) error {
 		return e.w.WriteBytes(mag)
 	case *vm.Void:
 		return e.w.WriteByte(TagVoid)
+	case *vm.UUID:
+		if err := e.w.WriteByte(TagUUID); err != nil {
+			return err
+		}
+		return e.writeStringRef(val.Unbox().(string))
 	case *vm.Func:
 		if err := e.w.WriteByte(TagFunc); err != nil {
 			return err

--- a/pkg/bytecode/lgb_integration_test.go
+++ b/pkg/bytecode/lgb_integration_test.go
@@ -257,4 +257,9 @@ func TestLGBParity(t *testing.T) {
 		(println (force d))
 		(println (force d))
 	`)
+
+	assertSourceMatchesLGB(t, "uuid-literal", `
+		(prn #uuid "550e8400-e29b-41d4-a716-446655440000")
+		(prn #uuid "00000000-0000-0000-0000-000000000000")
+	`)
 }

--- a/pkg/bytecode/tags.go
+++ b/pkg/bytecode/tags.go
@@ -24,6 +24,7 @@ const (
 	TagChar      byte = 0x08
 	TagBigInt    byte = 0x09
 	TagVoid      byte = 0x0A
+	TagUUID      byte = 0x0B
 	TagFunc      byte = 0x10
 	TagVarRef    byte = 0x11
 	TagEmptyList byte = 0x20


### PR DESCRIPTION
UUIDType was on the compiler's const-emit whitelist (pkg/compiler/compiler.go) but the bytecode encoder and decoder had no case for *vm.UUID, so AOT-compiling any source containing a #uuid literal failed with "unsupported value type for serialization: *vm.UUID":

    echo '(prn #uuid "00000000-0000-0000-0000-000000000000")' > /tmp/x.lg
    lg -c /tmp/x.lgb /tmp/x.lg

Allocates TagUUID = 0x0B in the scalar tag block, adds the matching encoder/decoder arms and the *vm.UUID case in internStringsForValue. UUIDs are encoded as their canonical lowercase string via the existing string table -- the form already exposed by (*UUID).Unbox(). The tag is an append-only addition under bytecode format v1; older decoders error on encountering it.

Tests: TestLGBParity gains a "uuid-literal" case (compile -> encode ->
decode -> run -> compare to source-direct run), TestUUIDRoundtrip locks in the value codec, TestUUIDRoundtripCanonicalisesUppercase asserts the reader's lowercasing survives the round-trip.