### PR TITLE
feat(reader): add #inst tagged literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ for what's available.
 - **Hierarchies** (`derive`, `underive`, `ancestors`, `descendants`, `parents`): stubs only
 - **`with-precision`**: `BigDecimal` works (`M` literals, `bigdec`, exact arithmetic) but `with-precision` is a no-op
 - **Chunked sequences**: lazy seqs are unchunked
-- **Reader tagged literals** (`#inst`, `#uuid`)
+- **Custom tagged literal readers**: built-in `#uuid` and `#inst` work; `*data-readers*` / `*default-data-reader-fn*` are not implemented
 - **`deftype`** (use `defrecord`)
 - **`reify`** (protocols can only be extended to named types)
 - **Spec** (no `clojure.spec`)

--- a/pkg/bytecode/bytecode_test.go
+++ b/pkg/bytecode/bytecode_test.go
@@ -267,6 +267,43 @@ func TestVoidRoundtrip(t *testing.T) {
 	}
 }
 
+func TestUUIDRoundtrip(t *testing.T) {
+	cases := []string{
+		"550e8400-e29b-41d4-a716-446655440000",
+		"00000000-0000-0000-0000-000000000000",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff",
+	}
+	for _, tc := range cases {
+		u := vm.NewUUID(tc)
+		got := roundtripValue(t, u)
+		gu, ok := got.(*vm.UUID)
+		if !ok {
+			t.Fatalf("expected *UUID, got %T", got)
+		}
+		if s := gu.Unbox().(string); s != tc {
+			t.Errorf("UUID roundtrip: got %q, want %q", s, tc)
+		}
+	}
+}
+
+// Uppercase input must canonicalise to lowercase through the reader (ParseUUID),
+// and that lowercase form must survive the bytecode round-trip unchanged.
+func TestUUIDRoundtripCanonicalisesUppercase(t *testing.T) {
+	u := vm.ParseUUID("550E8400-E29B-41D4-A716-446655440000")
+	if u == nil {
+		t.Fatal("ParseUUID returned nil for uppercase input")
+	}
+	got := roundtripValue(t, u)
+	gu, ok := got.(*vm.UUID)
+	if !ok {
+		t.Fatalf("expected *UUID, got %T", got)
+	}
+	want := "550e8400-e29b-41d4-a716-446655440000"
+	if s := gu.Unbox().(string); s != want {
+		t.Errorf("UUID canonicalisation: got %q, want %q", s, want)
+	}
+}
+
 func TestEmptyListRoundtrip(t *testing.T) {
 	got := roundtripValue(t, vm.EmptyList)
 	if got != vm.EmptyList {

--- a/pkg/bytecode/decoder.go
+++ b/pkg/bytecode/decoder.go
@@ -463,6 +463,16 @@ func (d *decoder) readValue() (vm.Value, error) {
 		return vm.NewBigInt(bi), nil
 	case TagVoid:
 		return vm.VOID, nil
+	case TagUUID:
+		s, err := d.readStringRef()
+		if err != nil {
+			return nil, err
+		}
+		u := vm.ParseUUID(s)
+		if u == nil {
+			return nil, fmt.Errorf("invalid UUID in bytecode: %q", s)
+		}
+		return u, nil
 	case TagFunc:
 		chunkIdx, err := d.r.ReadVarint()
 		if err != nil {

--- a/pkg/bytecode/decoder.go
+++ b/pkg/bytecode/decoder.go
@@ -473,6 +473,16 @@ func (d *decoder) readValue() (vm.Value, error) {
 			return nil, fmt.Errorf("invalid UUID in bytecode: %q", s)
 		}
 		return u, nil
+	case TagInstant:
+		s, err := d.readStringRef()
+		if err != nil {
+			return nil, err
+		}
+		i := vm.ParseInstant(s)
+		if i == nil {
+			return nil, fmt.Errorf("invalid #inst in bytecode: %q", s)
+		}
+		return i, nil
 	case TagFunc:
 		chunkIdx, err := d.r.ReadVarint()
 		if err != nil {

--- a/pkg/bytecode/encoder.go
+++ b/pkg/bytecode/encoder.go
@@ -191,6 +191,8 @@ func (b *ModuleBuilder) internStringsForValue(v vm.Value) {
 		}
 	case *vm.Regex:
 		b.internString(val.Pattern())
+	case *vm.UUID:
+		b.internString(val.Unbox().(string))
 	case *vm.List:
 		var s vm.Seq = val
 		for s != nil && s != vm.EmptyList {
@@ -438,6 +440,11 @@ func (e *encoder) writeValue(v vm.Value) error {
 		return e.w.WriteBytes(mag)
 	case *vm.Void:
 		return e.w.WriteByte(TagVoid)
+	case *vm.UUID:
+		if err := e.w.WriteByte(TagUUID); err != nil {
+			return err
+		}
+		return e.writeStringRef(val.Unbox().(string))
 	case *vm.Func:
 		if err := e.w.WriteByte(TagFunc); err != nil {
 			return err

--- a/pkg/bytecode/encoder.go
+++ b/pkg/bytecode/encoder.go
@@ -193,6 +193,8 @@ func (b *ModuleBuilder) internStringsForValue(v vm.Value) {
 		b.internString(val.Pattern())
 	case *vm.UUID:
 		b.internString(val.Unbox().(string))
+	case *vm.Instant:
+		b.internString(val.Val())
 	case *vm.List:
 		var s vm.Seq = val
 		for s != nil && s != vm.EmptyList {
@@ -445,6 +447,11 @@ func (e *encoder) writeValue(v vm.Value) error {
 			return err
 		}
 		return e.writeStringRef(val.Unbox().(string))
+	case *vm.Instant:
+		if err := e.w.WriteByte(TagInstant); err != nil {
+			return err
+		}
+		return e.writeStringRef(val.Val())
 	case *vm.Func:
 		if err := e.w.WriteByte(TagFunc); err != nil {
 			return err

--- a/pkg/bytecode/lgb_integration_test.go
+++ b/pkg/bytecode/lgb_integration_test.go
@@ -257,4 +257,9 @@ func TestLGBParity(t *testing.T) {
 		(println (force d))
 		(println (force d))
 	`)
+
+	assertSourceMatchesLGB(t, "uuid-literal", `
+		(prn #uuid "550e8400-e29b-41d4-a716-446655440000")
+		(prn #uuid "00000000-0000-0000-0000-000000000000")
+	`)
 }

--- a/pkg/bytecode/lgb_integration_test.go
+++ b/pkg/bytecode/lgb_integration_test.go
@@ -262,4 +262,10 @@ func TestLGBParity(t *testing.T) {
 		(prn #uuid "550e8400-e29b-41d4-a716-446655440000")
 		(prn #uuid "00000000-0000-0000-0000-000000000000")
 	`)
+
+	assertSourceMatchesLGB(t, "inst-literal", `
+		(prn #inst "2024-01-01T00:00:00Z")
+		(prn #inst "2023-12-31T19:00:00-05:00")
+		(prn #inst "2024-01-01T00:00:00.123456789Z")
+	`)
 }

--- a/pkg/bytecode/tags.go
+++ b/pkg/bytecode/tags.go
@@ -24,6 +24,7 @@ const (
 	TagChar      byte = 0x08
 	TagBigInt    byte = 0x09
 	TagVoid      byte = 0x0A
+	TagUUID      byte = 0x0B
 	TagFunc      byte = 0x10
 	TagVarRef    byte = 0x11
 	TagEmptyList byte = 0x20

--- a/pkg/bytecode/tags.go
+++ b/pkg/bytecode/tags.go
@@ -25,6 +25,7 @@ const (
 	TagBigInt    byte = 0x09
 	TagVoid      byte = 0x0A
 	TagUUID      byte = 0x0B
+	TagInstant   byte = 0x0C
 	TagFunc      byte = 0x10
 	TagVarRef    byte = 0x11
 	TagEmptyList byte = 0x20

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -304,7 +304,7 @@ func (c *Context) compileForm(o vm.Value) error {
 		c.chunk.AddSourceInfo(*info)
 	}
 	switch o.Type() {
-	case vm.IntType, vm.FloatType, vm.StringType, vm.NilType, vm.BooleanType, vm.KeywordType, vm.CharType, vm.VoidType, vm.FuncType, vm.BigIntType, vm.RatioType, vm.BigDecimalType, vm.UUIDType:
+	case vm.IntType, vm.FloatType, vm.StringType, vm.NilType, vm.BooleanType, vm.KeywordType, vm.CharType, vm.VoidType, vm.FuncType, vm.BigIntType, vm.RatioType, vm.BigDecimalType, vm.UUIDType, vm.InstantType:
 		n := c.constant(o)
 		c.emitWithArg(vm.OP_LOAD_CONST, n)
 		c.incSP(1)

--- a/pkg/compiler/reader.go
+++ b/pkg/compiler/reader.go
@@ -1355,6 +1355,16 @@ func readTaggedLiteral(r *LispReader, firstCh rune) (vm.Value, error) {
 			return vm.NIL, NewReaderError(r, fmt.Sprintf("invalid UUID string: %s", s))
 		}
 		return u, nil
+	case "inst":
+		s, ok := val.(vm.String)
+		if !ok {
+			return vm.NIL, NewReaderError(r, fmt.Sprintf("#inst requires a string, got %s", val.Type().Name()))
+		}
+		i := vm.ParseInstant(string(s))
+		if i == nil {
+			return vm.NIL, NewReaderError(r, fmt.Sprintf("invalid #inst literal: %s", s))
+		}
+		return i, nil
 	default:
 		// Unknown tags: just return the value (best-effort)
 		return val, nil

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5577,6 +5577,16 @@ func installLangNS() {
 	})
 	ns.Def("uuid?", isUUID)
 
+	// inst? — type predicate for Instant
+	isInst, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.FALSE, nil
+		}
+		_, ok := vs[0].(*vm.Instant)
+		return vm.Boolean(ok), nil
+	})
+	ns.Def("inst?", isInst)
+
 	// parse-uuid — parse a string into a UUID
 	parseUUID, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {

--- a/pkg/vm/compare.go
+++ b/pkg/vm/compare.go
@@ -107,6 +107,18 @@ func DefaultCompare(a, b Value) (int, error) {
 				return 0, nil
 			}
 		}
+	case *Instant:
+		if vb, ok := b.(*Instant); ok {
+			am, bm := va.t.UnixMilli(), vb.t.UnixMilli()
+			switch {
+			case am < bm:
+				return -1, nil
+			case am > bm:
+				return 1, nil
+			default:
+				return 0, nil
+			}
+		}
 	}
 	// Vectors/sequential: lexicographic comparison
 	if isSeqComparable(a) && isSeqComparable(b) {

--- a/pkg/vm/instant.go
+++ b/pkg/vm/instant.go
@@ -1,0 +1,95 @@
+package vm
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+type theInstantType struct{}
+
+func (t *theInstantType) String() string     { return t.Name() }
+func (t *theInstantType) Type() ValueType    { return TypeType }
+func (t *theInstantType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theInstantType) Name() string       { return "let-go.lang.Instant" }
+func (t *theInstantType) Box(bare interface{}) (Value, error) {
+	switch v := bare.(type) {
+	case string:
+		i := ParseInstant(v)
+		if i == nil {
+			return NIL, fmt.Errorf("invalid instant: %s", v)
+		}
+		return i, nil
+	case time.Time:
+		// RFC3339(Nano) requires a 4-digit year (0000..9999), so a
+		// time.Time outside that range cannot round-trip through
+		// Val()/ParseInstant — which would silently break AOT bytecode
+		// serialisation. Refuse at the host-interop boundary rather than
+		// producing a Val() string our own decoder can't read back.
+		// Year 0 is allowed because RFC3339 permits "0000-..." and
+		// time.Parse(RFC3339Nano) accepts it on the way back in.
+		if y := v.Year(); y < 0 || y > 9999 {
+			return NIL, fmt.Errorf("time.Time year %d outside RFC3339 range (0..9999)", y)
+		}
+		return NewInstant(v), nil
+	}
+	return NIL, NewTypeError(bare, "can't be boxed as", InstantType)
+}
+
+// InstantType is the type of Instant values.
+var InstantType *theInstantType = &theInstantType{}
+
+// Instant wraps a time.Time, normalised to UTC at millisecond precision.
+//
+// Precision is millisecond to match Clojure JVM (java.util.Date) and
+// ClojureScript (js/Date), so values round-trip cleanly through any
+// Clojure tool reading the same RFC3339 string.
+type Instant struct {
+	t time.Time
+}
+
+// ParseInstant parses an RFC3339 (or RFC3339Nano) timestamp. Returns nil if invalid.
+// Sub-millisecond precision in the input is truncated.
+func ParseInstant(s string) *Instant {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return nil
+	}
+	return &Instant{t: t.UTC().Truncate(time.Millisecond)}
+}
+
+// NewInstant constructs an Instant from a time.Time, normalising to UTC
+// at millisecond precision.
+//
+// The caller is responsible for ensuring the year is in 0..9999 — values
+// outside that range will not round-trip through Val()/ParseInstant and
+// will silently break AOT bytecode serialisation. The only value-system
+// entry point that takes a host time.Time is InstantType.Box, which
+// enforces this bound; direct Go callers must do the same.
+func NewInstant(t time.Time) *Instant {
+	return &Instant{t: t.UTC().Truncate(time.Millisecond)}
+}
+
+func (i *Instant) Type() ValueType    { return InstantType }
+func (i *Instant) Unbox() interface{} { return i.t }
+func (i *Instant) String() string     { return "#inst \"" + i.t.Format(time.RFC3339Nano) + "\"" }
+
+// Time returns the underlying time.Time (UTC, millisecond precision).
+func (i *Instant) Time() time.Time { return i.t }
+
+// Val returns the canonical RFC3339Nano string form (no #inst wrapping).
+func (i *Instant) Val() string { return i.t.Format(time.RFC3339Nano) }
+
+// Hash implements Hashable. Grounded in epoch milliseconds (the actual
+// value) rather than the formatted string so hash identity is independent
+// of presentation choices (RFC3339Nano trims trailing zeros, etc.).
+func (i *Instant) Hash() uint32 { return hashUint64(uint64(i.t.UnixMilli())) }
+
+// Equals compares by epoch milliseconds. After UTC+millis normalisation
+// in the constructors this matches t.Equal, but expressing it directly in
+// terms of UnixMilli decouples value identity from time.Time internals
+// (e.g. any monotonic clock reading).
+func (i *Instant) Equals(other Value) bool {
+	o, ok := other.(*Instant)
+	return ok && i.t.UnixMilli() == o.t.UnixMilli()
+}

--- a/test/quick_wins_test.lg
+++ b/test/quick_wins_test.lg
@@ -230,7 +230,7 @@
     (is (= 127 (byte 127)))
     (is (= -128 (byte -128)))
     (is (= 65 (byte 65.9)))
-    (is (= :caught (try (byte 127.000001) (catch e :caught)))))
+    (is (= :caught (try (byte 127.000001) (catch e :caught))))))
 
 (deftest unchecked-byte-test
   (testing "unchecked-byte wraps on overflow"
@@ -244,7 +244,7 @@
     (is (= 0 (short 0)))
     (is (= 32767 (short 32767)))
     (is (= -32768 (short -32768)))
-    (is (= :caught (try (short 32767.000001) (catch e :caught)))))
+    (is (= :caught (try (short 32767.000001) (catch e :caught))))))
 
 (deftest unchecked-short-test
   (testing "unchecked-short wraps on overflow"
@@ -343,6 +343,57 @@
            (parse-uuid "550E8400-E29B-41D4-A716-446655440000"))))
   (testing "#uuid reader literal produces a UUID"
     (is (uuid? #uuid "550e8400-e29b-41d4-a716-446655440000"))))
+
+;; --- reader tagged literals: #inst, unknown tags ---
+
+(deftest inst-reader-literal-test
+  (testing "#inst reader literal produces an instant value, not a string"
+    (let [v #inst "2024-01-01T00:00:00Z"]
+      (is (inst? v))
+      (is (not (string? v)))))
+  (testing "type of #inst is the let-go.lang.Instant type"
+    (is (= "let-go.lang.Instant" (str (type #inst "2024-01-01T00:00:00Z"))))
+    (is (= (type #inst "2024-01-01T00:00:00Z")
+           (type #inst "1999-12-31T23:59:59Z"))))
+  (testing "two #inst literals for the same moment are equal"
+    (is (= #inst "2024-01-01T00:00:00Z"
+           #inst "2024-01-01T00:00:00Z")))
+  (testing "#inst values from different timezones are equal when they denote the same moment (UTC normalisation)"
+    (is (= #inst "2024-01-01T00:00:00Z"
+           #inst "2023-12-31T19:00:00-05:00")))
+  (testing "#inst round-trips through pr-str / read-string"
+    (let [v #inst "2024-01-01T00:00:00Z"]
+      (is (= v (read-string (pr-str v))))))
+  (testing "#inst sub-millisecond precision is truncated at construction (matches Clojure JVM/cljs Date)"
+    (is (= #inst "2024-01-01T00:00:00.123Z"
+           #inst "2024-01-01T00:00:00.123456789Z")))
+  (testing "#inst hash matches across equal values (suitable as a map key)"
+    (let [a #inst "2024-01-01T00:00:00Z"
+          b #inst "2023-12-31T19:00:00-05:00"
+          m {a :hit}]
+      (is (= :hit (get m b)))))
+  (testing "#inst values sort chronologically"
+    (let [xs [#inst "2024-06-01T00:00:00Z"
+              #inst "2024-01-01T00:00:00Z"
+              #inst "2024-03-15T00:00:00Z"]]
+      (is (= [#inst "2024-01-01T00:00:00Z"
+              #inst "2024-03-15T00:00:00Z"
+              #inst "2024-06-01T00:00:00Z"]
+             (sort xs))))))
+
+(deftest inst-invalid-format-test
+  (testing "invalid RFC3339 string in #inst raises a reader error citing #inst"
+    (let [msg (try (read-string "#inst \"not-a-real-date\"")
+                   (catch e (ex-message e)))]
+      (is (s/includes? msg "invalid #inst literal"))))
+  (testing "non-string payload after #inst raises a reader error"
+    (let [msg (try (read-string "#inst 123") (catch e (ex-message e)))]
+      (is (s/includes? msg "#inst requires a string")))))
+
+(deftest tagged-literal-read-string-test
+  (testing "known tags work via read-string"
+    (is (uuid? (read-string "#uuid \"550e8400-e29b-41d4-a716-446655440000\"")))
+    (is (inst? (read-string "#inst \"2024-01-01T00:00:00Z\"")))))
 
 ;; --- run! ---
 


### PR DESCRIPTION
Adds Clojure-style `#inst` reader literal parsing RFC3339(Nano) strings into a new `vm.Instant` value type. (You'd invited a rough PR in your 2026-05-14 email — same branch family as the `#uuid` AOT fix in #15; this one stacks on top of that PR.)

## What's in

- `pkg/vm/instant.go` — `Instant` (wraps `time.Time`, normalised to UTC at millisecond precision), `InstantType`, `ParseInstant` / `NewInstant`, `Equals` / `Hash` / `DefaultCompare` grounded in `UnixMilli()` so value identity is independent of formatting. `String()` returns the reader form `#inst "..."`. Box's `time.Time` arm refuses years outside 0..9999 (RFC3339 requires a 4-digit year — `Val()` of an out-of-range value would not round-trip through `ParseInstant` and would silently break AOT).
- `pkg/compiler/reader.go` — `#inst` case in `readTaggedLiteral`.
- `pkg/compiler/compiler.go` — `vm.InstantType` added to the const-emit whitelist so literals reach the const pool.
- `pkg/bytecode/{tags,encoder,decoder}.go` — `TagInstant = 0x0C`, encode/decode arms, `internStringsForValue` entry. Built directly on the `TagUUID` infrastructure from #15.
- `pkg/vm/compare.go` — `*Instant` case in `DefaultCompare`.
- `pkg/rt/lang.go` — `inst?` predicate.
- Tests:
  - `test/quick_wins_test.lg` — equality, UTC normalisation across timezones, `pr-str` ↔ `read-string` round-trip, sort, hash as map key, sub-millisecond truncation, invalid-format errors.
  - `pkg/bytecode/lgb_integration_test.go` — `TestLGBParity/inst-literal` confirms AOT compile → encode → decode → run matches direct run.
- `README.md` — replace "reader tagged literals not implemented" with a bullet that says `#uuid` and `#inst` work and flags `*data-readers*` as the unimplemented piece.
- Drive-by: closing-paren fix on `byte-test` and `short-test` in `quick_wins_test.lg`. They ran fine because `deftest` registers regardless of nesting, but `unchecked-byte-test` / `unchecked-short-test` were syntactically inside their predecessors.

## Stacked on #15

PR #15 fixes the existing `#uuid` AOT bug. This PR builds on the same encoder/decoder/tags infrastructure for the `*vm.Instant` arms. Easiest review order is #15 first, then this. If you'd rather see a single combined PR, happy to fold them.

## Known divergences from Clojure

Worth surfacing explicitly so you can decide what's acceptable:

- **Reader input is narrower than `clojure.instant/parse-timestamp`.** We accept RFC3339(Nano) only. The following parse on JVM Clojure but raise here:
  - `#inst "2024"`
  - `#inst "2024-01"`
  - `#inst "2024-01-01"`
  - `#inst "2024-01-01T00:00:00"` (no zone — Clojure defaults to UTC)
  - `#inst "2024-01-01 00:00:00Z"` (space instead of T)

  Aligning is a real change (regex-based parser, default-fill rules, more tests). Worth doing in this PR, or follow-up?

- **Precision is millisecond.** Truncated at `ParseInstant` and `NewInstant`. Rationale: Clojure JVM `#inst` produces `java.util.Date` (millis), cljs `#inst` produces `js/Date` (millis). Preserving Go's nanoseconds in `.lgb` would mean values lose precision the moment any Clojure tool reads them back. RFC3339Nano input is still accepted — sub-ms is truncated post-parse. Reasonable, or do you want full nanosecond fidelity preserved internally with a separate decision on print form?

- **Extensibility hardcoded at the reader.** `#inst` → `vm.Instant` lives in `readTaggedLiteral`, same shape as `#uuid`. When `*data-readers*` / `*default-data-reader-fn*` land, both should probably become default mappings the user can override. Want that hook designed first, or is hardcoding fine for now and `*data-readers*` retrofits later?

- **\`String()\` returns reader syntax.** `(*Instant).String()` returns `#inst "..."` so `pr-str` and default printing produce readable output. let-go has no printer protocol today — `pr-str` is just `Value.String()`. If you plan to split reader-syntax from debug form via a protocol, `String()` should probably become the debug form and the reader-syntax should emit via that protocol. Pointer to where this should land would be welcome.

## Considered and not in this PR

- Unknown-tag reader tightening (raising on unknown `#foo`). It was bundled in an earlier draft; on review the current "best-effort return the value" behaviour is safer until `*data-readers*` exists.
- `*data-readers*` extension mechanism — separate, larger design.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`quick_wins_test.lg\` covers equality, sort, hash-as-map-key, round-trip via pr-str, millis truncation, invalid input
- [x] \`TestLGBParity/inst-literal\` covers the AOT path