### PR TITLE
feat(var): n-arg alter-var-root + read root, not dynamic binding

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5434,14 +5434,14 @@ func installLangNS() {
 	})
 	ns.Def("array?", isArrayf)
 
-	// alter-var-root — alter a var's root binding via (f root).
+	// alter-var-root — alter a var's root binding via (f root & args).
 	// Reads/writes the root, bypassing any current dynamic binding.
 	// TODO: the read/apply/write is not atomic. let-go evaluates synchronously
 	// today, so contention does not arise. If concurrent evaluation is added,
 	// centralize the RMW under Var-level synchronization.
 	alterVarRoot, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		if len(vs) != 2 {
-			return vm.NIL, fmt.Errorf("alter-var-root expects 2 args")
+		if len(vs) < 2 {
+			return vm.NIL, fmt.Errorf("alter-var-root expects at least 2 args")
 		}
 		v, ok := vs[0].(*vm.Var)
 		if !ok {
@@ -5452,7 +5452,7 @@ func installLangNS() {
 			return vm.NIL, fmt.Errorf("alter-var-root expects a function")
 		}
 		old := v.Root()
-		result, err := fn.Invoke([]vm.Value{old})
+		result, err := fn.Invoke(append([]vm.Value{old}, vs[2:]...))
 		if err != nil {
 			return vm.NIL, err
 		}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5434,7 +5434,11 @@ func installLangNS() {
 	})
 	ns.Def("array?", isArrayf)
 
-	// alter-var-root — atomically alter a var's root binding
+	// alter-var-root — alter a var's root binding via (f root).
+	// Reads/writes the root, bypassing any current dynamic binding.
+	// TODO: the read/apply/write is not atomic. let-go evaluates synchronously
+	// today, so contention does not arise. If concurrent evaluation is added,
+	// centralize the RMW under Var-level synchronization.
 	alterVarRoot, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 2 {
 			return vm.NIL, fmt.Errorf("alter-var-root expects 2 args")
@@ -5447,7 +5451,7 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("alter-var-root expects a function")
 		}
-		old := v.Deref()
+		old := v.Root()
 		result, err := fn.Invoke([]vm.Value{old})
 		if err != nil {
 			return vm.NIL, err

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5438,7 +5438,7 @@ func installLangNS() {
 	// Reads/writes the root, bypassing any current dynamic binding.
 	// TODO: the read/apply/write is not atomic. let-go evaluates synchronously
 	// today, so contention does not arise. If concurrent evaluation is added,
-	// centralize the RMW under Var-level synchronization.
+	// centralize the read/apply/write under Var-level synchronization.
 	alterVarRoot, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) < 2 {
 			return vm.NIL, fmt.Errorf("alter-var-root expects at least 2 args")

--- a/pkg/vm/var.go
+++ b/pkg/vm/var.go
@@ -58,6 +58,14 @@ func (v *Var) Deref() Value {
 	return v.root
 }
 
+// Root returns the var's root binding directly, bypassing any current
+// dynamic binding on the stack. Use this where Clojure semantics require
+// the root (e.g. alter-var-root) rather than the currently visible deref
+// value.
+func (v *Var) Root() Value {
+	return v.root
+}
+
 // PushBinding pushes a dynamic binding value.
 func (v *Var) PushBinding(val Value) {
 	v.bindings = append(v.bindings, val)

--- a/test/alter_var_root_test.lg
+++ b/test/alter_var_root_test.lg
@@ -1,0 +1,84 @@
+;; Tests for alter-var-root (2-arg form): return value, errors,
+;; exception bubbling, and dynamic-binding bypass (root semantics).
+(ns test.alter-var-root-test
+  (:require [test :refer :all]))
+
+;; --- 2-arg form ---
+
+(def t-2arg-x 10)
+
+(deftest two-arg-rebinds-root
+  (testing "(alter-var-root v f) calls (f @v) and sets the result as the new root"
+    (let [result (alter-var-root #'t-2arg-x inc)]
+      (is (= 11 result))
+      (is (= 11 t-2arg-x))
+      (is (= 11 @#'t-2arg-x))
+      (is (= 11 (var-get #'t-2arg-x))))))
+
+;; --- return value vs. var deref ---
+
+(def t-return-x {:n 0})
+
+(deftest return-value-equals-new-root
+  (testing "alter-var-root returns the new root, identical to subsequent deref"
+    (let [result (alter-var-root #'t-return-x (fn [m] (assoc m :n 42)))]
+      (is (= {:n 42} result))
+      (is (= result t-return-x))
+      (is (= result @#'t-return-x)))))
+
+;; --- arity errors ---
+
+(deftest zero-args-errors
+  (testing "(alter-var-root) raises"
+    (is (= :caught (try (alter-var-root) (catch e :caught))))))
+
+(def t-one-arg-x 10)
+
+(deftest one-arg-errors
+  (testing "(alter-var-root v) with no fn raises"
+    (is (= :caught (try (alter-var-root #'t-one-arg-x) (catch e :caught))))))
+
+;; --- type errors ---
+
+(deftest non-var-first-arg-errors
+  (testing "first arg must be a Var"
+    (is (= :caught (try (alter-var-root :not-a-var inc) (catch e :caught))))
+    (is (= :caught (try (alter-var-root 42 inc) (catch e :caught))))
+    (is (= :caught (try (alter-var-root "x" inc) (catch e :caught))))))
+
+(def t-non-fn-x 10)
+
+(deftest non-fn-second-arg-errors
+  (testing "second arg must be a function (numbers, strings, nil are not IFn)"
+    ;; Note: keywords, sets, maps, and vectors *are* IFn in Clojure and pass the
+    ;; gate; that's faithful behaviour, not a defect.
+    (is (= :caught (try (alter-var-root #'t-non-fn-x 42) (catch e :caught))))
+    (is (= :caught (try (alter-var-root #'t-non-fn-x "fn") (catch e :caught))))
+    (is (= :caught (try (alter-var-root #'t-non-fn-x nil) (catch e :caught))))))
+
+;; --- exception bubbling: errors from f propagate, root stays unchanged ---
+
+(def t-throw-x 10)
+
+(deftest fn-throw-leaves-root-unchanged
+  (testing "when f throws, the exception bubbles and the root is not mutated"
+    (is (= :caught
+           (try (alter-var-root #'t-throw-x (fn [_] (throw "boom")))
+                (catch e :caught))))
+    (is (= 10 t-throw-x))
+    (is (= 10 @#'t-throw-x))))
+
+;; --- dynamic-binding bypass (Clojure semantics: read/write root, not binding) ---
+
+(def ^:dynamic *t-dyn-x* 10)
+
+(deftest dynamic-binding-bypassed-2arg
+  (testing "inside a binding, alter-var-root reads root, writes root, and the binding wins for deref"
+    (binding [*t-dyn-x* 99]
+      ;; (inc 10) should be the new root, not (inc 99).
+      (let [result (alter-var-root #'*t-dyn-x* inc)]
+        (is (= 11 result))
+        ;; Within the binding block, *t-dyn-x* still observes the binding value.
+        (is (= 99 *t-dyn-x*))))
+    ;; After the binding pops, the root mutation is visible.
+    (is (= 11 *t-dyn-x*))))

--- a/test/alter_var_root_test.lg
+++ b/test/alter_var_root_test.lg
@@ -1,5 +1,5 @@
-;; Tests for alter-var-root (2-arg form): return value, errors,
-;; exception bubbling, and dynamic-binding bypass (root semantics).
+;; Tests for alter-var-root: 2-arg + n-arg shapes, return value, errors,
+;; argument order, and dynamic-binding bypass (root semantics).
 (ns test.alter-var-root-test
   (:require [test :refer :all]))
 
@@ -15,13 +15,42 @@
       (is (= 11 @#'t-2arg-x))
       (is (= 11 (var-get #'t-2arg-x))))))
 
+;; --- n-arg form ---
+
+(def t-narg-x 10)
+
+(deftest n-arg-extra-args
+  (testing "(alter-var-root v f a b) calls (f @v a b) and sets the result"
+    (let [result (alter-var-root #'t-narg-x + 1 2)]
+      (is (= 13 result))
+      (is (= 13 t-narg-x)))))
+
+(def t-narg-many 0)
+
+(deftest n-arg-many-extras
+  (testing "n-arg form with many trailing args"
+    (let [result (alter-var-root #'t-narg-many + 1 2 3 4 5)]
+      (is (= 15 result))
+      (is (= 15 t-narg-many)))))
+
+;; --- argument order (non-commutative op proves old is first) ---
+
+(def t-order-x 10)
+
+(deftest arg-order-puts-old-first
+  (testing "(alter-var-root v f extra) passes (f old extra), not (f extra old)"
+    ;; If args were reversed, (- 3 10) = -7 would surface here.
+    (let [result (alter-var-root #'t-order-x - 3)]
+      (is (= 7 result))
+      (is (= 7 t-order-x)))))
+
 ;; --- return value vs. var deref ---
 
 (def t-return-x {:n 0})
 
 (deftest return-value-equals-new-root
   (testing "alter-var-root returns the new root, identical to subsequent deref"
-    (let [result (alter-var-root #'t-return-x (fn [m] (assoc m :n 42)))]
+    (let [result (alter-var-root #'t-return-x assoc :n 42)]
       (is (= {:n 42} result))
       (is (= result t-return-x))
       (is (= result @#'t-return-x)))))
@@ -82,3 +111,13 @@
         (is (= 99 *t-dyn-x*))))
     ;; After the binding pops, the root mutation is visible.
     (is (= 11 *t-dyn-x*))))
+
+(def ^:dynamic *t-dyn-y* 10)
+
+(deftest dynamic-binding-bypassed-narg
+  (testing "n-arg form also reads/writes root, not binding"
+    (binding [*t-dyn-y* 99]
+      (let [result (alter-var-root #'*t-dyn-y* + 1 2)]
+        (is (= 13 result))
+        (is (= 99 *t-dyn-y*))))
+    (is (= 13 *t-dyn-y*))))


### PR DESCRIPTION
Completes `alter-var-root` with two changes, split across two commits for review hygiene:

**Commit 1 — `fix(var): alter-var-root reads root, not dynamic binding`**

The existing 2-arg native read `v.Deref()`, which returns the top of the dynamic binding stack when one is pushed. Clojure semantics require `alter-var-root` to read and write the *root* binding directly, regardless of any current dynamic binding. Adds `(*Var).Root()` accessor and switches the native to use it.

**Commit 2 — `feat(var): n-arg alter-var-root`**

Accepts `(alter-var-root v f & args)`, applying `(f root & args)` and setting the result as the new root. The 2-arg form continues to work unchanged. Matches Clojure's contract and unlocks idioms like `(alter-var-root #'global-hierarchy derive tag parent)` without falling back to atoms.

## Tests

New `test/alter_var_root_test.lg` covers 2-arg and n-arg forms, return value, type and arity errors, exception bubbling (root unchanged on throw), argument order (via a non-commutative op), and dynamic-binding bypass under both shapes.

## Note on atomicity

Clojure's `alter-var-root` guarantees an atomic read-modify-write. Because let-go evaluates synchronously today, this patch implements the semantic shape (bypassing dynamic bindings) but deliberately omits var-level synchronization. The read/apply/write in `pkg/rt/lang.go` will need a lock if/when let-go adds concurrent evaluation; an in-source TODO marks the spot.

## Out of scope

- README "Not implemented" list edit — left for a separate docs audit.
- `sync.Mutex` on `Var` — not added speculatively; let-go is single-threaded today.
- Switching `global-hierarchy` from atom to var-root — separate follow-up.

## Verification

- `go test ./...` green at HEAD and at the intermediate commit
- `go build ./...` clean