### PR TITLE
fix(pods): avoid stdin EOF shutdown for pods without shutdown op

### DIFF
--- a/pkg/rt/pods.go
+++ b/pkg/rt/pods.go
@@ -44,7 +44,7 @@ type Pod struct {
 
 	// Response routing
 	pending   map[string]chan podMsg // id -> response channel
-	streaming map[string]bool       // ids that should not auto-close on done
+	streaming map[string]bool        // ids that should not auto-close on done
 	pendingMu sync.Mutex
 	routerUp  bool
 }
@@ -150,7 +150,7 @@ func (p *Pod) startRouter() {
 
 			// Route by id
 			id := bencStr(msg, "id")
-if id == "" {
+			if id == "" {
 				continue
 			}
 
@@ -356,7 +356,13 @@ func (p *Pod) Shutdown() {
 	if p.ops != nil {
 		if _, ok := p.ops["shutdown"]; ok {
 			_ = p.send(map[string]interface{}{"op": "shutdown"})
+			p.stdin.Close()
+			p.cmd.Wait() //nolint:errcheck
+			return
 		}
+	}
+	if p.cmd != nil && p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
 	}
 	p.stdin.Close()
 	p.cmd.Wait() //nolint:errcheck
@@ -648,7 +654,7 @@ func installPodsNS() {
 						successFn = hmap.ValueAt(vm.Keyword("success"))
 						errorFn = hmap.ValueAt(vm.Keyword("error"))
 						doneFn = hmap.ValueAt(vm.Keyword("done"))
-						}
+					}
 
 					go func() {
 						for val := range ch {

--- a/pkg/rt/pods_test.go
+++ b/pkg/rt/pods_test.go
@@ -1,0 +1,58 @@
+//go:build !js
+
+/*
+ * Copyright (c) 2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestPodShutdownKillsPodWithoutShutdownOp(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestPodShutdownHelperProcess", "--")
+	cmd.Env = append(os.Environ(), "LET_GO_POD_SHUTDOWN_HELPER=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	stderrCh := make(chan []byte, 1)
+	go func() {
+		stderrBytes, _ := io.ReadAll(stderr)
+		stderrCh <- stderrBytes
+	}()
+
+	p := &Pod{
+		cmd:   cmd,
+		stdin: stdin,
+	}
+	p.Shutdown()
+
+	stderrBytes := <-stderrCh
+	if bytes.Contains(stderrBytes, []byte("stdin closed")) {
+		t.Fatalf("expected Shutdown to kill non-shutdown pod before closing stdin; stderr: %s", stderrBytes)
+	}
+}
+
+func TestPodShutdownHelperProcess(t *testing.T) {
+	if os.Getenv("LET_GO_POD_SHUTDOWN_HELPER") != "1" {
+		return
+	}
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	fmt.Fprint(os.Stderr, "stdin closed")
+	os.Exit(0)
+}


### PR DESCRIPTION
Fixes #19.

## What

Some pods, including `org.babashka/fswatcher` 0.0.7, do not advertise a `shutdown` op and panic when their stdin is closed as an EOF shutdown signal. Script mode exits immediately after loading a pod, so the deferred shutdown path exposed that panic even though the pod had loaded successfully.

This keeps graceful shutdown for pods that advertise `shutdown`, and kills pods that do not before closing stdin.

## Verification

- `go test ./pkg/rt -count=1 -run TestPodShutdownKillsPodWithoutShutdownOp -v`
- `go test ./test/ -count=1 -run TestRunner -v`
- `go test ./... -count=1`
- Throwaway fswatcher script observed a real file create event: `{:path "/tmp/let-go-fswatcher-e2e/touched.txt" :type "create"}`

Draft so this can be verified manually before marking ready.