### PR TITLE
Fix compilation on ARMv7

### DIFF
--- a/pkg/rt/syscall_linux.go
+++ b/pkg/rt/syscall_linux.go
@@ -1014,8 +1014,9 @@ func installSyscallNS() {
 	RegisterNS(ns)
 }
 
-// charsToString converts a null-terminated int8 array (from Utsname) to a string.
-func charsToString(ca []int8) string {
+// charsToString converts a null-terminated char array (from Utsname) to a string.
+// Utsname fields are []int8 on some Linux arches (amd64) and []uint8 on others (arm).
+func charsToString[T int8 | uint8](ca []T) string {
 	buf := make([]byte, 0, len(ca))
 	for _, c := range ca {
 		if c == 0 {


### PR DESCRIPTION
On some architectures on Linux (arm, ppc64, ppc64le, riscv64, s390x), fields in the `syscall.Utsname` struct are defined as arrays of `uint8` rather than `int8`. This fix makes let-go build on such architectures. Tested on a reMarkable 2 (arm).

Disclosure: fix identified and written by Claude Opus 4.7.