### PR TITLE
Fix Homebrew formula PR merge branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Merge Homebrew formula PR
         env:
           GH_TOKEN: ${{ secrets.GORELEASER_PAT }}
-        run: gh pr merge "goreleaser-brew-${GITHUB_REF_NAME}" --repo nooga/let-go --squash --admin --delete-branch
+        run: gh pr merge "goreleaser-brew-${GITHUB_REF_NAME#v}" --repo nooga/let-go --squash --admin --delete-branch


### PR DESCRIPTION
## Summary
- strip the leading v from GITHUB_REF_NAME when merging the GoReleaser-generated Homebrew formula PR
- matches GoReleaser's generated branch name, e.g. goreleaser-brew-2.0.2

## Testing
- goreleaser check