### PR TITLE
fix: LazySeq realizes empty Sequable inputs to EmptyList

### DIFF
--- a/pkg/vm/lazy_seq.go
+++ b/pkg/vm/lazy_seq.go
@@ -80,10 +80,16 @@ func (l *LazySeq) seq() Seq {
 		l.sv = nil
 		if sv == nil || sv == NIL {
 			l.s = nil
+		} else if seqable, ok := sv.(Sequable); ok {
+			// Prefer Sequable.Seq() over a direct Seq cast: Sequable
+			// canonicalizes empty collections (empty ArrayVector,
+			// PersistentSet, etc.) to EmptyList/nil, so `(lazy-seq [])`
+			// and `(lazy-seq #{})` equate to `()`. Without this, an
+			// empty collection that also satisfies Seq would be cached
+			// as l.s directly and equality vs () would fail.
+			l.s = seqable.Seq()
 		} else if seq, ok := sv.(Seq); ok {
 			l.s = seq
-		} else if seqable, ok := sv.(Sequable); ok {
-			l.s = seqable.Seq()
 		} else {
 			// Realized to a non-seq, non-Sequable value. Match JVM Clojure's
 			// behavior: throw rather than silently coercing to nil.

--- a/test/clojure_sequences_compat_test.lg
+++ b/test/clojure_sequences_compat_test.lg
@@ -54,13 +54,8 @@
       (lazy-seq nil) ()
       (lazy-seq [nil]) '(nil)
       (lazy-seq ()) ()
-      ;; TODO(next PR): `(lazy-seq [])` and `(lazy-seq #{})` currently
-      ;; preserve their realized value as-a-Seq (ArrayVector, PersistentSet)
-      ;; instead of canonicalizing to EmptyList via .Seq(). Tracked separately
-      ;; from the map/mapcat laziness fix; will re-add when (*LazySeq).seq()
-      ;; prefers Sequable normalization over direct Seq cast.
-      ;; (lazy-seq []) ()
-      ;; (lazy-seq #{}) ()
+      (lazy-seq []) ()
+      (lazy-seq #{}) ()
       (lazy-seq {}) ()
       (lazy-seq [3]) [3]
       (lazy-seq (list 1 2)) '(1 2)


### PR DESCRIPTION
**Stacked on #35** — merge that first.

When a `lazy-seq` body returned an empty collection that implements both `Seq` and `Sequable` (e.g. empty `ArrayVector`, `PersistentSet`), the realizer in `(*LazySeq).seq()` preferred the direct `Seq` cast and cached the raw collection as `l.s`. The cached value was an empty `ArrayVector` rather than `EmptyList`/nil, so equality vs `'()` failed:

```
(= (lazy-seq [])  ())  ;=> false   ;; Clojure: true
(= (lazy-seq #{}) ())  ;=> false   ;; Clojure: true
```

Fix: prefer `Sequable.Seq()` first. `Sequable` implementations canonicalize empty collections to `EmptyList`/nil; direct `Seq` cast only happens for values that aren't `Sequable`.

## Tests
Re-enables two assertions in `test/clojure_sequences_compat_test.lg` that were commented out in #35 with a `TODO(next PR)` marker. Both port directly from [`clojure/test/clojure/test_clojure/sequences.clj` `test-lazy-seq`](https://github.com/clojure/clojure/blob/master/test/clojure/test_clojure/sequences.clj).

## Verification
Full `TestRunner` green; `TestClojureTestSuite` 232 files / 5621 assertions / 0 fail.