### PR TITLE
fix: COI bootstrap works on Safari/Firefox, no reload loops

### DIFF
--- a/wasm.go
+++ b/wasm.go
@@ -111,8 +111,21 @@ const wasmHTMLTemplate = `<!doctype html>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
   <script>
-// --- Cross-origin isolation via Service Worker ---
-if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigator) {
+// --- Cross-origin isolation: prefer server headers, fall back to SW ---
+// When the dev/host server sends the COI headers itself (dev/serve.json
+// does this), crossOriginIsolated is already true and we don't need the
+// SW. Any leftover SW from a prior visit (e.g. earlier GitHub Pages load)
+// would intercept future fetches with stale content — unregister it now
+// so the headers path stays clean.
+if (crossOriginIsolated && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(rs => rs.forEach(r => r.unregister())).catch(()=>{});
+}
+// No isolation? Register the SW shim — but only once per tab. Without a
+// loop guard, a SW that fails to provide isolation (Safari rejects
+// credentialless, or activation races a tab close) reloads forever.
+if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigator
+    && !sessionStorage.getItem('_lgCoiTried')) {
+  sessionStorage.setItem('_lgCoiTried', '1');
   navigator.serviceWorker.register('coi-serviceworker.js').then(() => location.reload()).catch(()=>{});
 }
 

--- a/wasm.go
+++ b/wasm.go
@@ -343,8 +343,19 @@ addEventListener('fetch', e => {
   e.respondWith(fetch(e.request).then(r => {
     if (r.status === 0) return r;
     const h = new Headers(r.headers);
-    h.set('Cross-Origin-Embedder-Policy', 'credentialless');
-    h.set('Cross-Origin-Opener-Policy', 'same-origin');
+    // Pass server-set isolation headers through untouched. Overriding them
+    // (the previous behavior) broke require-corp setups on dev servers
+    // that already provide proper headers, by replacing them with the
+    // credentialless variant Safari rejects — yielding pages that look
+    // like they should be isolated but aren't.
+    if (!h.has('Cross-Origin-Embedder-Policy')) {
+      // require-corp is the broadest-compatible option: Safari, Firefox,
+      // and Chrome all accept it; credentialless is Chrome-only.
+      h.set('Cross-Origin-Embedder-Policy', 'require-corp');
+    }
+    if (!h.has('Cross-Origin-Opener-Policy')) {
+      h.set('Cross-Origin-Opener-Policy', 'same-origin');
+    }
     return new Response(r.body, {status: r.status, statusText: r.statusText, headers: h});
   }).catch(() => new Response(null, {status: 500})));
 });


### PR DESCRIPTION
Fixes two compounding bugs in the WASM template's `cross-origin-isolation` bootstrap.

Symptoms: pages flashing between "Interactive Input Unavailable" and "loading..." on Safari and Firefox mobile. See [nooga/xsofy#3](https://github.com/nooga/xsofy/issues/3) for the user-visible report.

## Causes

1. `coi-serviceworker.js` sets `Cross-Origin-Embedder-Policy: credentialless`. That value is Chrome-only — Safari and Firefox ignore it, so `crossOriginIsolated` never becomes true and `SharedArrayBuffer` stays gated.
2. The boot HTML does `register(...).then(() => location.reload())` with no loop guard. When (1) means isolation can never activate, every reload re-enters the same path, leading to  infinite reload.

| Browser | `credentialless` | `require-corp` |
|---------|------------------|----------------|
| Chrome  | accepted         | accepted       |
| Safari  | ignored          | accepted       |
| Firefox | ignored          | accepted       |

Support for `credentialless`:
<img width="713" height="238" alt="image" src="https://github.com/user-attachments/assets/8cf7202e-f9b2-4d6c-aa11-4794a937c42f" />

https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/IFrame_credentialless

## Changes

**wasm.go:**
- HTML bootstrap: register the SW at most once per tab (sessionStorage guard), and proactively unregister any stale SW when the page is already cross-origin-isolated from server headers.
- Service worker: only inject COOP/COEP when the response doesn't already carry them (so dev servers that send headers themselves aren't clobbered), and use `require-corp` instead of `credentialless` when injecting.

## Testing

- Chrome (macOS): boots to title screen on first visit; `crossOrigin Isolated === true`; SW auto-unregisters when server provides headers.
- iOS Safari: boots to title screen on first visit; no reload loop.

Cannot test Android Firefox directly (no device); the header-compatibility table above and the loop-guard logic should cover it, but confirmation from the original reporter would be welcome.

## Recovery for clients with the old SW cached

`skipWaiting` + `clients.claim` in the new SW swaps it in on next visit; the HTML's auto-unregister branch then removes it for good once headers isolate the page. Users who want to force the recovery immediately can clear site data once.

## other notes

- `./let-go/wasm.go`: the only file modified in the let-go PR.
- `./let-go/.git/refs/heads/expmt/js-bridge`:  source of the two cherry-picked SHAs (`f3ed218`, `44812e9`).
- `./xsofy/.github/workflows/deploy-pages.yml`: *not modified*, but referenced: confirms `let-go@latest` will pull the fix once merged. Worth considering pinning to a specific SHA instead (out of scope for this plan).
- This PR does not bump the `let-go@latest` pin in xsofy's workflow (no need; `@latest` resolves once the fix is merged and tagged).

## AI Disclosure

Claude Opus 4.7 was used extensively to debug and fix this issue.
