### PR TITLE
ci: add prek/pre-commit hooks mirroring CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,8 @@ linters:
     - unused
     - ineffassign
     - typecheck
+    - gofmt       # safety net — pre-commit hook auto-formats, this catches anything that slipped through
+    - goimports
   disable:
     - errcheck  # too noisy for a language runtime with many fire-and-forget calls
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,76 @@
+# Pre-commit / prek configuration. Mirrors .github/workflows/go.yml so local
+# checks catch what CI catches before pushing.
+#
+# Install:
+#   prek install --install-hooks --hook-type pre-commit --hook-type pre-push
+# Or with classic pre-commit:
+#   pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push
+#
+# Hook stages:
+#   pre-commit  → fast lint + build on every commit
+#   pre-push    → full test suite (including Clojure compat) before push
+#
+# Escape hatch for in-progress work:
+#   git commit --no-verify
+#   git push   --no-verify
+
+repos:
+  # golangci-lint via the official upstream — the binary is installed by
+  # prek/pre-commit on first run, so contributors don't need to install it
+  # separately. Pinned to the last v1.x release because .golangci.yml is in
+  # v1-format; bump to v2.x when the config is migrated.
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.64.8
+    hooks:
+      - id: golangci-lint-full
+        stages: [pre-commit]
+
+  - repo: local
+    hooks:
+      # Auto-fix formatting before linters run. gofmt ships with Go.
+      # goimports is fetched on demand via `go run ...@latest` so contributors
+      # don't need a separate install; the module cache makes subsequent runs
+      # cheap. -format-only matches gofmt's behavior plus import grouping,
+      # without trying to resolve new imports from the source tree.
+      - id: gofmt
+        name: gofmt -s -w
+        description: Auto-format Go sources (simplification + standard formatting)
+        entry: gofmt -s -w
+        language: system
+        types: [go]
+        stages: [pre-commit]
+
+      - id: goimports
+        name: goimports -w -format-only
+        description: Group and order imports (run after gofmt)
+        entry: go run golang.org/x/tools/cmd/goimports@latest -w -format-only
+        language: system
+        types: [go]
+        stages: [pre-commit]
+
+      - id: go-build
+        name: go build ./...
+        description: Verify the project builds (mirrors CI build step)
+        entry: go build ./...
+        language: system
+        types: [go]
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: go-test
+        name: go test ./... -skip TestClojureTestSuite
+        description: Run Go test suite excluding the slow Clojure compat suite (mirrors CI test step)
+        entry: go test -timeout 60s ./... -skip TestClojureTestSuite
+        language: system
+        types: [go]
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: clojure-compat-suite
+        name: Clojure compatibility test suite
+        description: Run the vendored jank-lang/clojure-test-suite (mirrors CI compat step)
+        entry: go test ./test/ -count=1 -run TestClojureTestSuite
+        language: system
+        types: [go]
+        pass_filenames: false
+        stages: [pre-push]


### PR DESCRIPTION
Adds a `.pre-commit-config.yaml` that mirrors `.github/workflows/go.yml` so contributors catch the same lint/build/test failures locally that CI catches on push. Works with either [prek](https://github.com/j178/prek) (Rust reimplementation, faster) or classic [pre-commit](https://pre-commit.com/).

Touches #41 — the pre-commit-hook half of nooga's claim. The `.lgb` drift-check hook is intentionally **not** here; it's cleaner as a follow-up after #45 lands (which makes `lgbgen` output deterministic).

## ⚠️ Depends on the format-fix PR landing first

Enabling the `gofmt` and `goimports` linters in `.golangci.yml` revealed 15 existing Go files with pre-existing format/lint debt. Those fixes are isolated in a separate PR (#47) so this PR stays focused on the tooling change. Merge order should be: **format-fix PR → this PR** to keep CI green on every commit.

## Stages

| Stage | Hook | Why |
|---|---|---|
| `pre-commit` | `golangci-lint-full` (with `--fix`) | Auto-fix anything golangci-lint's linters know how to fix |
| `pre-commit` | `gofmt -s -w` | Auto-apply gofmt simplification rules |
| `pre-commit` | `goimports -w -format-only` | Group + sort imports (fetched on demand via `go run ...@latest`) |
| `pre-commit` | `go build ./...` | Fail fast on broken builds |
| `pre-push` | `go test ./... -skip TestClojureTestSuite` | Full Go suite before code leaves the laptop |
| `pre-push` | `go test ./test/ -run TestClojureTestSuite` | Vendored jank-lang compat suite |

Auto-fix hooks run **before** the build/test hooks, so most format issues never reach a failure.

Also enables `gofmt` and `goimports` as linters in `.golangci.yml` — belt-and-suspenders for commits that slip through with `--no-verify`.

## Install

```sh
prek install --install-hooks --hook-type pre-commit --hook-type pre-push
# or
pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push
```

Escape hatch for in-progress work: `git commit --no-verify` / `git push --no-verify`.

## Pinning notes

`golangci-lint` is pinned to `v1.64.8` — the last v1.x release — because `.golangci.yml` is in v1 format. Bump to v2.x when the config is migrated.

`goimports` is invoked via `go run golang.org/x/tools/cmd/goimports@latest` so contributors don't need a separate install; first run populates the module cache.

## Test plan

Simulated post-merge state (test merge of this PR + format-fix PR) verified manually:

- [x] `prek run --all-files --hook-stage pre-commit` — all four hooks pass cleanly
- [x] `prek run --all-files --hook-stage pre-push` — full Go suite + Clojure compat suite pass
- [x] Config is purely additive — no existing CI or developer workflow changes