### PR TITLE
examples: ys-on-let-go — run yamlscript compiled output on let-go

### DIFF
--- a/examples/ys-on-let-go/01_hello.lg
+++ b/examples/ys-on-let-go/01_hello.lg
@@ -1,0 +1,5 @@
+;; Auto-generated from 01_hello.ys via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [say ARGS]])
+(defn main [] (say "hello from let-go via yamlscript"))
+(apply main ARGS)

--- a/examples/ys-on-let-go/01_hello.ys
+++ b/examples/ys-on-let-go/01_hello.ys
@@ -1,0 +1,4 @@
+!yamlscript/v0
+
+defn main():
+  say: "hello from let-go via yamlscript"

--- a/examples/ys-on-let-go/02_fizzbuzz.lg
+++ b/examples/ys-on-let-go/02_fizzbuzz.lg
@@ -1,0 +1,17 @@
+;; Auto-generated from 02_fizzbuzz.ys via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [say ARGS]])
+(defn
+ fizzbuzz
+ [n]
+ (cond
+  (zero? (mod n 15))
+  "FizzBuzz"
+  (zero? (mod n 3))
+  "Fizz"
+  (zero? (mod n 5))
+  "Buzz"
+  :else
+  (str n)))
+(defn main [] (doseq [i (range 1 16)] (say (fizzbuzz i))))
+(apply main ARGS)

--- a/examples/ys-on-let-go/02_fizzbuzz.ys
+++ b/examples/ys-on-let-go/02_fizzbuzz.ys
@@ -1,0 +1,12 @@
+!yamlscript/v0
+
+defn fizzbuzz(n):
+  cond:
+    (zero? (mod n 15)): "FizzBuzz"
+    (zero? (mod n 3)):  "Fizz"
+    (zero? (mod n 5)):  "Buzz"
+    :else: (str n)
+
+defn main():
+  doseq [i (range 1 16)]:
+    say: fizzbuzz(i)

--- a/examples/ys-on-let-go/03_classify.lg
+++ b/examples/ys-on-let-go/03_classify.lg
@@ -1,0 +1,12 @@
+;; Auto-generated from 03_classify.ys via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [say ARGS]])
+(defn
+ classify
+ [n]
+ (cond (pos? n) "positive" (neg? n) "negative" :else "zero"))
+(defn
+ main
+ []
+ (doseq [n (range -2 3)] (say (str n " is " (classify n)))))
+(apply main ARGS)

--- a/examples/ys-on-let-go/03_classify.ys
+++ b/examples/ys-on-let-go/03_classify.ys
@@ -1,0 +1,11 @@
+!yamlscript/v0
+
+defn classify(n):
+  cond:
+    (pos? n): "positive"
+    (neg? n): "negative"
+    :else:    "zero"
+
+defn main():
+  doseq [n (range -2 3)]:
+    say: str(n " is " (classify n))

--- a/examples/ys-on-let-go/04_data.lg
+++ b/examples/ys-on-let-go/04_data.lg
@@ -1,0 +1,9 @@
+;; Auto-generated from 04_data.yaml via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [%]])
+(def loaded
+(% "name" "Fido" "age" 6 "likes" ["running" "treats"])
+)
+(println loaded)
+(println "name:" (get loaded "name"))
+(println "likes:" (get loaded "likes"))

--- a/examples/ys-on-let-go/04_data.yaml
+++ b/examples/ys-on-let-go/04_data.yaml
@@ -1,0 +1,5 @@
+name: Fido
+age: 6
+likes:
+  - running
+  - treats

--- a/examples/ys-on-let-go/README.md
+++ b/examples/ys-on-let-go/README.md
@@ -1,0 +1,55 @@
+# Running YAMLScript (YS) on let-go
+
+[YAMLScript](https://yamlscript.org/) is a Clojure-based YAML loader and
+scripting language. Its compiler emits plain Clojure forms, which means
+the *output* of `ys --compile` can run on let-go with a small shim that
+provides the symbols from the YS standard library (`say`, `ARGS`, `%`,
+`sum`, ...).
+
+This directory contains four worked examples. The `.ys` / `.yaml` files
+are the sources; the `.lg` files are checked in so they can be run
+without `ys` installed.
+
+## Run the examples
+
+```bash
+cd examples/ys-on-let-go
+
+lg -source-paths . 01_hello.lg
+lg -source-paths . 02_fizzbuzz.lg
+lg -source-paths . 03_classify.lg
+lg -source-paths . 04_data.lg
+```
+
+Each one prints the same output it would print under native `ys`.
+
+## Regenerate after editing a `.ys` source
+
+```bash
+./build.sh    # requires ys in PATH
+```
+
+## What this covers and what it doesn't
+
+The `ys-runtime.lg` shim handles enough of the YS surface to run YS
+scripts that stay inside Clojure's pure-data and simple-logic
+fragments: `defn`, `let`, `cond`, `doseq`, `range`, string
+interpolation (compiled to `str`), `apply`, `get`, `hash-map`, plus YS
+helpers like `say`/`sum`/`%`.
+
+It does not handle:
+
+- `babashka.fs` / `babashka.process` / `babashka.http-client`
+- `java-time`
+- Ordered maps (YAML round-trip preserves data but not key order; YS's
+  `%` is aliased to `hash-map` here, not `flatland.ordered/ordered-map`)
+- YS stdlib symbols whose let-go equivalents live under different
+  names (e.g. `json/load` vs let-go's `json/read-json`). For now those
+  need a hand-edit or sed pass.
+
+The compiled-output approach is the lightest of three integration
+paths discussed in [issue
+#49](https://github.com/nooga/let-go/issues/49). For full embedded
+yamlscript, SCI itself would need to be ported (SCI is `.cljc` and
+let-go already supports `:lg` reader conditionals, so that is
+tractable but not free).

--- a/examples/ys-on-let-go/build.sh
+++ b/examples/ys-on-let-go/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Regenerate the .lg files in this directory from their .ys / .yaml sources.
+# Requires `ys` (https://yamlscript.org) in PATH.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if ! command -v ys >/dev/null 2>&1; then
+  echo "ys not found. Install from https://yamlscript.org/install or skip — checked-in .lg files are already runnable on let-go." >&2
+  exit 1
+fi
+
+for src in 01_hello.ys 02_fizzbuzz.ys 03_classify.ys; do
+  out="${src%.ys}.lg"
+  {
+    echo ";; Auto-generated from $src via: ys --compile"
+    echo ";; Do not edit by hand. Regenerate with: ./build.sh"
+    echo "(require '[ys-runtime :refer [say ARGS]])"
+    ys --compile "$src"
+  } > "$out"
+done
+
+# Data-mode YAML: emit a driver around the compiled (% ...) form.
+{
+  echo ";; Auto-generated from 04_data.yaml via: ys --compile"
+  echo ";; Do not edit by hand. Regenerate with: ./build.sh"
+  echo "(require '[ys-runtime :refer [%]])"
+  echo "(def loaded"
+  ys --compile 04_data.yaml
+  echo ")"
+  echo "(println loaded)"
+  echo "(println \"name:\" (get loaded \"name\"))"
+  echo "(println \"likes:\" (get loaded \"likes\"))"
+} > 04_data.lg
+
+echo "Regenerated 01_hello.lg 02_fizzbuzz.lg 03_classify.lg 04_data.lg"

--- a/examples/ys-on-let-go/ys-runtime.lg
+++ b/examples/ys-on-let-go/ys-runtime.lg
@@ -1,0 +1,52 @@
+;
+; Copyright (c) 2026 Marcin Gasperowicz <xnooga@gmail.com>
+; SPDX-License-Identifier: MIT
+;
+
+;; ys-runtime.lg — minimal shim namespace that lets the output of
+;; `ys --compile` run on let-go. yamlscript-compiled Clojure refers to
+;; symbols from the YS stdlib (say, sum, %, ARGS, ...) which are not
+;; part of let-go. This namespace provides enough of them to run
+;; small YS programs unmodified.
+;;
+;; Coverage: pure-Clojure subset of YS. No babashka.fs / process /
+;; http-client, no java-time, no ordered maps. Suitable for scripts
+;; that stay inside YS's data + simple-logic surface.
+
+(ns ys-runtime
+  (:require [clojure.string :as str]))
+
+;; --- runtime vars YS expects to be present ---------------------------
+
+(def ARGS [])
+(def ARGV [])
+(def ENV {})
+
+;; --- IO ---------------------------------------------------------------
+
+(defn say [& xs] (apply println xs))
+(defn warn [& xs] (binding [*out* *err*] (apply println xs)))
+(defn pp  [x]    (println x))
+
+;; --- arithmetic helpers YS exposes -----------------------------------
+
+(defn add [& xs] (apply + xs))
+(defn sub [& xs] (apply - xs))
+(defn mul [& xs] (apply * xs))
+(defn div [& xs] (apply / xs))
+(defn sum [xs]   (reduce + xs))
+
+;; --- string helpers ---------------------------------------------------
+
+(defn join
+  ([xs]     (apply str xs))
+  ([sep xs] (str/join sep xs)))
+
+(defn text [xs] (str/join "\n" xs))
+
+;; --- YAML data-mode constructor --------------------------------------
+
+;; YS data-mode YAML files compile to `(% k v k v ...)`. In real YS
+;; `%` is `flatland.ordered.map/ordered-map`; we fall back to
+;; `hash-map`, which preserves the data but not insertion order.
+(defn % [& kvs] (apply hash-map kvs))


### PR DESCRIPTION
## Summary

Adds `examples/ys-on-let-go/` showing how the output of `ys --compile` runs on let-go with a small `ys-runtime.lg` shim providing the YS stdlib symbols (`say`, `ARGS`, `sum`, `%`, ...) let-go doesn't ship.

Four worked examples: hello, fizzbuzz, conditional classify, and YAML data-mode loading. The `.lg` files are checked in so reviewers can run the examples without `ys` installed; `build.sh` regenerates them from the `.ys` / `.yaml` sources.

```bash
cd examples/ys-on-let-go
lg -source-paths . 01_hello.lg     # → hello from let-go via yamlscript
lg -source-paths . 02_fizzbuzz.lg  # → 1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz ...
lg -source-paths . 03_classify.lg  # → -2 is negative ... 2 is positive
lg -source-paths . 04_data.lg      # → {"name" "Fido" ...}
```

All four examples produce identical output to native `ys`.

## Scope

This is a docs/examples-only PR — no core changes. Independent of #51 and #52. The README links #49 and is explicit about what the shim does and doesn't cover (no `babashka.fs`/`process`/`http-client`, no `java-time`, no ordered maps).

## Test plan

- [x] All four `.lg` files run cleanly with `lg -source-paths .`
- [x] Output matches `ys` native run byte-for-byte for examples 01–03
- [x] `build.sh` regenerates the `.lg` files; bash syntax checked with `bash -n`

Context: #49.