### PR TITLE
feat: add lazy-seq? predicate; throw on lazy-seq of non-seq value

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5171,6 +5171,20 @@ func installLangNS() {
 	})
 	ns.Def("map-entry?", isMapEntry)
 
+	// lazy-seq? — test if value is a thunk-backed lazy seq. LazySeq.Type()
+	// reports ListType for print/seq compatibility, so user-side type
+	// checks can't reach the underlying Go type; this predicate does.
+	isLazySeq, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.FALSE, nil
+		}
+		if _, ok := vs[0].(*vm.LazySeq); ok {
+			return vm.TRUE, nil
+		}
+		return vm.FALSE, nil
+	})
+	ns.Def("lazy-seq?", isLazySeq)
+
 	// reversible? — test if value supports rseq
 	isReversible, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {

--- a/pkg/vm/lazy_seq.go
+++ b/pkg/vm/lazy_seq.go
@@ -5,7 +5,10 @@
 
 package vm
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // LazySeq delays computation of a sequence until first/next is called.
 // This is the foundation for lazy operations like map, filter, etc.
@@ -32,6 +35,10 @@ func (l *LazySeq) IsRealized() bool {
 func (l *LazySeq) sval() Value {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	// Re-raise stored error on repeated access, mirroring seq().
+	if l.err != nil {
+		panic(&thrownPanic{err: l.err})
+	}
 	if l.fn != nil {
 		sv, err := l.fn.Invoke(nil)
 		if err != nil {
@@ -77,6 +84,12 @@ func (l *LazySeq) seq() Seq {
 			l.s = seq
 		} else if seqable, ok := sv.(Sequable); ok {
 			l.s = seqable.Seq()
+		} else {
+			// Realized to a non-seq, non-Sequable value. Match JVM Clojure's
+			// behavior: throw rather than silently coercing to nil.
+			err := fmt.Errorf("don't know how to create ISeq from %s", sv.Type())
+			l.err = err
+			panic(&thrownPanic{err: err})
 		}
 	}
 

--- a/test/compat/clojure/core-test/portability.lg
+++ b/test/compat/clojure/core-test/portability.lg
@@ -27,6 +27,11 @@
 ;; Re-export let-go's native BigInt predicate under the suite-local helper name.
 (def big-int? clojure.core/big-int?)
 
+;; Re-export let-go's native lazy-seq? predicate. Upstream's lazy_seq.cljc
+;; and repeatedly.cljc tests assert that a (lazy-seq ...) form returns
+;; something distinguishable from a fully-realized seq.
+(def lazy-seq? clojure.core/lazy-seq?)
+
 ;; Most JVM/Clojure compatibility names used by the suite now live in core:
 ;; java.lang.* aliases, clojure.lang.* aliases, Long/Double constants,
 ;; definterface/new, with-precision, refs, and synchronous agent placeholders.

--- a/test/lazy_seq_pred_test.lg
+++ b/test/lazy_seq_pred_test.lg
@@ -1,0 +1,41 @@
+;; Tests for the lazy-seq? predicate — distinguishes thunk-backed lazy
+;; seqs from already-realized or differently-typed seqs.
+
+(ns test.lazy-seq-pred-test
+  (:require [test :refer :all]))
+
+(deftest lazy-seq?-predicate
+  (testing "lazy-seq form returns something lazy-seq? recognizes"
+    (is (lazy-seq? (lazy-seq (cons 1 nil)))))
+  (testing "non-lazy seqs are not lazy-seq?"
+    (is (not (lazy-seq? '(1 2 3))))
+    (is (not (lazy-seq? [1 2 3])))
+    (is (not (lazy-seq? #{1 2 3})))
+    (is (not (lazy-seq? {:a 1})))
+    (is (not (lazy-seq? nil))))
+  (testing "repeatedly returns a lazy-seq"
+    (is (lazy-seq? (repeatedly (fn [] 1))))))
+
+(defn- throws? [thunk]
+  (try (thunk) false (catch _ true)))
+
+(deftest lazy-seq-of-non-seq-throws
+  (testing "lazy-seq realized to a non-seq throws on first, matching JVM"
+    (is (throws? #(first (lazy-seq 1))))
+    (is (throws? #(first (lazy-seq :a))))
+    (is (throws? #(first (lazy-seq 3.14))))
+    (is (throws? #(first (lazy-seq true))))
+    (is (throws? #(first (lazy-seq (fn [] 1))))))
+  (testing "lazy-seq realized to nil or empty stays empty (does not throw)"
+    (is (nil? (first (lazy-seq nil))))
+    (is (nil? (first (lazy-seq []))))))
+
+(deftest broken-lazy-seq-state
+  (testing "second access to a broken lazy-seq re-throws the same error"
+    (let [ls (lazy-seq 1)]
+      (is (throws? #(first ls)))
+      (is (throws? #(first ls)))))
+  (testing "a broken lazy-seq is realized? = true (the thunk did run)"
+    (let [ls (lazy-seq 1)]
+      (try (first ls) (catch _ nil))
+      (is (realized? ls)))))


### PR DESCRIPTION
upstream jank-lang/clojure-test-suite added lazy_seq.cljc and repeatedly.cljc tests that rely on a (p/lazy-seq? x) predicate exported from the suite's portability namespace. let-go's local portability shim at test/compat/clojure/core-test/portability.lg didn't provide it, so both tests skipped with a compile error after the next submodule bump.

Three related changes:

1. Add lazy-seq? as a native predicate in pkg/rt/lang.go that detects the concrete *vm.LazySeq Go type. LazySeq.Type() reports ListType for print/seq compatibility, so user-side instance?/type checks can't reach it.

2. Make LazySeq.seq() in pkg/vm/lazy_seq.go throw when the realized thunk value is non-nil and neither Seq nor Sequable. Previously it silently coerced to nil and (first (lazy-seq 1)) returned nil; JVM Clojure throws 'don't know how to create ISeq from ...'. Matches the behavior of the top-level (seq x) fn for the same input.

3. Have sval() re-raise l.err on repeated access (mirrors the existing re-raise in seq()) so error propagation is symmetric across both realization entry points.

Also exports lazy-seq? from test/compat/clojure/core-test/portability.lg so the upstream tests resolve p/lazy-seq?.

Conformance suite results:
  pinned submodule (41290a6):  files=232 pass=5621 fail=0 skip=0  (unchanged)
  upstream HEAD (1b936df):     files=234 pass=5656 fail=0 skip=0
  upstream HEAD before:        files=232 pass=5621 fail=1 skip=2

Adds test/lazy_seq_pred_test.lg with 3 deftests / 16 assertions covering the predicate, the throw-on-non-seq behavior, idempotent re-raise on repeated access, and realized? state post-throw.

Context: #49.