### PR TITLE
fix: RegisterNS auto-refers CoreNS so (in-ns 'foo) preserves core macros

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -126,6 +126,13 @@ func NS(name string) *vm.Namespace {
 }
 
 func RegisterNS(namespace *vm.Namespace) *vm.Namespace {
+	// Auto-refer CoreNS so user code can use clojure.core symbols (defn, def,
+	// require, etc.) after switching into this namespace via (in-ns 'foo) —
+	// matching JVM Clojure semantics. Skip when registering CoreNS itself, and
+	// when CoreNS isn't installed yet (very early init).
+	if CoreNS != nil && namespace != CoreNS {
+		namespace.Refer(CoreNS, "", true)
+	}
 	nsRegistry[resolveNSAlias(namespace.Name())] = namespace
 	return namespace
 }

--- a/test/in_ns_auto_refer_test.lg
+++ b/test/in_ns_auto_refer_test.lg
@@ -1,0 +1,28 @@
+;; Tests that (in-ns 'foo) leaves clojure.core symbols (defn, def,
+;; require, etc.) available — matching JVM Clojure semantics where
+;; every namespace auto-refers clojure.core.
+;;
+;; Regression test for: extending a Go-installed namespace (json, os,
+;; http, etc.) was previously impossible because installXxxNS skipped
+;; the core refer. Fixed by having RegisterNS auto-refer CoreNS.
+
+;; Set up: extend json (a Go-installed ns) and a brand-new ns BEFORE
+;; the test ns is reopened. This exercises the auto-refer at in-ns
+;; time without trying to mix in-ns and (is ...) in the same form.
+
+(in-ns 'json)
+(defn ^:no-doc test-load [s] (read-json s))
+
+(in-ns 'test.in-ns-fresh-target)
+(defn ^:no-doc hello [] :ok)
+
+(in-ns 'test.in-ns-auto-refer-test)
+(clojure.core/require '[test :refer :all])
+
+(deftest in-ns-go-installed
+  (testing "in-ns into a Go-installed namespace allows core macros"
+    (is (= {"a" 1} (json/test-load "{\"a\":1}")))))
+
+(deftest in-ns-brand-new-ns
+  (testing "in-ns into a brand-new ns allows core macros"
+    (is (= :ok (test.in-ns-fresh-target/hello)))))


### PR DESCRIPTION
## Summary

Extending a Go-installed namespace (json, os, http, etc.) was broken:

```clojure
(in-ns 'json)
(defn load [s] (read-json s))
;; → error: Can't resolve defn in this context
```

**Cause:** `installXxxNS` functions build namespaces and register them via `RegisterNS`, but `RegisterNS` didn't add a refer to `CoreNS`. `.lg`-defined namespaces go through `LookupOrRegisterNS` which does refer; brand-new namespaces created on demand also do. Only Go-built ones were missing the refer — 13 of 18 `installXxxNS` functions (`http`, `json`, `hierarchy`, `iort`, `os`, `pods`, `pods_wasm`, `syscall_linux`, `syscall_other`, `system`, `test`, `transit`, `unix_linux`, `unix_other`).

**Fix:** rather than touch all 13 install functions, add the refer in the single `RegisterNS` chokepoint. Skip when registering `CoreNS` itself (would self-refer) and when `CoreNS` isn't installed yet (early init order — `installLangNS` runs first and assigns `CoreNS` before any other install touches `RegisterNS`).

Matches JVM Clojure where every ns auto-refers `clojure.core`.

## Test plan

- [x] `(in-ns 'json) (defn load [s] (read-json s))` resolves successfully
- [x] `(in-ns 'my-fresh-ns) (defn hello [] :ok)` still works (regression check on brand-new ns path)
- [x] `(in-ns 'walk) (defn my-extend ...)` still works (regression check on .lg-loaded ns path)
- [x] Adds `test/in_ns_auto_refer_test.lg` with 2 deftests covering Go-installed and brand-new paths
- [x] Full Go test suite passes
- [x] Conformance suite unchanged: pinned 5621/0/0/0/0; upstream HEAD 5656/0/0/0/0

Context: #49.