### PR TITLE
Fix nREPL port zero reporting

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -525,8 +525,9 @@ func main() {
 			err := nreplServe(context, nreplPort)
 			if err != nil {
 				fmt.Println("failed to run nREPL server on port", nreplPort, err)
+			} else {
+				fmt.Printf("nREPL server running at tcp://127.0.0.1:%d\n", nreplServer.Port())
 			}
-			fmt.Printf("nREPL server running at tcp://127.0.0.1:%d\n", nreplPort)
 		}
 		repl(context)
 	}

--- a/pkg/nrepl/server.go
+++ b/pkg/nrepl/server.go
@@ -45,6 +45,11 @@ func NewNreplServer(ctx *compiler.Context) *NreplServer {
 	}
 }
 
+// Port returns the TCP port the server is listening on.
+func (n *NreplServer) Port() int {
+	return n.port
+}
+
 func (n *NreplServer) newSession() *session {
 	id, err := uuid.GenerateUUID()
 	if err != nil {
@@ -83,6 +88,7 @@ func (n *NreplServer) Start(port int) error {
 	if err != nil {
 		return err
 	}
+	port = l.Addr().(*net.TCPAddr).Port
 	n.listener = l
 	n.port = port
 	n.stop = make(chan struct{})

--- a/pkg/nrepl/server_test.go
+++ b/pkg/nrepl/server_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package nrepl
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestStartWithPortZeroReportsBoundPort(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	srv := NewNreplServer(nil)
+	output := captureStdout(t, func() {
+		if err := srv.Start(0); err != nil {
+			t.Fatalf("Start(0) failed: %v", err)
+		}
+	})
+	t.Cleanup(srv.Stop)
+
+	if srv.Port() == 0 {
+		t.Fatal("Port() returned 0 after Start(0)")
+	}
+
+	portFile, err := os.ReadFile(".nrepl-port")
+	if err != nil {
+		t.Fatalf("reading .nrepl-port: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(portFile)), strconv.Itoa(srv.Port()); got != want {
+		t.Fatalf(".nrepl-port = %q, want %q", got, want)
+	}
+
+	if strings.Contains(output, "port 0") || strings.Contains(output, ":0") {
+		t.Fatalf("startup output contains port 0: %q", output)
+	}
+	if !strings.Contains(output, strconv.Itoa(srv.Port())) {
+		t.Fatalf("startup output %q does not contain bound port %d", output, srv.Port())
+	}
+}
+
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating stdout pipe: %v", err)
+	}
+
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	f()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stdout pipe: %v", err)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stdout pipe: %v", err)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary

- Resolve the actual listener port after binding nREPL with port 0
- Write the resolved port to .nrepl-port and print it in startup messages
- Add coverage for Start(0) reporting the bound port

## Tests

- go test ./pkg/nrepl -count=1 -v
- go test ./... -count=1