### PR TITLE
Some improvements to Makefile and report generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 /vendor/
 /Godeps/
 
+### Makes cache dir - https://github.com/makeplus/makes ###
+/.cache/
+
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,60 @@
-.PHONY: run generate build test clojure-compat-report clean lint install-golangci-lint
+###s
+# Auto install `go` into ./.cache/local/ if not available.
+# Also if `make ... GO-VERSION=1.x.y` is used.
 
-run: build
-	./lg
+ifneq (,$(or $(if $(shell which go),,1),$(GO-VERSION)))
+R := https://github.com/makeplus/makes
+M := .cache/makes
+$(shell [ -d '$M' ] || git clone -q $R '$M')
+include $M/init.mk
+# override default Go version with: `make ... GO-VERSION=1.x.y`
+GO-VERSION ?= 1.26.3
+include $M/go.mk
+include $M/shell.mk
+endif
 
-generate:
+# Prefer - to _ for make var names (won't conflict with env vars):
+LG := lg
+GOLANGCI-LINT := github.com/golangci/golangci-lint/cmd/golangci-lint
+REPORT-SCRIPT := scripts/clojure_compat_report.sh
+
+
+# Start repl by default:
+default:: run
+
+run: $(LG)
+	./$<
+
+build: $(LG)
+
+generate: $(GO)
 	go run ./cmd/lgbgen
 
-build: lg.go pkg/**/*
-	go build -ldflags="-s -w" -o lg .
+$(LG): $(GO) lg.go pkg/**/*
+	which go
+	go build -ldflags="-s -w" -o $@ .
 
-test: pkg/**/*
+test: pkg/**/* $(GO)
 	go test -count=1 -v ./test
 
-clojure-compat-report:
-	@./scripts/clojure_compat_report.sh
+clojure-compat-report: $(GO)
+	@$(REPORT-SCRIPT)
 
 clean:
-	rm ./lg
+	$(RM) $(LG)
+
+distclean: clean
+ifneq (,$(wildcard .cache))
+	chmod -R +w .cache
+	$(RM) -r .cache
+endif
 
 lint: install-golangci-lint
-	golangci-lint run 
+	golangci-lint run
 
-install-golangci-lint:
-	which golangci-lint || GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+install-golangci-lint: $(GO)
+	which golangci-lint || \
+	  GO111MODULE=off go get -u $(GO111MODULE-LINT)
+
+# PHONY targets are for ones that have conflicting files/dirs present:
+.PHONY: test

--- a/scripts/clojure_compat_report.sh
+++ b/scripts/clojure_compat_report.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-set -u
+set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOG="${TMPDIR:-/tmp}/let-go-clojure-compat-report.$$.$RANDOM.log"
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+LOG=${TMPDIR:-/tmp}/let-go-clojure-compat-report.$$.$RANDOM.log
 
-cd "$ROOT" || exit 1
+cd "$ROOT"
 
-go test ./test/ -count=1 -run TestClojureTestSuite -v >"$LOG" 2>&1
+go test ./test/ -count=1 -run TestClojureTestSuite -v 2>&1 | tee "$LOG"
 STATUS=$?
 
 awk -v status="$STATUS" -v logfile="$LOG" '


### PR DESCRIPTION
Makefile now installs a go binary as .cache/local/go-1.26.3/bin/go if user doesn't have go installed.

`make distclean` adds .cache/ to the clean targets.

Some minor bash adjustments. Still passes shellcheck.