### PR TITLE
Bootstrap stdlib bundle generation from source

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,11 +32,20 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Regenerate bundled bytecode
+        run: go generate ./pkg/rt/
+
       - name: Build
         run: go build -v ./...
 
-      - name: Test
+      - name: Test with bundled bytecode stdlib
         run: go test -v -timeout 60s ./... -skip TestClojureTestSuite
 
-      - name: Clojure compatibility test suite
+      - name: Clojure compatibility test suite with bundled bytecode stdlib
         run: go test ./test/ -count=1 -run TestClojureTestSuite -v
+
+      - name: Test with source stdlib bootstrap
+        run: go test -tags bootstrap -v -timeout 60s ./... -skip TestClojureTestSuite
+
+      - name: Clojure compatibility test suite with source stdlib bootstrap
+        run: go test -tags bootstrap ./test/ -count=1 -run TestClojureTestSuite -v

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ project_name: let-go
 before:
   hooks:
     - go mod tidy
+    - go generate ./pkg/rt/
     - go test -timeout 60s ./...
 
 builds:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ run: $(LG)
 build: $(LG)
 
 generate: $(GO)
-	go run ./cmd/lgbgen
+	go run -tags bootstrap ./cmd/lgbgen
 
 $(LG): $(GO) lg.go pkg/**/*
 	which go

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -1,5 +1,7 @@
+//go:build bootstrap
+
 // lgbgen compiles core.lg and all embedded namespaces into a pre-compiled .lgb bundle.
-// Usage: go run ./cmd/lgbgen [output-path]
+// Usage: go run -tags bootstrap ./cmd/lgbgen [output-path]
 // Default output: pkg/rt/core_compiled.lgb (when run from repo root)
 package main
 

--- a/cmd/lgbgen/main_stub.go
+++ b/cmd/lgbgen/main_stub.go
@@ -1,0 +1,13 @@
+//go:build !bootstrap
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "lgbgen must be run with source bootstrap enabled: go run -tags bootstrap ./cmd/lgbgen [output-path]")
+	os.Exit(2)
+}

--- a/cmd/lgbgen/main_test.go
+++ b/cmd/lgbgen/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLGBGenUsesSourceBootstrap(t *testing.T) {
+	root := repoRoot(t)
+	out := filepath.Join(t.TempDir(), "core_compiled.lgb")
+
+	cmd := exec.Command("go", "run", "-tags", "bootstrap", "./cmd/lgbgen", out)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("lgbgen source bootstrap failed: %v\n%s", err, output)
+	}
+
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("stat generated lgb: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("generated lgb is empty")
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/pkg/compiler/eval.go
+++ b/pkg/compiler/eval.go
@@ -64,7 +64,9 @@ func evalInit() {
 	}
 
 	// Original path: compile from source
-	_, err := Eval(rt.CoreSrc)
+	c := NewCompiler(consts, rt.NS(rt.NameCoreNS))
+	c.SetSource("<embedded:core>")
+	_, _, err := c.CompileMultiple(strings.NewReader(rt.CoreSrc))
 	if err != nil {
 		panic("core.lg compilation failed: " + err.Error())
 	}

--- a/pkg/rt/core/core.lg
+++ b/pkg/rt/core/core.lg
@@ -18,6 +18,15 @@
   (list 'do (cons 'defn (cons name (cons args body))) (list 'set-macro! (list 'var name))))
 (set-macro! (var defmacro))
 
+(defmacro def- [name form]
+  `(def ^:private ~name ~form))
+
+(defmacro defn- [name & forms]
+  `(def ^:private ~name (fn ~@forms)))
+
+(defmacro declare [name]
+  (list 'def name nil))
+
 (defmacro comment [& _] nil)
 
 ; define let as alias to let* for now
@@ -66,6 +75,17 @@
 (def <= le)
 
 (def parse-long parse-int)
+
+(declare odd?)
+(declare dec)
+(declare inc)
+(declare map)
+(declare integer?)
+(declare keyword?)
+(declare symbol?)
+(declare sequential?)
+(declare distinct)
+(declare list*)
 
 ;; lazy-seq macro - wraps body in a thunk that produces a seq when realized
 ;; Expands to: (lazy-seq* (fn [] body...))
@@ -409,6 +429,27 @@
              (cons x (filter f r))
              (filter f r))))))))
 
+(defmacro if-let
+  ([bindings then]
+   `(if-let ~bindings ~then nil))
+  ([bindings then else]
+   (let [form (bindings 0) tst (bindings 1)]
+     `(let [temp# ~tst]
+        (if temp#
+          (let [~form temp#]
+            ~then)
+          ~else)))))
+
+(defmacro when-let
+  [bindings & body]
+  (if (not (= 2 (count bindings)))
+    (throw "when-let requires exactly two forms in binding vector")
+    (let [form (bindings 0) tst (bindings 1)]
+      `(let [temp# ~tst]
+         (when temp#
+           (let [~form temp#]
+             ~@body))))))
+
 (defn take
   ([n]
    (fn [rf]
@@ -678,13 +719,6 @@
   (let [forms (if (string? (first forms)) (next forms) forms)]
     `(def ~name (fn ~@forms))))
 
-(defmacro def- [name form]
-  `(def ^:private ~name ~form))
-
-(defmacro defn- [name & forms]
-  (let [forms (if (string? (first forms)) (next forms) forms)]
-    `(def ^:private ~name (fn ~@forms))))
-
 (defmacro while [test & body]
   `(loop* [] (when ~test ~@body (recur))))
 
@@ -794,27 +828,6 @@
 
 (defn reverse [coll]
   (reduce conj () coll))
-
-(defmacro if-let
-  ([bindings then]
-   `(if-let ~bindings ~then nil))
-  ([bindings then else]
-   (let [form (bindings 0) tst (bindings 1)]
-     `(let [temp# ~tst]
-        (if temp#
-          (let [~form temp#]
-            ~then)
-          ~else)))))
-
-(defmacro when-let
-  [bindings & body]
-  (if (not (= 2 (count bindings)))
-    (throw "when-let requires exactly two forms in binding vector")
-    (let [form (bindings 0) tst (bindings 1)]
-      `(let [temp# ~tst]
-         (when temp#
-           (let [~form temp#]
-             ~@body))))))
 
 (defmacro when-first
   [bindings & body]

--- a/pkg/rt/core_embed.go
+++ b/pkg/rt/core_embed.go
@@ -1,8 +1,10 @@
+//go:build !bootstrap
+
 package rt
 
 import _ "embed"
 
-//go:generate go run ../../cmd/lgbgen core_compiled.lgb
+//go:generate go run -tags bootstrap ../../cmd/lgbgen core_compiled.lgb
 
 //go:embed core_compiled.lgb
 var CoreCompiledLGB []byte

--- a/pkg/rt/core_embed_bootstrap.go
+++ b/pkg/rt/core_embed_bootstrap.go
@@ -1,0 +1,5 @@
+//go:build bootstrap
+
+package rt
+
+var CoreCompiledLGB []byte


### PR DESCRIPTION
## Summary
- make lgbgen run only under the bootstrap tag so bundled bytecode is regenerated from source stdlib
- keep normal builds on embedded LGB while bootstrap builds force source fallback
- run CI tests against both bundled bytecode stdlib and source bootstrap stdlib, including the Clojure compatibility suite
- regenerate release LGB before GoReleaser tests/builds

Refs #42

## Tests
- go test -v -timeout 60s ./... -skip TestClojureTestSuite
- go test ./test/ -count=1 -run TestClojureTestSuite -v
- go test -tags bootstrap -v -timeout 60s ./... -skip TestClojureTestSuite
- go test -tags bootstrap ./test/ -count=1 -run TestClojureTestSuite -v