### PR TITLE
feat(vm/string): add .getBytes interop — returns UTF-8 byte-array

### DIFF
--- a/pkg/vm/string.go
+++ b/pkg/vm/string.go
@@ -77,6 +77,24 @@ func (l String) InvokeMethod(name Symbol, args []Value) (Value, error) {
 			return NIL, fmt.Errorf("String.replace expected String replacement")
 		}
 		return String(strings.ReplaceAll(string(l), string(old), string(repl))), nil
+	case "getBytes":
+		if len(args) == 0 {
+			// No-arg form: let-go String is Go's UTF-8 string, so the
+			// default encoding is UTF-8 by construction.
+			return NewByteArrayFrom([]byte(string(l))), nil
+		}
+		if len(args) == 1 {
+			enc, ok := args[0].(String)
+			if !ok {
+				return NIL, fmt.Errorf("String.getBytes encoding must be String, got %s", args[0].Type().Name())
+			}
+			e := strings.ToUpper(string(enc))
+			if e != "UTF-8" && e != "UTF8" {
+				return NIL, fmt.Errorf("String.getBytes: only UTF-8 supported, got %q", string(enc))
+			}
+			return NewByteArrayFrom([]byte(string(l))), nil
+		}
+		return NIL, fmt.Errorf("String.getBytes expected 0 or 1 argument, got %d", len(args))
 	default:
 		return NIL, fmt.Errorf("method %s not found on String", name)
 	}

--- a/test/string_getbytes_test.lg
+++ b/test/string_getbytes_test.lg
@@ -1,0 +1,99 @@
+(ns test.string-getbytes-test
+  "Tests for String.getBytes interop. let-go strings are Go's UTF-8 strings,
+   so (.getBytes s) and (.getBytes s \"UTF-8\") both return the same UTF-8
+   bytes as a typed byte-array.
+
+   Difference from JVM: let-go's byte-array Get returns unsigned 0..255 via
+   aget (matching the underlying []byte cast). The JVM returns signed bytes
+   (-128..127) and idiomatically masks with 0xFF. Cross-platform code can
+   mask anyway for safety; pure let-go code can skip the mask.
+
+   Ground truth captured from Clojure 1.12.5 REPL on 2026-05-22:
+     (.getBytes \"héllo\" \"UTF-8\")  // alength=6, masked bytes=[104 195 169 108 108 111]"
+  (:require [test :refer :all]))
+
+;; --- Default encoding (UTF-8) ---
+
+(deftest getBytes-ascii-no-args
+  (testing ".getBytes with no args returns UTF-8 bytes for ASCII"
+    (let [b (.getBytes "hello")]
+      (is (= 5 (alength b)))
+      (is (= 104 (aget b 0)))
+      (is (= 101 (aget b 1)))
+      (is (= 108 (aget b 2)))
+      (is (= 108 (aget b 3)))
+      (is (= 111 (aget b 4))))))
+
+(deftest getBytes-utf8-explicit
+  (testing ".getBytes with explicit \"UTF-8\" works"
+    (let [b (.getBytes "hello" "UTF-8")]
+      (is (= 5 (alength b)))
+      (is (= 104 (aget b 0))))))
+
+(deftest getBytes-default-eq-utf8
+  (testing "no-args .getBytes equals \"UTF-8\" .getBytes"
+    (let [a (.getBytes "héllo")
+          b (.getBytes "héllo" "UTF-8")]
+      (is (= (alength a) (alength b)))
+      (dotimes [i (alength a)]
+        (is (= (aget a i) (aget b i)))))))
+
+;; --- Multi-byte (UTF-8 spans) ---
+
+(deftest getBytes-multibyte
+  (testing ".getBytes on a multi-byte UTF-8 string"
+    ;; "héllo" = [h é(2-byte) l l o], é = U+00E9 = 0xC3 0xA9 in UTF-8
+    (let [b (.getBytes "héllo" "UTF-8")]
+      (is (= 6 (alength b)))
+      (is (= 104 (aget b 0)))
+      (is (= 195 (aget b 1)))
+      (is (= 169 (aget b 2)))
+      (is (= 108 (aget b 3)))
+      (is (= 108 (aget b 4)))
+      (is (= 111 (aget b 5))))))
+
+(deftest getBytes-3-byte-utf8
+  (testing ".getBytes on a 3-byte UTF-8 codepoint"
+    ;; "€" = U+20AC = 0xE2 0x82 0xAC in UTF-8
+    (let [b (.getBytes "€" "UTF-8")]
+      (is (= 3 (alength b)))
+      (is (= 226 (aget b 0)))
+      (is (= 130 (aget b 1)))
+      (is (= 172 (aget b 2))))))
+
+(deftest getBytes-4-byte-utf8
+  (testing ".getBytes on a 4-byte UTF-8 codepoint"
+    ;; "🍎" = U+1F34E = 0xF0 0x9F 0x8D 0x8E in UTF-8
+    (let [b (.getBytes "🍎" "UTF-8")]
+      (is (= 4 (alength b)))
+      (is (= 240 (aget b 0)))
+      (is (= 159 (aget b 1)))
+      (is (= 141 (aget b 2)))
+      (is (= 142 (aget b 3))))))
+
+;; --- Empty / edge cases ---
+
+(deftest getBytes-empty
+  (testing ".getBytes of empty string is zero-length byte-array"
+    (let [b (.getBytes "" "UTF-8")]
+      (is (= 0 (alength b))))))
+
+;; --- Type ---
+
+(deftest getBytes-returns-byte-array
+  (testing ".getBytes returns a byte-array (TypedArray of kind ArrayByte)"
+    (is (= (type (.getBytes "x" "UTF-8"))
+           (type (byte-array 0))))))
+
+;; --- Encoding validation ---
+
+(deftest getBytes-unsupported-encoding-errors
+  (testing ".getBytes with non-UTF-8 encoding errors"
+    (is (= :err (try (.getBytes "x" "ISO-8859-1") :ok (catch e :err))))
+    (is (= :err (try (.getBytes "x" "ASCII") :ok (catch e :err))))))
+
+;; --- Arity validation ---
+
+(deftest getBytes-rejects-extra-args
+  (testing ".getBytes with 2+ encoding args errors"
+    (is (= :err (try (.getBytes "x" "UTF-8" "extra") :ok (catch e :err))))))


### PR DESCRIPTION
## Summary

Adds `(.getBytes s)` and `(.getBytes s "UTF-8")` method interop to let-go's `String` type. Returns a typed `byte-array` (`*TypedArray` of kind `ArrayByte`).

## Why

Code porting from Clojure JVM commonly uses `(.getBytes s "UTF-8")` to get a byte sequence from a string. Before this PR, let-go users had to hand-roll UTF-8 encoding. This adds the standard interop and lets the same source file run on both runtimes (e.g., the hash/RNG porting pipeline that prompted the broader Clojure-interop alignment work).

## Behavior

- `(.getBytes "hello")` — no-arg form returns UTF-8 bytes. let-go strings are already UTF-8, so this is just exposing the underlying bytes.
- `(.getBytes s "UTF-8")` or `(.getBytes s "UTF8")` — explicit encoding, case-insensitive.
- `(.getBytes s "ISO-8859-1")` and any other encoding — errors. UTF-8 only.
- Output is a `byte-array` accessible via `aget` / `alength` / `aclone`.

## Asymmetry with JVM (documented)

JVM's `byte[]` is signed (-128..127); the canonical Clojure idiom masks with `(bit-and (long b) 0xFF)` to get unsigned. let-go's `aget` on a `byte-array` already returns unsigned 0..255 (matching the underlying `[]byte`). Cross-platform code should still mask with `0xFF` for portability; pure let-go code can skip it. The test file documents this in its docstring.

## Tests

`test/string_getbytes_test.lg`, 10 deftest blocks / 36 assertions:
- ASCII bytes match (no-args and explicit "UTF-8")
- Multi-byte (2-byte, 3-byte, 4-byte UTF-8 codepoints — "héllo" / "€" / "🍎") match Clojure JVM output
- Default and "UTF-8" forms produce identical bytes
- Empty string → zero-length byte-array
- Output type is `byte-array`, not vec
- Unsupported encodings error
- 2+ arg form errors

Verified against Clojure 1.12.5 ground truth on 2026-05-22. Full Go test sweep: 358 passed in 12 packages.

## Implementation

Single new `case "getBytes":` arm in `pkg/vm/string.go` `InvokeMethod` (around line 80). Uses the existing `NewByteArrayFrom([]byte)` constructor from `pkg/vm/typed_array.go`. No new types, no new files in `pkg/`. ~18 lines of Go.

## Independent of other in-flight work

No dependencies on PR #62, #63, or #66. Can land in any order.