### PR TITLE
fix(compiler): recurCompiler must count slots, not distinct names — fixes loop+shadow stack overflow

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -15,27 +15,35 @@ import (
 )
 
 type Context struct {
-	parent         *Context
-	consts         *vm.Consts
-	chunk          *vm.CodeChunk
-	formalArgs     map[vm.Symbol]int
-	argCount       int // total fixed-arity parameter slots, including `_`s
-	source         string
-	variadric      bool
-	locals         []map[vm.Symbol]int
-	sp             int
-	spMax          int
-	isFunction     bool
-	isClosure      bool
-	closedOversC   int
-	closedOvers    map[vm.Symbol]*closureCell
-	closedOversSeq []vm.Symbol
-	recurPoints    []*recurPoint
-	tailPosition   bool
-	debug          bool
-	defName        string
-	currentForm    vm.Value // tracks the form being compiled for error source info
-	currentList    vm.Value // tracks the enclosing list form for error source info
+	parent     *Context
+	consts     *vm.Consts
+	chunk      *vm.CodeChunk
+	formalArgs map[vm.Symbol]int
+	argCount   int // total fixed-arity parameter slots, including `_`s
+	source     string
+	variadric  bool
+	locals     []map[vm.Symbol]int
+	// localSlotCounts mirrors locals: each entry is the raw count of stack
+	// slots in that scope. We track this separately because shadowed bindings
+	// (e.g. `(let [[a w] ... [b w] ...])`) overwrite the symbol→slot map
+	// entry while the older stack slot is still live; len(locals[i]) under-
+	// counts in that case, but the stack footprint is bindn (matching
+	// let/loop's OP_POP_N). recurCompiler reads from here to compute its
+	// `ignore` operand correctly.
+	localSlotCounts []int
+	sp              int
+	spMax           int
+	isFunction      bool
+	isClosure       bool
+	closedOversC    int
+	closedOvers     map[vm.Symbol]*closureCell
+	closedOversSeq  []vm.Symbol
+	recurPoints     []*recurPoint
+	tailPosition    bool
+	debug           bool
+	defName         string
+	currentForm     vm.Value // tracks the form being compiled for error source info
+	currentList     vm.Value // tracks the enclosing list form for error source info
 }
 
 func NewCompiler(consts *vm.Consts, ns *vm.Namespace) *Context {
@@ -656,14 +664,20 @@ func (c *Context) updatePlaceholderArg(placeholder int, arg int) {
 
 func (c *Context) pushLocals() {
 	c.locals = append(c.locals, map[vm.Symbol]int{})
+	c.localSlotCounts = append(c.localSlotCounts, 0)
 }
 
 func (c *Context) popLocals() {
 	c.locals = c.locals[0 : len(c.locals)-1]
+	c.localSlotCounts = c.localSlotCounts[0 : len(c.localSlotCounts)-1]
 }
 
 func (c *Context) addLocal(name vm.Symbol) {
 	c.locals[len(c.locals)-1][name] = c.sp - 1
+	// Count every binding, even shadowed ones: the older slot is still on the
+	// stack and counts toward this scope's footprint. recurCompiler relies on
+	// this to compute `ignore` correctly when crossing a shadowing scope.
+	c.localSlotCounts[len(c.localSlotCounts)-1]++
 }
 
 func (c *Context) incSP(i int) {
@@ -991,7 +1005,10 @@ func recurCompiler(c *Context, form vm.Value) error {
 		if passedScopes > 0 {
 			passedLocals := 0
 			for i := 0; i < passedScopes; i++ {
-				passedLocals += len(c.locals[len(c.locals)-i-1])
+				// Use the per-scope slot count rather than len(map): a scope
+				// with shadowed names has more live stack slots than distinct
+				// symbols, and OP_RECUR must drop all of them.
+				passedLocals += c.localSlotCounts[len(c.localSlotCounts)-i-1]
 			}
 			ignore += passedLocals
 		}

--- a/test/recur_shadow_test.lg
+++ b/test/recur_shadow_test.lg
@@ -1,0 +1,63 @@
+;
+; Regression tests for recur with shadowed names in chained let bindings.
+;
+; Bug 2026-05-22: recurCompiler used len(scope_map) for the 'ignore' operand,
+; undercounting when bindings shadowed names — sp grew by 1 per iteration
+; until it overflowed maxStack and panicked.
+;
+; Root cause: pkg/compiler/compiler.go:992-996. Fix: track per-scope slot
+; count alongside the symbol map.
+;
+
+(ns test.recur-shadow-test
+  (:require [test :refer :all]))
+
+(deftest loop-with-chained-destructure-shadowing
+  (testing "loop + chained destructure + name shadowing + recur completes"
+    (is (= :done
+           (loop [w 1 n 2]
+             (if (<= n 0)
+               :done
+               (let [[a w] [w (inc w)]
+                     [b w] [w (inc w)]]
+                 (recur w (dec n)))))))))
+
+(deftest loop-shadow-many-iterations
+  (testing "verifies the bug scales — many iterations must not blow the stack"
+    (is (= :done
+           (loop [w 1 n 100]
+             (if (<= n 0)
+               :done
+               (let [[a w] [w (inc w)]
+                     [b w] [w (inc w)]]
+                 (recur w (dec n)))))))))
+
+(deftest let-shadow-without-loop-still-works
+  (testing "control: let with shadowing outside loop must still work"
+    (is (= [1 2 3]
+           (let [w 1
+                 [a w] [w (inc w)]
+                 [b w] [w (inc w)]]
+             [a b w])))))
+
+(deftest loop-without-shadow-still-works
+  (testing "control: loop without shadowing must still work"
+    (is (= :done
+           (loop [w 1 n 2]
+             (if (<= n 0)
+               :done
+               (let [a w
+                     new-w (inc w)]
+                 (recur new-w (dec n)))))))))
+
+(deftest loop-with-shadow-in-catch
+  (testing "recur past a try with a catch that uses a shadowed name"
+    (is (= :ok
+           (loop [w 1 n 2]
+             (if (<= n 0) :ok
+               (let [r (try
+                         (let [[a w] [w (inc w)]
+                               [b w] [w (inc w)]]
+                           w)
+                         (catch e :caught))]
+                 (recur r (dec n)))))))))


### PR DESCRIPTION
## Summary

Fixes a compiler bug where \`recur\` inside a loop body with chained shadowing bindings caused a runtime stack overflow on the second iteration. Root cause: \`recurCompiler\` used \`len(c.locals[scope])\` (a map of symbol→slot) for the \`ignore\` operand of \`OP_RECUR\`, but the map count undercounts the actual stack footprint whenever bindings shadow names — because shadowed map entries are overwritten while the older stack slots remain live.

## Reproducer

```clojure
(loop [w 1 n 2]
  (if (<= n 0) :done
    (let [[a w] [w (inc w)]
          [b w] [w (inc w)]]
      (recur w (dec n)))))
```

Before fix: \`runtime error: index out of range [N] with length N\` on iteration 2.
After fix: returns \`:done\`.

## Required ingredients (control-tested)

All four needed to trigger the bug:
1. Chained destructure in let bindings
2. Name shadowing within the chained destructure (\`w\` reused across binding pairs)
3. Inside a \`loop\` form
4. With \`recur\` jumping back at least once

Remove any one → no crash. Distinct-name loops, non-loop lets, and single-iteration loops were all unaffected.

## Root cause

\`c.locals []map[Symbol]int\` tracks symbol → slot-index. When a let binds \`[a w] [w (inc w)] [b w] [w (inc w)]\` (chained destructure with macroexpansion to \`vec__N + nth\` calls), each binding pair pushes one stack slot, but \`addLocal\` overwrites the map entry for \`w\` each time it's reused. \`letCompiler\` correctly emits \`OP_POP_N\` with the raw pair count, so the stack-footprint is correct at let exit. But \`recurCompiler\` reads \`len(map)\` — which counts distinct names — and bakes that undercount into the bytecode as \`OP_RECUR\`'s \`ignore\` operand.

\`OP_RECUR\` drops \`argc*2 + ignore\` slots on jump-back. With ignore undercounted by N (= number of shadowed names), the stack pointer grows by N every iteration → eventually overflows \`maxStack\` → panic.

## Fix

Added a parallel \`localSlotCounts []int\` to the compiler Context, mirroring \`c.locals\`. \`pushLocals\` appends \`0\`, \`popLocals\` slices off the last entry, \`addLocal\` increments the last entry unconditionally (including shadowed names). \`recurCompiler\` reads slot counts from this field instead of \`len(map)\`.

Small surgical change to compiler.go: ~15 logical lines plus a comment block at the field declaration explaining the invariant.

## Tests

New \`test/recur_shadow_test.lg\`:
- The exact bug reproducer (\`loop-with-chained-destructure-shadowing\`)
- 100-iteration scale test (\`loop-shadow-many-iterations\`) — would catch any residual off-by-one
- Control: let-shadow without loop still produces correct values (\`[1 2 3]\`)
- Control: loop without shadow still completes
- Try/catch with shadowed names inside recur (verifies the universal fix covers the analogous catch path automatically, since catch uses the same \`pushLocals\`/\`addLocal\`/\`popLocals\` infrastructure)

Full regression: 358 Go tests in 12 packages, all green. Full clojure-test-suite passes (no regression). Zero new failures vs. main.

## Independent of in-flight work

No dependencies on #62, #63, #66, #67, or the warn-on-core-shadow PR (also on a sibling branch). Lands cleanly on main.

## Investigation history

This bug was originally misattributed (downstream in xsofy) to a chained-destructure compiler bug. Investigation eventually root-caused the original incident to a different problem — xsofy.det shadowing \`clojure.core/nth\` (which prompted the separate warn-on-core-shadow PR). With the nth shadow ruled out, fresh examination of loop+shadow+chained-destructure surfaced this distinct compiler bug. Both bugs exist; PR-4 catches the namespace-shadow class, this PR fixes the slot-count class.