### PR TITLE
chore(tooling): git merge driver for core_compiled.lgb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.lg linguist-language=Clojure
 pkg/rt/core_compiled.lgb binary
+pkg/rt/core_compiled.lgb merge=lgb

--- a/README.md
+++ b/README.md
@@ -298,6 +298,27 @@ embedding examples (defs, structs, channels, function calls).
 go test ./... -count=1 -timeout 30s
 ```
 
+## Contributing
+
+### Git merge driver for `core_compiled.lgb` (one-time setup)
+
+`pkg/rt/core_compiled.lgb` is a binary bundle regenerated from the embedded
+`.lg` sources. Git cannot meaningfully merge this binary on rebase, so we ship
+a custom merge driver that regenerates from sources after the `.lg` files have
+been merged as text.
+
+After cloning the repo (or pulling for the first time after this driver was
+added), register it locally:
+
+```bash
+git config merge.lgb.name "Regenerate core_compiled.lgb from sources"
+git config merge.lgb.driver "scripts/git-merge-lgb.sh %O %A %B %L %P"
+```
+
+This is a one-time per-clone step. After registration, rebases that touch any
+embedded `.lg` source will regenerate the `.lgb` automatically — no more
+binary merge conflicts when stacking PRs that edit `core.lg` and friends.
+
 ---
 
 Ever wanted a 20MB pure-Go JS runtime that typechecks and runs TypeScript?

--- a/scripts/git-merge-lgb.sh
+++ b/scripts/git-merge-lgb.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Git custom merge driver for pkg/rt/core_compiled.lgb
+#
+# The .lgb is deterministic output from the embedded .lg sources. Instead of
+# attempting a 3-way binary merge (which always fails), we regenerate the .lgb
+# from the merged .lg sources. The .lg files merge cleanly as text; this script
+# rebuilds the binary to match.
+#
+# Git invokes this driver with:
+#   $1 = %O (path to common ancestor's version)
+#   $2 = %A (path to current branch's version — also the OUTPUT path)
+#   $3 = %B (path to merging branch's version)
+#   $4 = %L (merge marker size; unused)
+#   $5 = %P (pathname in the worktree)
+#
+# We ignore all five and just regenerate.
+
+set -e
+
+# Find repo root by walking up from this script's location.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Regenerate from sources. Output path comes from "$2" (%A).
+go run ./cmd/lgbgen "$2"


### PR DESCRIPTION
## Summary

Adds a custom git merge driver that regenerates \`pkg/rt/core_compiled.lgb\` from sources instead of attempting a 3-way binary merge. Eliminates the meaningless binary conflicts that fire on every rebase across a PR that touched any embedded \`.lg\` source.

## Motivation

I hit this earlier today rebasing #66 onto post-merge main. \`pkg/rt/core_compiled.lgb\` showed a 2-sided conflict because main had regen'd it (via #69's stdlib audit) and #66 had regen'd it independently — both versions were valid bundles, the conflict was meaningless. The dance was: \`jj resolve --tool :theirs pkg/rt/core_compiled.lgb\`, then \`go run ./cmd/lgbgen\` to regen properly, then verify clean. This driver automates that.

## What's added

\`scripts/git-merge-lgb.sh\` — invoked by git as the merge driver. Ignores all three merge inputs (%O ancestor, %A current, %B incoming) since the .lgb is deterministic output from the merged .lg sources. Just runs \`go run ./cmd/lgbgen "$2"\` (where \`$2\` is the output path git expects).

\`.gitattributes\` — adds \`pkg/rt/core_compiled.lgb merge=lgb\` so git routes merges through the driver.

\`README.md\` — one-time per-clone setup instructions:
\`\`\`
git config merge.lgb.name "Regenerate core_compiled.lgb from sources"
git config merge.lgb.driver "scripts/git-merge-lgb.sh %O %A %B %L %P"
\`\`\`

Per-clone because \`.gitattributes\` declares the *attribute*, but git only runs the actual driver after the user has registered its command locally (security feature — git won't run arbitrary scripts referenced from a fetched repo without consent).

## Coordination with #65

This is orthogonal to #65 (which fixes source-bootstrap with \`(declare ...)\` forms in core.lg + a build tag for source-bootstrap CI validation). Together they make the .lgb fully recoverable:

- **#65** lets \`lgbgen\` work from clean state — if the .lgb is missing/corrupt, source-compile recovers
- **this PR** removes the rebase-time noise that periodically required manual lgb regeneration (and risked corrupting the .lgb in the first place)

Either can land first; no dependency between them.

## Verification

I tested the driver mechanism by simulating a conflict locally:

1. \`cp pkg/rt/core_compiled.lgb /tmp/lgb-A.bin\`
2. Modify a .lg source, run \`go run ./cmd/lgbgen\`, \`cp pkg/rt/core_compiled.lgb /tmp/lgb-B.bin\` (different bytes)
3. \`git config merge.lgb.driver "scripts/git-merge-lgb.sh %O %A %B %L %P"\` (one-time)
4. Stage the A version, then attempt to merge in the B version → driver fires, regenerates from current .lg sources, output is the deterministic post-merge .lgb

Driver script is bash, executable bit set, syntax-checked with \`bash -n\`. No tests checked in since git merge driver behavior is environmental.

## Independent of in-flight work

No dependencies on #62, #63, or #65. Just \`.gitattributes\` + a script + README docs.