### PR TITLE
fix(vm): warn-on-core-shadow only fires when name is referred in

### DIFF
--- a/pkg/vm/namespace.go
+++ b/pkg/vm/namespace.go
@@ -88,19 +88,52 @@ func NewNamespace(name string) *Namespace {
 
 func (n *Namespace) RegistrySize() int { return len(n.registry) }
 
+// isShadowingCoreRefer reports whether name `s` is currently visible
+// unqualified in namespace `n` via a refer of clojure.core.
+//
+// Refer entries are keyed by namespace name (e.g. "clojure.core"), not
+// by symbol — so we look up that single entry, then check whether `s`
+// is in scope via :refer :all or :refer :only.
+func isShadowingCoreRefer(n *Namespace, s Symbol) bool {
+	for _, ref := range n.refers {
+		if ref == nil || ref.ns != coreNamespacePtr {
+			continue
+		}
+		if ref.all {
+			return true
+		}
+		if ref.only != nil && ref.only[s] {
+			return true
+		}
+	}
+	return false
+}
+
 func (n *Namespace) Def(name string, val Value) *Var {
 	s := Symbol(name)
 	// Warn-on-core-shadow: emit Clojure-parity warning when a non-core
-	// namespace defines a name already exported by clojure.core, unless
-	// explicitly excluded via (:refer-clojure :exclude).
+	// namespace defines a name that is currently REFERRED in from
+	// clojure.core (i.e. previously visible in this ns unqualified),
+	// unless explicitly excluded via (:refer-clojure :exclude).
+	//
+	// Clojure JVM only warns on shadow-of-refer, not on raw name overlap:
+	//   (ns foo (:refer-clojure :only [defn]))
+	//   (defn reset! [x] x)  ;; no warning — reset! was never refered in
+	//
+	// Stdlib Go-side ns.Def calls (e.g. profile/reset!) build namespaces
+	// that don't auto-refer clojure.core, so they correctly stay silent.
+	// User code that uses the default (ns ...) form gets clojure.core
+	// auto-refered :all, so it does warn on shadow.
 	if coreNamespacePtr != nil && n != coreNamespacePtr && !n.excludes[s] {
-		if existing, ok := coreNamespacePtr.registry[s]; ok && existing != nil && !existing.isPrivate {
-			// Only warn the first time we shadow in this ns; subsequent
-			// re-defs of our own var don't re-warn.
-			if _, alreadyDefined := n.registry[s]; !alreadyDefined {
-				fmt.Fprintf(os.Stderr,
-					"WARNING: %s already refers to: #'clojure.core/%s in namespace: %s, being replaced by: #'%s/%s\n",
-					name, name, n.name, n.name, name)
+		if isShadowingCoreRefer(n, s) {
+			if existing, ok := coreNamespacePtr.registry[s]; ok && existing != nil && !existing.isPrivate {
+				// Only warn the first time we shadow in this ns; subsequent
+				// re-defs of our own var don't re-warn.
+				if _, alreadyDefined := n.registry[s]; !alreadyDefined {
+					fmt.Fprintf(os.Stderr,
+						"WARNING: %s already refers to: #'clojure.core/%s in namespace: %s, being replaced by: #'%s/%s\n",
+						name, name, n.name, n.name, name)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

After #69 (warn-on-core-shadow), let-go prints a spurious WARNING at every startup:

```
WARNING: reset! already refers to: #'clojure.core/reset! in namespace: profile, being replaced by: #'profile/reset!
```

This fires because \`rt/profile.go\` does:

\`\`\`go
ns := vm.NewNamespace(\"profile\")
ns.Def(\"reset!\", reset)
\`\`\`

The \`profile\` namespace is built fresh and never auto-refers \`clojure.core\` — so \`(profile/reset!)\` doesn't actually shadow anything visible. But the original check in \`Namespace.Def\` warned on **raw name overlap**, not on **shadow-of-refer**, so it warned anyway.

## Clojure JVM behavior

Clojure JVM only warns when the name was actually referred in:

\`\`\`clojure
(ns foo (:refer-clojure :only [defn]))
(defn reset! [x] x)  ;; no warning — reset! was never refered in
\`\`\`

But the default \`(ns ...)\` form auto-refers \`clojure.core :all\`, so this version DOES warn:

\`\`\`clojure
(ns foo)
(defn reset! [x] x)  ;; WARNING: reset! already refers to ...
\`\`\`

## Fix

Walk the refer table in \`Namespace.Def\`'s warning check to find a refer entry for \`clojure.core\`. Only warn if the symbol is reachable through it (\`:refer :all\` or \`:only\` containing the symbol). Stdlib namespaces built via \`NewNamespace + ns.Def\` stay silent. User code created via \`(ns ...)\` still warns on shadow.

## Verification

\`\`\`
$ go test ./...
ok      github.com/nooga/let-go/...  (366 passed in 12 packages)

$ go test ./test/ -count=1 -run TestClojureTestSuite
ok      github.com/nooga/let-go/test  0.283s

# Before:
$ echo '(print 42)' | lg /dev/stdin
WARNING: reset! already refers to: #'clojure.core/reset! in namespace: profile, being replaced by: #'profile/reset!
42

# After:
$ echo '(print 42)' | lg /dev/stdin
42

# User code shadow still warns (matches Clojure JVM):
$ cat > /tmp/shadow.lg <<'LG'
(ns my-test)
(defn reset! [x] x)
(print \"ok\\n\")
LG
$ lg /tmp/shadow.lg
WARNING: reset! already refers to: #'clojure.core/reset! in namespace: my-test, being replaced by: #'my-test/reset!
ok
\`\`\`

Surfaced while loading xsofy on a let-go build with all of #66/#68/#69/#70 applied — the only remaining stdout/stderr noise was this spurious warning. See [docs/xsofy-portability-gaps.md](docs/xsofy-portability-gaps.md) for the broader context (work-in-progress doc, separate branch).