### PR TITLE
docs: use cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,7 @@ build of let-go.
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew tap nooga/let-go https://github.com/nooga/let-go
-brew install let-go
+brew install nooga/let-go/let-go
 ```
 
 ### Download

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -434,8 +434,7 @@
         <div class="install">
           <div class="box">
             <span class="label">homebrew</span>
-            <code>brew tap nooga/let-go https://github.com/nooga/let-go</code>
-            <code>brew install let-go</code>
+            <code>brew install nooga/let-go/let-go</code>
           </div>
           <div class="box">
             <span class="label">go</span>


### PR DESCRIPTION
## Summary

- replace the old Homebrew tap/install sequence with the cask-qualified command
- update both README and the WASM site install panel

## Tests

- not run; docs/site text only