### PR TITLE
docs: add contributors file

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,12 @@
+let-go contributors
+===================
+
+This file lists everyone who has contributed to let-go. Order is by
+first contribution, oldest first. Add yourself in a PR alongside your
+first change.
+
+  Marcin Gasperowicz <xnooga@gmail.com>
+  Norman Nunley, Jr <nnunley@gmail.com>
+
+The phrase "let-go contributors" in any header refers to the people
+listed here.


### PR DESCRIPTION
## Summary

- restore CONTRIBUTORS from the closed IR PRs
- list current contributors in first-contribution order

## Tests

- not run; docs-only change