### PR TITLE
fix(compiler): in-ns compile-time hook must not trigger ns reload

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1315,7 +1315,16 @@ func doCompiler(c *Context, form vm.Value) error {
 		return nil
 	}
 	for i := range args {
-		// Detect top-level (in-ns 'foo) and update compiler namespace early
+		// Detect top-level (in-ns 'foo) and update compiler namespace early.
+		// Use LookupOrRegisterNSNoLoad rather than rt.NS so we don't trigger
+		// the resolver to load 'foo from disk: if the file we're currently
+		// compiling declares (ns foo ...), and a candidate path for ns 'foo
+		// matches our file, rt.NS would re-load and re-execute that file
+		// inside our compile — the body runs twice.
+		//
+		// The (in-ns) runtime fn itself uses LookupOrRegisterNSNoLoad for
+		// the same reason. This fix aligns the compile-time early
+		// detection with the runtime semantics.
 		if i == 0 && args[i].Type() == vm.ListType {
 			lst := args[i].(vm.Seq)
 			if lst.First().Type() == vm.SymbolType && vm.Symbol(lst.First().(vm.Symbol)) == vm.Symbol("in-ns") {
@@ -1329,7 +1338,7 @@ func doCompiler(c *Context, form vm.Value) error {
 							if qqN != nil {
 								namev := qqN.First()
 								if namev.Type() == vm.SymbolType {
-									if ns := rt.NS(string(namev.(vm.Symbol))); ns != nil {
+									if ns := rt.LookupOrRegisterNSNoLoad(string(namev.(vm.Symbol))); ns != nil {
 										c.SetCurrentNS(ns)
 									}
 								}

--- a/test/script_ns_no_double_load_test.go
+++ b/test/script_ns_no_double_load_test.go
@@ -1,0 +1,63 @@
+package test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestScriptWithNsDoesNotReExecute exercises the case where a script
+// file declares a namespace whose name matches its filename. Without
+// the fix, the compile-time (in-ns 'foo) early-detection in
+// pkg/compiler/compiler.go would call rt.NS("foo"), which triggers
+// the resolver to find foo.lg on disk and re-execute it inside the
+// outer compile — producing duplicate side effects (println twice,
+// state allocations twice).
+//
+// The fix swaps rt.NS for rt.LookupOrRegisterNSNoLoad in the
+// compile-time hook, matching what the (in-ns) runtime function
+// already does.
+func TestScriptWithNsDoesNotReExecute(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "lg-ns-noreload-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// A minimal script: file 'foo.lg' declares (ns foo) and prints once.
+	// The bug would cause it to print twice.
+	scriptPath := filepath.Join(tmpDir, "foo.lg")
+	script := "(ns foo)\n(println \"hello from foo\")\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the lg binary from the package we're testing.
+	lgPath := filepath.Join(tmpDir, "lg-bin")
+	build := exec.Command("go", "build", "-o", lgPath, "../")
+	build.Dir = "." // tests run from the test/ directory
+	var buildErr bytes.Buffer
+	build.Stderr = &buildErr
+	if err := build.Run(); err != nil {
+		t.Fatalf("failed to build lg: %v\nstderr: %s", err, buildErr.String())
+	}
+
+	cmd := exec.Command(lgPath, scriptPath)
+	cmd.Dir = tmpDir
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("lg failed: %v\noutput:\n%s", err, out.String())
+	}
+
+	output := out.String()
+	count := strings.Count(output, "hello from foo")
+	if count != 1 {
+		t.Errorf("expected script body to execute exactly once (1 println), got %d executions\nfull output:\n%s",
+			count, output)
+	}
+}


### PR DESCRIPTION
## Problem

When a script declares `(ns foo ...)` and the file `foo.lg` exists on the resolver search path (typically because the script IS `foo.lg` and the cwd is in the path), the compile-time `(in-ns)` early-detection in `compileForm` calls `rt.NS(name)`. `rt.NS` calls `LookupOrRegisterNS`, which invokes the resolver to load the namespace from disk — **re-executing the same file we're currently compiling**. Every top-level form runs twice.

### Symptoms

- `println` output appears twice
- `deftest` registers each test twice
- atom values get double-incremented
- `run-tests` reports double the expected pass count

### Reproducer

```bash
cd /tmp
echo '(ns foo)' > foo.lg
echo '(println "hi")' >> foo.lg
lg foo.lg
# Prints "hi" twice
```

## Root Cause

`pkg/compiler/compiler.go:1332` detects top-level `(in-ns 'foo)` early so subsequent forms in the same `do` can resolve against the new namespace. It calls `rt.NS(name)`, which goes through `LookupOrRegisterNS` and triggers the resolver's load path. For a file declaring its own ns, the resolver finds the file we're compiling and runs it again as a side effect of the lookup.

The runtime `(in-ns)` fn itself does NOT have this problem — it uses `LookupOrRegisterNSNoLoad`. The compile-time hook should follow the same pattern.

## Fix

Swap `rt.NS` for `rt.LookupOrRegisterNSNoLoad` in the compile-time hook. At the point a file declares its own ns, the file IS providing the namespace; there's no reason to look elsewhere. Aligns compile-time and runtime behavior.

Adds a regression test that compiles + runs `lg` on a script whose ns name matches its filename and asserts the body fires exactly once.

## Verification

```
$ go test ./...
Go test: 367 passed in 12 packages
```

(One added test = 366 before, 367 now.)

```
$ go test ./test/ -count=1 -run TestClojureTestSuite
ok    github.com/nooga/let-go/test  0.433s
```

Surfaced while running xsofy's test suite: the `(ns xsofy.test.run ...)` declaration in `xsofy/test/run.lg` caused `(run-tests)` to fire twice, with the second run seeing accumulated state from the first and producing spurious failures. The xsofy test suite is now silent on this entire class of issue with the fix applied.