### PR TITLE
chore: migrate golangci-lint to v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,42 +1,53 @@
+version: "2"
 linters:
-  enable:
-    - govet
-    - staticcheck
-    - unused
-    - ineffassign
-    - typecheck
-    - gofmt       # safety net — pre-commit hook auto-formats, this catches anything that slipped through
-    - goimports
   disable:
-    - errcheck  # too noisy for a language runtime with many fire-and-forget calls
-
-linters-settings:
-  govet:
-    enable-all: false
-  staticcheck:
-    checks:
-      - all
-      - -SA1019  # deprecated usage (we use some old stdlib APIs intentionally)
-
+    - errcheck
+  settings:
+    govet:
+      enable-all: false
+    staticcheck:
+      checks:
+        - all
+        - -SA1019
+        - -ST1003
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - unused
+        path: pkg/vm/
+        text: func.*is unused
+      - linters:
+          - unused
+        path: pkg/compiler/
+        text: func.*is unused
+      - linters:
+          - staticcheck
+        path: pkg/compiler/reader.go
+        text: S1040
+    paths:
+      - .*_test\.go
+      - ^wasm/
+      - third_party$
+      - builtin$
+      - ^examples/
 issues:
-  exclude-dirs:
-    - wasm
-  exclude-files:
-    - ".*_test\\.go"
-  exclude-rules:
-    # Allow unused utility functions in VM and compiler — kept for debugging/future use
-    - path: pkg/vm/
-      linters: [unused]
-      text: "func.*is unused"
-    - path: pkg/compiler/
-      linters: [unused]
-      text: "func.*is unused"
-    # Allow type assertions to same type in reader (clarity over brevity)
-    - path: pkg/compiler/reader.go
-      linters: [gosimple]
-      text: "S1040"
   max-issues-per-linter: 0
   max-same-issues: 0
-
-run:
-  timeout: 5m
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .*_test\.go
+      - ^wasm/
+      - third_party$
+      - builtin$
+      - ^examples/

--- a/lg.go
+++ b/lg.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,9 +193,7 @@ func bundleBinary(ctx *compiler.Context, nsRes *resolver.NSResolver, src string,
 	if len(nsRes.LoadedChunks) > 0 {
 		mainNS := ctx.CurrentNS().Name()
 		nsChunks := make(map[string]*vm.CodeChunk, len(nsRes.LoadedChunks)+1)
-		for k, v := range nsRes.LoadedChunks {
-			nsChunks[k] = v
-		}
+		maps.Copy(nsChunks, nsRes.LoadedChunks)
 		nsChunks[mainNS] = chunk
 		nsOrder := append(nsRes.LoadOrder, mainNS)
 		if err := bytecode.EncodeBundleOrdered(&lgbBuf, ctx.Consts(), nsChunks, nsOrder); err != nil {
@@ -299,9 +298,7 @@ func compileLG(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ds
 		// Include the main chunk under its namespace name, last in order
 		mainNS := ctx.CurrentNS().Name()
 		nsChunks := make(map[string]*vm.CodeChunk, len(nsRes.LoadedChunks)+1)
-		for k, v := range nsRes.LoadedChunks {
-			nsChunks[k] = v
-		}
+		maps.Copy(nsChunks, nsRes.LoadedChunks)
 		nsChunks[mainNS] = chunk
 		nsOrder := append(nsRes.LoadOrder, mainNS)
 		return bytecode.EncodeBundleOrdered(out, ctx.Consts(), nsChunks, nsOrder)

--- a/lg_ansi.go
+++ b/lg_ansi.go
@@ -8,10 +8,10 @@
 package main
 
 const (
-	ansiBold     = "[1m"
-	ansiBoldCyan = "[1;36m"
-	ansiDim      = "[90m"
-	ansiReset    = "[0m"
+	ansiBold     = "\x1b[1m"
+	ansiBoldCyan = "\x1b[1;36m"
+	ansiDim      = "\x1b[90m"
+	ansiReset    = "\x1b[0m"
 
 	bannerQuitHint = "Ctrl-C to quit"
 )

--- a/lg_repl.go
+++ b/lg_repl.go
@@ -92,10 +92,7 @@ func repl(ctx *compiler.Context) {
 			editor.Stylize(line.Span{Start: uint32(t.Start), End: uint32(t.End), Mode: line.SpanModeByte}, style)
 		}
 	})
-	for {
-		if interrupted {
-			break
-		}
+	for !interrupted {
 		in, err := editor.GetLine(prompt)
 		if err != nil {
 			fmt.Println("prompt failed: ", err)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -32,7 +32,7 @@ func (l *LetGo) SetLoadPath(path []string) {
 	l.loader.SetPath(path)
 }
 
-func (l *LetGo) Def(name string, value interface{}) error {
+func (l *LetGo) Def(name string, value any) error {
 	val, err := vm.BoxValue(reflect.ValueOf(value))
 	if err != nil {
 		return err

--- a/pkg/api/interop_test.go
+++ b/pkg/api/interop_test.go
@@ -44,7 +44,7 @@ func TestDef(t *testing.T) {
 	assert.NoError(t, err)
 	tests := []struct {
 		code   string
-		result interface{}
+		result any
 	}{
 		{"(def y (+ x 11))", 13},
 		{"(f x y)", 26},
@@ -77,13 +77,13 @@ func TestChannels(t *testing.T) {
 	assert.NoError(t, err)
 
 	go func() {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			inch <- i
 		}
 		close(inch)
 	}()
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		j := <-outch
 		assert.Equal(t, i+1, j.Unbox())
 	}

--- a/pkg/bytecode/bytecode_test.go
+++ b/pkg/bytecode/bytecode_test.go
@@ -956,7 +956,7 @@ func makeBundleChunks(consts *vm.Consts) map[string]*vm.CodeChunk {
 func TestEncodeBundleOrderedIsDeterministic(t *testing.T) {
 	order := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"}
 	var first []byte
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		consts := vm.NewConsts()
 		chunks := makeBundleChunks(consts)
 		var buf bytes.Buffer
@@ -977,7 +977,7 @@ func TestEncodeBundleOrderedIsDeterministic(t *testing.T) {
 // produces byte-identical output across runs (it sorts NS names internally).
 func TestEncodeBundleIsDeterministic(t *testing.T) {
 	var first []byte
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		consts := vm.NewConsts()
 		chunks := makeBundleChunks(consts)
 		var buf bytes.Buffer
@@ -1016,10 +1016,10 @@ func BenchmarkEncodeModule(b *testing.B) {
 	chunk.SetMaxStack(1)
 	mb.AddChunk(chunk)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		mb.AddConst(vm.Int(i))
 	}
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		mb.AddConst(vm.Keyword("key"))
 	}
 	m := mb.Build()
@@ -1040,10 +1040,10 @@ func BenchmarkDecodeModule(b *testing.B) {
 	chunk.SetMaxStack(1)
 	mb.AddChunk(chunk)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		mb.AddConst(vm.Int(i))
 	}
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		mb.AddConst(vm.Keyword("key"))
 	}
 	m := mb.Build()

--- a/pkg/bytecode/encoding.go
+++ b/pkg/bytecode/encoding.go
@@ -100,7 +100,7 @@ func NewReader(r io.Reader) *Reader {
 func (r *Reader) ReadVarint() (uint64, error) {
 	var result uint64
 	var shift uint
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		b, err := r.r.ReadByte()
 		if err != nil {
 			return 0, err

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1004,7 +1004,7 @@ func recurCompiler(c *Context, form vm.Value) error {
 		ignore := 0
 		if passedScopes > 0 {
 			passedLocals := 0
-			for i := 0; i < passedScopes; i++ {
+			for i := range passedScopes {
 				// Use the per-scope slot count rather than len(map): a scope
 				// with shadowed names has more live stack slots than distinct
 				// symbols, and OP_RECUR must drop all of them.

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestContext_Compile(t *testing.T) {
-	tests := map[string]interface{}{
+	tests := map[string]any{
 		"(+ (* 2 20) 2)":          42,
 		"(- 10 2)":                8,
 		`(if true "big" "meh")`:   "big",
@@ -51,7 +51,7 @@ func TestContext_CompileFn(t *testing.T) {
 	assert.NoError(t, err)
 
 	var inc func(int) int
-	out.Unbox().(func(interface{}))(&inc)
+	out.Unbox().(func(any))(&inc)
 
 	assert.NotNil(t, inc)
 
@@ -63,7 +63,7 @@ func TestContext_CompileFnPoly(t *testing.T) {
 	out, err := Eval("(fn [x] x)")
 	assert.NoError(t, err)
 
-	identity := out.Unbox().(func(interface{}))
+	identity := out.Unbox().(func(any))
 
 	var intIdentity func(int) int
 	identity(&intIdentity)

--- a/pkg/compiler/reader.go
+++ b/pkg/compiler/reader.go
@@ -419,7 +419,7 @@ func readRegex(r *LispReader, _ rune) (vm.Value, error) {
 // handling.
 func readHexEscape(r *LispReader) (int, error) {
 	hex := ""
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ch, err := r.next()
 		if err != nil || !isHexDigit(ch) {
 			return 0, NewReaderError(r, fmt.Sprintf("invalid escape sequence \\u%s", hex))
@@ -623,10 +623,9 @@ func readNumber(r *LispReader, ru rune) (vm.Value, error) {
 
 func readList(r *LispReader, _ rune) (vm.Value, error) {
 	startLine := r.line
-	startCol := r.column - 1 // -1 because '(' was already consumed
-	if startCol < 0 {
-		startCol = 0
-	}
+	startCol := max(
+		// -1 because '(' was already consumed
+		r.column-1, 0)
 	var ret []vm.Value
 	for {
 		ch2, err := r.eatWhitespace()
@@ -658,10 +657,7 @@ func readList(r *LispReader, _ rune) (vm.Value, error) {
 
 func readVector(r *LispReader, _ rune) (vm.Value, error) {
 	startLine := r.line
-	startCol := r.column - 1
-	if startCol < 0 {
-		startCol = 0
-	}
+	startCol := max(r.column-1, 0)
 	ret := make([]vm.Value, 0)
 	for {
 		ch2, err := r.eatWhitespace()
@@ -690,10 +686,7 @@ func readVector(r *LispReader, _ rune) (vm.Value, error) {
 
 func readMap(r *LispReader, _ rune) (vm.Value, error) {
 	startLine := r.line
-	startCol := r.column - 1
-	if startCol < 0 {
-		startCol = 0
-	}
+	startCol := max(r.column-1, 0)
 	ret := make([]vm.Value, 0)
 	for {
 		ch2, err := r.eatWhitespace()
@@ -731,10 +724,9 @@ func readMap(r *LispReader, _ rune) (vm.Value, error) {
 
 func readSet(r *LispReader, _ rune) (vm.Value, error) {
 	startLine := r.line
-	startCol := r.column - 2 // -2 because '#' and '{' were consumed
-	if startCol < 0 {
-		startCol = 0
-	}
+	startCol := max(
+		// -2 because '#' and '{' were consumed
+		r.column-2, 0)
 	ret := vm.EmptyList
 	for {
 		ch2, err := r.eatWhitespace()
@@ -1003,10 +995,9 @@ func readVarQuote(r *LispReader, _ rune) (vm.Value, error) {
 
 func readShortFn(r *LispReader, _ rune) (vm.Value, error) {
 	startLine := r.line
-	startCol := r.column - 2 // -2 because '#' and '(' were consumed
-	if startCol < 0 {
-		startCol = 0
-	}
+	startCol := max(
+		// -2 because '#' and '(' were consumed
+		r.column-2, 0)
 	var ret []vm.Value
 	r.maxPercent = 0
 	for {
@@ -1167,9 +1158,10 @@ func skipReaderForm(r *LispReader) {
 				return
 			}
 			if inString {
-				if c == '\\' {
+				switch c {
+				case '\\':
 					r.next() // skip escaped char
-				} else if c == '"' {
+				case '"':
 					inString = false
 				}
 				continue

--- a/pkg/nrepl/server.go
+++ b/pkg/nrepl/server.go
@@ -88,13 +88,11 @@ func (n *NreplServer) Start(port int) error {
 	n.stop = make(chan struct{})
 
 	// Write .nrepl-port file
-	os.WriteFile(".nrepl-port", []byte(fmt.Sprintf("%d", port)), 0644)
+	os.WriteFile(".nrepl-port", fmt.Appendf(nil, "%d", port), 0644)
 
 	fmt.Printf("nREPL server started on port %d on host 127.0.0.1 - nrepl://127.0.0.1:%d\n", port, port)
 
-	n.wg.Add(1)
-	go func() {
-		defer n.wg.Done()
+	n.wg.Go(func() {
 		for {
 			select {
 			case <-n.stop:
@@ -112,7 +110,7 @@ func (n *NreplServer) Start(port int) error {
 				go n.handleConn(conn)
 			}
 		}
-	}()
+	})
 	return nil
 }
 
@@ -130,7 +128,7 @@ func (n *NreplServer) handleConn(conn net.Conn) {
 	dec := bencode.NewDecoder(conn)
 
 	for {
-		var msg map[string]interface{}
+		var msg map[string]any
 		err := dec.Decode(&msg)
 		if err != nil {
 			if err == io.EOF {
@@ -143,7 +141,7 @@ func (n *NreplServer) handleConn(conn net.Conn) {
 }
 
 // handleMsg dispatches a single nREPL message.
-func (n *NreplServer) handleMsg(conn net.Conn, msg map[string]interface{}) {
+func (n *NreplServer) handleMsg(conn net.Conn, msg map[string]any) {
 	op, _ := msg["op"].(string)
 	id := msgStr(msg, "id")
 	sessID := msgStr(msg, "session")
@@ -151,7 +149,7 @@ func (n *NreplServer) handleMsg(conn net.Conn, msg map[string]interface{}) {
 	switch op {
 	case "clone":
 		s := n.newSession()
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":          id,
 			"status":      []string{"done"},
 			"new-session": s.id,
@@ -159,37 +157,37 @@ func (n *NreplServer) handleMsg(conn net.Conn, msg map[string]interface{}) {
 
 	case "close":
 		n.closeSession(sessID)
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":      id,
 			"session": sessID,
 			"status":  []string{"done", "session-closed"},
 		})
 
 	case "describe":
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":      id,
 			"session": sessID,
-			"ops": map[string]interface{}{
-				"clone":       map[string]interface{}{},
-				"close":       map[string]interface{}{},
-				"eval":        map[string]interface{}{},
-				"load-file":   map[string]interface{}{},
-				"describe":    map[string]interface{}{},
-				"completions": map[string]interface{}{},
-				"lookup":      map[string]interface{}{},
-				"info":        map[string]interface{}{},
-				"complete":    map[string]interface{}{},
-				"ls-sessions": map[string]interface{}{},
+			"ops": map[string]any{
+				"clone":       map[string]any{},
+				"close":       map[string]any{},
+				"eval":        map[string]any{},
+				"load-file":   map[string]any{},
+				"describe":    map[string]any{},
+				"completions": map[string]any{},
+				"lookup":      map[string]any{},
+				"info":        map[string]any{},
+				"complete":    map[string]any{},
+				"ls-sessions": map[string]any{},
 			},
-			"versions": map[string]interface{}{
-				"let-go": map[string]interface{}{
+			"versions": map[string]any{
+				"let-go": map[string]any{
 					"major": "1", "minor": "0",
 				},
-				"nrepl": map[string]interface{}{
+				"nrepl": map[string]any{
 					"major": "1", "minor": "0",
 				},
 			},
-			"aux":    map[string]interface{}{},
+			"aux":    map[string]any{},
 			"status": []string{"done"},
 		})
 
@@ -209,7 +207,7 @@ func (n *NreplServer) handleMsg(conn net.Conn, msg map[string]interface{}) {
 		n.handleInfo(conn, msg)
 
 	case "ls-sessions":
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":       id,
 			"session":  sessID,
 			"sessions": n.sessionIDs(),
@@ -217,14 +215,14 @@ func (n *NreplServer) handleMsg(conn net.Conn, msg map[string]interface{}) {
 		})
 
 	case "interrupt":
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":      id,
 			"session": sessID,
 			"status":  []string{"done", "session-idle"},
 		})
 
 	default:
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":      id,
 			"session": sessID,
 			"status":  []string{"done", "error", "unknown-op"},
@@ -233,7 +231,7 @@ func (n *NreplServer) handleMsg(conn net.Conn, msg map[string]interface{}) {
 }
 
 // handleEval evaluates code and streams out/err/value/done messages.
-func (n *NreplServer) handleEval(conn net.Conn, msg map[string]interface{}) {
+func (n *NreplServer) handleEval(conn net.Conn, msg map[string]any) {
 	id := msgStr(msg, "id")
 	sessID := msgStr(msg, "session")
 	code := msgStr(msg, "code")
@@ -261,7 +259,7 @@ func (n *NreplServer) handleEval(conn net.Conn, msg map[string]interface{}) {
 
 	// Send stdout if any
 	if outBuf.Len() > 0 {
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":      id,
 			"session": sessID,
 			"out":     outBuf.String(),
@@ -270,7 +268,7 @@ func (n *NreplServer) handleEval(conn net.Conn, msg map[string]interface{}) {
 
 	if err != nil {
 		errStr := vm.FormatError(err)
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":      id,
 			"session": sessID,
 			"err":     errStr + "\n",
@@ -282,7 +280,7 @@ func (n *NreplServer) handleEval(conn net.Conn, msg map[string]interface{}) {
 		if val != nil {
 			valStr = val.String()
 		}
-		respond(conn, map[string]interface{}{
+		respond(conn, map[string]any{
 			"id":      id,
 			"session": sessID,
 			"value":   valStr,
@@ -291,7 +289,7 @@ func (n *NreplServer) handleEval(conn net.Conn, msg map[string]interface{}) {
 	}
 
 	// Always end with done
-	respond(conn, map[string]interface{}{
+	respond(conn, map[string]any{
 		"id":      id,
 		"session": sessID,
 		"status":  []string{"done"},
@@ -299,7 +297,7 @@ func (n *NreplServer) handleEval(conn net.Conn, msg map[string]interface{}) {
 }
 
 // handleCompletions returns completion candidates.
-func (n *NreplServer) handleCompletions(conn net.Conn, msg map[string]interface{}) {
+func (n *NreplServer) handleCompletions(conn net.Conn, msg map[string]any) {
 	id := msgStr(msg, "id")
 	sessID := msgStr(msg, "session")
 
@@ -308,12 +306,12 @@ func (n *NreplServer) handleCompletions(conn net.Conn, msg map[string]interface{
 		prefix = msgStr(msg, "symbol")
 	}
 
-	var completions []interface{}
+	var completions []any
 	if prefix != "" {
 		sym := vm.Symbol(prefix)
 		matches := rt.FuzzyNamespacedSymbolLookup(n.ctx.CurrentNS(), sym)
 		for _, m := range matches {
-			completions = append(completions, map[string]interface{}{
+			completions = append(completions, map[string]any{
 				"candidate": string(m),
 				"type":      "function",
 			})
@@ -321,10 +319,10 @@ func (n *NreplServer) handleCompletions(conn net.Conn, msg map[string]interface{
 	}
 
 	if completions == nil {
-		completions = []interface{}{}
+		completions = []any{}
 	}
 
-	respond(conn, map[string]interface{}{
+	respond(conn, map[string]any{
 		"id":          id,
 		"session":     sessID,
 		"completions": completions,
@@ -333,7 +331,7 @@ func (n *NreplServer) handleCompletions(conn net.Conn, msg map[string]interface{
 }
 
 // handleInfo returns symbol info.
-func (n *NreplServer) handleInfo(conn net.Conn, msg map[string]interface{}) {
+func (n *NreplServer) handleInfo(conn net.Conn, msg map[string]any) {
 	id := msgStr(msg, "id")
 	sessID := msgStr(msg, "session")
 	op := msgStr(msg, "op")
@@ -348,7 +346,7 @@ func (n *NreplServer) handleInfo(conn net.Conn, msg map[string]interface{}) {
 		nsName = n.ctx.CurrentNS().Name()
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"id":      id,
 		"session": sessID,
 		"status":  []string{"done"},
@@ -364,7 +362,7 @@ func (n *NreplServer) handleInfo(conn net.Conn, msg map[string]interface{}) {
 		}
 		v := ns.Lookup(vm.Symbol(sym))
 		if v != vm.NIL {
-			info := map[string]interface{}{
+			info := map[string]any{
 				"name": sym,
 				"ns":   nsName,
 			}
@@ -386,7 +384,7 @@ func (n *NreplServer) handleInfo(conn net.Conn, msg map[string]interface{}) {
 
 // --- Helpers ---
 
-func respond(conn net.Conn, msg map[string]interface{}) {
+func respond(conn net.Conn, msg map[string]any) {
 	bs, err := bencode.EncodeBytes(msg)
 	if err != nil {
 		return
@@ -394,7 +392,7 @@ func respond(conn net.Conn, msg map[string]interface{}) {
 	conn.Write(bs)
 }
 
-func msgStr(msg map[string]interface{}, key string) string {
+func msgStr(msg map[string]any, key string) string {
 	v, ok := msg[key]
 	if !ok || v == nil {
 		return ""

--- a/pkg/rt/async.go
+++ b/pkg/rt/async.go
@@ -30,7 +30,7 @@ type Mult struct {
 type Pub struct {
 	src     vm.Chan
 	topicFn vm.Fn
-	subs    map[interface{}]vm.Chan
+	subs    map[any]vm.Chan
 	mu      sync.Mutex
 }
 
@@ -534,7 +534,7 @@ func installAsyncNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("pub expected Fn")
 		}
-		p := &Pub{src: src, topicFn: topicFn, subs: make(map[interface{}]vm.Chan)}
+		p := &Pub{src: src, topicFn: topicFn, subs: make(map[any]vm.Chan)}
 		go func() {
 			for v := range src {
 				topic, err := topicFn.Invoke([]vm.Value{v})
@@ -699,7 +699,7 @@ func installAsyncNS() {
 		out := make(vm.Chan)
 		go func() {
 			count := int(n)
-			for i := 0; i < count; i++ {
+			for range count {
 				v, ok := <-ch
 				if !ok {
 					break

--- a/pkg/rt/gogen.go
+++ b/pkg/rt/gogen.go
@@ -38,9 +38,9 @@ type theGoASTType struct{}
 
 func (t *theGoASTType) String() string     { return t.Name() }
 func (t *theGoASTType) Type() vm.ValueType { return vm.TypeType }
-func (t *theGoASTType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theGoASTType) Unbox() any         { return reflect.TypeFor[*theGoASTType]() }
 func (t *theGoASTType) Name() string       { return "let-go.lang.GoAST" }
-func (t *theGoASTType) Box(_ interface{}) (vm.Value, error) {
+func (t *theGoASTType) Box(_ any) (vm.Value, error) {
 	return vm.NIL, fmt.Errorf("gogen: GoAST values are constructed via gogen/* fns, not boxed")
 }
 
@@ -50,7 +50,7 @@ type goASTValue struct{ node ast.Node }
 
 func (g *goASTValue) String() string     { return fmt.Sprintf("#<go-ast %T>", g.node) }
 func (g *goASTValue) Type() vm.ValueType { return GoASTType }
-func (g *goASTValue) Unbox() interface{} { return g.node }
+func (g *goASTValue) Unbox() any         { return g.node }
 
 func box(n ast.Node) vm.Value {
 	if n == nil {

--- a/pkg/rt/gogen_test.go
+++ b/pkg/rt/gogen_test.go
@@ -420,7 +420,7 @@ func TestRenderIsDeterministic(t *testing.T) {
 	}
 
 	first := render(t, buildAST())
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		got := render(t, buildAST())
 		if got != first {
 			t.Fatalf("render %d differs from first:\nfirst:\n%s\nlater:\n%s", i, first, got)

--- a/pkg/rt/http.go
+++ b/pkg/rt/http.go
@@ -69,7 +69,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
 	bodyBytes, err := io.ReadAll(request.Body)
 	if err != nil {
 		resp.WriteHeader(500)
-		_, err := resp.Write([]byte(fmt.Sprintf("%s", err)))
+		_, err := resp.Write(fmt.Appendf(nil, "%s", err))
 		if err != nil {
 			fmt.Println("HTTP Error while writing error 500", err)
 		}
@@ -104,7 +104,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
 	res, err := h.fn.Invoke([]vm.Value{req})
 	if err != nil {
 		resp.WriteHeader(500)
-		_, err := resp.Write([]byte(fmt.Sprintf("%s", err)))
+		_, err := resp.Write(fmt.Appendf(nil, "%s", err))
 		if err != nil {
 			fmt.Println("HTTP Error while writing error 500", err)
 		}

--- a/pkg/rt/json.go
+++ b/pkg/rt/json.go
@@ -12,7 +12,7 @@ import (
 	"github.com/nooga/let-go/pkg/vm"
 )
 
-func toValue(keywordize bool, i interface{}) (vm.Value, error) {
+func toValue(keywordize bool, i any) (vm.Value, error) {
 	switch i := i.(type) {
 	case string:
 		return vm.String(i), nil
@@ -25,9 +25,9 @@ func toValue(keywordize bool, i interface{}) (vm.Value, error) {
 		return vm.Float(i), nil
 	case nil:
 		return vm.NIL, nil
-	case []interface{}:
+	case []any:
 		r := make([]vm.Value, len(i))
-		for j := 0; j < len(i); j++ {
+		for j := range i {
 			v, e := toValue(keywordize, i[j])
 			if e != nil {
 				return vm.NIL, e
@@ -35,7 +35,7 @@ func toValue(keywordize bool, i interface{}) (vm.Value, error) {
 			r[j] = v
 		}
 		return vm.NewArrayVector(r), nil
-	case map[string]interface{}:
+	case map[string]any:
 		newmap := vm.EmptyPersistentMap
 		for k, v := range i {
 			ve, e := toValue(keywordize, v)
@@ -55,8 +55,8 @@ func toValue(keywordize bool, i interface{}) (vm.Value, error) {
 	}
 }
 
-func fromMapValue(v vm.Value) (interface{}, error) {
-	r := map[string]interface{}{}
+func fromMapValue(v vm.Value) (any, error) {
+	r := map[string]any{}
 	if sq, ok := v.(vm.Sequable); ok {
 		for s := sq.Seq(); s != nil && s != vm.EmptyList; s = s.Next() {
 			entry := s.First()
@@ -82,8 +82,8 @@ func fromMapValue(v vm.Value) (interface{}, error) {
 	return r, nil
 }
 
-func fromSeqValue(s vm.Seq) (interface{}, error) {
-	r := []interface{}{}
+func fromSeqValue(s vm.Seq) (any, error) {
+	r := []any{}
 	for s != nil && s != vm.EmptyList {
 		uv, e := fromValue(s.First())
 		if e != nil {
@@ -95,7 +95,7 @@ func fromSeqValue(s vm.Seq) (interface{}, error) {
 	return r, nil
 }
 
-func fromValue(v vm.Value) (interface{}, error) {
+func fromValue(v vm.Value) (any, error) {
 	switch v.Type() {
 	case vm.StringType:
 		return string(v.(vm.String)), nil
@@ -162,7 +162,7 @@ func installJSONNS() {
 			}
 		}
 
-		var v interface{}
+		var v any
 		err = json.Unmarshal([]byte(s), &v)
 		if err != nil {
 			return vm.NIL, err

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3424,7 +3424,7 @@ func installLangNS() {
 			return vm.NIL, fmt.Errorf("format expected String")
 		}
 		fmts := string(fmtStr)
-		args := make([]interface{}, len(vs)-1)
+		args := make([]any, len(vs)-1)
 		// Scan format string to determine which args need float promotion
 		vi := 0
 		for fi := 0; fi < len(fmts) && vi < len(args); fi++ {
@@ -3536,7 +3536,7 @@ func installLangNS() {
 		}
 		// Fallback: iterate
 		s, _ := seqOf(vs[0])
-		for i := 0; i < idx; i++ {
+		for range idx {
 			s = s.Next()
 		}
 		return s.First(), nil
@@ -5521,7 +5521,7 @@ func installLangNS() {
 				return vm.NIL, nil
 			}
 			var s vm.Seq = vm.EmptyList
-			for i := 0; i < n; i++ {
+			for i := range n {
 				s = vm.NewCons(v[i], s)
 			}
 			return s, nil
@@ -5531,7 +5531,7 @@ func installLangNS() {
 				return vm.NIL, nil
 			}
 			var s vm.Seq = vm.EmptyList
-			for i := 0; i < n; i++ {
+			for i := range n {
 				s = vm.NewCons(v.ValueAt(vm.MakeInt(i)), s)
 			}
 			return s, nil
@@ -5917,7 +5917,7 @@ func installLangNS() {
 				arr = vm.NewObjectArray(size)
 			}
 			if len(vs) == 2 {
-				for i := 0; i < size; i++ {
+				for i := range size {
 					if err := arr.Set(i, vs[1]); err != nil {
 						return vm.NIL, err
 					}

--- a/pkg/rt/pods.go
+++ b/pkg/rt/pods.go
@@ -23,7 +23,7 @@ import (
 
 // podMsg is a decoded bencode message from a pod.
 type podMsg struct {
-	raw map[string]interface{}
+	raw map[string]any
 }
 
 // Pod represents a running babashka pod subprocess.
@@ -38,7 +38,7 @@ type Pod struct {
 	decoder    *bencode.Decoder
 	writeMu    sync.Mutex // protects stdin writes
 	namespaces []podNamespace
-	ops        map[string]interface{}
+	ops        map[string]any
 	idCounter  atomic.Int64
 	shutdown   bool
 
@@ -101,7 +101,7 @@ func (p *Pod) nextID() string {
 	return fmt.Sprintf("lg-%d", p.idCounter.Add(1))
 }
 
-func (p *Pod) send(msg map[string]interface{}) error {
+func (p *Pod) send(msg map[string]any) error {
 	p.writeMu.Lock()
 	defer p.writeMu.Unlock()
 	bs, err := bencode.EncodeBytes(msg)
@@ -113,8 +113,8 @@ func (p *Pod) send(msg map[string]interface{}) error {
 }
 
 // recvRaw reads a single message (only used during describe before router starts).
-func (p *Pod) recvRaw() (map[string]interface{}, error) {
-	var msg map[string]interface{}
+func (p *Pod) recvRaw() (map[string]any, error) {
+	var msg map[string]any
 	if err := p.decoder.Decode(&msg); err != nil {
 		return nil, fmt.Errorf("pod %s: bencode decode: %w", p.name, err)
 	}
@@ -128,7 +128,7 @@ func (p *Pod) startRouter() {
 	p.routerUp = true
 	go func() {
 		for {
-			var msg map[string]interface{}
+			var msg map[string]any
 			if err := p.decoder.Decode(&msg); err != nil {
 				// Pod closed or errored - close all pending channels
 				p.pendingMu.Lock()
@@ -197,7 +197,7 @@ func (p *Pod) registerStreaming(id string) chan podMsg {
 }
 
 func (p *Pod) describe() error {
-	if err := p.send(map[string]interface{}{"op": "describe"}); err != nil {
+	if err := p.send(map[string]any{"op": "describe"}); err != nil {
 		return err
 	}
 	msg, err := p.recvRaw()
@@ -211,13 +211,13 @@ func (p *Pod) describe() error {
 		p.format = "json"
 	}
 
-	if ops, ok := msg["ops"].(map[string]interface{}); ok {
+	if ops, ok := msg["ops"].(map[string]any); ok {
 		p.ops = ops
 	}
 
-	if nsList, ok := msg["namespaces"].([]interface{}); ok {
+	if nsList, ok := msg["namespaces"].([]any); ok {
 		for _, nsRaw := range nsList {
-			nsMap, ok := nsRaw.(map[string]interface{})
+			nsMap, ok := nsRaw.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -225,9 +225,9 @@ func (p *Pod) describe() error {
 			if d, _ := nsMap["defer"].(string); d == "true" {
 				pns.defer_ = true
 			}
-			if varsList, ok := nsMap["vars"].([]interface{}); ok {
+			if varsList, ok := nsMap["vars"].([]any); ok {
 				for _, varRaw := range varsList {
-					varMap, ok := varRaw.(map[string]interface{})
+					varMap, ok := varRaw.(map[string]any)
 					if !ok {
 						continue
 					}
@@ -263,7 +263,7 @@ func (p *Pod) Invoke(varName string, args []vm.Value) (vm.Value, error) {
 	id := p.nextID()
 	ch := p.registerPending(id)
 
-	if err := p.send(map[string]interface{}{
+	if err := p.send(map[string]any{
 		"op":   "invoke",
 		"id":   id,
 		"var":  varName,
@@ -311,7 +311,7 @@ func (p *Pod) InvokeAsync(varName string, args []vm.Value) (vm.Chan, error) {
 	// Register as streaming (don't auto-close on done)
 	routerCh := p.registerStreaming(id)
 
-	if err := p.send(map[string]interface{}{
+	if err := p.send(map[string]any{
 		"op":   "invoke",
 		"id":   id,
 		"var":  varName,
@@ -355,7 +355,7 @@ func (p *Pod) Shutdown() {
 	p.shutdown = true
 	if p.ops != nil {
 		if _, ok := p.ops["shutdown"]; ok {
-			_ = p.send(map[string]interface{}{"op": "shutdown"})
+			_ = p.send(map[string]any{"op": "shutdown"})
 			p.stdin.Close()
 			p.cmd.Wait() //nolint:errcheck
 			return
@@ -536,7 +536,7 @@ func startPod(binary string) (*Pod, error) {
 
 // --- Helpers ---
 
-func isDone(msg map[string]interface{}) bool {
+func isDone(msg map[string]any) bool {
 	statusRaw, ok := msg["status"]
 	if !ok {
 		return false
@@ -544,7 +544,7 @@ func isDone(msg map[string]interface{}) bool {
 	switch s := statusRaw.(type) {
 	case string:
 		return s == "done" || s == `["done"]`
-	case []interface{}:
+	case []any:
 		for _, v := range s {
 			if str, ok := v.(string); ok && str == "done" {
 				return true
@@ -554,7 +554,7 @@ func isDone(msg map[string]interface{}) bool {
 	return false
 }
 
-func bencStr(m map[string]interface{}, key string) string {
+func bencStr(m map[string]any, key string) string {
 	v, ok := m[key]
 	if !ok {
 		return ""

--- a/pkg/rt/transit.go
+++ b/pkg/rt/transit.go
@@ -124,14 +124,14 @@ func NewTransitDecoder() *TransitDecoder {
 
 // Decode parses a transit+json string into a vm.Value.
 func (d *TransitDecoder) Decode(s string) (vm.Value, error) {
-	var raw interface{}
+	var raw any
 	if err := json.Unmarshal([]byte(s), &raw); err != nil {
 		return vm.NIL, fmt.Errorf("transit: invalid JSON: %w", err)
 	}
 	return d.decodeValue(raw)
 }
 
-func (d *TransitDecoder) decodeValue(v interface{}) (vm.Value, error) {
+func (d *TransitDecoder) decodeValue(v any) (vm.Value, error) {
 	switch val := v.(type) {
 	case string:
 		return d.decodeString(val, false), nil
@@ -144,9 +144,9 @@ func (d *TransitDecoder) decodeValue(v interface{}) (vm.Value, error) {
 		return vm.Boolean(val), nil
 	case nil:
 		return vm.NIL, nil
-	case []interface{}:
+	case []any:
 		return d.decodeArray(val)
-	case map[string]interface{}:
+	case map[string]any:
 		return d.decodeObject(val)
 	default:
 		return vm.NIL, fmt.Errorf("transit: unsupported JSON type %T", v)
@@ -203,7 +203,7 @@ func parseTransit(s string) vm.Value {
 	}
 }
 
-func (d *TransitDecoder) decodeArray(arr []interface{}) (vm.Value, error) {
+func (d *TransitDecoder) decodeArray(arr []any) (vm.Value, error) {
 	if len(arr) == 0 {
 		return vm.NewArrayVector(nil), nil
 	}
@@ -237,7 +237,7 @@ func (d *TransitDecoder) decodeArray(arr []interface{}) (vm.Value, error) {
 	return vm.NewArrayVector(vals), nil
 }
 
-func (d *TransitDecoder) decodeMapArray(arr []interface{}) (vm.Value, error) {
+func (d *TransitDecoder) decodeMapArray(arr []any) (vm.Value, error) {
 	m := vm.EmptyPersistentMap
 	for i := 1; i+1 < len(arr); i += 2 {
 		k, err := d.decodeKeyValue(arr[i])
@@ -253,10 +253,10 @@ func (d *TransitDecoder) decodeMapArray(arr []interface{}) (vm.Value, error) {
 	return m, nil
 }
 
-func (d *TransitDecoder) decodeTagged(tag string, payload interface{}) (vm.Value, error) {
+func (d *TransitDecoder) decodeTagged(tag string, payload any) (vm.Value, error) {
 	switch tag {
 	case "set":
-		if items, ok := payload.([]interface{}); ok {
+		if items, ok := payload.([]any); ok {
 			set := vm.EmptyPersistentSet
 			for _, item := range items {
 				v, err := d.decodeValue(item)
@@ -268,7 +268,7 @@ func (d *TransitDecoder) decodeTagged(tag string, payload interface{}) (vm.Value
 			return set, nil
 		}
 	case "list":
-		if items, ok := payload.([]interface{}); ok {
+		if items, ok := payload.([]any); ok {
 			vals := make([]vm.Value, len(items))
 			for i, item := range items {
 				v, err := d.decodeValue(item)
@@ -288,7 +288,7 @@ func (d *TransitDecoder) decodeTagged(tag string, payload interface{}) (vm.Value
 		return d.decodeValue(payload)
 	case "cmap":
 		// Verbose map (array of k-v pairs when keys aren't stringable)
-		if items, ok := payload.([]interface{}); ok {
+		if items, ok := payload.([]any); ok {
 			m := vm.EmptyPersistentMap
 			for i := 0; i+1 < len(items); i += 2 {
 				k, err := d.decodeValue(items[i])
@@ -309,14 +309,14 @@ func (d *TransitDecoder) decodeTagged(tag string, payload interface{}) (vm.Value
 }
 
 // decodeKeyValue decodes a value in key position (enables caching for map keys).
-func (d *TransitDecoder) decodeKeyValue(v interface{}) (vm.Value, error) {
+func (d *TransitDecoder) decodeKeyValue(v any) (vm.Value, error) {
 	if s, ok := v.(string); ok {
 		return d.decodeString(s, true), nil
 	}
 	return d.decodeValue(v)
 }
 
-func (d *TransitDecoder) decodeObject(m map[string]interface{}) (vm.Value, error) {
+func (d *TransitDecoder) decodeObject(m map[string]any) (vm.Value, error) {
 	// JSON objects are rare in transit+json (maps use array encoding)
 	// but can appear for string-keyed maps
 	result := vm.EmptyPersistentMap
@@ -358,7 +358,7 @@ func (e *TransitEncoder) Encode(v vm.Value) (string, error) {
 
 // EncodeList encodes a slice of values as a transit list (used for pod args).
 func (e *TransitEncoder) EncodeList(vals []vm.Value) (string, error) {
-	items := make([]interface{}, len(vals))
+	items := make([]any, len(vals))
 	for i, v := range vals {
 		raw, err := e.encodeValue(v)
 		if err != nil {
@@ -366,12 +366,12 @@ func (e *TransitEncoder) EncodeList(vals []vm.Value) (string, error) {
 		}
 		items[i] = raw
 	}
-	list := []interface{}{"~#list", items}
+	list := []any{"~#list", items}
 	bs, err := json.Marshal(list)
 	return string(bs), err
 }
 
-func (e *TransitEncoder) encodeValue(v vm.Value) (interface{}, error) {
+func (e *TransitEncoder) encodeValue(v vm.Value) (any, error) {
 	switch v.Type() {
 	case vm.NilType:
 		return nil, nil
@@ -411,15 +411,15 @@ func (e *TransitEncoder) encodeValue(v vm.Value) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return []interface{}{"~#set", items}, nil
+		return []any{"~#set", items}, nil
 	default:
 		// Lists and other seqs -> transit list tag
 		if sq, ok := v.(vm.Sequable); ok {
 			seq := sq.Seq()
 			if seq == nil {
-				return []interface{}{"~#list", []interface{}{}}, nil
+				return []any{"~#list", []any{}}, nil
 			}
-			var items []interface{}
+			var items []any
 			for s := seq; s != nil; s = s.Next() {
 				item, err := e.encodeValue(s.First())
 				if err != nil {
@@ -427,7 +427,7 @@ func (e *TransitEncoder) encodeValue(v vm.Value) (interface{}, error) {
 				}
 				items = append(items, item)
 			}
-			return []interface{}{"~#list", items}, nil
+			return []any{"~#list", items}, nil
 		}
 		// Records and other map-like types
 		if _, ok := v.(*vm.Record); ok {
@@ -438,12 +438,12 @@ func (e *TransitEncoder) encodeValue(v vm.Value) (interface{}, error) {
 	}
 }
 
-func (e *TransitEncoder) encodeSeqAsArray(v vm.Value) ([]interface{}, error) {
+func (e *TransitEncoder) encodeSeqAsArray(v vm.Value) ([]any, error) {
 	sq, ok := v.(vm.Sequable)
 	if !ok {
 		return nil, fmt.Errorf("transit: cannot seq %s", v.Type().Name())
 	}
-	var result []interface{}
+	var result []any
 	for s := sq.Seq(); s != nil; s = s.Next() {
 		item, err := e.encodeValue(s.First())
 		if err != nil {
@@ -452,17 +452,17 @@ func (e *TransitEncoder) encodeSeqAsArray(v vm.Value) ([]interface{}, error) {
 		result = append(result, item)
 	}
 	if result == nil {
-		result = []interface{}{}
+		result = []any{}
 	}
 	return result, nil
 }
 
-func (e *TransitEncoder) encodeMap(v vm.Value) (interface{}, error) {
+func (e *TransitEncoder) encodeMap(v vm.Value) (any, error) {
 	sq, ok := v.(vm.Sequable)
 	if !ok {
 		return nil, fmt.Errorf("transit: cannot seq map %s", v.Type().Name())
 	}
-	result := []interface{}{mapMarker}
+	result := []any{mapMarker}
 	for s := sq.Seq(); s != nil; s = s.Next() {
 		entry := s.First()
 		eSeq, ok := entry.(vm.Sequable)
@@ -483,7 +483,7 @@ func (e *TransitEncoder) encodeMap(v vm.Value) (interface{}, error) {
 	return result, nil
 }
 
-func (e *TransitEncoder) encodeKeyValue(v vm.Value) (interface{}, error) {
+func (e *TransitEncoder) encodeKeyValue(v vm.Value) (any, error) {
 	switch v.Type() {
 	case vm.KeywordType:
 		raw := kwPrefix + string(v.(vm.Keyword))
@@ -604,7 +604,7 @@ func SetEvalInNS(fn func(string, *vm.Namespace) (vm.Value, error)) {
 
 // JSONEncodeArgs encodes args as a plain JSON array string.
 func JSONEncodeArgs(args []vm.Value) (string, error) {
-	goArgs := make([]interface{}, len(args))
+	goArgs := make([]any, len(args))
 	for i, a := range args {
 		v, err := fromValue(a)
 		if err != nil {
@@ -618,7 +618,7 @@ func JSONEncodeArgs(args []vm.Value) (string, error) {
 
 // JSONDecodeValue decodes a JSON string into a vm.Value.
 func JSONDecodeValue(s string) (vm.Value, error) {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal([]byte(s), &v); err != nil {
 		return vm.NIL, err
 	}

--- a/pkg/vm/atom.go
+++ b/pkg/vm/atom.go
@@ -14,12 +14,12 @@ import (
 type theAtomType struct {
 }
 
-func (t *theAtomType) String() string     { return t.Name() }
-func (t *theAtomType) Type() ValueType    { return TypeType }
-func (t *theAtomType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theAtomType) String() string  { return t.Name() }
+func (t *theAtomType) Type() ValueType { return TypeType }
+func (t *theAtomType) Unbox() any      { return reflect.TypeFor[*theAtomType]() }
 
 func (t *theAtomType) Name() string { return "let-go.lang.Atom" }
-func (t *theAtomType) Box(b interface{}) (Value, error) {
+func (t *theAtomType) Box(b any) (Value, error) {
 	val, err := BoxValue(reflect.ValueOf(b))
 	if err != nil {
 		return NIL, err
@@ -194,18 +194,18 @@ func (a *Atom) Deref() Value {
 	return v
 }
 
-func (v *Atom) Type() ValueType {
+func (a *Atom) Type() ValueType {
 	return AtomType
 }
 
-func (v *Atom) Unbox() interface{} {
-	return v
+func (a *Atom) Unbox() any {
+	return a
 }
 
-func (v *Atom) Hash() uint32 {
-	return hashString(fmt.Sprintf("%p", v))
+func (a *Atom) Hash() uint32 {
+	return hashString(fmt.Sprintf("%p", a))
 }
 
-func (v *Atom) String() string {
-	return fmt.Sprintf("<%s %s>", AtomType, v.Deref())
+func (a *Atom) String() string {
+	return fmt.Sprintf("<%s %s>", AtomType, a.Deref())
 }

--- a/pkg/vm/bench_test.go
+++ b/pkg/vm/bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkFrameDispatch(b *testing.B) {
 	// 100 iterations of load+pop, then one final load+return
 	chunk := NewCodeChunk(consts)
 	iterations := 100
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		chunk.Append(OP_LOAD_CONST | (int32(i%8) << 16))
 		chunk.Append32(idx)
 		chunk.Append(OP_POP)
@@ -246,7 +246,7 @@ func BenchmarkConj(b *testing.B) {
 	b.Run("List", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var c Collection = EmptyList
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				c = c.Conj(Int(j))
 			}
 		}
@@ -254,7 +254,7 @@ func BenchmarkConj(b *testing.B) {
 	b.Run("ArrayVector", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var c Collection = ArrayVector{}
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				c = c.Conj(Int(j))
 			}
 		}
@@ -262,7 +262,7 @@ func BenchmarkConj(b *testing.B) {
 	b.Run("Map", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var c Collection = make(Map)
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				c = c.Conj(ArrayVector{Int(j), Int(j * 10)})
 			}
 		}
@@ -274,7 +274,7 @@ func BenchmarkMapAssoc(b *testing.B) {
 	for _, size := range sizes {
 		// Build PersistentMap (HAMT)
 		pm := EmptyPersistentMap
-		for i := 0; i < size; i++ {
+		for i := range size {
 			pm = pm.Assoc(Int(i), Int(i*10)).(*PersistentMap)
 		}
 
@@ -296,7 +296,7 @@ func BenchmarkMapAssoc(b *testing.B) {
 
 		// Build old Map (copy-on-write) for comparison
 		om := make(Map, size)
-		for i := 0; i < size; i++ {
+		for i := range size {
 			om[Int(i)] = Int(i * 10)
 		}
 		b.Run("GoMap-Assoc/"+itoa(size), func(b *testing.B) {

--- a/pkg/vm/bigdecimal.go
+++ b/pkg/vm/bigdecimal.go
@@ -11,12 +11,12 @@ import (
 
 type theBigDecimalType struct{}
 
-func (t *theBigDecimalType) String() string     { return t.Name() }
-func (t *theBigDecimalType) Type() ValueType    { return TypeType }
-func (t *theBigDecimalType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theBigDecimalType) Name() string       { return "let-go.lang.BigDecimal" }
+func (t *theBigDecimalType) String() string  { return t.Name() }
+func (t *theBigDecimalType) Type() ValueType { return TypeType }
+func (t *theBigDecimalType) Unbox() any      { return reflect.TypeFor[*theBigDecimalType]() }
+func (t *theBigDecimalType) Name() string    { return "let-go.lang.BigDecimal" }
 
-func (t *theBigDecimalType) Box(bare interface{}) (Value, error) {
+func (t *theBigDecimalType) Box(bare any) (Value, error) {
 	switch v := bare.(type) {
 	case *big.Float:
 		return &BigDecimal{val: v}, nil
@@ -56,8 +56,8 @@ func NewBigDecimalFromInt64(n int64) *BigDecimal {
 
 func (b *BigDecimal) Val() *big.Float { return b.val }
 
-func (b *BigDecimal) Type() ValueType    { return BigDecimalType }
-func (b *BigDecimal) Unbox() interface{} { return b.val }
+func (b *BigDecimal) Type() ValueType { return BigDecimalType }
+func (b *BigDecimal) Unbox() any      { return b.val }
 
 func (b *BigDecimal) String() string {
 	s := b.val.Text('f', -1)

--- a/pkg/vm/bigint.go
+++ b/pkg/vm/bigint.go
@@ -8,12 +8,12 @@ import (
 
 type theBigIntType struct{}
 
-func (t *theBigIntType) String() string     { return t.Name() }
-func (t *theBigIntType) Type() ValueType    { return TypeType }
-func (t *theBigIntType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theBigIntType) Name() string       { return "let-go.lang.BigInt" }
+func (t *theBigIntType) String() string  { return t.Name() }
+func (t *theBigIntType) Type() ValueType { return TypeType }
+func (t *theBigIntType) Unbox() any      { return reflect.TypeFor[*theBigIntType]() }
+func (t *theBigIntType) Name() string    { return "let-go.lang.BigInt" }
 
-func (t *theBigIntType) Box(bare interface{}) (Value, error) {
+func (t *theBigIntType) Box(bare any) (Value, error) {
 	switch v := bare.(type) {
 	case *big.Int:
 		return &BigInt{val: v}, nil
@@ -50,8 +50,8 @@ func NewBigIntFromInt64(n int64) *BigInt {
 
 func (b *BigInt) Val() *big.Int { return b.val }
 
-func (b *BigInt) Type() ValueType    { return BigIntType }
-func (b *BigInt) Unbox() interface{} { return b.val }
+func (b *BigInt) Type() ValueType { return BigIntType }
+func (b *BigInt) Unbox() any      { return b.val }
 
 func (b *BigInt) String() string {
 	return b.val.String() + "N"

--- a/pkg/vm/bool.go
+++ b/pkg/vm/bool.go
@@ -11,12 +11,12 @@ type theBooleanType struct {
 	zero Boolean
 }
 
-func (t *theBooleanType) String() string     { return t.Name() }
-func (t *theBooleanType) Type() ValueType    { return TypeType }
-func (t *theBooleanType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theBooleanType) String() string  { return t.Name() }
+func (t *theBooleanType) Type() ValueType { return TypeType }
+func (t *theBooleanType) Unbox() any      { return reflect.TypeFor[*theBooleanType]() }
 
 func (t *theBooleanType) Name() string { return "let-go.lang.Boolean" }
-func (t *theBooleanType) Box(b interface{}) (Value, error) {
+func (t *theBooleanType) Box(b any) (Value, error) {
 	rb, ok := b.(bool)
 	if !ok {
 		return BooleanType.zero, NewTypeError(b, "can't be boxed as", t)
@@ -39,7 +39,7 @@ func (n Boolean) Hash() uint32 {
 func (n Boolean) Type() ValueType { return BooleanType }
 
 // Unbox implements Value
-func (n Boolean) Unbox() interface{} { return bool(n) }
+func (n Boolean) Unbox() any { return bool(n) }
 
 // BooleanType is the type of Boolean
 var BooleanType *theBooleanType = &theBooleanType{zero: FALSE}

--- a/pkg/vm/boxed.go
+++ b/pkg/vm/boxed.go
@@ -15,12 +15,12 @@ type aBoxedType struct {
 	methods map[Symbol]*NativeFn
 }
 
-func (t *aBoxedType) String() string     { return t.Name() }
-func (t *aBoxedType) Type() ValueType    { return TypeType }
-func (t *aBoxedType) Unbox() interface{} { return t.typ }
+func (t *aBoxedType) String() string  { return t.Name() }
+func (t *aBoxedType) Type() ValueType { return TypeType }
+func (t *aBoxedType) Unbox() any      { return t.typ }
 
 func (t *aBoxedType) Name() string { return "go." + t.typ.String() }
-func (t *aBoxedType) Box(value interface{}) (Value, error) {
+func (t *aBoxedType) Box(value any) (Value, error) {
 	if !reflect.TypeOf(value).ConvertibleTo(t.typ) {
 		return NIL, NewTypeError(value, "can't be boxed as", t)
 	}
@@ -28,7 +28,7 @@ func (t *aBoxedType) Box(value interface{}) (Value, error) {
 }
 
 type Boxed struct {
-	value interface{}
+	value any
 	typ   *aBoxedType
 }
 
@@ -36,7 +36,7 @@ type Boxed struct {
 func (n *Boxed) Type() ValueType { return n.typ }
 
 // Unbox implements Value
-func (n *Boxed) Unbox() interface{} { return n.value }
+func (n *Boxed) Unbox() any { return n.value }
 
 func (n *Boxed) String() string {
 	return fmt.Sprintf("<%s %v>", n.typ.Name(), n.value)
@@ -72,7 +72,7 @@ func (n *Boxed) ValueAtOr(key Value, dflt Value) Value {
 // BoxedType is the type of NilValues
 var BoxedTypes map[string]*aBoxedType = map[string]*aBoxedType{}
 
-func valueType(value interface{}) *aBoxedType {
+func valueType(value any) *aBoxedType {
 	reflected := reflect.TypeOf(value)
 	t, ok := BoxedTypes[reflected.Name()]
 	if ok {
@@ -85,7 +85,7 @@ func valueType(value interface{}) *aBoxedType {
 	methodc := reflected.NumMethod()
 	if methodc > 0 {
 		t.methods = map[Symbol]*NativeFn{}
-		for i := 0; i < methodc; i++ {
+		for i := range methodc {
 			m := reflected.Method(i)
 			me, err := NativeFnType.Box(m.Func.Interface())
 			if err != nil {
@@ -104,6 +104,6 @@ func valueType(value interface{}) *aBoxedType {
 	return t
 }
 
-func NewBoxed(value interface{}) *Boxed {
+func NewBoxed(value any) *Boxed {
 	return &Boxed{value: value, typ: valueType(value)}
 }

--- a/pkg/vm/chan.go
+++ b/pkg/vm/chan.go
@@ -13,12 +13,12 @@ import (
 type theChanType struct {
 }
 
-func (t *theChanType) String() string     { return t.Name() }
-func (t *theChanType) Type() ValueType    { return TypeType }
-func (t *theChanType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theChanType) String() string  { return t.Name() }
+func (t *theChanType) Type() ValueType { return TypeType }
+func (t *theChanType) Unbox() any      { return reflect.TypeFor[*theChanType]() }
 
 func (t *theChanType) Name() string { return "let-go.lang.Chan" }
-func (t *theChanType) Box(b interface{}) (Value, error) {
+func (t *theChanType) Box(b any) (Value, error) {
 	chv := reflect.ValueOf(b)
 	if chv.Type().Kind() != reflect.Chan {
 		return NIL, NewTypeError(b, "is not a channel", t)
@@ -45,7 +45,7 @@ type Chan chan Value
 func (n Chan) Type() ValueType { return ChanType }
 
 // Unbox implements Value
-func (n Chan) Unbox() interface{} { return n }
+func (n Chan) Unbox() any { return n }
 
 // ChanType is the type of Chan
 var ChanType *theChanType = &theChanType{}

--- a/pkg/vm/char.go
+++ b/pkg/vm/char.go
@@ -14,16 +14,16 @@ type theCharType struct {
 	zero Char
 }
 
-func (t *theCharType) String() string     { return t.Name() }
-func (t *theCharType) Type() ValueType    { return TypeType }
-func (t *theCharType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theCharType) String() string  { return t.Name() }
+func (t *theCharType) Type() ValueType { return TypeType }
+func (t *theCharType) Unbox() any      { return reflect.TypeFor[*theCharType]() }
 
-func (lt *theCharType) Name() string { return "let-go.lang.Character" }
+func (t *theCharType) Name() string { return "let-go.lang.Character" }
 
-func (lt *theCharType) Box(bare interface{}) (Value, error) {
+func (t *theCharType) Box(bare any) (Value, error) {
 	raw, ok := bare.(rune)
 	if !ok {
-		return CharType.zero, NewTypeError(bare, "can't be boxed as", lt)
+		return CharType.zero, NewTypeError(bare, "can't be boxed as", t)
 	}
 	return Char(raw), nil
 }
@@ -41,7 +41,7 @@ func (l Char) Hash() uint32 { return hashUint64(uint64(l)) }
 func (l Char) Type() ValueType { return CharType }
 
 // Unbox implements Unbox
-func (l Char) Unbox() interface{} {
+func (l Char) Unbox() any {
 	return rune(l)
 }
 

--- a/pkg/vm/cons.go
+++ b/pkg/vm/cons.go
@@ -32,8 +32,8 @@ func (c *Cons) String() string {
 	return b.String()
 }
 
-func (c *Cons) Type() ValueType    { return ListType }
-func (c *Cons) Unbox() interface{} { return c }
+func (c *Cons) Type() ValueType { return ListType }
+func (c *Cons) Unbox() any      { return c }
 
 func (c *Cons) First() Value {
 	return c.first

--- a/pkg/vm/constpool.go
+++ b/pkg/vm/constpool.go
@@ -158,10 +158,7 @@ func (c *Consts) insertBucket(h uint32, idx int, v Value) {
 }
 
 func (c *Consts) grow() {
-	newSize := (c.mask + 1) * 2
-	if newSize < 16 {
-		newSize = 16
-	}
+	newSize := max((c.mask+1)*2, 16)
 	old := c.buckets
 	c.buckets = make([]constBucket, newSize)
 	c.mask = uint32(newSize - 1)

--- a/pkg/vm/deftype.go
+++ b/pkg/vm/deftype.go
@@ -28,13 +28,13 @@ func NewDType(name string, fields []Symbol) *DType {
 	return &DType{typeName: name, fields: fields, fieldIdx: idx}
 }
 
-func (t *DType) String() string     { return t.typeName }
-func (t *DType) Type() ValueType    { return TypeType }
-func (t *DType) Unbox() interface{} { return t }
-func (t *DType) Name() string       { return t.typeName }
-func (t *DType) Fields() []Symbol   { return t.fields }
+func (t *DType) String() string   { return t.typeName }
+func (t *DType) Type() ValueType  { return TypeType }
+func (t *DType) Unbox() any       { return t }
+func (t *DType) Name() string     { return t.typeName }
+func (t *DType) Fields() []Symbol { return t.fields }
 
-func (t *DType) Box(bare interface{}) (Value, error) {
+func (t *DType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 
@@ -60,8 +60,8 @@ func NewDTypeInstance(dt *DType, fields []Value) *DTypeInstance {
 	return &DTypeInstance{dtype: dt, fields: fields}
 }
 
-func (d *DTypeInstance) Type() ValueType    { return d.dtype }
-func (d *DTypeInstance) Unbox() interface{} { return d }
+func (d *DTypeInstance) Type() ValueType { return d.dtype }
+func (d *DTypeInstance) Unbox() any      { return d }
 
 func (d *DTypeInstance) String() string {
 	b := &strings.Builder{}

--- a/pkg/vm/delay.go
+++ b/pkg/vm/delay.go
@@ -53,8 +53,8 @@ func (d *Delay) Deref() Value {
 	return v
 }
 
-func (d *Delay) Type() ValueType    { return DelayType }
-func (d *Delay) Unbox() interface{} { return d }
+func (d *Delay) Type() ValueType { return DelayType }
+func (d *Delay) Unbox() any      { return d }
 func (d *Delay) String() string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -67,11 +67,11 @@ func (d *Delay) String() string {
 // DelayType
 type theDelayType struct{}
 
-func (t *theDelayType) String() string     { return t.Name() }
-func (t *theDelayType) Type() ValueType    { return TypeType }
-func (t *theDelayType) Unbox() interface{} { return nil }
-func (t *theDelayType) Name() string       { return "let-go.lang.Delay" }
-func (t *theDelayType) Box(bare interface{}) (Value, error) {
+func (t *theDelayType) String() string  { return t.Name() }
+func (t *theDelayType) Type() ValueType { return TypeType }
+func (t *theDelayType) Unbox() any      { return nil }
+func (t *theDelayType) Name() string    { return "let-go.lang.Delay" }
+func (t *theDelayType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/errfmt.go
+++ b/pkg/vm/errfmt.go
@@ -120,10 +120,7 @@ func writeSnippet(b *strings.Builder, info *SourceInfo) {
 	fmt.Fprintf(b, " "+ansiBoldBlue+"%d"+ansiReset+" "+ansiBoldBlue+"|"+ansiReset+" %s\n", lineNum, line)
 
 	// Position indicator
-	col := info.Column
-	if col < 0 {
-		col = 0
-	}
+	col := max(info.Column, 0)
 	pointer := strings.Repeat(" ", col) + ansiBoldRed + "^^^" + ansiReset
 	fmt.Fprintf(b, " %s "+ansiBoldBlue+"|"+ansiReset+" %s\n", padding, pointer)
 }

--- a/pkg/vm/errors.go
+++ b/pkg/vm/errors.go
@@ -19,14 +19,14 @@ import (
 //	TypeError: (encountered type name) ... message ... (expected type name)
 type TypeError struct {
 	message  string
-	value    interface{}
+	value    any
 	expected ValueType
 	cause    error
 }
 
 // NewTypeError creates a new type error. This error will print the
 // problematic value's (either interface{} or Value) type name, a message, and expected type name.
-func NewTypeError(value interface{}, message string, expected ValueType) *TypeError {
+func NewTypeError(value any, message string, expected ValueType) *TypeError {
 	return &TypeError{
 		message:  message,
 		expected: expected,

--- a/pkg/vm/exinfo.go
+++ b/pkg/vm/exinfo.go
@@ -14,8 +14,8 @@ func NewExInfo(message string, data *PersistentMap, cause error) *ExInfo {
 	return &ExInfo{message: message, data: data, cause: cause}
 }
 
-func (e *ExInfo) Type() ValueType    { return ExInfoType }
-func (e *ExInfo) Unbox() interface{} { return e }
+func (e *ExInfo) Type() ValueType { return ExInfoType }
+func (e *ExInfo) Unbox() any      { return e }
 func (e *ExInfo) String() string {
 	return fmt.Sprintf("#error {:message %q, :data %s}", e.message, e.data.String())
 }
@@ -26,11 +26,11 @@ func (e *ExInfo) Cause() error         { return e.cause }
 
 type theExInfoType struct{}
 
-func (t *theExInfoType) String() string     { return t.Name() }
-func (t *theExInfoType) Type() ValueType    { return TypeType }
-func (t *theExInfoType) Unbox() interface{} { return nil }
-func (t *theExInfoType) Name() string       { return "let-go.lang.ExceptionInfo" }
-func (t *theExInfoType) Box(bare interface{}) (Value, error) {
+func (t *theExInfoType) String() string  { return t.Name() }
+func (t *theExInfoType) Type() ValueType { return TypeType }
+func (t *theExInfoType) Unbox() any      { return nil }
+func (t *theExInfoType) Name() string    { return "let-go.lang.ExceptionInfo" }
+func (t *theExInfoType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/float.go
+++ b/pkg/vm/float.go
@@ -16,13 +16,13 @@ type theFloatType struct {
 	zero Float
 }
 
-func (t *theFloatType) String() string     { return t.Name() }
-func (t *theFloatType) Type() ValueType    { return TypeType }
-func (t *theFloatType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theFloatType) String() string  { return t.Name() }
+func (t *theFloatType) Type() ValueType { return TypeType }
+func (t *theFloatType) Unbox() any      { return reflect.TypeFor[*theFloatType]() }
 
 func (t *theFloatType) Name() string { return "let-go.lang.Float" }
 
-func (t *theFloatType) Box(bare interface{}) (Value, error) {
+func (t *theFloatType) Box(bare any) (Value, error) {
 	raw, ok := bare.(float64)
 	if !ok {
 		return FloatType.zero, NewTypeError(bare, "can't be boxed as", t)
@@ -53,11 +53,11 @@ func (l Float) Type() ValueType   { return FloatType }
 func (l Float32) Type() ValueType { return FloatType }
 
 // Unbox implements Unbox
-func (l Float) Unbox() interface{} {
+func (l Float) Unbox() any {
 	return float64(l)
 }
 
-func (l Float32) Unbox() interface{} {
+func (l Float32) Unbox() any {
 	return float64(l)
 }
 

--- a/pkg/vm/func.go
+++ b/pkg/vm/func.go
@@ -12,12 +12,12 @@ import (
 
 type theFuncType struct{}
 
-func (t *theFuncType) String() string     { return t.Name() }
-func (t *theFuncType) Type() ValueType    { return TypeType }
-func (t *theFuncType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theFuncType) String() string  { return t.Name() }
+func (t *theFuncType) Type() ValueType { return TypeType }
+func (t *theFuncType) Unbox() any      { return reflect.TypeFor[*theFuncType]() }
 
 func (t *theFuncType) Name() string { return "let-go.lang.Fn" }
-func (t *theFuncType) Box(fn interface{}) (Value, error) {
+func (t *theFuncType) Box(fn any) (Value, error) {
 	return NIL, NewTypeError(fn, "can't be boxed as", t)
 }
 
@@ -44,10 +44,10 @@ func (l *Func) SetName(n string) {
 
 func (l *Func) Type() ValueType { return FuncType }
 
-type FuncInterface func(interface{})
+type FuncInterface func(any)
 
 // Unbox implements Unbox
-func (l *Func) Unbox() interface{} {
+func (l *Func) Unbox() any {
 	proxy := func(in []reflect.Value) []reflect.Value {
 		args := make([]Value, len(in))
 		for i := range in {
@@ -58,7 +58,7 @@ func (l *Func) Unbox() interface{} {
 		out, _ := f.Run() // error not propagatable through reflect proxy
 		return []reflect.Value{reflect.ValueOf(out.Unbox())}
 	}
-	return func(fptr interface{}) {
+	return func(fptr any) {
 		fn := reflect.ValueOf(fptr).Elem()
 		v := reflect.MakeFunc(fn.Type(), proxy)
 		fn.Set(v)
@@ -122,7 +122,7 @@ type Closure struct {
 func (l *Closure) Type() ValueType { return FuncType }
 
 // Unbox implements Unbox
-func (l *Closure) Unbox() interface{} {
+func (l *Closure) Unbox() any {
 	proxy := func(in []reflect.Value) []reflect.Value {
 		args := make([]Value, len(in))
 		for i := range in {
@@ -134,7 +134,7 @@ func (l *Closure) Unbox() interface{} {
 		out, _ := f.Run() // error not propagatable through reflect proxy
 		return []reflect.Value{reflect.ValueOf(out.Unbox())}
 	}
-	return func(fptr interface{}) {
+	return func(fptr any) {
 		fn := reflect.ValueOf(fptr).Elem()
 		v := reflect.MakeFunc(fn.Type(), proxy)
 		fn.Set(v)
@@ -182,7 +182,7 @@ type MultiArityFn struct {
 func (l *MultiArityFn) Type() ValueType { return FuncType }
 
 // Unbox implements Unbox
-func (l *MultiArityFn) Unbox() interface{} {
+func (l *MultiArityFn) Unbox() any {
 	proxy := func(in []reflect.Value) []reflect.Value {
 		args := make([]Value, len(in))
 		for i := range in {
@@ -192,7 +192,7 @@ func (l *MultiArityFn) Unbox() interface{} {
 		out, _ := l.Invoke(args)
 		return []reflect.Value{reflect.ValueOf(out.Unbox())}
 	}
-	return func(fptr interface{}) {
+	return func(fptr any) {
 		fn := reflect.ValueOf(fptr).Elem()
 		v := reflect.MakeFunc(fn.Type(), proxy)
 		fn.Set(v)

--- a/pkg/vm/instant.go
+++ b/pkg/vm/instant.go
@@ -8,11 +8,11 @@ import (
 
 type theInstantType struct{}
 
-func (t *theInstantType) String() string     { return t.Name() }
-func (t *theInstantType) Type() ValueType    { return TypeType }
-func (t *theInstantType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theInstantType) Name() string       { return "let-go.lang.Instant" }
-func (t *theInstantType) Box(bare interface{}) (Value, error) {
+func (t *theInstantType) String() string  { return t.Name() }
+func (t *theInstantType) Type() ValueType { return TypeType }
+func (t *theInstantType) Unbox() any      { return reflect.TypeFor[*theInstantType]() }
+func (t *theInstantType) Name() string    { return "let-go.lang.Instant" }
+func (t *theInstantType) Box(bare any) (Value, error) {
 	switch v := bare.(type) {
 	case string:
 		i := ParseInstant(v)
@@ -70,9 +70,9 @@ func NewInstant(t time.Time) *Instant {
 	return &Instant{t: t.UTC().Truncate(time.Millisecond)}
 }
 
-func (i *Instant) Type() ValueType    { return InstantType }
-func (i *Instant) Unbox() interface{} { return i.t }
-func (i *Instant) String() string     { return "#inst \"" + i.t.Format(time.RFC3339Nano) + "\"" }
+func (i *Instant) Type() ValueType { return InstantType }
+func (i *Instant) Unbox() any      { return i.t }
+func (i *Instant) String() string  { return "#inst \"" + i.t.Format(time.RFC3339Nano) + "\"" }
 
 // Time returns the underlying time.Time (UTC, millisecond precision).
 func (i *Instant) Time() time.Time { return i.t }

--- a/pkg/vm/int.go
+++ b/pkg/vm/int.go
@@ -14,13 +14,13 @@ type theIntType struct {
 	zero Int
 }
 
-func (t *theIntType) String() string     { return t.Name() }
-func (t *theIntType) Type() ValueType    { return TypeType }
-func (t *theIntType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theIntType) String() string  { return t.Name() }
+func (t *theIntType) Type() ValueType { return TypeType }
+func (t *theIntType) Unbox() any      { return reflect.TypeFor[*theIntType]() }
 
 func (t *theIntType) Name() string { return "let-go.lang.Int" }
 
-func (t *theIntType) Box(bare interface{}) (Value, error) {
+func (t *theIntType) Box(bare any) (Value, error) {
 	raw, ok := bare.(int)
 	if !ok {
 		return IntType.zero, NewTypeError(bare, "can't be boxed as", t)
@@ -41,7 +41,7 @@ func (l Int) Hash() uint32 { return hashUint64(uint64(l)) }
 func (l Int) Type() ValueType { return IntType }
 
 // Unbox implements Unbox
-func (l Int) Unbox() interface{} {
+func (l Int) Unbox() any {
 	return int(l)
 }
 

--- a/pkg/vm/iterate.go
+++ b/pkg/vm/iterate.go
@@ -11,12 +11,12 @@ type theIterateType struct {
 	zero *Iterate
 }
 
-func (t *theIterateType) String() string     { return t.Name() }
-func (t *theIterateType) Type() ValueType    { return IterateType }
-func (t *theIterateType) Unbox() interface{} { return nil }
+func (t *theIterateType) String() string  { return t.Name() }
+func (t *theIterateType) Type() ValueType { return IterateType }
+func (t *theIterateType) Unbox() any      { return nil }
 
-func (t *theIterateType) Name() string                     { return "let-go.lang.Iterate" }
-func (t *theIterateType) Box(_ interface{}) (Value, error) { return t.zero, nil }
+func (t *theIterateType) Name() string             { return "let-go.lang.Iterate" }
+func (t *theIterateType) Box(_ any) (Value, error) { return t.zero, nil }
 
 // Iterate is a Value whose only value is Iterate
 type Iterate struct {
@@ -59,7 +59,7 @@ func (n *Iterate) Seq() Seq {
 func (n *Iterate) Type() ValueType { return IterateType }
 
 // Unbox implements Value
-func (n *Iterate) Unbox() interface{} { return nil }
+func (n *Iterate) Unbox() any { return nil }
 
 // IterateType is the type of IterateValues
 var IterateType *theIterateType = &theIterateType{zero: nil}

--- a/pkg/vm/keyword.go
+++ b/pkg/vm/keyword.go
@@ -15,13 +15,13 @@ type theKeywordType struct {
 	zero Keyword
 }
 
-func (t *theKeywordType) String() string     { return t.Name() }
-func (t *theKeywordType) Type() ValueType    { return TypeType }
-func (t *theKeywordType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theKeywordType) String() string  { return t.Name() }
+func (t *theKeywordType) Type() ValueType { return TypeType }
+func (t *theKeywordType) Unbox() any      { return reflect.TypeFor[*theKeywordType]() }
 
 func (t *theKeywordType) Name() string { return "let-go.lang.Keyword" }
 
-func (t *theKeywordType) Box(bare interface{}) (Value, error) {
+func (t *theKeywordType) Box(bare any) (Value, error) {
 	raw, ok := bare.(fmt.Stringer)
 	if !ok {
 		return BooleanType.zero, NewTypeError(bare, "can't be boxed as", t)
@@ -42,7 +42,7 @@ func (l Keyword) Hash() uint32 { return hashUnencodedChars(string(l)) + 0x9e3779
 func (l Keyword) Type() ValueType { return KeywordType }
 
 // Unbox implements Unbox
-func (l Keyword) Unbox() interface{} {
+func (l Keyword) Unbox() any {
 	return string(l)
 }
 

--- a/pkg/vm/lazy_seq.go
+++ b/pkg/vm/lazy_seq.go
@@ -110,8 +110,8 @@ func (l *LazySeq) String() string {
 	return s.String()
 }
 
-func (l *LazySeq) Type() ValueType    { return ListType }
-func (l *LazySeq) Unbox() interface{} { return l.seq() }
+func (l *LazySeq) Type() ValueType { return ListType }
+func (l *LazySeq) Unbox() any      { return l.seq() }
 
 func (l *LazySeq) First() Value {
 	s := l.Resolve()

--- a/pkg/vm/list.go
+++ b/pkg/vm/list.go
@@ -12,16 +12,16 @@ import (
 
 type theListType struct{}
 
-func (t *theListType) String() string     { return t.Name() }
-func (t *theListType) Type() ValueType    { return TypeType }
-func (t *theListType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theListType) String() string  { return t.Name() }
+func (t *theListType) Type() ValueType { return TypeType }
+func (t *theListType) Unbox() any      { return reflect.TypeFor[*theListType]() }
 
-func (lt *theListType) Name() string { return "let-go.lang.PersistentList" }
+func (t *theListType) Name() string { return "let-go.lang.PersistentList" }
 
-func (lt *theListType) Box(bare interface{}) (Value, error) {
+func (t *theListType) Box(bare any) (Value, error) {
 	arr, ok := bare.([]Value)
 	if !ok {
-		return EmptyList, NewTypeError(bare, "can't be boxed as", lt)
+		return EmptyList, NewTypeError(bare, "can't be boxed as", t)
 	}
 	var ret Seq = EmptyList
 	n := len(arr)
@@ -85,7 +85,7 @@ func (l *List) Conj(value Value) Collection {
 func (l *List) Type() ValueType { return ListType }
 
 // Unbox implements Value
-func (l *List) Unbox() interface{} {
+func (l *List) Unbox() any {
 	if l.count == 0 {
 		return []Value{}
 	}

--- a/pkg/vm/map.go
+++ b/pkg/vm/map.go
@@ -7,19 +7,20 @@ package vm
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 )
 
 type theMapType struct{}
 
-func (t *theMapType) String() string     { return t.Name() }
-func (t *theMapType) Type() ValueType    { return TypeType }
-func (t *theMapType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theMapType) String() string  { return t.Name() }
+func (t *theMapType) Type() ValueType { return TypeType }
+func (t *theMapType) Unbox() any      { return reflect.TypeFor[*theMapType]() }
 
 func (t *theMapType) Name() string { return "let-go.lang.Map" }
 
-func (t *theMapType) Box(bare interface{}) (Value, error) {
+func (t *theMapType) Box(bare any) (Value, error) {
 	casted, ok := bare.(map[Value]Value)
 	if !ok {
 		return NIL, NewTypeError(bare, "can't be boxed as", t)
@@ -54,7 +55,7 @@ func (l Map) Conj(value Value) Collection {
 func (l Map) Type() ValueType { return MapType }
 
 // Unbox implements Value
-func (l Map) Unbox() interface{} {
+func (l Map) Unbox() any {
 	return map[Value]Value(l)
 }
 
@@ -124,8 +125,8 @@ func (s *MapSeq) String() string {
 	return b.String()
 }
 
-func (s *MapSeq) Type() ValueType    { return ListType }
-func (s *MapSeq) Unbox() interface{} { return s.entries[s.i:] }
+func (s *MapSeq) Type() ValueType { return ListType }
+func (s *MapSeq) Unbox() any      { return s.entries[s.i:] }
 
 func (s *MapSeq) First() Value {
 	if s.i >= len(s.entries) {
@@ -174,9 +175,7 @@ func (l Map) Empty() Collection {
 
 func (l Map) Assoc(k Value, v Value) Associative {
 	newmap := make(Map)
-	for ok, ov := range l {
-		newmap[ok] = ov
-	}
+	maps.Copy(newmap, l)
 	newmap[k] = v
 	return newmap
 }

--- a/pkg/vm/multifn.go
+++ b/pkg/vm/multifn.go
@@ -25,8 +25,8 @@ func NewMultiFn(name string, dispatchFn Fn, defaultVal Value) *MultiFn {
 	}
 }
 
-func (m *MultiFn) Type() ValueType    { return MultiFnType }
-func (m *MultiFn) Unbox() interface{} { return m }
+func (m *MultiFn) Type() ValueType { return MultiFnType }
+func (m *MultiFn) Unbox() any      { return m }
 
 func (m *MultiFn) String() string {
 	return fmt.Sprintf("<multifn %s>", m.name)
@@ -88,11 +88,11 @@ func (m *MultiFn) Methods() *PersistentMap {
 
 type theMultiFnType struct{}
 
-func (t *theMultiFnType) String() string     { return t.Name() }
-func (t *theMultiFnType) Type() ValueType    { return TypeType }
-func (t *theMultiFnType) Unbox() interface{} { return nil }
-func (t *theMultiFnType) Name() string       { return "let-go.lang.MultiFn" }
-func (t *theMultiFnType) Box(bare interface{}) (Value, error) {
+func (t *theMultiFnType) String() string  { return t.Name() }
+func (t *theMultiFnType) Type() ValueType { return TypeType }
+func (t *theMultiFnType) Unbox() any      { return nil }
+func (t *theMultiFnType) Name() string    { return "let-go.lang.MultiFn" }
+func (t *theMultiFnType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/namespace.go
+++ b/pkg/vm/namespace.go
@@ -14,12 +14,12 @@ import (
 
 type theNamespaceType struct{}
 
-func (t *theNamespaceType) String() string     { return t.Name() }
-func (t *theNamespaceType) Type() ValueType    { return TypeType }
-func (t *theNamespaceType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theNamespaceType) String() string  { return t.Name() }
+func (t *theNamespaceType) Type() ValueType { return TypeType }
+func (t *theNamespaceType) Unbox() any      { return reflect.TypeFor[*theNamespaceType]() }
 
 func (t *theNamespaceType) Name() string { return "let-go.lang.Namespace" }
-func (t *theNamespaceType) Box(fn interface{}) (Value, error) {
+func (t *theNamespaceType) Box(fn any) (Value, error) {
 	return NIL, NewTypeError(fn, "can't be boxed as", t)
 }
 
@@ -72,7 +72,7 @@ func (n *Namespace) IsExcluded(name Symbol) bool {
 func (n *Namespace) Type() ValueType { return NamespaceType }
 
 // Unbox implements Unbox
-func (n *Namespace) Unbox() interface{} {
+func (n *Namespace) Unbox() any {
 	return nil
 }
 

--- a/pkg/vm/native_func.go
+++ b/pkg/vm/native_func.go
@@ -12,12 +12,12 @@ import (
 
 type theNativeFnType struct{}
 
-func (t *theNativeFnType) String() string     { return t.Name() }
-func (t *theNativeFnType) Type() ValueType    { return TypeType }
-func (t *theNativeFnType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theNativeFnType) String() string  { return t.Name() }
+func (t *theNativeFnType) Type() ValueType { return TypeType }
+func (t *theNativeFnType) Unbox() any      { return reflect.TypeFor[*theNativeFnType]() }
 
 func (t *theNativeFnType) Name() string { return "let-go.lang.NativeFn" }
-func (t *theNativeFnType) Box(fn interface{}) (Value, error) {
+func (t *theNativeFnType) Box(fn any) (Value, error) {
 	ty := reflect.TypeOf(fn)
 	if ty.Kind() != reflect.Func {
 		return NIL, NewTypeError(fn, "can't be boxed into", t)
@@ -62,7 +62,7 @@ func (t *theNativeFnType) Box(fn interface{}) (Value, error) {
 		if err != nil {
 			return NIL, err
 		}
-		errorInterface := reflect.TypeOf((*error)(nil)).Elem()
+		errorInterface := reflect.TypeFor[error]()
 		if res[1].Type() == errorInterface && res[1].Interface() != nil {
 			return wv, res[1].Interface().(error)
 		}
@@ -126,7 +126,7 @@ type NativeFn struct {
 	name        string
 	arity       int
 	isVariadric bool
-	fn          interface{}
+	fn          any
 	proxy       func([]Value) (Value, error)
 }
 
@@ -135,7 +135,7 @@ func (l *NativeFn) SetName(n string) { l.name = n }
 func (l *NativeFn) Type() ValueType { return NativeFnType }
 
 // Unbox implements Unbox
-func (l *NativeFn) Unbox() interface{} {
+func (l *NativeFn) Unbox() any {
 	return l.fn
 }
 

--- a/pkg/vm/nil.go
+++ b/pkg/vm/nil.go
@@ -9,12 +9,12 @@ type theNilType struct {
 	zero *Nil
 }
 
-func (t *theNilType) String() string     { return t.Name() }
-func (t *theNilType) Type() ValueType    { return NilType }
-func (t *theNilType) Unbox() interface{} { return nil }
+func (t *theNilType) String() string  { return t.Name() }
+func (t *theNilType) Type() ValueType { return NilType }
+func (t *theNilType) Unbox() any      { return nil }
 
-func (t *theNilType) Name() string                     { return "nil" }
-func (t *theNilType) Box(_ interface{}) (Value, error) { return t.zero, nil }
+func (t *theNilType) Name() string             { return "nil" }
+func (t *theNilType) Box(_ any) (Value, error) { return t.zero, nil }
 
 // Nil is a Value whose only value is Nil
 type Nil struct{}
@@ -55,11 +55,11 @@ func (n *Nil) Seq() Seq {
 	return n
 }
 
-func (l *Nil) Assoc(k Value, v Value) Associative {
+func (n *Nil) Assoc(k Value, v Value) Associative {
 	return EmptyPersistentMap.Assoc(k, v)
 }
 
-func (l *Nil) Dissoc(k Value) Associative {
+func (n *Nil) Dissoc(k Value) Associative {
 	return NIL
 }
 
@@ -67,7 +67,7 @@ func (l *Nil) Dissoc(k Value) Associative {
 func (n *Nil) Type() ValueType { return NilType }
 
 // Unbox implements Value
-func (n *Nil) Unbox() interface{} { return nil }
+func (n *Nil) Unbox() any { return nil }
 
 // NilType is the type of NilValues
 var NilType *theNilType = &theNilType{zero: nil}

--- a/pkg/vm/persistent_map.go
+++ b/pkg/vm/persistent_map.go
@@ -22,12 +22,12 @@ const (
 
 type thePersistentMapType struct{}
 
-func (t *thePersistentMapType) String() string     { return t.Name() }
-func (t *thePersistentMapType) Type() ValueType    { return TypeType }
-func (t *thePersistentMapType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *thePersistentMapType) Name() string       { return "let-go.lang.PersistentHashMap" }
+func (t *thePersistentMapType) String() string  { return t.Name() }
+func (t *thePersistentMapType) Type() ValueType { return TypeType }
+func (t *thePersistentMapType) Unbox() any      { return reflect.TypeFor[*thePersistentMapType]() }
+func (t *thePersistentMapType) Name() string    { return "let-go.lang.PersistentHashMap" }
 
-func (t *thePersistentMapType) Box(bare interface{}) (Value, error) {
+func (t *thePersistentMapType) Box(bare any) (Value, error) {
 	if m, ok := bare.(*PersistentMap); ok {
 		return m, nil
 	}
@@ -53,8 +53,8 @@ type MapEntry struct {
 	Value Value
 }
 
-func (e MapEntry) Type() ValueType    { return ArrayVectorType }
-func (e MapEntry) Unbox() interface{} { return []Value{e.Key, e.Value} }
+func (e MapEntry) Type() ValueType { return ArrayVectorType }
+func (e MapEntry) Unbox() any      { return []Value{e.Key, e.Value} }
 func (e MapEntry) String() string {
 	return "[" + e.Key.String() + " " + e.Value.String() + "]"
 }
@@ -129,8 +129,8 @@ func hmapIndex(bitmap uint32, bit uint32) int {
 
 type hmapBitmapNode struct {
 	bitmap uint32
-	array  []interface{} // pairs: [key-or-nil, val-or-child, ...]
-	edit   *atomic.Bool  // non-nil for transient-owned nodes
+	array  []any        // pairs: [key-or-nil, val-or-child, ...]
+	edit   *atomic.Bool // non-nil for transient-owned nodes
 	// If array[2*i] == nil, then array[2*i+1] is an hmapNode child.
 	// If array[2*i] != nil, then array[2*i] is key and array[2*i+1] is value.
 }
@@ -194,7 +194,7 @@ func (n *hmapBitmapNode) assoc(shift uint, hash uint32, key Value, val Value, ad
 	// New entry — expand the array
 	*addedLeaf = true
 	nEntries := bits.OnesCount32(n.bitmap)
-	newArray := make([]interface{}, 2*(nEntries+1))
+	newArray := make([]any, 2*(nEntries+1))
 	// Copy entries before idx
 	copy(newArray, n.array[:2*idx])
 	// Insert new entry
@@ -249,7 +249,7 @@ func (n *hmapBitmapNode) dissoc(shift uint, hash uint32, key Value) hmapNode {
 func (n *hmapBitmapNode) nodeSeq() []MapEntry {
 	var entries []MapEntry
 	nSlots := len(n.array) / 2
-	for i := 0; i < nSlots; i++ {
+	for i := range nSlots {
 		keyOrNil := n.array[2*i]
 		valOrNode := n.array[2*i+1]
 		if keyOrNil != nil {
@@ -261,15 +261,15 @@ func (n *hmapBitmapNode) nodeSeq() []MapEntry {
 	return entries
 }
 
-func (n *hmapBitmapNode) cloneAndSet(i int, val interface{}) *hmapBitmapNode {
-	newArray := make([]interface{}, len(n.array))
+func (n *hmapBitmapNode) cloneAndSet(i int, val any) *hmapBitmapNode {
+	newArray := make([]any, len(n.array))
 	copy(newArray, n.array)
 	newArray[i] = val
 	return &hmapBitmapNode{bitmap: n.bitmap, array: newArray}
 }
 
-func (n *hmapBitmapNode) cloneAndSet2(i int, a interface{}, j int, b interface{}) *hmapBitmapNode {
-	newArray := make([]interface{}, len(n.array))
+func (n *hmapBitmapNode) cloneAndSet2(i int, a any, j int, b any) *hmapBitmapNode {
+	newArray := make([]any, len(n.array))
 	copy(newArray, n.array)
 	newArray[i] = a
 	newArray[j] = b
@@ -278,7 +278,7 @@ func (n *hmapBitmapNode) cloneAndSet2(i int, a interface{}, j int, b interface{}
 
 // editAndSet mutates in place if this node is owned by the given edit token,
 // otherwise clones and sets.
-func (n *hmapBitmapNode) editAndSet(edit *atomic.Bool, i int, val interface{}) *hmapBitmapNode {
+func (n *hmapBitmapNode) editAndSet(edit *atomic.Bool, i int, val any) *hmapBitmapNode {
 	if n.edit == edit {
 		n.array[i] = val
 		return n
@@ -286,7 +286,7 @@ func (n *hmapBitmapNode) editAndSet(edit *atomic.Bool, i int, val interface{}) *
 	return n.cloneAndSet(i, val)
 }
 
-func (n *hmapBitmapNode) editAndSet2(edit *atomic.Bool, i int, a interface{}, j int, b interface{}) *hmapBitmapNode {
+func (n *hmapBitmapNode) editAndSet2(edit *atomic.Bool, i int, a any, j int, b any) *hmapBitmapNode {
 	if n.edit == edit {
 		n.array[i] = a
 		n.array[j] = b
@@ -302,11 +302,8 @@ func (n *hmapBitmapNode) ensureEditable(edit *atomic.Bool) *hmapBitmapNode {
 	}
 	nEntries := bits.OnesCount32(n.bitmap)
 	// Allocate with room to grow (avoid frequent realloc during transient batch ops)
-	newLen := 2 * (nEntries + 1)
-	if newLen < len(n.array) {
-		newLen = len(n.array)
-	}
-	newArray := make([]interface{}, newLen)
+	newLen := max(2*(nEntries+1), len(n.array))
+	newArray := make([]any, newLen)
 	copy(newArray, n.array)
 	return &hmapBitmapNode{bitmap: n.bitmap, array: newArray[:len(n.array)], edit: edit}
 }
@@ -356,7 +353,7 @@ func (n *hmapBitmapNode) assocTransient(edit *atomic.Bool, shift uint, hash uint
 	nEntries := bits.OnesCount32(n.bitmap)
 	editable := n.ensureEditable(edit)
 	// Need to grow the array
-	newArray := make([]interface{}, 2*(nEntries+1))
+	newArray := make([]any, 2*(nEntries+1))
 	copy(newArray, editable.array[:2*idx])
 	newArray[2*idx] = key
 	newArray[2*idx+1] = val
@@ -367,7 +364,7 @@ func (n *hmapBitmapNode) assocTransient(edit *atomic.Bool, shift uint, hash uint
 }
 
 func (n *hmapBitmapNode) removePair(idx int) *hmapBitmapNode {
-	newArray := make([]interface{}, len(n.array)-2)
+	newArray := make([]any, len(n.array)-2)
 	copy(newArray, n.array[:2*idx])
 	copy(newArray[2*idx:], n.array[2*(idx+1):])
 	bit := uint32(1) << uint(n.indexToBit(idx))
@@ -383,7 +380,7 @@ func (n *hmapBitmapNode) removePair(idx int) *hmapBitmapNode {
 func (n *hmapBitmapNode) bitAtIndex(idx int) uint32 {
 	// Walk the bitmap to find the idx-th set bit
 	b := n.bitmap
-	for i := 0; i < idx; i++ {
+	for range idx {
 		b &= b - 1 // Clear lowest set bit
 	}
 	return b & (^b + 1) // Isolate lowest set bit
@@ -391,7 +388,7 @@ func (n *hmapBitmapNode) bitAtIndex(idx int) uint32 {
 
 func (n *hmapBitmapNode) indexToBit(idx int) int {
 	b := n.bitmap
-	for i := 0; i < idx; i++ {
+	for range idx {
 		b &= b - 1
 	}
 	return bits.TrailingZeros32(b)
@@ -404,7 +401,7 @@ func createNode(shift uint, hash1 uint32, key1 Value, val1 Value, hash2 uint32, 
 		return &hmapCollisionNode{
 			hash:  hash1,
 			count: 2,
-			array: []interface{}{key1, val1, key2, val2},
+			array: []any{key1, val1, key2, val2},
 		}
 	}
 	addedLeaf := false
@@ -417,7 +414,7 @@ func createNode(shift uint, hash1 uint32, key1 Value, val1 Value, hash2 uint32, 
 type hmapCollisionNode struct {
 	hash  uint32
 	count int
-	array []interface{} // pairs: [key0, val0, key1, val1, ...]
+	array []any // pairs: [key0, val0, key1, val1, ...]
 }
 
 func (n *hmapCollisionNode) find(shift uint, hash uint32, key Value) (Value, bool) {
@@ -437,14 +434,14 @@ func (n *hmapCollisionNode) assoc(shift uint, hash uint32, key Value, val Value,
 			if valueEquiv(n.array[idx+1].(Value), val) {
 				return n
 			}
-			newArray := make([]interface{}, len(n.array))
+			newArray := make([]any, len(n.array))
 			copy(newArray, n.array)
 			newArray[idx+1] = val
 			return &hmapCollisionNode{hash: n.hash, count: n.count, array: newArray}
 		}
 		// New key in collision bucket
 		*addedLeaf = true
-		newArray := make([]interface{}, len(n.array)+2)
+		newArray := make([]any, len(n.array)+2)
 		copy(newArray, n.array)
 		newArray[len(n.array)] = key
 		newArray[len(n.array)+1] = val
@@ -454,7 +451,7 @@ func (n *hmapCollisionNode) assoc(shift uint, hash uint32, key Value, val Value,
 	*addedLeaf = true
 	newNode := &hmapBitmapNode{
 		bitmap: hmapBitpos(n.hash, shift),
-		array:  []interface{}{nil, n},
+		array:  []any{nil, n},
 	}
 	return newNode.assoc(shift, hash, key, val, addedLeaf)
 }
@@ -479,7 +476,7 @@ func (n *hmapCollisionNode) dissoc(shift uint, hash uint32, key Value) hmapNode 
 		return (&hmapBitmapNode{}).assoc(0, n.hash, remainKey, remainVal, &addedLeaf)
 	}
 	// Remove the pair at idx
-	newArray := make([]interface{}, len(n.array)-2)
+	newArray := make([]any, len(n.array)-2)
 	copy(newArray, n.array[:idx])
 	copy(newArray[idx:], n.array[idx+2:])
 	return &hmapCollisionNode{hash: n.hash, count: n.count - 1, array: newArray}
@@ -592,8 +589,8 @@ func (m *PersistentMap) Hash() uint32 {
 	return m._hash
 }
 
-func (m *PersistentMap) Type() ValueType    { return MapType }
-func (m *PersistentMap) Unbox() interface{} { return m }
+func (m *PersistentMap) Type() ValueType { return MapType }
+func (m *PersistentMap) Unbox() any      { return m }
 
 func (m *PersistentMap) String() string {
 	b := &strings.Builder{}

--- a/pkg/vm/persistent_map_test.go
+++ b/pkg/vm/persistent_map_test.go
@@ -92,13 +92,13 @@ func TestPersistentMapEmpty(t *testing.T) {
 func TestPersistentMapLarge(t *testing.T) {
 	m := EmptyPersistentMap
 	n := 1000
-	for i := 0; i < n; i++ {
+	for i := range n {
 		m = m.Assoc(Int(i), Int(i*10)).(*PersistentMap)
 	}
 	if m.RawCount() != n {
 		t.Errorf("expected count %d, got %d", n, m.RawCount())
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		v := m.ValueAt(Int(i))
 		if v != Int(i*10) {
 			t.Errorf("at key %d: expected %d, got %v", i, i*10, v)
@@ -318,14 +318,14 @@ func TestPersistentMapHashCollision(t *testing.T) {
 	// With 1000+ keys, some will share prefix bits and exercise deeper trie levels.
 	m := EmptyPersistentMap
 	n := 500
-	for i := 0; i < n; i++ {
+	for i := range n {
 		k := String(fmt.Sprintf("key-%d", i))
 		m = m.Assoc(k, Int(i)).(*PersistentMap)
 	}
 	if m.RawCount() != n {
 		t.Fatalf("expected count %d, got %d", n, m.RawCount())
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		k := String(fmt.Sprintf("key-%d", i))
 		v := m.ValueAt(k)
 		if v != Int(i) {
@@ -341,7 +341,7 @@ func TestPersistentMapHashCollision(t *testing.T) {
 	if m.RawCount() != expectedCount {
 		t.Fatalf("after dissoc expected count %d, got %d", expectedCount, m.RawCount())
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		k := String(fmt.Sprintf("key-%d", i))
 		v := m.ValueAt(k)
 		if i%2 == 0 {
@@ -363,7 +363,7 @@ func TestPersistentMapCollisionNode(t *testing.T) {
 	cn := &hmapCollisionNode{
 		hash:  12345,
 		count: 2,
-		array: []interface{}{Keyword("a"), Int(1), Keyword("b"), Int(2)},
+		array: []any{Keyword("a"), Int(1), Keyword("b"), Int(2)},
 	}
 
 	// find
@@ -416,11 +416,11 @@ func TestPersistentMapCollisionNode(t *testing.T) {
 func TestPersistentMapLargeDissoc(t *testing.T) {
 	m := EmptyPersistentMap
 	n := 200
-	for i := 0; i < n; i++ {
+	for i := range n {
 		m = m.Assoc(Int(i), Int(i)).(*PersistentMap)
 	}
 	// Remove all
-	for i := 0; i < n; i++ {
+	for i := range n {
 		m = m.Dissoc(Int(i)).(*PersistentMap)
 	}
 	if m.RawCount() != 0 {

--- a/pkg/vm/persistent_set.go
+++ b/pkg/vm/persistent_set.go
@@ -35,8 +35,8 @@ func NewPersistentSet(vals []Value) *PersistentSet {
 
 // --- Value interface ---
 
-func (s *PersistentSet) Type() ValueType    { return SetType }
-func (s *PersistentSet) Unbox() interface{} { return s.keys() }
+func (s *PersistentSet) Type() ValueType { return SetType }
+func (s *PersistentSet) Unbox() any      { return s.keys() }
 
 func (s *PersistentSet) String() string {
 	b := &strings.Builder{}

--- a/pkg/vm/persistent_vector.go
+++ b/pkg/vm/persistent_vector.go
@@ -18,21 +18,21 @@ const (
 )
 
 type vnode struct {
-	array []interface{} // can hold either Values or other nodes
+	array []any // can hold either Values or other nodes
 }
 
 func newNode() *vnode {
-	return &vnode{array: make([]interface{}, 0, nodeCap)}
+	return &vnode{array: make([]any, 0, nodeCap)}
 }
 
 type thePersistentVectorType struct{}
 
-func (t *thePersistentVectorType) String() string     { return t.Name() }
-func (t *thePersistentVectorType) Type() ValueType    { return TypeType }
-func (t *thePersistentVectorType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *thePersistentVectorType) Name() string       { return "let-go.lang.PersistentVector" }
+func (t *thePersistentVectorType) String() string  { return t.Name() }
+func (t *thePersistentVectorType) Type() ValueType { return TypeType }
+func (t *thePersistentVectorType) Unbox() any      { return reflect.TypeFor[*thePersistentVectorType]() }
+func (t *thePersistentVectorType) Name() string    { return "let-go.lang.PersistentVector" }
 
-func (t *thePersistentVectorType) Box(bare interface{}) (Value, error) {
+func (t *thePersistentVectorType) Box(bare any) (Value, error) {
 	arr, ok := bare.([]Value)
 	if !ok {
 		return NIL, NewTypeError(bare, "can't be boxed as", t)
@@ -90,7 +90,7 @@ func (v PersistentVector) String() string {
 }
 
 // Unbox implements Value
-func (v PersistentVector) Unbox() interface{} {
+func (v PersistentVector) Unbox() any {
 	ret := make([]Value, v.count)
 	for i := 0; i < v.count; i++ {
 		ret[i] = v.ValueAt(Int(i))
@@ -353,7 +353,7 @@ func pushTail(level uint, parent *vnode, tailOff int, tail []Value) *vnode {
 	subidx := (tailOff >> level) & nodeMask
 
 	// Copy parent
-	ret := &vnode{array: make([]interface{}, len(parent.array))}
+	ret := &vnode{array: make([]any, len(parent.array))}
 	copy(ret.array, parent.array)
 
 	if level == shift {
@@ -485,7 +485,7 @@ func (v PersistentVector) Assoc(key Value, val Value) Associative {
 }
 
 func (v PersistentVector) doAssoc(n *vnode, level uint, idx int, val Value) *vnode {
-	newNode := &vnode{array: make([]interface{}, len(n.array))}
+	newNode := &vnode{array: make([]any, len(n.array))}
 	copy(newNode.array, n.array)
 
 	if level == 0 {
@@ -556,10 +556,10 @@ func NewPersistentVector(values []Value) Value {
 	// Build leaf nodes
 	leafCount := treeSize / nodeCap
 	leaves := make([]*vnode, leafCount)
-	for i := 0; i < leafCount; i++ {
-		node := &vnode{array: make([]interface{}, nodeCap)}
+	for i := range leafCount {
+		node := &vnode{array: make([]any, nodeCap)}
 		base := i * nodeCap
-		for j := 0; j < nodeCap; j++ {
+		for j := range nodeCap {
 			node.array[j] = values[base+j]
 		}
 		leaves[i] = node
@@ -571,13 +571,10 @@ func NewPersistentVector(values []Value) Value {
 	for len(currentLevel) > nodeCap {
 		parentCount := (len(currentLevel) + nodeCap - 1) / nodeCap
 		parents := make([]*vnode, parentCount)
-		for i := 0; i < parentCount; i++ {
+		for i := range parentCount {
 			start := i * nodeCap
-			end := start + nodeCap
-			if end > len(currentLevel) {
-				end = len(currentLevel)
-			}
-			node := &vnode{array: make([]interface{}, end-start)}
+			end := min(start+nodeCap, len(currentLevel))
+			node := &vnode{array: make([]any, end-start)}
 			for j := start; j < end; j++ {
 				node.array[j-start] = currentLevel[j]
 			}
@@ -588,7 +585,7 @@ func NewPersistentVector(values []Value) Value {
 	}
 
 	// Final root node wrapping the top-level nodes
-	root := &vnode{array: make([]interface{}, len(currentLevel))}
+	root := &vnode{array: make([]any, len(currentLevel))}
 	for i, n := range currentLevel {
 		root.array[i] = n
 	}
@@ -613,9 +610,9 @@ func (s *PersistentVectorSeq) Type() ValueType {
 }
 
 // Unbox implements Value
-func (s *PersistentVectorSeq) Unbox() interface{} {
+func (s *PersistentVectorSeq) Unbox() any {
 	vals := make([]Value, s.vec.count-s.i)
-	for i := 0; i < len(vals); i++ {
+	for i := range vals {
 		vals[i] = s.vec.ValueAt(Int(s.i + i))
 	}
 	return vals
@@ -650,12 +647,12 @@ func (s *PersistentVectorSeq) Conj(val Value) Collection {
 
 type theSequenceType struct{}
 
-func (t *theSequenceType) String() string     { return t.Name() }
-func (t *theSequenceType) Type() ValueType    { return TypeType }
-func (t *theSequenceType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theSequenceType) Name() string       { return "let-go.lang.Sequence" }
+func (t *theSequenceType) String() string  { return t.Name() }
+func (t *theSequenceType) Type() ValueType { return TypeType }
+func (t *theSequenceType) Unbox() any      { return reflect.TypeFor[*theSequenceType]() }
+func (t *theSequenceType) Name() string    { return "let-go.lang.Sequence" }
 
-func (t *theSequenceType) Box(bare interface{}) (Value, error) {
+func (t *theSequenceType) Box(bare any) (Value, error) {
 	return nil, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -50,8 +50,8 @@ func (p *Promise) IsRealized() bool {
 	return p.delivered
 }
 
-func (p *Promise) Type() ValueType    { return PromiseType }
-func (p *Promise) Unbox() interface{} { return p }
+func (p *Promise) Type() ValueType { return PromiseType }
+func (p *Promise) Unbox() any      { return p }
 func (p *Promise) String() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -63,11 +63,11 @@ func (p *Promise) String() string {
 
 type thePromiseType struct{}
 
-func (t *thePromiseType) String() string     { return t.Name() }
-func (t *thePromiseType) Type() ValueType    { return TypeType }
-func (t *thePromiseType) Unbox() interface{} { return nil }
-func (t *thePromiseType) Name() string       { return "let-go.lang.Promise" }
-func (t *thePromiseType) Box(bare interface{}) (Value, error) {
+func (t *thePromiseType) String() string  { return t.Name() }
+func (t *thePromiseType) Type() ValueType { return TypeType }
+func (t *thePromiseType) Unbox() any      { return nil }
+func (t *thePromiseType) Name() string    { return "let-go.lang.Promise" }
+func (t *thePromiseType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/protocol.go
+++ b/pkg/vm/protocol.go
@@ -23,11 +23,11 @@ func NewProtocol(name string, methods []Symbol) *Protocol {
 	}
 }
 
-func (p *Protocol) Type() ValueType    { return ProtocolType }
-func (p *Protocol) Unbox() interface{} { return p }
-func (p *Protocol) String() string     { return fmt.Sprintf("<protocol %s>", p.name) }
-func (p *Protocol) Name() string       { return p.name }
-func (p *Protocol) Methods() []Symbol  { return p.methods }
+func (p *Protocol) Type() ValueType   { return ProtocolType }
+func (p *Protocol) Unbox() any        { return p }
+func (p *Protocol) String() string    { return fmt.Sprintf("<protocol %s>", p.name) }
+func (p *Protocol) Name() string      { return p.name }
+func (p *Protocol) Methods() []Symbol { return p.methods }
 
 // Extend adds implementations for a type.
 // implMap is a PersistentMap of {method-keyword → fn}.
@@ -95,8 +95,8 @@ func NewProtocolFn(protocol *Protocol, methodName Symbol) *ProtocolFn {
 	}
 }
 
-func (f *ProtocolFn) Type() ValueType    { return FuncType }
-func (f *ProtocolFn) Unbox() interface{} { return f }
+func (f *ProtocolFn) Type() ValueType { return FuncType }
+func (f *ProtocolFn) Unbox() any      { return f }
 func (f *ProtocolFn) String() string {
 	return fmt.Sprintf("<protocol-fn %s/%s>", f.protocol.name, f.name)
 }
@@ -124,11 +124,11 @@ func (f *ProtocolFn) Invoke(args []Value) (Value, error) {
 
 type theProtocolType struct{}
 
-func (t *theProtocolType) String() string     { return t.Name() }
-func (t *theProtocolType) Type() ValueType    { return TypeType }
-func (t *theProtocolType) Unbox() interface{} { return nil }
-func (t *theProtocolType) Name() string       { return "let-go.lang.Protocol" }
-func (t *theProtocolType) Box(bare interface{}) (Value, error) {
+func (t *theProtocolType) String() string  { return t.Name() }
+func (t *theProtocolType) Type() ValueType { return TypeType }
+func (t *theProtocolType) Unbox() any      { return nil }
+func (t *theProtocolType) Name() string    { return "let-go.lang.Protocol" }
+func (t *theProtocolType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/range.go
+++ b/pkg/vm/range.go
@@ -11,13 +11,13 @@ import (
 
 type theRangeType struct{}
 
-func (t *theRangeType) String() string     { return t.Name() }
-func (t *theRangeType) Type() ValueType    { return TypeType }
-func (t *theRangeType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theRangeType) String() string  { return t.Name() }
+func (t *theRangeType) Type() ValueType { return TypeType }
+func (t *theRangeType) Unbox() any      { return reflect.TypeFor[*theRangeType]() }
 
 func (t *theRangeType) Name() string { return "let-go.lang.Range" }
 
-func (t *theRangeType) Box(bare interface{}) (Value, error) {
+func (t *theRangeType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 
@@ -43,7 +43,7 @@ func (l *Range) inBounds(val int) bool {
 func (l *Range) Type() ValueType { return RangeType }
 
 // Unbox implements Value
-func (l *Range) Unbox() interface{} {
+func (l *Range) Unbox() any {
 	return nil
 }
 
@@ -152,9 +152,9 @@ func NewInfiniteRange(start, step int) *InfiniteRange {
 	return &InfiniteRange{start: start, step: step}
 }
 
-func (r *InfiniteRange) Type() ValueType    { return RangeType }
-func (r *InfiniteRange) Unbox() interface{} { return nil }
-func (r *InfiniteRange) First() Value       { return Int(r.start) }
+func (r *InfiniteRange) Type() ValueType { return RangeType }
+func (r *InfiniteRange) Unbox() any      { return nil }
+func (r *InfiniteRange) First() Value    { return Int(r.start) }
 
 func (r *InfiniteRange) Next() Seq {
 	return &InfiniteRange{start: r.start + r.step, step: r.step}

--- a/pkg/vm/ratio.go
+++ b/pkg/vm/ratio.go
@@ -8,12 +8,12 @@ import (
 
 type theRatioType struct{}
 
-func (t *theRatioType) String() string     { return t.Name() }
-func (t *theRatioType) Type() ValueType    { return TypeType }
-func (t *theRatioType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theRatioType) Name() string       { return "let-go.lang.Ratio" }
+func (t *theRatioType) String() string  { return t.Name() }
+func (t *theRatioType) Type() ValueType { return TypeType }
+func (t *theRatioType) Unbox() any      { return reflect.TypeFor[*theRatioType]() }
+func (t *theRatioType) Name() string    { return "let-go.lang.Ratio" }
 
-func (t *theRatioType) Box(bare interface{}) (Value, error) {
+func (t *theRatioType) Box(bare any) (Value, error) {
 	switch v := bare.(type) {
 	case *big.Rat:
 		return NewRatio(v), nil
@@ -38,8 +38,8 @@ func NewRatioFromInts(num, den int64) *Ratio {
 
 func (r *Ratio) Val() *big.Rat { return r.val }
 
-func (r *Ratio) Type() ValueType    { return RatioType }
-func (r *Ratio) Unbox() interface{} { return r.val }
+func (r *Ratio) Type() ValueType { return RatioType }
+func (r *Ratio) Unbox() any      { return r.val }
 
 func (r *Ratio) String() string {
 	return r.val.RatString()

--- a/pkg/vm/record.go
+++ b/pkg/vm/record.go
@@ -26,13 +26,13 @@ func NewRecordType(name string, fields []Keyword) *RecordType {
 	return &RecordType{typeName: name, fields: fields, fieldIdx: idx}
 }
 
-func (t *RecordType) String() string     { return t.Name() }
-func (t *RecordType) Type() ValueType    { return TypeType }
-func (t *RecordType) Unbox() interface{} { return t }
-func (t *RecordType) Name() string       { return t.typeName }
-func (t *RecordType) Fields() []Keyword  { return t.fields }
+func (t *RecordType) String() string    { return t.Name() }
+func (t *RecordType) Type() ValueType   { return TypeType }
+func (t *RecordType) Unbox() any        { return t }
+func (t *RecordType) Name() string      { return t.typeName }
+func (t *RecordType) Fields() []Keyword { return t.fields }
 
-func (t *RecordType) Box(bare interface{}) (Value, error) {
+func (t *RecordType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 
@@ -45,7 +45,7 @@ type Record struct {
 	fields []Value        // fixed fields, indexed by RecordType.fieldIdx
 	extra  *PersistentMap // overflow for assoc'd keys not in the record definition
 	meta   Value
-	origin interface{} // original Go struct for fast roundtrip (nil if mutated)
+	origin any // original Go struct for fast roundtrip (nil if mutated)
 }
 
 func NewRecord(rtype *RecordType, data *PersistentMap) *Record {
@@ -84,7 +84,7 @@ func NewRecord(rtype *RecordType, data *PersistentMap) *Record {
 // --- Value interface ---
 
 func (r *Record) Type() ValueType { return r.rtype }
-func (r *Record) Unbox() interface{} {
+func (r *Record) Unbox() any {
 	if r.origin != nil {
 		return r.origin
 	}
@@ -92,7 +92,7 @@ func (r *Record) Unbox() interface{} {
 }
 
 // Origin returns the original Go struct if this Record was created from one, or nil.
-func (r *Record) Origin() interface{} { return r.origin }
+func (r *Record) Origin() any { return r.origin }
 
 func (r *Record) String() string {
 	b := &strings.Builder{}
@@ -343,7 +343,7 @@ func (r *Record) FixedFields() []Value { return r.fields }
 func (r *Record) Extra() *PersistentMap { return r.extra }
 
 // TypeName returns the record type name.
-func (rt *RecordType) TypeName() string { return rt.typeName }
+func (t *RecordType) TypeName() string { return t.typeName }
 
 // --- RecordType accessor ---
 

--- a/pkg/vm/reduced.go
+++ b/pkg/vm/reduced.go
@@ -11,9 +11,9 @@ func NewReduced(v Value) *Reduced {
 	return &Reduced{value: v}
 }
 
-func (r *Reduced) Deref() Value       { return r.value }
-func (r *Reduced) Type() ValueType    { return ReducedType }
-func (r *Reduced) Unbox() interface{} { return r.value }
+func (r *Reduced) Deref() Value    { return r.value }
+func (r *Reduced) Type() ValueType { return ReducedType }
+func (r *Reduced) Unbox() any      { return r.value }
 func (r *Reduced) String() string {
 	return fmt.Sprintf("#reduced<%s>", r.value.String())
 }
@@ -26,11 +26,11 @@ func IsReduced(v Value) bool {
 // ReducedType
 type theReducedType struct{}
 
-func (t *theReducedType) String() string     { return t.Name() }
-func (t *theReducedType) Type() ValueType    { return TypeType }
-func (t *theReducedType) Unbox() interface{} { return nil }
-func (t *theReducedType) Name() string       { return "let-go.lang.Reduced" }
-func (t *theReducedType) Box(bare interface{}) (Value, error) {
+func (t *theReducedType) String() string  { return t.Name() }
+func (t *theReducedType) Type() ValueType { return TypeType }
+func (t *theReducedType) Unbox() any      { return nil }
+func (t *theReducedType) Name() string    { return "let-go.lang.Reduced" }
+func (t *theReducedType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -14,13 +14,13 @@ import (
 type theRegexType struct {
 }
 
-func (t *theRegexType) String() string     { return t.Name() }
-func (t *theRegexType) Type() ValueType    { return TypeType }
-func (t *theRegexType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theRegexType) String() string  { return t.Name() }
+func (t *theRegexType) Type() ValueType { return TypeType }
+func (t *theRegexType) Unbox() any      { return reflect.TypeFor[*theRegexType]() }
 
 func (t *theRegexType) Name() string { return "let-go.lang.Regex" }
 
-func (t *theRegexType) Box(bare interface{}) (Value, error) {
+func (t *theRegexType) Box(bare any) (Value, error) {
 	raw, ok := bare.(*regexp.Regexp)
 	if !ok {
 		return NIL, NewTypeError(bare, "can't be boxed as", t)
@@ -40,7 +40,7 @@ type Regex struct {
 func (l *Regex) Type() ValueType { return RegexType }
 
 // Unbox implements Unbox
-func (l *Regex) Unbox() interface{} {
+func (l *Regex) Unbox() any {
 	return l
 }
 

--- a/pkg/vm/repeat.go
+++ b/pkg/vm/repeat.go
@@ -11,12 +11,12 @@ type theRepeatType struct {
 	zero *Repeat
 }
 
-func (t *theRepeatType) String() string     { return t.Name() }
-func (t *theRepeatType) Type() ValueType    { return RepeatType }
-func (t *theRepeatType) Unbox() interface{} { return nil }
+func (t *theRepeatType) String() string  { return t.Name() }
+func (t *theRepeatType) Type() ValueType { return RepeatType }
+func (t *theRepeatType) Unbox() any      { return nil }
 
-func (t *theRepeatType) Name() string                     { return "let-go.lang.Repeat" }
-func (t *theRepeatType) Box(_ interface{}) (Value, error) { return t.zero, nil }
+func (t *theRepeatType) Name() string             { return "let-go.lang.Repeat" }
+func (t *theRepeatType) Box(_ any) (Value, error) { return t.zero, nil }
 
 // Repeat is a Value whose only value is Repeat
 type Repeat struct {
@@ -77,7 +77,7 @@ func (n *Repeat) RawCount() int {
 func (n *Repeat) Type() ValueType { return RepeatType }
 
 // Unbox implements Value
-func (n *Repeat) Unbox() interface{} { return nil }
+func (n *Repeat) Unbox() any { return nil }
 
 // RepeatType is the type of RepeatValues
 var RepeatType *theRepeatType = &theRepeatType{zero: nil}

--- a/pkg/vm/set.go
+++ b/pkg/vm/set.go
@@ -13,13 +13,13 @@ import (
 
 type theSetType struct{}
 
-func (t *theSetType) String() string     { return t.Name() }
-func (t *theSetType) Type() ValueType    { return TypeType }
-func (t *theSetType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theSetType) String() string  { return t.Name() }
+func (t *theSetType) Type() ValueType { return TypeType }
+func (t *theSetType) Unbox() any      { return reflect.TypeFor[*theSetType]() }
 
 func (t *theSetType) Name() string { return "let-go.lang.Set" }
 
-func (t *theSetType) Box(bare interface{}) (Value, error) {
+func (t *theSetType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 
@@ -87,7 +87,7 @@ func (l Set) keys() []Value {
 }
 
 // Unbox implements Value
-func (l Set) Unbox() interface{} {
+func (l Set) Unbox() any {
 	return l.keys()
 }
 
@@ -146,8 +146,8 @@ func (s *SetSeq) String() string {
 	return b.String()
 }
 
-func (s *SetSeq) Type() ValueType    { return ListType }
-func (s *SetSeq) Unbox() interface{} { return s.keys[s.i:] }
+func (s *SetSeq) Type() ValueType { return ListType }
+func (s *SetSeq) Unbox() any      { return s.keys[s.i:] }
 
 func (s *SetSeq) First() Value {
 	if s.i >= len(s.keys) {

--- a/pkg/vm/sorted_map.go
+++ b/pkg/vm/sorted_map.go
@@ -15,12 +15,12 @@ import (
 
 type theSortedMapType struct{}
 
-func (t *theSortedMapType) String() string     { return t.Name() }
-func (t *theSortedMapType) Type() ValueType    { return TypeType }
-func (t *theSortedMapType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theSortedMapType) Name() string       { return "let-go.lang.PersistentTreeMap" }
+func (t *theSortedMapType) String() string  { return t.Name() }
+func (t *theSortedMapType) Type() ValueType { return TypeType }
+func (t *theSortedMapType) Unbox() any      { return reflect.TypeFor[*theSortedMapType]() }
+func (t *theSortedMapType) Name() string    { return "let-go.lang.PersistentTreeMap" }
 
-func (t *theSortedMapType) Box(bare interface{}) (Value, error) {
+func (t *theSortedMapType) Box(bare any) (Value, error) {
 	if m, ok := bare.(*SortedMap); ok {
 		return m, nil
 	}
@@ -335,8 +335,8 @@ func (m *SortedMap) assocImpl(key, val Value) *SortedMap {
 
 // --- Value ---
 
-func (m *SortedMap) Type() ValueType    { return SortedMapType }
-func (m *SortedMap) Unbox() interface{} { return m.entries() }
+func (m *SortedMap) Type() ValueType { return SortedMapType }
+func (m *SortedMap) Unbox() any      { return m.entries() }
 
 func (m *SortedMap) String() string {
 	b := &strings.Builder{}
@@ -547,8 +547,8 @@ type SortedMapSeq struct {
 	i       int
 }
 
-func (s *SortedMapSeq) Type() ValueType    { return ListType }
-func (s *SortedMapSeq) Unbox() interface{} { return s.entries[s.i:] }
+func (s *SortedMapSeq) Type() ValueType { return ListType }
+func (s *SortedMapSeq) Unbox() any      { return s.entries[s.i:] }
 
 func (s *SortedMapSeq) String() string {
 	b := &strings.Builder{}

--- a/pkg/vm/sorted_set.go
+++ b/pkg/vm/sorted_set.go
@@ -14,12 +14,12 @@ import (
 
 type theSortedSetType struct{}
 
-func (t *theSortedSetType) String() string     { return t.Name() }
-func (t *theSortedSetType) Type() ValueType    { return TypeType }
-func (t *theSortedSetType) Unbox() interface{} { return t }
-func (t *theSortedSetType) Name() string       { return "let-go.lang.PersistentTreeSet" }
+func (t *theSortedSetType) String() string  { return t.Name() }
+func (t *theSortedSetType) Type() ValueType { return TypeType }
+func (t *theSortedSetType) Unbox() any      { return t }
+func (t *theSortedSetType) Name() string    { return "let-go.lang.PersistentTreeSet" }
 
-func (t *theSortedSetType) Box(bare interface{}) (Value, error) {
+func (t *theSortedSetType) Box(bare any) (Value, error) {
 	if s, ok := bare.(*SortedSet); ok {
 		return s, nil
 	}
@@ -52,8 +52,8 @@ func NewSortedSet(cmp Comparator, vals []Value) *SortedSet {
 
 // --- Value ---
 
-func (s *SortedSet) Type() ValueType    { return SortedSetType }
-func (s *SortedSet) Unbox() interface{} { return s.elements() }
+func (s *SortedSet) Type() ValueType { return SortedSetType }
+func (s *SortedSet) Unbox() any      { return s.elements() }
 
 func (s *SortedSet) String() string {
 	b := &strings.Builder{}
@@ -260,8 +260,8 @@ type SortedSetSeq struct {
 	i    int
 }
 
-func (s *SortedSetSeq) Type() ValueType    { return ListType }
-func (s *SortedSetSeq) Unbox() interface{} { return s.keys[s.i:] }
+func (s *SortedSetSeq) Type() ValueType { return ListType }
+func (s *SortedSetSeq) Unbox() any      { return s.keys[s.i:] }
 
 func (s *SortedSetSeq) String() string {
 	b := &strings.Builder{}

--- a/pkg/vm/source.go
+++ b/pkg/vm/source.go
@@ -134,11 +134,11 @@ func splitLines(s string) []string {
 // Used by the compiler to attach source info to bytecode.
 // Only pointer-based types (like *List) can be tracked; slice/value types
 // are not hashable and are silently ignored.
-var FormSource = &formSourceMap{m: map[interface{}]*SourceInfo{}}
+var FormSource = &formSourceMap{m: map[any]*SourceInfo{}}
 
 type formSourceMap struct {
 	mu sync.RWMutex
-	m  map[interface{}]*SourceInfo
+	m  map[any]*SourceInfo
 }
 
 // Set associates a source location with a form value.

--- a/pkg/vm/string.go
+++ b/pkg/vm/string.go
@@ -15,13 +15,13 @@ type theStringType struct {
 	zero String
 }
 
-func (t *theStringType) String() string     { return t.Name() }
-func (t *theStringType) Type() ValueType    { return TypeType }
-func (t *theStringType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theStringType) String() string  { return t.Name() }
+func (t *theStringType) Type() ValueType { return TypeType }
+func (t *theStringType) Unbox() any      { return reflect.TypeFor[*theStringType]() }
 
 func (t *theStringType) Name() string { return "let-go.lang.String" }
 
-func (t *theStringType) Box(bare interface{}) (Value, error) {
+func (t *theStringType) Box(bare any) (Value, error) {
 	raw, ok := bare.(string)
 	if !ok {
 		return StringType.zero, NewTypeError(bare, "can't be boxed as", t)
@@ -58,7 +58,7 @@ func (l String) Hash() uint32 { return hashString(string(l)) }
 func (l String) Type() ValueType { return StringType }
 
 // Unbox implements Unbox
-func (l String) Unbox() interface{} {
+func (l String) Unbox() any {
 	return string(l)
 }
 
@@ -66,15 +66,15 @@ func (l String) InvokeMethod(name Symbol, args []Value) (Value, error) {
 	switch name {
 	case "replace":
 		if len(args) != 2 {
-			return NIL, fmt.Errorf("String.replace expected 2 arguments")
+			return NIL, fmt.Errorf("string.replace expected 2 arguments")
 		}
 		old, ok := args[0].(String)
 		if !ok {
-			return NIL, fmt.Errorf("String.replace expected String target")
+			return NIL, fmt.Errorf("string.replace expected string target")
 		}
 		repl, ok := args[1].(String)
 		if !ok {
-			return NIL, fmt.Errorf("String.replace expected String replacement")
+			return NIL, fmt.Errorf("string.replace expected string replacement")
 		}
 		return String(strings.ReplaceAll(string(l), string(old), string(repl))), nil
 	case "getBytes":
@@ -86,17 +86,17 @@ func (l String) InvokeMethod(name Symbol, args []Value) (Value, error) {
 		if len(args) == 1 {
 			enc, ok := args[0].(String)
 			if !ok {
-				return NIL, fmt.Errorf("String.getBytes encoding must be String, got %s", args[0].Type().Name())
+				return NIL, fmt.Errorf("string.getBytes encoding must be string, got %s", args[0].Type().Name())
 			}
 			e := strings.ToUpper(string(enc))
 			if e != "UTF-8" && e != "UTF8" {
-				return NIL, fmt.Errorf("String.getBytes: only UTF-8 supported, got %q", string(enc))
+				return NIL, fmt.Errorf("string.getBytes: only UTF-8 supported, got %q", string(enc))
 			}
 			return NewByteArrayFrom([]byte(string(l))), nil
 		}
-		return NIL, fmt.Errorf("String.getBytes expected 0 or 1 argument, got %d", len(args))
+		return NIL, fmt.Errorf("string.getBytes expected 0 or 1 argument, got %d", len(args))
 	default:
-		return NIL, fmt.Errorf("method %s not found on String", name)
+		return NIL, fmt.Errorf("method %s not found on string", name)
 	}
 }
 

--- a/pkg/vm/struct_mapping.go
+++ b/pkg/vm/struct_mapping.go
@@ -32,7 +32,7 @@ var structMappingsByRecord = map[*RecordType]*StructMapping{}
 // converted from CamelCase to kebab-case (e.g. FirstName → first-name).
 // Fields tagged `letgo:"-"` are skipped.
 func RegisterStructType(goType reflect.Type, name string) *StructMapping {
-	if goType.Kind() == reflect.Ptr {
+	if goType.Kind() == reflect.Pointer {
 		goType = goType.Elem()
 	}
 	if goType.Kind() != reflect.Struct {
@@ -103,7 +103,7 @@ func makeFieldConverter(t reflect.Type) fieldConverter {
 		return func(v reflect.Value) Value { return String(v.String()) }
 	case reflect.Interface:
 		// If the field is already a Value (e.g. vm.Value), return it directly.
-		valueInterface := reflect.TypeOf((*Value)(nil)).Elem()
+		valueInterface := reflect.TypeFor[Value]()
 		if t.Implements(valueInterface) || t == valueInterface {
 			return func(v reflect.Value) Value {
 				if v.IsNil() {
@@ -190,7 +190,7 @@ func makeFieldDeconverter(t reflect.Type) fieldDeconverter {
 			return fmt.Errorf("expected String, got %s", val.Type().Name())
 		}
 	case reflect.Interface:
-		valueInterface := reflect.TypeOf((*Value)(nil)).Elem()
+		valueInterface := reflect.TypeFor[Value]()
 		if t.Implements(valueInterface) || t == valueInterface {
 			return func(target reflect.Value, val Value) error {
 				target.Set(reflect.ValueOf(val))
@@ -211,9 +211,9 @@ func makeFieldDeconverter(t reflect.Type) fieldDeconverter {
 // StructToRecord converts a Go struct value to a Record.
 // The original value is stored for fast roundtrip back to Go.
 // Uses cached per-field converters to avoid BoxValue dispatch overhead.
-func (m *StructMapping) StructToRecord(v interface{}) *Record {
+func (m *StructMapping) StructToRecord(v any) *Record {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 
@@ -232,16 +232,16 @@ func (m *StructMapping) StructToRecord(v interface{}) *Record {
 
 // RecordToStruct populates a Go struct from a Record's fields.
 // If the Record has an origin of the same type, returns it directly (fast path).
-func (m *StructMapping) RecordToStruct(r *Record, target interface{}) error {
+func (m *StructMapping) RecordToStruct(r *Record, target any) error {
 	// Fast path: if record has origin of same type, copy it
 	if r.origin != nil {
 		ov := reflect.ValueOf(r.origin)
-		if ov.Kind() == reflect.Ptr {
+		if ov.Kind() == reflect.Pointer {
 			ov = ov.Elem()
 		}
 		if ov.Type() == m.GoType {
 			tv := reflect.ValueOf(target)
-			if tv.Kind() != reflect.Ptr {
+			if tv.Kind() != reflect.Pointer {
 				return fmt.Errorf("target must be a pointer")
 			}
 			tv.Elem().Set(ov)
@@ -251,7 +251,7 @@ func (m *StructMapping) RecordToStruct(r *Record, target interface{}) error {
 
 	// Slow path: read fields from the Record using cached deconverters
 	tv := reflect.ValueOf(target)
-	if tv.Kind() != reflect.Ptr {
+	if tv.Kind() != reflect.Pointer {
 		return fmt.Errorf("target must be a pointer")
 	}
 	tv = tv.Elem()
@@ -270,7 +270,7 @@ func (m *StructMapping) RecordToStruct(r *Record, target interface{}) error {
 
 // LookupStructMapping returns the mapping for a Go type, or nil if not registered.
 func LookupStructMapping(goType reflect.Type) *StructMapping {
-	if goType.Kind() == reflect.Ptr {
+	if goType.Kind() == reflect.Pointer {
 		goType = goType.Elem()
 	}
 	return structMappings[goType]
@@ -321,7 +321,7 @@ func unboxInto(target reflect.Value, val Value) error {
 		if sq, ok := val.(Sequable); ok {
 			return unboxSliceInto(target, sq.Seq())
 		}
-	case reflect.Ptr:
+	case reflect.Pointer:
 		// If it's a Boxed value holding a pointer of the right type, unwrap it
 		if b, ok := val.(*Boxed); ok {
 			bv := reflect.ValueOf(b.Unbox())

--- a/pkg/vm/struct_mapping_test.go
+++ b/pkg/vm/struct_mapping_test.go
@@ -259,7 +259,7 @@ type TestWithSlice struct {
 // short-circuits empty inputs to EmptyList.
 func TestUnboxSliceInto_EmptyList(t *testing.T) {
 	// Direct test of the helper using EmptyList as input.
-	target := reflect.New(reflect.TypeOf([]string{})).Elem()
+	target := reflect.New(reflect.TypeFor[[]string]()).Elem()
 	err := unboxSliceInto(target, EmptyList)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, target.Len(), "EmptyList must produce empty slice, not 1-element nil-filled slice")

--- a/pkg/vm/symbol.go
+++ b/pkg/vm/symbol.go
@@ -15,16 +15,16 @@ type theSymbolType struct {
 	zero Symbol
 }
 
-func (t *theSymbolType) String() string     { return t.Name() }
-func (t *theSymbolType) Type() ValueType    { return TypeType }
-func (t *theSymbolType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theSymbolType) String() string  { return t.Name() }
+func (t *theSymbolType) Type() ValueType { return TypeType }
+func (t *theSymbolType) Unbox() any      { return reflect.TypeFor[*theSymbolType]() }
 
-func (lt *theSymbolType) Name() string { return "let-go.lang.Symbol" }
+func (t *theSymbolType) Name() string { return "let-go.lang.Symbol" }
 
-func (lt *theSymbolType) Box(bare interface{}) (Value, error) {
+func (t *theSymbolType) Box(bare any) (Value, error) {
 	raw, ok := bare.(fmt.Stringer)
 	if !ok {
-		return BooleanType.zero, NewTypeError(bare, "can't be boxed as", lt)
+		return BooleanType.zero, NewTypeError(bare, "can't be boxed as", t)
 	}
 	return Symbol(raw.String()), nil
 }
@@ -42,7 +42,7 @@ func (l Symbol) Hash() uint32 { return hashUnencodedChars(string(l)) }
 func (l Symbol) Type() ValueType { return SymbolType }
 
 // Unbox implements Unbox
-func (l Symbol) Unbox() interface{} {
+func (l Symbol) Unbox() any {
 	return string(l)
 }
 

--- a/pkg/vm/transient.go
+++ b/pkg/vm/transient.go
@@ -35,9 +35,9 @@ func (t *TransientMap) ensureEditable() error {
 	return nil
 }
 
-func (t *TransientMap) Type() ValueType    { return TransientMapType }
-func (t *TransientMap) Unbox() interface{} { return t }
-func (t *TransientMap) String() string     { return fmt.Sprintf("<transient-map count=%d>", t.count) }
+func (t *TransientMap) Type() ValueType { return TransientMapType }
+func (t *TransientMap) Unbox() any      { return t }
+func (t *TransientMap) String() string  { return fmt.Sprintf("<transient-map count=%d>", t.count) }
 
 // Assoc mutates the transient map in place.
 func (t *TransientMap) Assoc(key Value, val Value) (*TransientMap, error) {
@@ -198,8 +198,8 @@ func (t *TransientVector) ensureEditable() error {
 	return nil
 }
 
-func (t *TransientVector) Type() ValueType    { return TransientVectorType }
-func (t *TransientVector) Unbox() interface{} { return t }
+func (t *TransientVector) Type() ValueType { return TransientVectorType }
+func (t *TransientVector) Unbox() any      { return t }
 func (t *TransientVector) String() string {
 	return fmt.Sprintf("<transient-vector count=%d>", len(t.array))
 }
@@ -307,11 +307,11 @@ func (t *TransientVector) RawCount() int { return len(t.array) }
 
 type theTransientMapType struct{}
 
-func (t *theTransientMapType) String() string     { return t.Name() }
-func (t *theTransientMapType) Type() ValueType    { return TypeType }
-func (t *theTransientMapType) Unbox() interface{} { return nil }
-func (t *theTransientMapType) Name() string       { return "let-go.lang.TransientMap" }
-func (t *theTransientMapType) Box(bare interface{}) (Value, error) {
+func (t *theTransientMapType) String() string  { return t.Name() }
+func (t *theTransientMapType) Type() ValueType { return TypeType }
+func (t *theTransientMapType) Unbox() any      { return nil }
+func (t *theTransientMapType) Name() string    { return "let-go.lang.TransientMap" }
+func (t *theTransientMapType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 
@@ -319,11 +319,11 @@ var TransientMapType *theTransientMapType = &theTransientMapType{}
 
 type theTransientVectorType struct{}
 
-func (t *theTransientVectorType) String() string     { return t.Name() }
-func (t *theTransientVectorType) Type() ValueType    { return TypeType }
-func (t *theTransientVectorType) Unbox() interface{} { return nil }
-func (t *theTransientVectorType) Name() string       { return "let-go.lang.TransientVector" }
-func (t *theTransientVectorType) Box(bare interface{}) (Value, error) {
+func (t *theTransientVectorType) String() string  { return t.Name() }
+func (t *theTransientVectorType) Type() ValueType { return TypeType }
+func (t *theTransientVectorType) Unbox() any      { return nil }
+func (t *theTransientVectorType) Name() string    { return "let-go.lang.TransientVector" }
+func (t *theTransientVectorType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 
@@ -356,8 +356,8 @@ func (t *TransientSet) ensureEditable() error {
 	return nil
 }
 
-func (t *TransientSet) Type() ValueType    { return TransientSetType }
-func (t *TransientSet) Unbox() interface{} { return t }
+func (t *TransientSet) Type() ValueType { return TransientSetType }
+func (t *TransientSet) Unbox() any      { return t }
 func (t *TransientSet) String() string {
 	return fmt.Sprintf("<transient-set count=%d>", t.tm.count)
 }
@@ -418,11 +418,11 @@ func (t *TransientSet) RawCount() int { return t.tm.count }
 
 type theTransientSetType struct{}
 
-func (t *theTransientSetType) String() string     { return t.Name() }
-func (t *theTransientSetType) Type() ValueType    { return TypeType }
-func (t *theTransientSetType) Unbox() interface{} { return nil }
-func (t *theTransientSetType) Name() string       { return "let-go.lang.TransientSet" }
-func (t *theTransientSetType) Box(bare interface{}) (Value, error) {
+func (t *theTransientSetType) String() string  { return t.Name() }
+func (t *theTransientSetType) Type() ValueType { return TypeType }
+func (t *theTransientSetType) Unbox() any      { return nil }
+func (t *theTransientSetType) Name() string    { return "let-go.lang.TransientSet" }
+func (t *theTransientSetType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/pkg/vm/typed_array.go
+++ b/pkg/vm/typed_array.go
@@ -23,11 +23,11 @@ const (
 
 type theTypedArrayType struct{}
 
-func (t *theTypedArrayType) String() string     { return t.Name() }
-func (t *theTypedArrayType) Type() ValueType    { return TypeType }
-func (t *theTypedArrayType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theTypedArrayType) Name() string       { return "let-go.lang.Array" }
-func (t *theTypedArrayType) Box(bare interface{}) (Value, error) {
+func (t *theTypedArrayType) String() string  { return t.Name() }
+func (t *theTypedArrayType) Type() ValueType { return TypeType }
+func (t *theTypedArrayType) Unbox() any      { return reflect.TypeFor[*theTypedArrayType]() }
+func (t *theTypedArrayType) Name() string    { return "let-go.lang.Array" }
+func (t *theTypedArrayType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 
@@ -38,7 +38,7 @@ var TypedArrayType *theTypedArrayType = &theTypedArrayType{}
 // Unlike persistent collections, arrays support in-place mutation via Set.
 type TypedArray struct {
 	kind ArrayKind
-	data interface{} // one of: []byte, []int64, []float64, []Value
+	data any // one of: []byte, []int64, []float64, []Value
 }
 
 // --- Constructors ---
@@ -84,7 +84,7 @@ func NewObjectArrayFrom(data []Value) *TypedArray {
 func (a *TypedArray) Type() ValueType { return TypedArrayType }
 
 // Unbox returns the underlying Go slice directly for interop.
-func (a *TypedArray) Unbox() interface{} { return a.data }
+func (a *TypedArray) Unbox() any { return a.data }
 
 // Kind returns the element kind.
 func (a *TypedArray) Kind() ArrayKind { return a.kind }
@@ -102,7 +102,7 @@ func (a *TypedArray) String() string {
 	case ArrayObject:
 		b.WriteString("#object-array[")
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i > 0 {
 			b.WriteRune(' ')
 		}
@@ -219,7 +219,7 @@ func (a *TypedArray) Conj(v Value) Collection {
 	// Conj on an array creates a new object-array with element appended
 	n := a.Len()
 	vals := make([]Value, n+1)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		vals[i] = a.Get(i)
 	}
 	vals[n] = v
@@ -278,7 +278,7 @@ type TypedArraySeq struct {
 }
 
 func (s *TypedArraySeq) Type() ValueType        { return ListType }
-func (s *TypedArraySeq) Unbox() interface{}     { return s }
+func (s *TypedArraySeq) Unbox() any             { return s }
 func (s *TypedArraySeq) Meta() Value            { return NIL }
 func (s *TypedArraySeq) WithMeta(_ Value) Value { return s }
 

--- a/pkg/vm/uuid.go
+++ b/pkg/vm/uuid.go
@@ -9,11 +9,11 @@ import (
 
 type theUUIDType struct{}
 
-func (t *theUUIDType) String() string     { return t.Name() }
-func (t *theUUIDType) Type() ValueType    { return TypeType }
-func (t *theUUIDType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theUUIDType) Name() string       { return "let-go.lang.UUID" }
-func (t *theUUIDType) Box(bare interface{}) (Value, error) {
+func (t *theUUIDType) String() string  { return t.Name() }
+func (t *theUUIDType) Type() ValueType { return TypeType }
+func (t *theUUIDType) Unbox() any      { return reflect.TypeFor[*theUUIDType]() }
+func (t *theUUIDType) Name() string    { return "let-go.lang.UUID" }
+func (t *theUUIDType) Box(bare any) (Value, error) {
 	switch v := bare.(type) {
 	case string:
 		u := ParseUUID(v)
@@ -60,7 +60,7 @@ func normalizeLenientUUID(s string) (string, bool) {
 			return "", false
 		}
 		for _, r := range p {
-			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
 				return "", false
 			}
 		}
@@ -80,9 +80,9 @@ func NewUUID(s string) *UUID {
 	return &UUID{val: s}
 }
 
-func (u *UUID) Type() ValueType    { return UUIDType }
-func (u *UUID) Unbox() interface{} { return u.val }
-func (u *UUID) String() string     { return "#uuid \"" + u.val + "\"" }
+func (u *UUID) Type() ValueType { return UUIDType }
+func (u *UUID) Unbox() any      { return u.val }
+func (u *UUID) String() string  { return "#uuid \"" + u.val + "\"" }
 
 // Hash implements Hashable.
 func (u *UUID) Hash() uint32 { return hashString(u.val) }

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -14,14 +14,14 @@ import (
 type ValueType interface {
 	Value
 	Name() string
-	Box(interface{}) (Value, error)
+	Box(any) (Value, error)
 }
 
 // Value is implemented by all LETGO values
 type Value interface {
 	fmt.Stringer
 	Type() ValueType
-	Unbox() interface{}
+	Unbox() any
 }
 
 // IMeta is implemented by values that support metadata.
@@ -100,12 +100,12 @@ type theTypeType struct{}
 
 var TypeType *theTypeType = &theTypeType{}
 
-func (t *theTypeType) String() string     { return t.Name() }
-func (t *theTypeType) Type() ValueType    { return t }
-func (t *theTypeType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theTypeType) String() string  { return t.Name() }
+func (t *theTypeType) Type() ValueType { return t }
+func (t *theTypeType) Unbox() any      { return reflect.TypeFor[*theTypeType]() }
 
 func (t *theTypeType) Name() string { return "let-go.lang.Type" }
-func (t *theTypeType) Box(b interface{}) (Value, error) {
+func (t *theTypeType) Box(b any) (Value, error) {
 	return NIL, NewTypeError(b, "can't be boxed as", t)
 }
 
@@ -113,15 +113,15 @@ type theAnyType struct{}
 
 var AnyType *theAnyType = &theAnyType{}
 
-func (t *theAnyType) String() string     { return t.Name() }
-func (t *theAnyType) Type() ValueType    { return TypeType }
-func (t *theAnyType) Unbox() interface{} { return reflect.TypeOf(t) }
-func (t *theAnyType) Name() string       { return "java.lang.Object" }
-func (t *theAnyType) Box(b interface{}) (Value, error) {
+func (t *theAnyType) String() string  { return t.Name() }
+func (t *theAnyType) Type() ValueType { return TypeType }
+func (t *theAnyType) Unbox() any      { return reflect.TypeFor[*theAnyType]() }
+func (t *theAnyType) Name() string    { return "java.lang.Object" }
+func (t *theAnyType) Box(b any) (Value, error) {
 	return NIL, NewTypeError(b, "can't be boxed as", t)
 }
 
-func ToLetGo(v interface{}) (Value, error) {
+func ToLetGo(v any) (Value, error) {
 	return BoxValue(reflect.ValueOf(v))
 }
 
@@ -156,7 +156,7 @@ func BoxValue(v reflect.Value) (Value, error) {
 			return NewBoxed(v.Interface()), nil
 		}
 		return NIL, NewTypeError(v, "is not boxable", nil)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.IsNil() {
 			return NIL, nil
 		}
@@ -231,5 +231,5 @@ func BoxValue(v reflect.Value) (Value, error) {
 }
 
 func IsTruthy(v Value) bool {
-	return !(v == NIL || v == FALSE)
+	return v != NIL && v != FALSE
 }

--- a/pkg/vm/var.go
+++ b/pkg/vm/var.go
@@ -7,6 +7,7 @@ package vm
 
 import (
 	"fmt"
+	"maps"
 	"sync"
 )
 
@@ -174,9 +175,7 @@ func (v *Var) notifyWatches(oldVal, newVal Value) error {
 		return nil
 	}
 	watches := make(map[Value]Fn, len(v.watches))
-	for key, fn := range v.watches {
-		watches[key] = fn
-	}
+	maps.Copy(watches, v.watches)
 	v.mu.Unlock()
 	for key, fn := range watches {
 		if _, err := fn.Invoke([]Value{key, v, oldVal, newVal}); err != nil {
@@ -224,7 +223,7 @@ func (v *Var) Type() ValueType {
 	return v.Deref().Type()
 }
 
-func (v *Var) Unbox() interface{} {
+func (v *Var) Unbox() any {
 	return v.Deref().Unbox()
 }
 

--- a/pkg/vm/vector.go
+++ b/pkg/vm/vector.go
@@ -13,16 +13,16 @@ import (
 
 type theArrayVectorType struct{}
 
-func (t *theArrayVectorType) String() string     { return t.Name() }
-func (t *theArrayVectorType) Type() ValueType    { return TypeType }
-func (t *theArrayVectorType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theArrayVectorType) String() string  { return t.Name() }
+func (t *theArrayVectorType) Type() ValueType { return TypeType }
+func (t *theArrayVectorType) Unbox() any      { return reflect.TypeFor[*theArrayVectorType]() }
 
-func (lt *theArrayVectorType) Name() string { return "let-go.lang.ArrayVector" }
+func (t *theArrayVectorType) Name() string { return "let-go.lang.ArrayVector" }
 
-func (lt *theArrayVectorType) Box(bare interface{}) (Value, error) {
+func (t *theArrayVectorType) Box(bare any) (Value, error) {
 	arr, ok := bare.([]Value)
 	if !ok {
-		return NIL, NewTypeError(bare, "can't be boxed as", lt)
+		return NIL, NewTypeError(bare, "can't be boxed as", t)
 	}
 
 	return ArrayVector(arr), nil
@@ -74,7 +74,7 @@ func (l ArrayVector) WithMeta(m Value) Value {
 func (l ArrayVector) Type() ValueType { return ArrayVectorType }
 
 // Unbox implements Value
-func (l ArrayVector) Unbox() interface{} {
+func (l ArrayVector) Unbox() any {
 	return []Value(l)
 }
 
@@ -183,7 +183,7 @@ func (s *ArrayVectorSeq) Type() ValueType {
 	return ListType // seqs print as lists
 }
 
-func (s *ArrayVectorSeq) Unbox() interface{} {
+func (s *ArrayVectorSeq) Unbox() any {
 	return []Value(s.vec[s.i:])
 }
 
@@ -298,7 +298,7 @@ func (l ArrayVector) Contains(value Value) Boolean {
 }
 
 func (l ArrayVector) Assoc(k Value, v Value) Associative {
-	var new ArrayVector = NewArrayVector(l).(ArrayVector)
+	new := NewArrayVector(l).(ArrayVector)
 	ik, ok := k.(Int)
 	if !ok {
 		return NIL

--- a/pkg/vm/vector_benchmark_test.go
+++ b/pkg/vm/vector_benchmark_test.go
@@ -76,7 +76,7 @@ func BenchmarkVectorConj(b *testing.B) {
 				b.StartTimer()
 
 				// Add elements one by one
-				for j := 0; j < size; j++ {
+				for j := range size {
 					vec = vec.Conj(Int(j))
 				}
 			}
@@ -89,7 +89,7 @@ func BenchmarkVectorConj(b *testing.B) {
 				b.StartTimer()
 
 				// Add elements one by one
-				for j := 0; j < size; j++ {
+				for j := range size {
 					vec = vec.Conj(Int(j))
 				}
 			}
@@ -187,7 +187,7 @@ func BenchmarkLargeVectorAppend(b *testing.B) {
 	b.Run("ArrayVector", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			vec := NewArrayVector([]Value{}).(Collection)
-			for j := 0; j < size; j++ {
+			for j := range size {
 				vec = vec.Conj(Int(j))
 			}
 		}
@@ -196,7 +196,7 @@ func BenchmarkLargeVectorAppend(b *testing.B) {
 	b.Run("PersistentVector", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			vec := NewPersistentVector([]Value{}).(Collection)
-			for j := 0; j < size; j++ {
+			for j := range size {
 				vec = vec.Conj(Int(j))
 			}
 		}
@@ -224,7 +224,7 @@ func BenchmarkVectorVersioning(b *testing.B) {
 			versions[0] = original.(Lookup)
 
 			// Create multiple versions through updates
-			for j := 0; j < numUpdates; j++ {
+			for j := range numUpdates {
 				// Create a copy
 				originalValues := original.Unbox().([]Value)
 				copyValues := make([]Value, len(originalValues))
@@ -252,7 +252,7 @@ func BenchmarkVectorVersioning(b *testing.B) {
 
 			// Create multiple versions through updates
 			current := original
-			for j := 0; j < numUpdates; j++ {
+			for j := range numUpdates {
 				// The beauty of persistent vectors - no need to copy
 				nextVersion := current.Assoc(Int(j%initialSize), Int(-j))
 				versions[j+1] = nextVersion.(Lookup)

--- a/pkg/vm/vector_test.go
+++ b/pkg/vm/vector_test.go
@@ -333,7 +333,7 @@ func TestPersistentVectorSeq(t *testing.T) {
 
 		// Navigate to tail section (after index 32)
 		var seq Seq = largeSeq
-		for i := 0; i < 33; i++ {
+		for range 33 {
 			seq = seq.Next()
 		}
 
@@ -389,7 +389,7 @@ func TestPersistentVectorLargeAssoc(t *testing.T) {
 
 func TestPersistentVectorLargeConjNoMissingValues(t *testing.T) {
 	var c Collection = ArrayVector{}
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		c = c.Conj(Int(i))
 	}
 	v := c.(PersistentVector)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -261,17 +261,14 @@ type Frame struct {
 // framePool reuses Frame structs to avoid per-call heap allocation.
 // The stack slice is kept and grown as needed; references are cleared on release.
 var framePool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Frame{}
 	},
 }
 
 func NewFrame(code *CodeChunk, args []Value) *Frame {
 	f := framePool.Get().(*Frame)
-	needed := code.maxStack
-	if needed < 4 {
-		needed = 4
-	}
+	needed := max(code.maxStack, 4)
 	if cap(f.stack) >= needed {
 		f.stack = f.stack[:needed]
 	} else {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -21,7 +21,7 @@ func TestNilType(t *testing.T) {
 }
 
 func TestIntType(t *testing.T) {
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		v := rand.Int()
 		bv, err := IntType.Box(v)
 		assert.NoError(t, err)
@@ -113,7 +113,7 @@ func TestListType(t *testing.T) {
 
 	n := 100
 	values := make([]Value, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		v, err := IntType.Box(rand.Int())
 		assert.NoError(t, err)
 		if err != nil {
@@ -127,7 +127,7 @@ func TestListType(t *testing.T) {
 	assert.Equal(t, n, list.(*List).count)
 
 	randomValues := list.Unbox().([]Value)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		assert.Equal(t, values[i], randomValues[i])
 	}
 

--- a/pkg/vm/void.go
+++ b/pkg/vm/void.go
@@ -11,12 +11,12 @@ type theVoidType struct {
 	zero *Void
 }
 
-func (t *theVoidType) String() string     { return t.Name() }
-func (t *theVoidType) Type() ValueType    { return TypeType }
-func (t *theVoidType) Unbox() interface{} { return reflect.TypeOf(t) }
+func (t *theVoidType) String() string  { return t.Name() }
+func (t *theVoidType) Type() ValueType { return TypeType }
+func (t *theVoidType) Unbox() any      { return reflect.TypeFor[*theVoidType]() }
 
-func (t *theVoidType) Name() string                     { return "VOID" }
-func (t *theVoidType) Box(_ interface{}) (Value, error) { return t.zero, nil }
+func (t *theVoidType) Name() string             { return "VOID" }
+func (t *theVoidType) Box(_ any) (Value, error) { return t.zero, nil }
 
 // Void is a Value whose only value is Void
 type Void struct{}
@@ -25,7 +25,7 @@ type Void struct{}
 func (n *Void) Type() ValueType { return VoidType }
 
 // Unbox implements Value
-func (n *Void) Unbox() interface{} { return nil }
+func (n *Void) Unbox() any { return nil }
 
 // VoidType is the type of VoidValues
 var VoidType *theVoidType = &theVoidType{zero: &Void{}}

--- a/pkg/vm/volatile.go
+++ b/pkg/vm/volatile.go
@@ -23,8 +23,8 @@ func (v *Volatile) Reset(val Value) Value {
 	return val
 }
 
-func (v *Volatile) Type() ValueType    { return VolatileType }
-func (v *Volatile) Unbox() interface{} { return v }
+func (v *Volatile) Type() ValueType { return VolatileType }
+func (v *Volatile) Unbox() any      { return v }
 func (v *Volatile) String() string {
 	return fmt.Sprintf("#<Volatile@%p: %s>", v, v.value.String())
 }
@@ -32,11 +32,11 @@ func (v *Volatile) String() string {
 // VolatileType
 type theVolatileType struct{}
 
-func (t *theVolatileType) String() string     { return t.Name() }
-func (t *theVolatileType) Type() ValueType    { return TypeType }
-func (t *theVolatileType) Unbox() interface{} { return nil }
-func (t *theVolatileType) Name() string       { return "let-go.lang.Volatile" }
-func (t *theVolatileType) Box(bare interface{}) (Value, error) {
+func (t *theVolatileType) String() string  { return t.Name() }
+func (t *theVolatileType) Type() ValueType { return TypeType }
+func (t *theVolatileType) Unbox() any      { return nil }
+func (t *theVolatileType) Name() string    { return "let-go.lang.Volatile" }
+func (t *theVolatileType) Box(bare any) (Value, error) {
 	return NIL, NewTypeError(bare, "can't be boxed as", t)
 }
 

--- a/wasm.go
+++ b/wasm.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -378,9 +379,7 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	if len(nsRes.LoadedChunks) > 0 {
 		mainNS := ctx.CurrentNS().Name()
 		nsChunks := make(map[string]*vm.CodeChunk, len(nsRes.LoadedChunks)+1)
-		for k, v := range nsRes.LoadedChunks {
-			nsChunks[k] = v
-		}
+		maps.Copy(nsChunks, nsRes.LoadedChunks)
 		nsChunks[mainNS] = chunk
 		nsOrder := append(nsRes.LoadOrder, mainNS)
 		if err := bytecode.EncodeBundleOrdered(&lgbBuf, ctx.Consts(), nsChunks, nsOrder); err != nil {


### PR DESCRIPTION
## Summary
- migrate golangci-lint config/workflow to v2
- run go fix and gofmt -s for a mechanical baseline cleanup
- fix or narrowly exclude the staticcheck findings exposed by v2

## Verification
- `go fix ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./... -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m`