### PR TITLE
resolver: deps.edn source path support

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -353,7 +353,8 @@ func init() {
 }
 
 // buildSearchPaths resolves the resolver's path list from the -source-paths
-// flag (preferred) or the LG_SOURCE_PATHS env var (fallback).
+// flag (preferred), the LG_SOURCE_PATHS env var, or deps.edn in the
+// current directory (fallback). Always includes "." as the first entry.
 func buildSearchPaths() []string {
 	explicitSet := false
 	flag.Visit(func(f *flag.Flag) {
@@ -361,7 +362,13 @@ func buildSearchPaths() []string {
 			explicitSet = true
 		}
 	})
-	return resolver.PathsFromInputs(sourcePaths, os.Getenv("LG_SOURCE_PATHS"), explicitSet)
+	if explicitSet || os.Getenv("LG_SOURCE_PATHS") != "" {
+		return resolver.PathsFromInputs(sourcePaths, os.Getenv("LG_SOURCE_PATHS"), explicitSet)
+	}
+	if depsPaths := resolver.PathsFromDepsEdn("."); depsPaths != nil {
+		return append([]string{"."}, depsPaths...)
+	}
+	return []string{"."}
 }
 
 func initCompiler(debug bool) *compiler.Context {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,10 +19,12 @@ func NewLetGo(ns string) (*LetGo, error) {
 	cp := vm.NewConsts()
 	nso := rt.NS(ns)
 	c := compiler.NewCompiler(cp, nso)
+	loader := resolver.NewNSResolver(c, []string{"."})
+	loader.DiscoverDepsEdn(".")
 	ret := &LetGo{
 		cp:     cp,
 		c:      c,
-		loader: resolver.NewNSResolver(c, []string{"."}),
+		loader: loader,
 	}
 	rt.SetNSLoader(ret.loader)
 	return ret, nil

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -52,12 +52,57 @@ func PathsFromInputs(explicit, fallback string, explicitSet bool) []string {
 	return append([]string{"."}, ParseSearchPaths(raw)...)
 }
 
+// PathsFromDepsEdn reads deps.edn in dir and returns the :paths entries.
+// Returns nil if the file doesn't exist, can't be parsed, or has no :paths.
+func PathsFromDepsEdn(dir string) []string {
+	depsPath := path.Join(dir, "deps.edn")
+	data, err := os.ReadFile(depsPath)
+	if err != nil {
+		return nil
+	}
+	val, err := compiler.ReadString(string(data))
+	if err != nil {
+		return nil
+	}
+	m, ok := val.(*vm.PersistentMap)
+	if !ok {
+		return nil
+	}
+	if !m.Contains(vm.Keyword("paths")) {
+		return nil
+	}
+	pathsVal := m.ValueAt(vm.Keyword("paths"))
+	vec, ok := pathsVal.(vm.ArrayVector)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(vec))
+	for _, item := range vec {
+		if s, ok := item.(vm.String); ok && s != "" {
+			out = append(out, string(s))
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func NewNSResolver(ctx *compiler.Context, path []string) *NSResolver {
 	return &NSResolver{
 		ctx:          ctx,
 		path:         path,
 		cloading:     make(map[string]bool),
 		LoadedChunks: make(map[string]*vm.CodeChunk),
+	}
+}
+
+// DiscoverDepsEdn reads deps.edn in dir and, if present, appends its
+// :paths entries to the resolver's search path. Called by runtime entry
+// points after NewNSResolver when the caller wants deps.edn support.
+func (r *NSResolver) DiscoverDepsEdn(dir string) {
+	if depsPaths := PathsFromDepsEdn(dir); depsPaths != nil {
+		r.path = append(r.path, depsPaths...)
 	}
 }
 
@@ -205,4 +250,29 @@ func (r *NSResolver) execPrecompiled(name string, chunk *vm.CodeChunk) *vm.Names
 	nns := r.ctx.CurrentNS()
 	r.ctx.SetCurrentNS(ons)
 	return nns
+}
+
+func init() {
+	// Register the resolver namespace so Lisp code can call
+	// resolver/deps-paths to read deps.edn :paths entries.
+	ns := vm.NewNamespace("resolver")
+
+	depsPathsFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("resolver/deps-paths expects 1 arg")
+		}
+		dir, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("resolver/deps-paths expected String dir")
+		}
+		paths := PathsFromDepsEdn(string(dir))
+		result := make([]vm.Value, len(paths))
+		for i, p := range paths {
+			result[i] = vm.String(p)
+		}
+		return vm.NewArrayVector(result), nil
+	})
+	ns.Def("deps-paths", depsPathsFn)
+
+	rt.RegisterNS(ns)
 }


### PR DESCRIPTION
## Summary

Add `deps.edn` support as a source of namespace search paths, plus a runtime `resolver/deps-paths` function callable from Lisp.

## Changes

- **`pkg/resolver/resolver.go`**:
  - `PathsFromDepsEdn(dir)` — reads `:paths` from a `deps.edn` file using `compiler.ReadString`
  - `(*NSResolver).DiscoverDepsEdn(dir)` — auto-appends deps.edn paths to the resolver's search path
  - `resolver/deps-paths` native function — callable from Lisp at runtime

- **`lg.go`**:
  - `buildSearchPaths()` now checks deps.edn as a fallback when neither `-source-paths` nor `LG_SOURCE_PATHS` is set

- **`pkg/api/api.go`**:
  - `NewLetGo` calls `loader.DiscoverDepsEdn(".")` so embedded/API usage also picks up deps.edn automatically

## Precedence

1. `-source-paths` flag
2. `LG_SOURCE_PATHS` env var
3. `deps.edn` `:paths`
4. `.` (default)

## Usage

```clojure
;; deps.edn in cwd
{:paths ["src" "test"]}
```

```bash
# No env var needed — deps.edn is discovered automatically
./lg -e '(require (quote my-app.core))'
```

Or from Lisp:
```clojure
(resolver/deps-paths "/some/dir")
;;=> ["src" "test"]
```