### PR TITLE
scripts: atomic gofmt write in IR generator scripts

### DIFF
--- a/scripts/generate-ir-bridge.sh
+++ b/scripts/generate-ir-bridge.sh
@@ -19,7 +19,7 @@ fi
 
 OUT=pkg/rt/ir_bridge_generated.go
 TMP=$(mktemp)
-trap 'rm -f "$TMP"' EXIT
+trap 'rm -f "$TMP" "$OUT.tmp"' EXIT
 
 cat > "$TMP" <<'EOF'
 /*
@@ -53,6 +53,7 @@ EOF
 
 ./lg -source-paths examples/go-gen examples/go-gen/ir_bridge.lg >> "$TMP"
 
-gofmt "$TMP" > "$OUT"
+gofmt "$TMP" > "$OUT.tmp"
+mv "$OUT.tmp" "$OUT"
 
 echo "wrote $OUT"

--- a/scripts/generate-ir-ops.sh
+++ b/scripts/generate-ir-ops.sh
@@ -27,7 +27,7 @@ fi
 
 OUT=pkg/ir/op_generated.go
 TMP=$(mktemp)
-trap 'rm -f "$TMP"' EXIT
+trap 'rm -f "$TMP" "$OUT.tmp"' EXIT
 
 cat > "$TMP" <<'EOF'
 /*
@@ -62,6 +62,7 @@ EOF
 # Pipe through gofmt so the table literal and const block get canonical
 # layout (multi-line, aligned). gogen's render is correct Go but uses
 # go/format.Node's "compact" output for embedded nodes.
-gofmt "$TMP" > "$OUT"
+gofmt "$TMP" > "$OUT.tmp"
+mv "$OUT.tmp" "$OUT"
 
 echo "wrote $OUT"


### PR DESCRIPTION
## Summary

- `scripts/generate-ir-ops.sh` and `scripts/generate-ir-bridge.sh` previously ran `gofmt "$TMP" > "$OUT"`. If `gofmt` fails partway, `$OUT` is created/truncated before the failure surfaces under `set -euo pipefail`, leaving a half-written file on disk.
- The next `go build` then consumes the truncated generator output — either failing confusingly or silently using stale results if the truncated output happens to be a prefix of valid Go.
- Fix: write to `$OUT.tmp` first, then `mv "$OUT.tmp" "$OUT"` on success. Extended the existing `trap` to also clean up `$OUT.tmp`.
- `set -euo pipefail` was already at the top of both scripts.
- `scripts/generate-ir-data.sh` was checked but doesn't use `gofmt` (emits Lisp directly).

Surfaced by the band2 code review (finding B2, generator pipeline).

## Test plan

- [ ] `bash -n scripts/generate-ir-ops.sh && bash -n scripts/generate-ir-bridge.sh`
- [ ] `make generate` on a clean tree produces identical output to `main`
- [ ] Force a generator failure and confirm `$OUT` is unchanged