### PR TITLE
chore(pre-commit): bump golangci-lint to v2.12.2 to match v2 config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,10 @@
 repos:
   # golangci-lint via the official upstream — the binary is installed by
   # prek/pre-commit on first run, so contributors don't need to install it
-  # separately. Pinned to the last v1.x release because .golangci.yml is in
-  # v1-format; bump to v2.x when the config is migrated.
+  # separately. Pinned to v2.x to match the v2-format .golangci.yml (migrated
+  # in commit a8cdf40b / PR #82).
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.64.8
+    rev: v2.12.2
     hooks:
       - id: golangci-lint-full
         stages: [pre-commit]


### PR DESCRIPTION
## Summary

`.golangci.yml` was migrated to v2 format in PR #82 (commit a8cdf40b) but the pre-commit rev pin in `.pre-commit-config.yaml` was left at `v1.64.8`. The result: the `golangci-lint-full` hook fails on every commit with:

> Error: you are using a configuration file for golangci-lint v2 with golangci-lint v1: please use golangci-lint v2

…because pre-commit installs its own pinned binary regardless of the contributor's local install. Contributors have to pass `--no-verify` to get around it, which is the kind of thing that silently disables every other check too.

This PR bumps the pin to `v2.12.2` (current stable v2.x) and removes the stale "bump when the config is migrated" comment.

## Test plan

- [ ] `prek run --all-files golangci-lint-full` succeeds
- [ ] A no-op commit goes through the pre-commit hook chain without `--no-verify`