### PR TITLE
perf(gogen): lazy AddLine for synthetic positions (~9 ms startup recovery)

### DIFF
--- a/pkg/rt/gogen.go
+++ b/pkg/rt/gogen.go
@@ -1435,28 +1435,27 @@ var goFset = token.NewFileSet()
 // composite literals) depend on adjacent nodes having distinct line
 // positions, even if the actual offsets don't refer to real source.
 //
-// We pre-allocate a generous range of line offsets so allocPos() can
-// hand out fresh positions on different lines without ever needing to
-// re-AddLine. Each call to allocPos consumes one line.
+// Line offsets are registered lazily in allocPos so processes that never
+// touch gogen pay no startup cost. Each call to allocPos consumes one
+// line.
 var (
 	goSynthFile = goFset.AddFile("gogen.synthetic.go", -1, 1<<28)
 	goPosNext   = 1 // next byte offset to hand out (1-based)
 )
 
-// init pre-fills the synthetic file with line starts so token.Pos values
-// returned by allocPos all map to distinct lines.
-func init() {
-	for i := 1; i < 1<<20; i++ {
-		goSynthFile.AddLine(i)
-	}
-}
-
 // allocPos returns a fresh token.Pos on a new synthetic line. Used by
 // constructors that need to position adjacent nodes (e.g. const specs in
 // a block, fields in a struct, elements of a composite literal) on
 // distinct lines so go/format.Node emits them on separate output lines.
+//
+// The synthetic file's line table is extended on demand: the first call
+// registers offset 1 as the start of line 2, the next registers offset 2
+// as the start of line 3, and so on. token.File.AddLine ignores
+// duplicate or out-of-order offsets, so repeated calls past the high
+// water mark remain safe.
 func allocPos() token.Pos {
 	p := token.Pos(goPosNext)
+	goSynthFile.AddLine(goPosNext)
 	goPosNext++
 	return p
 }


### PR DESCRIPTION
## Summary

`pkg/rt/gogen.go` pre-allocates `1 << 20` line entries on the synthetic `go/token.File` at package init time. Every `lg` invocation pays this cost — including invocations that never touch the gogen pipeline. On my darwin/arm64 box it's worth roughly 9 ms of startup.

This PR moves the `AddLine` call into `allocPos`, registering offsets only when actually consumed. `go/token.File.AddLine` ignores duplicate or out-of-order offsets, so the behaviour is identical for any code that already called `allocPos`.

## Measurements

Same machine, `hyperfine -N --warmup 5 --runs 50 -- "<binary> -e '(println 1)'"`:

| Build | Mean | σ |
|---|---|---|
| installed `lg` 1.8.0 (`3d5af1c`) | 4.7 ms | ±0.2 ms |
| current `main` | ~15.5 ms | ±0.4 ms |
| **this PR (on main)** | **5.7 ms** | ±0.4 ms |

Most of the post-1.8.0 startup regression was this single init loop.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/rt/` — 38/38 pass (gogen unit tests cover construction + rendering paths that consume `allocPos`)
- [x] `go test ./test/` — 121/121 pass (covers the gogen integration via `test/gogen_test.lg`)
- [x] hyperfine startup: 5.7 ms ± 0.4 ms on darwin/arm64

## Notes

This is a pure perf fix, no behaviour change. Same Pos values are handed out in the same order; the only difference is that line offsets are registered when consumed instead of all at startup.