### PR TITLE
scripts: corpus-agnostic ir-stress harness

### DIFF
--- a/scripts/ir-stress.lg
+++ b/scripts/ir-stress.lg
@@ -1,19 +1,60 @@
-;; IR-pipeline coverage stress test against xsofy.
+;; IR-pipeline coverage stress test — corpus-agnostic.
 ;;
-;; For each listed xsofy .lg file, read its top-level (defn ...) forms
-;; and attempt (ir.passes.pipeline/compile-form form). Print per-file
-;; pass rate and a tally of the most common error-message prefixes.
+;; Drives a corpus of .lg files through the IR pipeline, reporting per-
+;; file pass rates, error buckets, and cold + warm timing. Replaces the
+;; previous xsofy-hardcoded harness.
 ;;
-;; Skips cleanly if xsofy isn't checked out at the expected path.
+;; Usage:
+;;   go run . scripts/ir-stress.lg <dir> <file> [<file>...]
 ;;
-;; Usage:  LG_SOURCE_PATHS=/path/to/xsofy go run . scripts/ir-stress.lg
+;;   <dir>   corpus root (absolute or relative to cwd)
+;;   <file>  one or more .lg paths relative to <dir>
+;;
+;; Each top-level (defn ...) form is evaluated under
+;;   (binding [*ir-compile* true] (eval form))
+;; so the IR pipeline drives the compile path. Bodies that fail to
+;; IR-compile are bucketed by classify-error so the output highlights
+;; which language features still need IR support.
+;;
+;; Examples:
+;;   # xsofy IR-compile pass rate
+;;   LG_SOURCE_PATHS=/path/to/xsofy go run . scripts/ir-stress.lg \
+;;     /path/to/xsofy/xsofy \
+;;     util.lg combat.lg ai.lg items.lg fov.lg fire.lg effects.lg \
+;;     bestiary.lg input.lg lighting.lg runes.lg sound.lg det.lg \
+;;     entities.lg check.lg
+;;
+;;   # pkg/rt/core/ir self-load pass rate
+;;   go run . scripts/ir-stress.lg pkg/rt/core/ir \
+;;     data.lg zipper.lg build.lg lower.lg passes.lg \
+;;     passes/constfold.lg passes/cse.lg passes/dce.lg \
+;;     passes/licm.lg passes/pipeline.lg
+;;
+;; Per-fixture timeout via LG_STRESS_TIMEOUT_MS (default 5000).
+
 (require 'ir.data)
 (require 'ir.passes.pipeline)
 
-(def xsofy-dir "/Users/ndn/development/xsofy/xsofy/")
-(def files ["util.lg" "combat.lg" "ai.lg" "items.lg" "fov.lg" "fire.lg"
-            "effects.lg" "bestiary.lg" "input.lg" "lighting.lg"
-            "runes.lg" "sound.lg" "det.lg" "entities.lg" "check.lg"])
+(defn- usage-and-exit [msg]
+  (println (str "ir-stress: " msg))
+  (println "Usage: go run . scripts/ir-stress.lg <dir> <file>...")
+  (println "  <dir>:  corpus root")
+  (println "  <file>: one or more .lg paths relative to <dir>")
+  (System/exit 1))
+
+;; os/args is [binary script user-arg user-arg...]
+(def user-args (vec (drop 2 (seq os/args))))
+(when (< (count user-args) 2)
+  (usage-and-exit "expected at least 2 args (dir, file)"))
+
+(def raw-dir (nth user-args 0))
+(def corpus-dir
+  (let [n (count raw-dir)]
+    (if (and (pos? n) (= \/ (nth raw-dir (dec n))))
+      raw-dir
+      (str raw-dir "/"))))
+(def files (vec (drop 1 user-args)))
+(def stress-target (str corpus-dir " (" (count files) " files)"))
 
 (defn read-all [path]
   (try
@@ -55,10 +96,75 @@
         n (min 60 (count m))]
     (subs m 0 n)))
 
-(defn try-ir [form]
-  (try
-    (do (ir.passes.pipeline/compile-form form) :ok)
-    (catch e (err-prefix e))))
+(defn classify-error [err-str]
+  "Classify error into bucket: :unresolved-symbol, :unsupported-special-form,
+   :destructure-rejection, or :other (with first 100 chars)."
+  (let [m (str err-str)
+        truncated (if (> (count m) 100) (str (subs m 0 100) "...") m)]
+    (cond
+      (or (re-find #"unresolved symbol" m)
+          (re-find #"Can't resolve" m))
+        :unresolved-symbol
+
+      (or (re-find #"def\s" m)
+          (re-find #"set!" m)
+          (re-find #"\btry\b" m)
+          (re-find #"catch" m)
+          (re-find #"\bvar\b" m)
+          (re-find #"trace" m))
+        :unsupported-special-form
+
+      (re-find #"destructur" m)
+        :destructure-rejection
+
+      :else
+        (str ":other | " truncated))))
+
+(def per-fixture-timeout-ms
+  (let [v (System/getenv "LG_STRESS_TIMEOUT_MS")]
+    (if (and v (not= v "")) (parse-int v) 5000)))
+
+(defn try-with-timeout [thunk timeout-ms]
+  "Run thunk in a goroutine; return its result (or thrown exception) within
+   timeout-ms, else :stress/timeout. On timeout the goroutine keeps running
+   in the background — acceptable for a one-shot harness, do not reuse in
+   long-lived processes."
+  (let [f (future* thunk)
+        deadline-ns (+ (System/nanoTime) (* timeout-ms 1000000))]
+    (loop []
+      (cond
+        (realized? f)
+          (try (deref f) (catch e e))
+        (> (System/nanoTime) deadline-ns)
+          :stress/timeout
+        :else
+          (do (sleep 10) (recur))))))
+
+(defn try-ir-compile-timed [form]
+  "Evaluate form under (binding [*ir-compile* true] ...) with a per-fixture
+   timeout. Returns [result-key time-ms]."
+  (let [thunk (fn [] (try
+                       (binding [*ir-compile* true]
+                         (eval form))
+                       :ok
+                       (catch e (classify-error e))))
+        t0 (System/nanoTime)
+        result (try-with-timeout thunk per-fixture-timeout-ms)
+        t1 (System/nanoTime)
+        ms (double (/ (- t1 t0) 1000000.0))]
+    [result ms]))
+
+(defn stats-for [times]
+  (if (empty? times)
+    {:mean 0 :median 0 :p95 0}
+    (let [sorted (sort times)
+          n (count sorted)
+          sum (reduce + times)
+          mean (/ sum n)
+          median (nth sorted (int (/ n 2)))
+          p95-idx (max 0 (int (* n 0.95)))
+          p95 (nth sorted p95-idx)]
+      {:mean mean :median median :p95 p95})))
 
 (defn stress-file [path]
   (let [parsed (read-all path)
@@ -68,34 +174,87 @@
       (let [ns-form- (first (filter (fn [f] (and (seq? f) (= (first f) 'ns)))
                                     (rest parsed)))
             ns-sym   (ns-name-from ns-form-)]
-        ;; Switch to the file's namespace so aliases resolve correctly
         (when ns-sym
           (try
             (eval (list 'in-ns (list 'quote ns-sym)))
             (catch e nil)))
-        ;; Load dependencies (but not the file itself — that can fail
-        ;; due to unsupported forms in the Go compiler).
         (require-deps! ns-form-)
-        (let [results (mapv (fn [d] [(nth d 1) (try-ir d)]) defns)
-              ok     (count (filter (fn [[_ r]] (= :ok r)) results))
-              errs   (filter (fn [[_ r]] (not= :ok r)) results)
-              classes (frequencies (map (fn [[_ r]] r) errs))]
+        (let [results (mapv (fn [d] [(nth d 1) (try-ir-compile-timed d)]) defns)
+              ok     (count (filter (fn [[_ [r _]]] (= :ok r)) results))
+              errs   (filter (fn [[_ [r _]]] (not= :ok r)) results)
+              times  (map (fn [[_ [_ t]]] t) results)
+              err-classifications (map (fn [[_ [r _]]] r) errs)
+              error-buckets (frequencies (filter (fn [e] (not (nil? e))) err-classifications))]
           {:file path :total (count defns) :ok ok :err (count errs)
-           :classes (take 5 (reverse (sort-by val classes)))})))))
+           :times times
+           :error-buckets error-buckets})))))
 
 (defn run []
-  (println "=== IR-pipeline coverage stress test ===")
-  (let [results (mapv (fn [f] (stress-file (str xsofy-dir f))) files)
-        total   (reduce + 0 (map (fn [r] (or (:total r) 0)) results))
-        oks     (reduce + 0 (map (fn [r] (or (:ok r) 0)) results))
-        agg     (apply merge-with + (map (fn [r] (into {} (:classes r))) results))]
-    (doseq [r results]
-      (if (:read-error r)
-        (println (str (:file r) ": READ-ERROR (xsofy not checked out?)"))
-        (println (str (:file r) ": " (:ok r) "/" (:total r) " ok"))))
-    (println (str "\nTOTAL: " oks "/" total " ok"))
-    (println "\nTop error classes:")
-    (doseq [[msg n] (take 5 (reverse (sort-by val agg)))]
-      (println (str "  " n "  " msg)))))
+  (println (str "=== IR-pipeline stress test — target: " stress-target " ===\n"))
+
+  ;; Load all corpus modules upfront so cross-file refs resolve
+  (print "Loading corpus dependencies... ")
+  (let [t0 (System/nanoTime)]
+    (doseq [f files]
+      (try
+        (let [parsed (read-all (str corpus-dir f))
+              ns-form- (first (filter (fn [x] (and (seq? x) (= (first x) 'ns)))
+                                      (rest parsed)))
+              ns-sym (ns-name-from ns-form-)]
+          (when ns-sym
+            (eval (list 'in-ns (list 'quote ns-sym))))
+          (require-deps! ns-form-))
+        (catch e nil)))
+    (let [t1 (System/nanoTime)
+          ms (double (/ (- t1 t0) 1000000.0))]
+      (println (format "done in %.1f ms\n" ms))))
+
+  ;; COLD pass: compile all fixtures once
+  (print "Cold pass (first run)... ")
+  (let [t0 (System/nanoTime)
+        results (mapv (fn [f] (stress-file (str corpus-dir f))) files)
+        t1 (System/nanoTime)
+        cold-ms (double (/ (- t1 t0) 1000000.0))]
+
+    ;; WARM pass: run again
+    (print (format "done in %.0f ms\nWarm pass (second run)... " cold-ms))
+    (let [t0 (System/nanoTime)
+          results2 (mapv (fn [f] (stress-file (str corpus-dir f))) files)
+          t1 (System/nanoTime)
+          warm-ms (double (/ (- t1 t0) 1000000.0))]
+
+      (println (format "done in %.0f ms\n" warm-ms))
+
+      ;; Aggregate both passes
+      (let [all-results (concat results results2)
+            total   (reduce + 0 (map (fn [r] (or (:total r) 0)) all-results))
+            oks     (reduce + 0 (map (fn [r] (or (:ok r) 0)) all-results))
+            all-errs (reduce (fn [acc r]
+                              (merge-with + acc (or (:error-buckets r) {})))
+                            {}
+                            all-results)]
+
+        (println "=== Per-file results (cold pass) ===")
+        (doseq [r results]
+          (if (:read-error r)
+            (println (str (:file r) ": READ-ERROR"))
+            (println (str (:file r) ": " (:ok r) "/" (:total r) " ok"))))
+
+        (println (str "\n=== Summary (both passes combined) ==="))
+        (println (str "Total fixtures: " total))
+        (println (str "Passed: " oks " (" (int (/ (* oks 100) (max 1 total))) "%)"))
+        (println (str "Failed: " (- total oks)))
+
+        (let [cold-stats (stats-for (mapcat (fn [r] (or (:times r) [])) results))
+              warm-stats (stats-for (mapcat (fn [r] (or (:times r) [])) results2))]
+          (println (str "\n=== Timing Statistics ==="))
+          (println (format "Cold pass (first run):  mean=%.2f ms  median=%.2f ms  p95=%.2f ms"
+                          (:mean cold-stats) (:median cold-stats) (:p95 cold-stats)))
+          (println (format "Warm pass (second run): mean=%.2f ms  median=%.2f ms  p95=%.2f ms"
+                          (:mean warm-stats) (:median warm-stats) (:p95 warm-stats))))
+
+        (println (str "\n=== Failure Buckets ==="))
+        (doseq [[bucket count] (sort-by val (fn [a b] (compare b a)) all-errs)]
+          (println (format "  %-40s %3d" (str bucket) count)))))))
 
 (run)


### PR DESCRIPTION
## Summary

Replaces the xsofy-hardcoded `scripts/ir-stress.lg` with a corpus-agnostic harness. CLI:

```
go run . scripts/ir-stress.lg <dir> <file>...
```

Each top-level `(defn ...)` form in each file is evaluated under `(binding [*ir-compile* true] (eval form))` so PR #77's IR pipeline drives the compile path. Bodies that fail to IR-compile are bucketed so the output highlights which language features still need IR support.

## What's new

- **Corpus-agnostic.** Pass any directory + list of `.lg` files; the old script only knew about xsofy.
- **Per-fixture timeout** via `LG_STRESS_TIMEOUT_MS` (default 5000 ms). Goroutine-backed, so a runaway fixture doesn't wedge the harness.
- **Failure buckets:** `:unresolved-symbol`, `:unsupported-special-form`, `:destructure-rejection`, `:other | <message-prefix>`.
- **Cold + warm timing.** Two passes, with mean/median/p95 reported separately. The cold/warm gap surfaces caching effects in the IR pipeline.
- **Corpus-dependency preload.** Each file's `(ns ... (:require ...))` is processed up-front so cross-file refs resolve.

## Examples

```bash
# External corpus (e.g. xsofy)
LG_SOURCE_PATHS=/path/to/xsofy go run . scripts/ir-stress.lg \
  /path/to/xsofy/xsofy \
  util.lg combat.lg ai.lg items.lg fov.lg fire.lg effects.lg \
  bestiary.lg input.lg lighting.lg runes.lg sound.lg det.lg \
  entities.lg check.lg

# Self-load: pkg/rt/core/ir against its own IR pipeline
go run . scripts/ir-stress.lg pkg/rt/core/ir \
  data.lg zipper.lg build.lg lower.lg passes.lg \
  passes/constfold.lg passes/cse.lg passes/dce.lg \
  passes/licm.lg passes/pipeline.lg
```

## Test plan

- [x] Usage banner on no args
- [x] Smoke run against a tiny synthetic corpus — buckets and timing report correctly
- [x] \`go build ./...\` clean

## Follow-up

A future PR will add a \`--target=go\` mode once the lower-go pipeline lands. The harness shape already accommodates it (`try-ir-compile-timed` is the obvious extension point).