### PR TITLE
feat(core): graph ns (toposort, Tarjan SCC) + read-all-string + sort-defns script

### DIFF
--- a/pkg/compiler/eval.go
+++ b/pkg/compiler/eval.go
@@ -7,9 +7,12 @@ package compiler
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"strings"
 
 	"github.com/nooga/let-go/pkg/bytecode"
+	"github.com/nooga/let-go/pkg/errors"
 	"github.com/nooga/let-go/pkg/rt"
 	"github.com/nooga/let-go/pkg/vm"
 )
@@ -131,20 +134,64 @@ func loadPrecompiledBundle() error {
 }
 
 func postCoreInit() {
-	// Register read-string (needs the reader which lives in the compiler package)
+	// read-string: parse a single form from a string. Errors loudly on
+	// wrong arity, non-string args, or parse failures.
 	readStringFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
-			return vm.NIL, nil
+			return vm.NIL, fmt.Errorf("read-string: wrong number of arguments %d (expected 1)", len(vs))
 		}
 		s, ok := vs[0].(vm.String)
 		if !ok {
-			return vm.NIL, nil
+			return vm.NIL, fmt.Errorf("read-string: expected String, got %T", vs[0])
 		}
 		return ReadString(string(s))
 	})
 	coreNS := rt.NS(rt.NameCoreNS)
 	rsVar := coreNS.LookupOrAdd(vm.Symbol("read-string"))
 	rsVar.(*vm.Var).SetRoot(readStringFn)
+
+	// read-all-string: parse every top-level form from a string,
+	// return as a vector. Useful for scripts that walk source
+	// form-by-form (dependency analysis, codegen). EOF at a form
+	// boundary stops cleanly; EOF mid-form or any other reader
+	// error is propagated so callers see syntax errors instead of
+	// silent truncation.
+	readAllStringFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("read-all-string: wrong number of arguments %d (expected 1)", len(vs))
+		}
+		s, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("read-all-string: expected String, got %T", vs[0])
+		}
+		reader := NewLispReader(strings.NewReader(string(s)), "<read-all-string>")
+		forms := []vm.Value{}
+		for {
+			// Peek: skip whitespace, then either give up cleanly (EOF
+			// at form boundary) or put the char back so Read can see
+			// the start of the next form. Distinguishes clean EOF
+			// from mid-form EOF — both surface as IsCausedBy(io.EOF)
+			// but only the former is acceptable.
+			_, err := reader.eatWhitespace()
+			if err != nil {
+				if errors.IsCausedBy(err, io.EOF) {
+					break
+				}
+				return vm.NIL, err
+			}
+			if err := reader.unread(); err != nil {
+				return vm.NIL, err
+			}
+			form, err := reader.Read()
+			if err != nil {
+				return vm.NIL, err
+			}
+			forms = append(forms, form)
+		}
+		return vm.NewPersistentVector(forms), nil
+	})
+	rasVar := coreNS.LookupOrAdd(vm.Symbol("read-all-string"))
+	rasVar.(*vm.Var).SetRoot(readAllStringFn)
 
 	// load-string: compile and evaluate a string of code, returning the last value.
 	loadStringFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -35,6 +35,7 @@ var embeddedSources = map[string]*string{
 	"async":               &rt.AsyncSrc,
 	"zip":                 &rt.ZipSrc,
 	"data":                &rt.DataSrc,
+	"graph":               &rt.GraphSrc,
 	"ir.data":             &rt.IRDataSrc,
 	"ir.zipper":           &rt.IRZipperSrc,
 	"ir.passes":           &rt.IRPassesSrc,

--- a/pkg/rt/core/graph.lg
+++ b/pkg/rt/core/graph.lg
@@ -1,0 +1,116 @@
+;; Generic graph algorithms.
+;;
+;; A graph is represented as a map {node -> coll-of-deps}. Nodes can
+;; be any value usable as a map key. Missing keys are treated as
+;; nodes with no outgoing edges.
+
+(ns graph)
+
+;; --- toposort --------------------------------------------------------
+
+(defn toposort [graph]
+  "Topologically sort the nodes of `graph` in dependencies-first order.
+   `graph` is a map {node -> coll-of-deps}. Returns a vector of all
+   reachable nodes (including transitive deps not present as keys).
+   Returns nil if the graph contains a cycle — use `sccs` to handle
+   cyclic graphs explicitly."
+  (let [state  (atom {})        ; node -> :gray | :black
+        result (atom (transient []))
+        cycle? (atom false)]
+    (letfn [(visit [n]
+              (when-not @cycle?
+                (let [s (get @state n)]
+                  (cond
+                    (= :black s) nil
+                    (= :gray  s) (reset! cycle? true)
+                    :else
+                    (do
+                      (swap! state assoc n :gray)
+                      (doseq [d (get graph n)] (visit d))
+                      (swap! state assoc n :black)
+                      (swap! result conj! n))))))]
+      (doseq [n (keys graph)] (visit n)))
+    (when-not @cycle? (persistent! @result))))
+
+(defn toposort-by [key-fn xs deps-fn]
+  "Topologically sort the collection `xs` using `key-fn` for node
+   identity and `deps-fn` for outgoing edges. Returns the input
+   elements in deps-first order, or nil on cycle."
+  (let [by-key (reduce (fn [m x]
+                         (let [k (key-fn x)]
+                           (if (contains? m k) m (assoc m k x))))
+                       {} xs)
+        graph  (reduce-kv (fn [g k x] (assoc g k (deps-fn x))) {} by-key)
+        order  (toposort graph)]
+    (when order (vec (keep by-key order)))))
+
+;; --- strongly connected components -----------------------------------
+;;
+;; Tarjan's algorithm. Returns a vector of SCCs in dependencies-first
+;; order: an SCC appears after every SCC it depends on. Singleton
+;; nodes (the common case) come back as 1-element vectors. Non-trivial
+;; SCCs (size > 1) represent cycles of mutually recursive nodes — the
+;; caller can detect cycles via (> (count scc) 1) and decide how to
+;; handle them (e.g., emit forward declarations for mutual recursion).
+
+(defn sccs [graph]
+  "Return a vector of strongly connected components, each itself a
+   vector of node IDs, in dependencies-first topological order over
+   the condensation DAG. A component of size > 1 represents a cycle."
+  (let [index   (atom 0)
+        idx     (atom {})       ; node -> dfs index
+        low     (atom {})       ; node -> lowlink
+        stk     (atom [])       ; node stack
+        on-stk  (atom #{})      ; nodes currently on stk
+        result  (atom [])]      ; SCCs collected (reverse topo order)
+    (letfn [(strong [v]
+              (let [i @index]
+                (swap! idx assoc v i)
+                (swap! low assoc v i)
+                (swap! index inc))
+              (swap! stk conj v)
+              (swap! on-stk conj v)
+              (doseq [w (get graph v)]
+                (cond
+                  (not (contains? @idx w))
+                  (do (strong w)
+                      (swap! low assoc v (min (get @low v) (get @low w))))
+                  (contains? @on-stk w)
+                  (swap! low assoc v (min (get @low v) (get @idx w)))))
+              ;; If v is an SCC root, pop the stack down to v.
+              (when (= (get @low v) (get @idx v))
+                (let [scc (loop [acc []]
+                            (let [w (peek @stk)]
+                              (swap! stk pop)
+                              (swap! on-stk disj w)
+                              (let [acc' (conj acc w)]
+                                (if (= w v) acc' (recur acc')))))]
+                  (swap! result conj scc))))]
+      (doseq [n (keys graph)]
+        (when-not (contains? @idx n) (strong n))))
+    ;; Tarjan emits SCCs in deps-first order naturally: a component's
+    ;; root finishes DFS only after all its dependencies' roots have
+    ;; finished and been emitted. No reversal needed.
+    @result))
+
+(defn cyclic? [scc]
+  "True if `scc` (from `sccs`) represents a cycle — i.e. has > 1
+   node, OR is a self-loop (single node with itself in its deps).
+   Use this to decide whether to emit forward declarations."
+  (> (count scc) 1))
+
+(defn has-cycle? [graph]
+  "True iff `graph` contains at least one cycle (self-loop or larger)."
+  (boolean (some cyclic? (sccs graph))))
+
+;; --- reachability ----------------------------------------------------
+
+(defn reachable [graph from]
+  "Return the set of nodes reachable from `from`, inclusive."
+  (let [seen (atom #{})]
+    (letfn [(visit [n]
+              (when-not (@seen n)
+                (swap! seen conj n)
+                (doseq [d (get graph n)] (visit d))))]
+      (visit from))
+    @seen))

--- a/pkg/rt/graph.go
+++ b/pkg/rt/graph.go
@@ -1,0 +1,6 @@
+package rt
+
+import _ "embed"
+
+//go:embed core/graph.lg
+var GraphSrc string

--- a/scripts/sort-defns.lg
+++ b/scripts/sort-defns.lg
@@ -1,0 +1,96 @@
+;; Topologically sort top-level definitions in a .lg file.
+;;
+;; Usage:
+;;   ./lg scripts/sort-defns.lg <path>           ; print sorted file to stdout
+;;
+;; Reads the source, parses every top-level form, identifies defn /
+;; defn- / defmacro / def, builds the call graph between them, runs
+;; SCC analysis, and emits the file in dependencies-first order.
+;; SCCs of size > 1 (mutually recursive groups) get a `(declare ...)`
+;; emitted before them.
+;;
+;; Non-defn forms (the (ns ...) declaration, top-level (let …)
+;; export blocks, etc.) are preserved in their original order; defns
+;; are placed in-between in topo order. The result is a no-op rewrite
+;; for files that are already correctly sorted.
+;;
+;; Comments are dropped — the reader doesn't preserve them. Run a
+;; diff against the original if you want to keep prose; for code
+;; this script is meant to be idempotent.
+
+(require '[graph :as g])
+
+(def ^:private defn-heads
+  #{'defn 'defn- 'defmacro 'def 'def- 'declare})
+
+(defn- form-name
+  "Return the defined name (symbol) if `form` is a top-level defn-like
+   form, else nil."
+  [form]
+  (when (and (seq? form) (defn-heads (first form)))
+    (let [s (second form)]
+      (when (symbol? s) s))))
+
+(defn- collect-refs
+  "Walk `form` and return the set of symbols it references that are
+   in `known` (the file's defn-name set, minus self)."
+  [form known]
+  (let [acc (atom #{})]
+    (letfn [(visit [v]
+              (cond
+                (symbol? v) (when (contains? known v) (swap! acc conj v))
+                (seq? v)    (doseq [x v] (visit x))
+                (vector? v) (doseq [x v] (visit x))
+                (map? v)    (doseq [[k vv] v] (visit k) (visit vv))
+                (set? v)    (doseq [x v] (visit x))
+                :else nil))]
+      (visit form))
+    @acc))
+
+(defn- pp [form]
+  "Render `form` as source-readable text."
+  (pr-str form))
+
+(defn- sort-file [path]
+  (let [source     (slurp path)
+        forms      (read-all-string source)
+        defns      (filter form-name forms)
+        names      (set (map form-name defns))
+        ;; Group multi-arity defs by name (first def-form per name wins
+        ;; for graph purposes; we'll preserve order of duplicates below).
+        name->form (reduce (fn [m f]
+                             (let [n (form-name f)]
+                               (if (contains? m n) m (assoc m n f))))
+                           {} defns)
+        graph      (reduce-kv (fn [g n f]
+                                (assoc g n (disj (collect-refs f names) n)))
+                              {} name->form)
+        sccs       (g/sccs graph)
+        ;; Things that aren't defn-likes: the (ns …), any top-level let,
+        ;; the export block. Preserve order.
+        non-defns  (remove form-name forms)
+        ;; Find the (ns …) form if any — it must come first.
+        ns-form    (first (filter #(and (seq? %) (= 'ns (first %))) non-defns))
+        rest-non   (remove #(= % ns-form) non-defns)]
+    (let [out (atom [])]
+      (letfn [(emit [s] (swap! out conj s))]
+        (when ns-form
+          (emit (pp ns-form)) (emit "\n\n"))
+        (doseq [scc sccs]
+          (when (g/cyclic? scc)
+            (emit (str "(declare " (apply str (interpose " " scc)) ")\n\n")))
+          (doseq [n scc]
+            (when-let [f (get name->form n)]
+              (emit (pp f)) (emit "\n\n"))))
+        ;; Trailing non-defn forms (export block, etc.)
+        (doseq [f rest-non]
+          (emit (pp f)) (emit "\n\n"))
+        (print (apply str @out))))))
+
+;; os/args is [binary script user-arg user-arg...]
+(let [args (vec (drop 2 (seq os/args)))]
+  (if (= 1 (count args))
+    (sort-file (first args))
+    (do
+      (println "Usage: lg scripts/sort-defns.lg <path>")
+      (System/exit 1))))


### PR DESCRIPTION
## Summary

Adds three layered additions enabling automated topological ordering of let-go source files by call-dependency. Pure additions — no existing behavior changes (aside from tightened error handling on `read-string`, which previously returned `nil` on bad args).

### 1. `read-string` / `read-all-string` (pkg/compiler/eval.go)

`read-string` already existed but silently returned `nil` on bad args; now errors loudly with arity/type info. New `read-all-string` parses every top-level form from a string into a vector — needed by any script that walks source form-by-form (dependency analysis, codegen, etc.).

The naive `read-all-string` implementation has a subtle footgun: clean end-of-input and mid-form EOF both surface as `IsCausedBy(io.EOF)` because the reader wraps both through the same code path. A `(read-all-string "(a) (b")` would silently return `[(a)]` and drop the unbalanced second form. Solved with a peek-then-read pattern: `eatWhitespace` to advance to either the next form or true EOF, `unread` to put the char back, then `Read`. Any `Read` error is now a real syntax error.

### 2. `graph` ns (pkg/rt/core/graph.lg)

Generic graph algorithms over `{node -> coll-of-deps}` maps:

- `toposort` — deps-first order; `nil` on cycle.
- `sccs` — Tarjan's strongly-connected components, returned in deps-first topological order over the condensation DAG. Singleton SCCs are 1-element vecs; size > 1 SCCs represent cycles. The script layer below uses this to emit forward declarations for mutually recursive groups instead of failing.
- `has-cycle?`, `cyclic?`, `reachable`, `toposort-by` helpers.

Wired as a source-loaded namespace via `pkg/rt/graph.go` (`go:embed`) and the resolver's `embeddedSources` map. No precompile-bundle changes — first `(require 'graph)` loads it from source.

### 3. `scripts/sort-defns.lg`

Takes a `.lg` file path, parses every top-level form, builds the call graph between defn-like forms (`defn`, `defn-`, `defmacro`, `def`, `declare`), runs SCC analysis, emits the file in deps-first order. SCCs of size > 1 get a `(declare a b c …)` preamble so mutually recursive groups resolve at compile time.

```clojure
;; input
(defn high-level [x] (mid x))
(defn mid [x] (low x))
(defn low [x] (* x 2))
(defn a [x] (b x))
(defn b [x] (a x))
(def threshold 10)
```

```clojure
;; output
(defn low [x] (* x 2))
(defn mid [x] (low x))
(defn high-level [x] (mid x))
(def threshold 10)
(declare a b)
(defn a [x] (b x))
(defn b [x] (a x))
```

### Motivation

`let-go` resolves names top-to-bottom within a file, so any defn must come after its callees. Files like `pkg/rt/core/ir/data.lg` are large enough that manual ordering becomes error-prone — recent edits there hit `Can't resolve foo in this context` errors twice in the same session because foundational helpers had drifted below their users. The script automates that toposort.

## Known limitations (deferred follow-ups)

- Comments are stripped — the reader doesn't preserve them. A future revision could preserve top-of-file headers and section markers via positional source-range tracking.
- Output isn't pretty-printed; each form lands on a single line. Diff against the original to keep prose; or pipe through a formatter.
- Sibling order within the same dependency level isn't stable — Tarjan visits in `(keys graph)` iteration order. Worth stabilizing by original source position in a follow-up.

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./pkg/compiler/... ./pkg/rt/...`
- [ ] Manual: `./lg` REPL, `(require 'graph)`, exercise `g/toposort`, `g/sccs`, `g/cyclic?`.
- [ ] Manual: `(read-string)` and `(read-all-string)` error on bad args.
- [ ] Manual: `(read-all-string "(a) (b")` returns an error, not `[(a)]`.
- [ ] Manual: `./lg scripts/sort-defns.lg <some .lg file>` produces a valid topo-sorted output.