### PR TITLE
chore: gitignore /lgbgen, drop unused lg-baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,6 @@ AGENTS.md
 
 # Local goreleaser / cross-build artifacts
 /dist/
-lg-baseline
+
+# AOT codegen tool — built ad-hoc, not checked in
+/lgbgen


### PR DESCRIPTION
Two cleanups to \`.gitignore\`:

1. **Add \`/lgbgen\`** — the AOT codegen tool built by \`go run -tags bootstrap ./cmd/lgbgen\` lands a binary at the repo root if anyone runs \`go build ./cmd/lgbgen\` directly. Should be ignored alongside the existing \`/dist/\` entry.

2. **Remove \`lg-baseline\`** — nothing in the repo generates this file (\`grep -r lg-baseline\` finds it only in \`.gitignore\` itself). Looks like a speculative add that never got a producer; cleaning it up.

Net: +1 line, -1 line. No behavior change.