### PR TITLE
docs: bump README minimum Go version to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ brew install let-go
 Prebuilt binaries for Linux, macOS, and Plan 9 in
 [Releases](https://github.com/nooga/let-go/releases).
 
-### From source (Go 1.22+)
+### From source (Go 1.26+)
 
 ```bash
 go install github.com/nooga/let-go@latest


### PR DESCRIPTION
## Summary

- README listed `Go 1.22+` as the minimum for `go install`, but `go.mod` already requires `go 1.26`. Updated the README to match.

## Validation

While here, I spot-checked the rest of the README against `main`:

- jank-lang test suite: `make test` (with `test/clojure-test-suite` submodule initialized) reports `files=232 assertions: pass=5621 fail=0` — matches the claim verbatim.
- All listed standard namespaces, CLI flags (`-e -r -d -c -b -w -n -p -v --bundle-base --source-paths`), and nREPL ops (`clone close eval load-file describe completions complete info lookup ls-sessions interrupt`) are present.
- Embedding API (`NewLetGo`, `Def`, `Run`, `RegisterStruct`, `ToStruct`) is present at the documented paths.
- "Known limitations" section is accurate: STM/agent aliases live in `pkg/rt/core/core.lg:2034-2064`, the tagged-literal reader at `pkg/compiler/reader.go:1344-1368` handles only `#uuid`/`#inst` and returns the bare payload for unknown tags, no chunked-seq machinery, no `subseq`/`rsubseq`, no `clojure.spec`.

No other staleness found.

## Test plan

- [x] `make test` passes locally (1.6s without submodule; 3.2s including the 232-file Clojure compat suite, 5621/5621 assertions)