### PR TITLE
feat(rt+vm): xxh3 hash namespace + numeric-width interop widening

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.26
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/stretchr/testify v1.8.4
+	github.com/zeebo/xxh3 v1.1.0
 )
+
+require github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 
 require (
 	github.com/chzyer/test v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -23,8 +25,12 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/bencode v1.0.0 h1:zgop0Wu1nu4IexAZeCZ5qbsjU4O1vMrfCrVgUjbHVuA=
 github.com/zeebo/bencode v1.0.0/go.mod h1:Ct7CkrWIQuLWAy9M3atFHYq4kG9Ao/SsY5cdtCXmp9Y=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=

--- a/pkg/rt/hash.go
+++ b/pkg/rt/hash.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"github.com/zeebo/xxh3"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func mustBox(name string, fn any) vm.Value {
+	v, err := vm.NativeFnType.Box(fn)
+	if err != nil {
+		panic("hash NS: " + name + ": " + err.Error())
+	}
+	return v
+}
+
+func makeXxh3Hasher(h *xxh3.Hasher) vm.Value {
+	write := mustBox("xxh3-hasher/write", func(b []byte) {
+		_, _ = h.Write(b)
+	})
+	writeStr := mustBox("xxh3-hasher/write-str", func(s string) {
+		_, _ = h.WriteString(s)
+	})
+	sum := mustBox("xxh3-hasher/sum", h.Sum64)
+	reset := mustBox("xxh3-hasher/reset", h.Reset)
+
+	m := vm.EmptyPersistentMap.
+		Assoc(vm.Keyword("write"), write).(*vm.PersistentMap).
+		Assoc(vm.Keyword("write-str"), writeStr).(*vm.PersistentMap).
+		Assoc(vm.Keyword("sum"), sum).(*vm.PersistentMap).
+		Assoc(vm.Keyword("reset"), reset).(*vm.PersistentMap)
+	return m
+}
+
+// nolint
+func installHashNS() {
+	ns := vm.NewNamespace("hash")
+
+	ns.Def("xxh3-64", mustBox("xxh3-64", xxh3.Hash))
+	ns.Def("xxh3-64-seed", mustBox("xxh3-64-seed", xxh3.HashSeed))
+	ns.Def("xxh3-64-str", mustBox("xxh3-64-str", xxh3.HashString))
+	ns.Def("xxh3-64-str-seed", mustBox("xxh3-64-str-seed", xxh3.HashStringSeed))
+
+	ns.Def("xxh3-hasher", mustBox("xxh3-hasher", func() vm.Value {
+		return makeXxh3Hasher(xxh3.New())
+	}))
+	ns.Def("xxh3-hasher-seed", mustBox("xxh3-hasher-seed", func(seed uint64) vm.Value {
+		return makeXxh3Hasher(xxh3.NewSeed(seed))
+	}))
+
+	RegisterNS(ns)
+}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -108,6 +108,7 @@ func init() {
 	installSyscallNS()
 	installUnixNS()
 	installSystemNS()
+	installHashNS()
 	installGogenNS()
 	installDisasmNS()
 	installProfileNS()

--- a/pkg/vm/int.go
+++ b/pkg/vm/int.go
@@ -21,11 +21,29 @@ func (t *theIntType) Unbox() any      { return reflect.TypeFor[*theIntType]() }
 func (t *theIntType) Name() string { return "let-go.lang.Int" }
 
 func (t *theIntType) Box(bare any) (Value, error) {
-	raw, ok := bare.(int)
-	if !ok {
-		return IntType.zero, NewTypeError(bare, "can't be boxed as", t)
+	switch v := bare.(type) {
+	case int:
+		return Int(v), nil
+	case int8:
+		return Int(v), nil
+	case int16:
+		return Int(v), nil
+	case int32:
+		return Int(v), nil
+	case int64:
+		return Int(v), nil
+	case uint:
+		return Int(v), nil
+	case uint8:
+		return Int(v), nil
+	case uint16:
+		return Int(v), nil
+	case uint32:
+		return Int(v), nil
+	case uint64:
+		return Int(v), nil
 	}
-	return Int(raw), nil
+	return IntType.zero, NewTypeError(bare, "can't be boxed as", t)
 }
 
 // IntType is the type of IntValues

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -136,8 +136,10 @@ func BoxValue(v reflect.Value) (Value, error) {
 		}
 	}
 	switch v.Type().Kind() {
-	case reflect.Int:
-		return IntType.Box(v.Interface())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return Int(v.Int()), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return Int(v.Uint()), nil
 	case reflect.String:
 		return StringType.Box(v.Interface())
 	case reflect.Float32, reflect.Float64:


### PR DESCRIPTION
Adds a `hash` namespace exposing `github.com/zeebo/xxh3`:

- Pure fns: `xxh3-64`, `xxh3-64-seed`, `xxh3-64-str`, `xxh3-64-str-seed`.
- Stateful: `(hash/xxh3-hasher)` / `(hash/xxh3-hasher-seed seed)` returns `{:write :write-str :sum :reset}` — methods bound directly from `*xxh3.Hasher`.

Companion change to the boxing layer because xxh3 returns `uint64`:

- `IntType.Box` accepts every signed/unsigned int width (`int8..int64`, `uint..uint64`) instead of `int`-only.
- `BoxValue` in `pkg/vm/value.go` collapses `reflect.Int*` / `reflect.Uint*` and dispatches via `v.Int()` / `v.Uint()` so named int types (e.g. `time.Duration`) round-trip correctly.

The widening is generally useful — any Go library whose signature uses width-typed ints is now usable from let-go without per-call adapters.

## Smoke

```clojure
(hash/xxh3-64-str "hello, world")
;; => 3471384689615110252

(let [h (hash/xxh3-hasher)]
  ((:write-str h) "hello, ")
  ((:write-str h) "world")
  ((:sum h)))
;; => 3471384689615110252
```

## Test plan

- [x] `make test` — full suite passes locally
- [x] Smoke above matches between one-shot and streaming hasher paths