### PR TITLE
fix(vm): Go-fn-call-boundary fixes + Closure as Fn interface

### DIFF
--- a/pkg/vm/box_value_passthrough_test.go
+++ b/pkg/vm/box_value_passthrough_test.go
@@ -1,0 +1,25 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func TestBoxValueArgPassthrough(t *testing.T) {
+	// Box a Go fn whose param is vm.Value. Call it with an Int.
+	// Before fix: reflect.Call panicked because Int.Unbox() → int64.
+	fn, err := vm.NativeFnType.Box(func(v vm.Value) vm.Value {
+		return v
+	})
+	if err != nil {
+		t.Fatalf("Box: %v", err)
+	}
+	got, err := fn.(*vm.NativeFn).Invoke([]vm.Value{vm.Int(42)})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if i, ok := got.(vm.Int); !ok || int64(i) != 42 {
+		t.Fatalf("expected Int(42), got %v (%T)", got, got)
+	}
+}

--- a/pkg/vm/errors.go
+++ b/pkg/vm/errors.go
@@ -7,7 +7,9 @@ package vm
 
 import (
 	"fmt"
+	"os"
 	"reflect"
+	"runtime/debug"
 
 	"github.com/nooga/let-go/pkg/errors"
 )
@@ -171,7 +173,13 @@ func recoverThrownPanic(errp *error) {
 		if tp, ok := r.(*thrownPanic); ok {
 			*errp = tp.err
 		} else {
-			// Convert arbitrary Go panics to let-go errors
+			// Convert arbitrary Go panics to let-go errors. When
+			// LG_PANIC_STACK=1, also dump the Go stack trace so
+			// gogen_ir self-host bugs surface their actual location
+			// instead of being lost behind a wrapped error.
+			if os.Getenv("LG_PANIC_STACK") != "" {
+				fmt.Fprintf(os.Stderr, "[panic-recover] %v\n%s\n", r, debug.Stack())
+			}
 			*errp = fmt.Errorf("%v", r)
 		}
 	}

--- a/pkg/vm/func.go
+++ b/pkg/vm/func.go
@@ -116,7 +116,7 @@ func (l *Func) MakeClosure() Fn {
 
 type Closure struct {
 	closedOvers []Value
-	fn          *Func
+	fn          Fn
 }
 
 func (l *Closure) Type() ValueType { return FuncType }
@@ -129,9 +129,7 @@ func (l *Closure) Unbox() any {
 			a, _ := BoxValue(in[i]) // error not propagatable through reflect proxy
 			args[i] = a
 		}
-		f := NewFrame(l.fn.chunk, args)
-		f.closedOvers = l.closedOvers
-		out, _ := f.Run() // error not propagatable through reflect proxy
+		out, _ := l.Invoke(args)
 		return []reflect.Value{reflect.ValueOf(out.Unbox())}
 	}
 	return func(fptr any) {
@@ -142,30 +140,55 @@ func (l *Closure) Unbox() any {
 }
 
 func (l *Closure) Arity() int {
-	return l.fn.arity
+	return l.fn.Arity()
 }
 
 func (l *Closure) Invoke(pargs []Value) (result Value, err error) {
-	args := pargs
-	if l.fn.isVariadric {
-		if len(args) < l.fn.arity-1 {
-			return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", l, l.fn.arity-1, len(args)))
+	if f, ok := l.fn.(*Func); ok {
+		args := pargs
+		if f.isVariadric {
+			if len(args) < f.arity-1 {
+				return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", l, f.arity-1, len(args)))
+			}
+			sargs := args[0 : f.arity-1]
+			rest := args[f.arity-1:]
+			restlist, boxErr := ListType.Box(rest)
+			if boxErr != nil {
+				return NIL, boxErr
+			}
+			args = append(sargs, restlist)
+		} else if len(args) != f.arity {
+			return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, f.arity, len(args)))
 		}
-		sargs := args[0 : l.fn.arity-1]
-		rest := args[l.fn.arity-1:]
-		restlist, boxErr := ListType.Box(rest)
-		if boxErr != nil {
-			return NIL, boxErr
-		}
-		args = append(sargs, restlist)
-	} else if len(args) != l.fn.arity {
-		return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, l.fn.arity, len(args)))
+		frame := NewFrame(f.chunk, args)
+		frame.closedOvers = l.closedOvers
+		result, err = frame.Run()
+		ReleaseFrame(frame)
+		return result, err
 	}
-	f := NewFrame(l.fn.chunk, args)
-	f.closedOvers = l.closedOvers
-	result, err = f.Run()
-	ReleaseFrame(f)
-	return result, err
+
+	if mfn, ok := l.fn.(*MultiArityFn); ok {
+		le := len(pargs)
+		var variant Fn
+		if f, ok := mfn.fns[le]; ok {
+			variant = f
+		} else if mfn.rest != nil && le >= mfn.rest.Arity() {
+			variant = mfn.rest
+		} else {
+			return NIL, NewExecutionError(fmt.Sprintf("function %s doesn't have a %d-arity variant", l, le))
+		}
+
+		if f, ok := variant.(*Func); ok {
+			subClosure := &Closure{
+				closedOvers: l.closedOvers,
+				fn:          f,
+			}
+			return subClosure.Invoke(pargs)
+		}
+		return variant.Invoke(pargs)
+	}
+
+	return NIL, NewExecutionError("unsupported closure function type")
 }
 
 func (l *Closure) String() string {
@@ -239,11 +262,22 @@ func MakeMultiArity(fns []Value) (*MultiArityFn, error) {
 		}
 		if rest, ok := f.(*Func); ok && rest.isVariadric {
 			ma.rest = rest
-		} else if rest, ok := f.(*Closure); ok && rest.fn.isVariadric {
-			ma.rest = rest
+		} else if rest, ok := f.(*Closure); ok {
+			if ff, ok := rest.fn.(*Func); ok && ff.isVariadric {
+				ma.rest = rest
+			} else {
+				ma.fns[a] = f
+			}
 		} else {
 			ma.fns[a] = f
 		}
 	}
 	return ma, nil
+}
+
+func (l *MultiArityFn) MakeClosure() Fn {
+	return &Closure{
+		closedOvers: nil,
+		fn:          l,
+	}
 }

--- a/pkg/vm/native_func.go
+++ b/pkg/vm/native_func.go
@@ -7,6 +7,7 @@ package vm
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 )
 
@@ -31,14 +32,28 @@ func (t *theNativeFnType) Box(fn any) (Value, error) {
 		rawArgs := make([]reflect.Value, len(args))
 
 		for i := range args {
-			j := i
+			// For variadic fns called via reflect.Call (not CallSlice),
+			// each variadic arg slot expects the slice's ELEMENT type, not
+			// the slice type itself. Previously the loop used the slice
+			// type ([]vm.Value) for variadic args, which sent vm.String
+			// through the slice-target branch of boxArgForReflect and out
+			// the Unbox fallback — surfacing a Go primitive that reflect
+			// rejected when dispatching through the let-go Value interface.
+			var in reflect.Type
 			if variadric && i >= declArgs-1 {
-				j = declArgs - 1
+				in = ty.In(declArgs - 1).Elem()
+			} else {
+				in = ty.In(i)
 			}
-			in := ty.In(j)
 			if args[i] != NIL {
 				rawArgs[i] = boxArgForReflect(args[i], in)
-				if rawArgs[i].CanConvert(in) {
+				// Skip the .Convert() step when the prepared value is
+				// already assignable to the param's interface type — Convert
+				// to an interface erases the dynamic type info reflect.Call
+				// needs to dispatch through the let-go Value interface.
+				if rawArgs[i].IsValid() && rawArgs[i].Type().AssignableTo(in) {
+					// already valid as-is
+				} else if rawArgs[i].CanConvert(in) {
 					rawArgs[i] = rawArgs[i].Convert(in)
 				}
 			} else {
@@ -86,6 +101,9 @@ func (t *theNativeFnType) Box(fn any) (Value, error) {
 // machinery already does this via unboxSliceInto, so we delegate to it.
 // For non-slice targets and for boxed Go values, plain Unbox is correct.
 func boxArgForReflect(v Value, target reflect.Type) reflect.Value {
+	if debugBoxArgs {
+		fmt.Fprintf(os.Stderr, "[boxArgForReflect] v=%T target=%s kind=%s\n", v, target.String(), target.Kind())
+	}
 	if target.Kind() == reflect.Slice || target.Kind() == reflect.Array {
 		if sq, ok := v.(Sequable); ok {
 			out := reflect.New(target).Elem()
@@ -94,8 +112,27 @@ func boxArgForReflect(v Value, target reflect.Type) reflect.Value {
 			}
 		}
 	}
+	// When the Go param is an interface (typically vm.Value itself), pass
+	// the boxed Value directly. Unboxing first would surface a Go-native
+	// type (int64, string, []any, …) that reflect.Call can't assign to a
+	// vm.Value-typed slot. The Generated Go IR-stack code (lowered defns
+	// wrapping inner closures via BoxNativeFn) relies on this path.
+	if target.Kind() == reflect.Interface {
+		rv := reflect.ValueOf(v)
+		if debugBoxArgs {
+			fmt.Fprintf(os.Stderr, "[boxArgForReflect]   interface path: rv.Type=%s assignable=%v\n", rv.Type().String(), rv.Type().AssignableTo(target))
+		}
+		if rv.IsValid() && rv.Type().AssignableTo(target) {
+			return rv
+		}
+	}
+	if debugBoxArgs {
+		fmt.Fprintf(os.Stderr, "[boxArgForReflect]   FALLBACK Unbox: v.Unbox()=%T\n", v.Unbox())
+	}
 	return reflect.ValueOf(v.Unbox())
 }
+
+var debugBoxArgs = os.Getenv("LG_BOXARGS_DEBUG") != ""
 
 func (t *theNativeFnType) WrapNoErr(fn func([]Value) Value) (Value, error) {
 	return t.Wrap(func(args []Value) (Value, error) {

--- a/pkg/vm/source.go
+++ b/pkg/vm/source.go
@@ -11,12 +11,19 @@ import (
 )
 
 // SourceInfo tracks the source location of a form.
+//
+// Symbol is an optional user-visible name for the value the form binds
+// (e.g. a let-binding or parameter name). It is empty for SourceInfos
+// attached purely for line/column tracking, and populated by the IR
+// builder when a value flows through a `bind-local!` site so downstream
+// passes (notably lower-go) can emit human-readable identifiers.
 type SourceInfo struct {
 	File      string
 	Line      int // 0-based
 	Column    int // 0-based
 	EndLine   int
 	EndColumn int
+	Symbol    string
 }
 
 func (s *SourceInfo) String() string {

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -129,9 +129,19 @@ func BoxValue(v reflect.Value) (Value, error) {
 	if !v.IsValid() {
 		return NIL, NewTypeError(v, "can't be boxed", nil)
 	}
+	// A reflect.Value carrying a nil-typed interface (e.g. a Go fn returned
+	// `(vm.Value)(nil)` instead of vm.NIL) reaches the default branch of the
+	// switch below and panics inside NewBoxed → reflect.TypeOf(nil).Name().
+	// Treat all nil-interface returns as let-go NIL up front.
+	if v.IsValid() && v.Kind() == reflect.Interface && v.IsNil() {
+		return NIL, nil
+	}
 	if v.CanInterface() {
 		rv, ok := v.Interface().(Value)
 		if ok {
+			if rv == nil {
+				return NIL, nil
+			}
 			return rv, nil
 		}
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -50,16 +50,17 @@ const (
 
 	// Specialized arithmetic/comparison opcodes (binary, stack: [a b] -> [result])
 	// These inline the common int64 fast path and fall back to generic NumXxx for other types.
-	OP_ADD // + (2 args)
-	OP_SUB // - (2 args)
-	OP_MUL // * (2 args)
-	OP_LT  // < (2 args)
-	OP_LTE // <= (2 args)
-	OP_GT  // > (2 args)
-	OP_GTE // >= (2 args)
-	OP_EQ  // = (2 args)
-	OP_INC // inc (1 arg)
-	OP_DEC // dec (1 arg)
+	OP_ADD  // + (2 args)
+	OP_SUB  // - (2 args)
+	OP_MUL  // * (2 args)
+	OP_LT   // < (2 args)
+	OP_LTE  // <= (2 args)
+	OP_GT   // > (2 args)
+	OP_GTE  // >= (2 args)
+	OP_EQ   // = (2 args)
+	OP_INC  // inc (1 arg)
+	OP_DEC  // dec (1 arg)
+	OP_QUOT // quot — integer quotient, truncated toward zero (2 args)
 )
 
 func OpcodeToString(op int32) string {
@@ -101,6 +102,7 @@ func OpcodeToString(op int32) string {
 		"EQ",
 		"INC",
 		"DEC",
+		"QUOT",
 	}
 	if int(inst) < len(ops) {
 		return fmt.Sprintf("%d/%-16s", sp, ops[inst])
@@ -793,7 +795,10 @@ func (f *Frame) Run() (Value, error) {
 			if idx < 0 {
 				return NIL, NewExecutionError("MAKE_CLOSURE stack underflow")
 			}
-			fn, ok := f.stack[idx].(*Func)
+			type closureCreator interface {
+				MakeClosure() Fn
+			}
+			fn, ok := f.stack[idx].(closureCreator)
 			if !ok {
 				return NIL, NewExecutionError("MAKE_CLOSURE invalid func on stack")
 			}
@@ -997,6 +1002,36 @@ func (f *Frame) Run() (Value, error) {
 				}
 			}
 			r, err := NumMul(a, b)
+			if err != nil {
+				if f.handleError(err) {
+					continue
+				}
+				return NIL, err
+			}
+			f.stack[f.sp-2] = r
+			f.sp--
+			f.ip++
+
+		case OP_QUOT:
+			b := f.stack[f.sp-1]
+			a := f.stack[f.sp-2]
+			if ai, ok := a.(Int); ok {
+				if bi, ok := b.(Int); ok {
+					if bi == 0 {
+						if f.handleError(NewExecutionError("integer division by zero")) {
+							continue
+						}
+						return NIL, NewExecutionError("integer division by zero")
+					}
+					// Int quot is truncated toward zero — Go's / on
+					// signed ints matches Clojure's quot semantics.
+					f.stack[f.sp-2] = Int(int64(ai) / int64(bi))
+					f.sp--
+					f.ip++
+					continue
+				}
+			}
+			r, err := NumQuot(a, b)
 			if err != nil {
 				if f.handleError(err) {
 					continue


### PR DESCRIPTION
## Summary

Bundle of correctness fixes around the Go ↔ let-go function-call boundary, plus a structural change to support multi-arity closures.

- **BoxValue nil-interface handling** — a `reflect.Value` carrying a nil-typed interface (e.g. a Go fn returned `(vm.Value)(nil)`) previously reached the default switch branch and panicked inside `NewBoxed`. Now returns `NIL` up front.
- **native_func variadic boxArgForReflect** — variadic fns called via `reflect.Call` (not `CallSlice`) need each variadic arg slot's ELEMENT type, not the slice type. Previously sent `vm.String` through the slice-target branch of `boxArgForReflect` and surfaced a Go primitive that reflect rejected.
- **Closure.fn: \\*Func → Fn interface** — closures now wrap either `\\*Func` or `\\*MultiArityFn`, enabling multi-arity closures end-to-end.
- Supporting changes in `errors.go`, `source.go`, `vm.go`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/vm/ ./pkg/rt/`
- [x] `go run -tags bootstrap ./cmd/lgbgen`
- New regression test `pkg/vm/box_value_passthrough_test.go`