### PR TITLE
feat(ir+scripts): substrate observability + small ops + ir-stress harness

### DIFF
--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -60,6 +60,7 @@ var embeddedNS = []struct {
 	{"ir.build", &rt.IRBuildSrc},
 	{"ir.passes.pipeline", &rt.IRPassPipelineSrc},
 	{"ir.dump", &rt.IRDumpSrc},
+	{"ir.passes.trace", &rt.IRPassTraceSrc},
 	// zip and data are loaded from source on demand (precompiled ns chunks
 	// only replay nil stubs for defn, not the actual function bodies)
 }

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -50,6 +50,7 @@ var embeddedSources = map[string]*string{
 	"ir.build":            &rt.IRBuildSrc,
 	"ir.validate":         &rt.IRValidateSrc,
 	"ir.passes.pipeline":  &rt.IRPassPipelineSrc,
+	"ir.passes.trace":     &rt.IRPassTraceSrc,
 	"ir.dump":             &rt.IRDumpSrc,
 	"check":               &rt.CheckSrc,
 }

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -112,7 +112,7 @@
 
 (declare build-list build-symbol build-if build-let build-do build-quote
          build-loop build-recur build-fn*
-         build-vector build-map)
+         build-vector build-map build-call)
 
 ;; Sentinel returned by recur / any form whose current-block is already
 ;; terminated. Callers must check for this before emitting more code.
@@ -204,14 +204,19 @@
 ;; dispatch table the single source of truth.
 
 (def builtin-ops
-  {'+  :add
-   '-  :sub
-   '*  :mul
-   '<  :lt
-   '<= :lte
-   '>  :gt
-   '>= :gte
-   '=  :eq})
+  {'+   :add
+   '-   :sub
+   '*   :mul
+   '<   :lt
+   '<=  :lte
+   '>   :gt
+   '>=  :gte
+   '=   :eq
+   'inc :inc
+   'dec :dec})
+
+;; Ops whose arity-1 form is the canonical shape (no n-ary folding).
+(def unary-only-ops #{:inc :dec})
 
 (defn build-args [forms ctx]
   ;; Build each arg, AND register its result as a temporary live local
@@ -272,8 +277,15 @@
 
 (defn build-builtin-op [op-kw form ctx]
   ;; Builtin ops are binary (stack-effect 2→1). Fold n-ary calls.
+  ;; Unary-only ops (:inc, :dec) take exactly one ref.
   (let [args (build-args (rest form) ctx)]
     (cond
+      (contains? unary-only-ops op-kw)
+        (if (= 1 (count args))
+          (ir/add-inst (ctx-fn ctx) (ctx-block ctx) op-kw [(nth args 0)] nil)
+          ;; Wrong-arity (inc) / (inc x y) — fall back to a generic call so
+          ;; the runtime arity-error surfaces normally.
+          (build-call form ctx))
       ;; Unary: (- x) → (sub 0 x); (+ x), (* x), comparisons → identity.
       (= 1 (count args))
         (if (= op-kw :sub)

--- a/pkg/rt/core/ir/data.lg
+++ b/pkg/rt/core/ir/data.lg
@@ -242,9 +242,12 @@
         seed  (vec (repeat (count insts) []))]
     (reduce-kv
       (fn [acc i inst]
-        (-> acc
-            (accumulate-uses-from-refs i (nth inst 1))
-            (accumulate-uses-from-aux i inst)))
+        ;; Skip :invalid insts (those marked for removal).
+        (if (= :invalid (nth inst 0))
+          acc
+          (-> acc
+              (accumulate-uses-from-refs i (nth inst 1))
+              (accumulate-uses-from-aux i inst))))
       seed
       insts)))
 

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -5,7 +5,7 @@
 ;;   - strict mode: unsupported ops/shapes throw
 ;;   - bridge mode: unsupported functions fall back at whole-function granularity
 ;;   - supported ops: const, load-arg, block-arg, add/sub/mul, lt/lte/gt/gte/eq,
-;;     return, branch, branch-if, tail-call
+;;     inc/dec, return, branch, branch-if, tail-call
 ;;   - control flow lowers from block-parameter SSA to mutable locals plus labels/gotos
 
 (ns ir.lower-go
@@ -119,8 +119,26 @@
 (defn- value-name [nid]
   (str "v" nid))
 
+;; Munge Lisp-idiomatic identifier chars to a valid Go identifier.
+;; Convention is Clojure-flavoured: each unsafe char maps to a distinct
+;; underscore-bracketed token so munged names don't collide with
+;; legitimately-named Go identifiers like `foo_bang` already in source.
+(def go-name-munge-map
+  {\-  "_"
+   \!  "_BANG_"
+   \?  "_QMARK_"
+   \*  "_STAR_"
+   \/  "_SLASH_"
+   \+  "_PLUS_"
+   \=  "_EQ_"
+   \<  "_LT_"
+   \>  "_GT_"})
+
 (defn- go-name [s]
-  (apply str (map (fn [ch] (if (= ch \-) \_ ch)) s)))
+  (apply str
+         (map (fn [ch]
+                (or (get go-name-munge-map ch) ch))
+              s)))
 
 (defn- import-entry [path alias]
   {:path path :alias alias})
@@ -149,6 +167,8 @@
 (defn- local-carrying-op? [op]
   (or (= op :block-arg)
       (= op :call)
+      (= op :inc)
+      (= op :dec)
       (contains? binary-op op)))
 
 (defn- used? [f nid]
@@ -275,6 +295,11 @@
               rhs (value-expr f closed-exprs (nth refs 1))]
           (when (and lhs rhs)
             (gogen/binary (get binary-op op) lhs rhs)))
+
+      (or (= op :inc) (= op :dec))
+        (let [lhs (value-expr f closed-exprs (nth refs 0))]
+          (when lhs
+            (gogen/binary (if (= op :inc) "+" "-") lhs (gogen/int-lit 1))))
 
       :else nil)))
 
@@ -414,6 +439,12 @@
       (= op :push-closed)  []
       (= op :block-arg) []
       (contains? binary-op op)
+        (if (used? f nid)
+          (let [rhs (inst-rhs f closed-exprs nid)]
+            (when rhs
+              [(gogen/assign "=" (value-ident nid) rhs)]))
+          [])
+      (or (= op :inc) (= op :dec))
         (if (used? f nid)
           (let [rhs (inst-rhs f closed-exprs nid)]
             (when rhs

--- a/pkg/rt/core/ir/passes/trace.lg
+++ b/pkg/rt/core/ir/passes/trace.lg
@@ -1,0 +1,154 @@
+;; Instrumentation for the optimization pipeline.
+;;
+;; Two layers:
+;;   1. `trace-pass` macro — wraps a single pass call, records the
+;;      live-inst-count delta and wall-clock time into `*pass-trace*`.
+;;   2. `optimize-fn-traced` — same fixpoint loop as `optimize-fn`,
+;;      with every pass wrapped in `trace-pass`. Returns the fn
+;;      (still mutated in place) and the trace as a side channel via
+;;      `*pass-trace*`.
+;;
+;; Use `(with-trace ... )` to bind a fresh trace atom for a scope and
+;; `(print-trace)` to render iter-by-iter pass deltas to stdout.
+;;
+;; Why this exists: the fixpoint loop runs each pass N times, and a
+;; subtle bug in any pass shows up as wasted iterations, slow
+;; convergence, or fixtures pushed past timeout. Without per-pass
+;; visibility, every regression debug starts from scratch with
+;; `ir.dump/dump` sprinkled by hand.
+
+(ns ir.passes.trace
+  (:require ir.dump
+            [ir.passes.constfold :refer [constfold]]
+            [ir.passes.cse :refer [cse]]
+            [ir.passes.dce :refer [dce]]
+            [ir.passes.licm :refer [licm]]
+            [ir.passes.typeinfer :refer [typeinfer]]
+            [ir.validate :refer [validate-fn!]]))
+
+;; --- live inst count (duplicated from pipeline.lg — not exported) -----
+
+(defn live-inst-count [f]
+  "Count valid (non-invalid) instructions across all blocks."
+  (reduce + (map (fn [bid] (count (ir/block-insts bid f)))
+                 (ir/blocks f))))
+
+;; --- trace atom + helpers ---------------------------------------------
+
+(def ^:dynamic *pass-trace* nil)
+
+(defn ns-now [] (System/nanoTime))
+
+;; --- the macro --------------------------------------------------------
+;;
+;; Note: the macro body is fully inlined to avoid forward-reference
+;; resolution issues during ns load. Calls to live-inst-count and
+;; ns-now use unqualified names — the expansion site provides them
+;; via :refer/:use or being in the same ns. If you call trace-pass
+;; from outside ir.passes.trace, refer-all the ns first.
+
+(defmacro trace-pass [pass-name iter pass-call f]
+  "Wrap a pass call to record into *pass-trace*.
+   `pass-call` is the actual invocation, e.g. (constfold f).
+   Returns the result of pass-call (the mutated f)."
+  `(let [_b#  (live-inst-count ~f)
+         _t0# (System/nanoTime)
+         _r#  ~pass-call
+         _t1# (System/nanoTime)
+         _a#  (live-inst-count ~f)
+         _ns# (- _t1# _t0#)]
+     (when *pass-trace*
+       (swap! *pass-trace* conj
+              {:pass    ~pass-name
+               :iter    ~iter
+               :before  _b#
+               :after   _a#
+               :delta   (- _b# _a#)
+               :ns      _ns#
+               :ms      (/ _ns# 1000000.0)}))
+     _r#))
+
+;; --- traced optimize-fn -----------------------------------------------
+
+(defn optimize-fn-traced [f]
+  "Same as ir.passes.pipeline/optimize-fn but every pass is
+   wrapped in `trace-pass`. Caller binds *pass-trace* to an atom
+   to receive the recording."
+  (validate-fn! f "build")
+  (trace-pass "typeinfer-pre" -1 (typeinfer f) f)
+  (loop [iter 0]
+    (let [before (live-inst-count f)]
+      (trace-pass "constfold" iter (constfold f) f)
+      (validate-fn! f (str "constfold/" iter))
+      (trace-pass "cse" iter (cse f) f)
+      (validate-fn! f (str "cse/" iter))
+      (trace-pass "licm" iter (licm f) f)
+      (validate-fn! f (str "licm/" iter))
+      (trace-pass "dce" iter (dce f) f)
+      (validate-fn! f (str "dce/" iter))
+      (let [after (live-inst-count f)]
+        (cond
+          (= before after) f
+          (>= iter 15)
+            (do (println (str "warn: optimize-fn-traced max iters (16) reached, "
+                              before " insts after 16 cycles"))
+                f)
+          :else (recur (inc iter))))))
+  (trace-pass "typeinfer-post" -1 (typeinfer f) f)
+  f)
+
+;; --- scope helpers ----------------------------------------------------
+
+(defmacro with-trace [& body]
+  "Binds *pass-trace* to a fresh atom for the duration of body.
+   Returns [result trace-vector]."
+  `(let [t# (atom [])]
+     (binding [*pass-trace* t#]
+       (let [r# (do ~@body)]
+         [r# @t#]))))
+
+;; --- pretty printer ---------------------------------------------------
+
+(defn print-trace [trace]
+  "Render a trace vector as a table:
+     iter  pass             before  after  delta    ms
+        0  typeinfer-pre        6      6      0   1.23
+        0  constfold            6      6      0   0.45
+        0  cse                  6      6      0   0.31
+        0  licm                 6      6      0   0.22
+        0  dce                  6      5      1   0.18
+        1  constfold            5      5      0   0.10
+        ...
+   `delta` is positive for removals, negative for adds (no pass
+   should add insts; negative is a bug signal)."
+  (println (format "%4s  %-18s  %6s  %6s  %6s  %7s"
+                   "iter" "pass" "before" "after" "delta" "ms"))
+  (println (apply str (repeat 55 "-")))
+  (doseq [e trace]
+    (println (format "%4d  %-18s  %6d  %6d  %+6d  %7.2f"
+                     (:iter e) (:pass e) (:before e) (:after e)
+                     (:delta e) (:ms e))))
+  (let [total-ms (reduce + (map :ms trace))
+        total-removed (reduce + (map :delta trace))]
+    (println (apply str (repeat 55 "-")))
+    (println (format "  %d passes, %d insts removed, %.2f ms total"
+                     (count trace) total-removed total-ms))))
+
+;; --- IR-level dump pairing --------------------------------------------
+
+(defn dump-pair [pass-name pass-fn f]
+  "Run a single pass and return {:before dump :after dump
+   :delta n :ms n}. For one-off pass-level inspection.
+   Does not touch *pass-trace*."
+  (let [before-dump (ir.dump/dump f)
+        before-cnt  (live-inst-count f)
+        t0          (ns-now)
+        _           (pass-fn f)
+        t1          (ns-now)
+        after-cnt   (live-inst-count f)
+        after-dump  (ir.dump/dump f)]
+    {:pass   pass-name
+     :before before-dump
+     :after  after-dump
+     :delta  (- before-cnt after-cnt)
+     :ms     (/ (- t1 t0) 1000000.0)}))

--- a/pkg/rt/core/ir/validate.lg
+++ b/pkg/rt/core/ir/validate.lg
@@ -47,7 +47,6 @@
         (recur (inc i))))))
 
 (defn- check-blocks-terminated! [f label]
-  (println "VALIDATE-DEBUG: running check-blocks-terminated!")
   (let [blocks (:blocks @f)
         insts  (:insts @f)]
     (loop [i 0]
@@ -59,7 +58,7 @@
           ;; unused join blocks from nested ifs where both branches terminate.
           (when (or (= i 0) (seq preds))
             (when (nil? term-id)
-              (throw (str "VALIDATE-BANANA after " label
+              (throw (str "validate after " label
                           ": block #" i " has no :term field")))
             (when (or (< term-id 0) (>= term-id (count insts)))
               (throw (str "validate after " label

--- a/pkg/rt/irpasses.go
+++ b/pkg/rt/irpasses.go
@@ -32,6 +32,9 @@ var IRPassLICMSrc string
 //go:embed core/ir/passes/pipeline.lg
 var IRPassPipelineSrc string
 
+//go:embed core/ir/passes/trace.lg
+var IRPassTraceSrc string
+
 //go:embed core/ir/dump.lg
 var IRDumpSrc string
 

--- a/scripts/ir-stress.lg
+++ b/scripts/ir-stress.lg
@@ -1,59 +1,56 @@
 ;; IR-pipeline coverage stress test — corpus-agnostic.
 ;;
-;; Drives a corpus of .lg files through the IR pipeline, reporting per-
-;; file pass rates, error buckets, and cold + warm timing. Replaces the
-;; previous xsofy-hardcoded harness.
-;;
 ;; Usage:
-;;   go run . scripts/ir-stress.lg <dir> <file> [<file>...]
+;;   go run . scripts/ir-stress.lg <mode> <dir> <file> [<file>...]
 ;;
+;;   <mode>  ir-compile  — eval each defn under (binding [*ir-compile* true])
+;;                         measures what users experience at load time
+;;           lower-go    — build IR + lower-go in :bridge mode, no eval
+;;                         measures AOT pass rate, safe to run vs live pipeline
 ;;   <dir>   corpus root (absolute or relative to cwd)
 ;;   <file>  one or more .lg paths relative to <dir>
 ;;
-;; Each top-level (defn ...) form is evaluated under
-;;   (binding [*ir-compile* true] (eval form))
-;; so the IR pipeline drives the compile path. Bodies that fail to
-;; IR-compile are bucketed by classify-error so the output highlights
-;; which language features still need IR support.
-;;
 ;; Examples:
 ;;   # xsofy IR-compile pass rate
-;;   LG_SOURCE_PATHS=/path/to/xsofy go run . scripts/ir-stress.lg \
-;;     /path/to/xsofy/xsofy \
+;;   LG_SOURCE_PATHS=/Users/ndn/development/xsofy go run . scripts/ir-stress.lg \
+;;     ir-compile /Users/ndn/development/xsofy/xsofy \
 ;;     util.lg combat.lg ai.lg items.lg fov.lg fire.lg effects.lg \
-;;     bestiary.lg input.lg lighting.lg runes.lg sound.lg det.lg \
-;;     entities.lg check.lg
+;;     bestiary.lg input.lg lighting.lg runes.lg sound.lg det.lg entities.lg check.lg
 ;;
-;;   # pkg/rt/core/ir self-load pass rate
-;;   go run . scripts/ir-stress.lg pkg/rt/core/ir \
-;;     data.lg zipper.lg build.lg lower.lg passes.lg \
-;;     passes/constfold.lg passes/cse.lg passes/dce.lg \
+;;   # IR-pipeline self-AOT pass rate
+;;   go run . scripts/ir-stress.lg lower-go pkg/rt/core/ir \
+;;     data.lg zipper.lg build.lg lower.lg lower_go.lg passes.lg \
+;;     passes/constfold.lg passes/cse.lg passes/dce.lg passes/typeinfer.lg \
 ;;     passes/licm.lg passes/pipeline.lg
-;;
-;; Per-fixture timeout via LG_STRESS_TIMEOUT_MS (default 5000).
-
 (require 'ir.data)
 (require 'ir.passes.pipeline)
 
 (defn- usage-and-exit [msg]
   (println (str "ir-stress: " msg))
-  (println "Usage: go run . scripts/ir-stress.lg <dir> <file>...")
+  (println "Usage: go run . scripts/ir-stress.lg <mode> <dir> <file>...")
+  (println "  <mode>: ir-compile | lower-go")
   (println "  <dir>:  corpus root")
   (println "  <file>: one or more .lg paths relative to <dir>")
   (System/exit 1))
 
 ;; os/args is [binary script user-arg user-arg...]
 (def user-args (vec (drop 2 (seq os/args))))
-(when (< (count user-args) 2)
-  (usage-and-exit "expected at least 2 args (dir, file)"))
+(when (< (count user-args) 3)
+  (usage-and-exit "expected at least 3 args (mode, dir, file)"))
 
-(def raw-dir (nth user-args 0))
+(def measurement-mode
+  (let [m (nth user-args 0)]
+    (cond
+      (= m "lower-go")   :lower-go
+      (= m "ir-compile") :ir-compile
+      :else (usage-and-exit (str "<mode> must be 'ir-compile' or 'lower-go', got: " m)))))
+(def raw-dir (nth user-args 1))
 (def corpus-dir
   (let [n (count raw-dir)]
     (if (and (pos? n) (= \/ (nth raw-dir (dec n))))
       raw-dir
       (str raw-dir "/"))))
-(def files (vec (drop 1 user-args)))
+(def files (vec (drop 2 user-args)))
 (def stress-target (str corpus-dir " (" (count files) " files)"))
 
 (defn read-all [path]
@@ -102,10 +99,12 @@
   (let [m (str err-str)
         truncated (if (> (count m) 100) (str (subs m 0 100) "...") m)]
     (cond
+      ;; Unresolved symbol errors
       (or (re-find #"unresolved symbol" m)
           (re-find #"Can't resolve" m))
         :unresolved-symbol
 
+      ;; Unsupported special forms
       (or (re-find #"def\s" m)
           (re-find #"set!" m)
           (re-find #"\btry\b" m)
@@ -114,9 +113,11 @@
           (re-find #"trace" m))
         :unsupported-special-form
 
+      ;; Destructuring issues
       (re-find #"destructur" m)
         :destructure-rejection
 
+      ;; Everything else: store the actual error message
       :else
         (str ":other | " truncated))))
 
@@ -140,14 +141,43 @@
         :else
           (do (sleep 10) (recur))))))
 
-(defn try-ir-compile-timed [form]
-  "Evaluate form under (binding [*ir-compile* true] ...) with a per-fixture
-   timeout. Returns [result-key time-ms]."
-  (let [thunk (fn [] (try
-                       (binding [*ir-compile* true]
-                         (eval form))
-                       :ok
-                       (catch e (classify-error e))))
+(defn try-lower-go [form]
+  "Run form through the AOT path: build IR + lower to Go (bridge mode).
+   Returns :ok | :fallback-<reason> | error-classification.
+   Does NOT eval/intern — safe to run against the live IR pipeline."
+  (try
+    (binding [ir.passes.pipeline/*target* :go]
+      (let [result (ir.passes.pipeline/compile-form form)]
+        (cond
+          ;; Single-arity success
+          (and (map? result) (= :lowered (:status result)))
+            :ok
+          ;; Single-arity fallback — capture reason
+          (and (map? result) (= :fallback (:status result)))
+            (let [reason (or (:reason result) "no-reason")
+                  short  (if (> (count reason) 60) (str (subs reason 0 60) "...") reason)]
+              (keyword (str "fallback | " short)))
+          ;; Multi-arity template: succeed if every arity lowered
+          (and (map? result) (= :multi-fn-template (:kind result)))
+            (if (every? (fn [e] (some? (:fn e))) (:fns result))
+              :ok
+              :multi-arity-partial-fallback)
+          :else :ok)))
+    (catch e (classify-error e))))
+
+(defn try-ir-timed [form]
+  "Per-fixture measurement, dispatched by measurement-mode.
+   :ir-compile  — eval via *ir-compile* (xsofy: measures user-load behavior)
+   :lower-go    — lower IR to Go via :bridge mode (ir-stack: AOT pass rate)
+   Wrapped in per-fixture-timeout-ms; runaway fixtures return :stress/timeout.
+   Returns [result-key time-ms]."
+  (let [thunk (if (= measurement-mode :lower-go)
+                (fn [] (try-lower-go form))
+                (fn [] (try
+                         (binding [*ir-compile* true]
+                           (eval form))
+                         :ok
+                         (catch e (classify-error e)))))
         t0 (System/nanoTime)
         result (try-with-timeout thunk per-fixture-timeout-ms)
         t1 (System/nanoTime)
@@ -155,6 +185,7 @@
     [result ms]))
 
 (defn stats-for [times]
+  "Given a list of times (ms), return {:mean N :median N :p95 N}."
   (if (empty? times)
     {:mean 0 :median 0 :p95 0}
     (let [sorted (sort times)
@@ -167,6 +198,7 @@
       {:mean mean :median median :p95 p95})))
 
 (defn stress-file [path]
+  "Compile each defn in path, tracking times and error buckets."
   (let [parsed (read-all path)
         defns  (vec (defn-forms parsed))]
     (if (nil? parsed)
@@ -179,7 +211,7 @@
             (eval (list 'in-ns (list 'quote ns-sym)))
             (catch e nil)))
         (require-deps! ns-form-)
-        (let [results (mapv (fn [d] [(nth d 1) (try-ir-compile-timed d)]) defns)
+        (let [results (mapv (fn [d] [(nth d 1) (try-ir-timed d)]) defns)
               ok     (count (filter (fn [[_ [r _]]] (= :ok r)) results))
               errs   (filter (fn [[_ [r _]]] (not= :ok r)) results)
               times  (map (fn [[_ [_ t]]] t) results)
@@ -190,7 +222,8 @@
            :error-buckets error-buckets})))))
 
 (defn run []
-  (println (str "=== IR-pipeline stress test — target: " stress-target " ===\n"))
+  (println (str "=== IR-pipeline stress test — target: " stress-target
+                " — mode: " measurement-mode " ===\n"))
 
   ;; Load all corpus modules upfront so cross-file refs resolve
   (print "Loading corpus dependencies... ")
@@ -204,7 +237,7 @@
           (when ns-sym
             (eval (list 'in-ns (list 'quote ns-sym))))
           (require-deps! ns-form-))
-        (catch e nil)))
+        (catch e nil)))  ;; Silently skip load errors; we'll catch them per-fixture
     (let [t1 (System/nanoTime)
           ms (double (/ (- t1 t0) 1000000.0))]
       (println (format "done in %.1f ms\n" ms))))
@@ -229,22 +262,26 @@
       (let [all-results (concat results results2)
             total   (reduce + 0 (map (fn [r] (or (:total r) 0)) all-results))
             oks     (reduce + 0 (map (fn [r] (or (:ok r) 0)) all-results))
+            all-times (mapcat (fn [r] (or (:times r) [])) all-results)
             all-errs (reduce (fn [acc r]
                               (merge-with + acc (or (:error-buckets r) {})))
                             {}
                             all-results)]
 
+        ;; Per-file summary
         (println "=== Per-file results (cold pass) ===")
         (doseq [r results]
           (if (:read-error r)
-            (println (str (:file r) ": READ-ERROR"))
+            (println (str (:file r) ": READ-ERROR (xsofy not checked out?)"))
             (println (str (:file r) ": " (:ok r) "/" (:total r) " ok"))))
 
+        ;; Overall stats
         (println (str "\n=== Summary (both passes combined) ==="))
         (println (str "Total fixtures: " total))
         (println (str "Passed: " oks " (" (int (/ (* oks 100) (max 1 total))) "%)"))
         (println (str "Failed: " (- total oks)))
 
+        ;; Timing stats
         (let [cold-stats (stats-for (mapcat (fn [r] (or (:times r) [])) results))
               warm-stats (stats-for (mapcat (fn [r] (or (:times r) [])) results2))]
           (println (str "\n=== Timing Statistics ==="))
@@ -253,6 +290,7 @@
           (println (format "Warm pass (second run): mean=%.2f ms  median=%.2f ms  p95=%.2f ms"
                           (:mean warm-stats) (:median warm-stats) (:p95 warm-stats))))
 
+        ;; Error buckets
         (println (str "\n=== Failure Buckets ==="))
         (doseq [[bucket count] (sort-by val (fn [a b] (compare b a)) all-errs)]
           (println (format "  %-40s %3d" (str bucket) count)))))))


### PR DESCRIPTION
## Summary

Bundle of 6 atomic improvements to the IR substrate and dev tooling, squashed for review (extracted from pre-rebase recovery history):

- **Corpus-agnostic ir-stress harness** with \`ir-compile\` and \`lower-go\` modes, per-fixture timeout (\`LG_STRESS_TIMEOUT_MS\`, default 5000), bucket-by-symbol output, per-defn TSV log.
- **\`:inc\` / \`:dec\` ops** emitted by build, lowered to Go.
- **validate diagnostic cleanup + go-name munge** for \`!\` / \`?\` / \`*\` (Lisp-idiomatic chars in generated Go identifiers).
- **compute-uses skips :invalid insts** in data.lg so DCE removes cascading dead defs in one pass.
- **\`ir.passes.trace\` ns** — per-pass instrumentation for the optimization pipeline: \`trace-pass\` macro, \`with-trace\`, \`print-trace\`, \`dump-pair\`.

Built to diagnose the DCE pipeline-loop regression and similar optimization-pipeline visibility gaps.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/ir/ ./pkg/vm/ ./pkg/rt/\` — all green
- [x] \`go run -tags bootstrap ./cmd/lgbgen\` — bundle regenerated and included

## Note

Replaces the work in retracted #104 and #96-extended; this version is verified via lgbgen and tests at every step instead of squashed all-at-once.