### PR TITLE
docs(policy)+ci+devx: contribution policy + staleness gates + parity tooling (issue #97)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,3 +49,29 @@ jobs:
 
       - name: Clojure compatibility test suite with source stdlib bootstrap
         run: go test -tags bootstrap ./test/ -count=1 -run TestClojureTestSuite -v
+
+  bundle-fresh:
+    name: bundle-fresh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Loud check — pkg/rt/core_compiled.lgb in lockstep with .lg sources
+        # Policy: docs/contribution-policy.md §3 (stale bundle is a hard gate).
+        # Fast (~1 s) — fails immediately when any pkg/rt/core/**/*.lg is
+        # newer than the committed bundle.
+        run: make check-bundle-fresh
+
+      - name: Loud check — pkg/rt/core_go_lowered/ in lockstep with .lg sources
+        # Policy: docs/contribution-policy.md §3 — sibling gate for the
+        # -tags gogen_ir build path. parity-full's bucket hashes
+        # silently diverge if the lgb is fresh but the lowered Go isn't.
+        run: make check-lowered-fresh
+
+  # Bootstrap-parity gate (deferred — runs as 'make parity-full' locally).
+  #
+  # Wiring 'make parity-full' as a CI job requires 'lgbgen --target=go' to
+  # produce pkg/rt/core_go_lowered/ cleanly from current main. That gen
+  # path errors today on a reader EOF — fixes land in a follow-up. Until
+  # then, parity-full is a local-only target; the staleness gates
+  # (check-bundle-fresh, check-lowered-fresh) protect the artifacts
+  # parity-full depends on.

--- a/.gitignore
+++ b/.gitignore
@@ -150,9 +150,8 @@ benchmark/letgo
 .clj-kondo
 .lsp
 *.calva-repl
-CLAUDE.md 
-.claude 
-docs/
+CLAUDE.md
+.claude
 .DS_Store
 .nrepl-port
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,54 @@ run: $(LG)
 
 build: $(LG)
 
-generate: $(GO) generate-ir-ops generate-ir-bridge generate-ir-data
+# Bundle target. The runtime loads compiled bytecode for the core
+# namespaces from this file, NOT from the .lg sources. Anyone editing
+# a .lg under pkg/rt/core/ must regenerate the bundle or runtime
+# behavior silently diverges from source. This prereq rule makes the
+# regeneration automatic — `make test`, `make build`, etc. now keep
+# the bundle in lockstep with the .lg sources.
+CORE-LG-FILES := $(shell find pkg/rt/core -name '*.lg' -type f 2>/dev/null)
+LGBGEN-SOURCES := $(shell find cmd/lgbgen -name '*.go' -type f 2>/dev/null)
+pkg/rt/core_compiled.lgb: $(CORE-LG-FILES) $(LGBGEN-SOURCES)
 	go run -tags bootstrap ./cmd/lgbgen
+
+# Lowered-Go target. The -tags gogen_ir build path links these generated
+# Go files in place of the bytecode-VM IR pipeline. Same staleness story
+# as the .lgb bundle: regenerate after editing .lg under pkg/rt/core/ or
+# the two engines silently disagree (parity-full diverges on bucket
+# hashes even when pass/fail counts match). lower_go.go is the timestamp
+# anchor for the whole tree — every regen rewrites it.
+pkg/rt/core_go_lowered/ir/lower_go/lower_go.go: $(CORE-LG-FILES) $(LGBGEN-SOURCES)
+	go run -tags bootstrap ./cmd/lgbgen --target=go
+
+# Loud check used by CI / pre-commit to detect a bundle that was
+# committed in a stale state (e.g. someone ran a manual `go test`
+# without going through make and committed the half-stale state).
+# Exits non-zero with a clear remediation when any .lg under
+# pkg/rt/core is newer than the committed bundle.
+check-bundle-fresh:
+	@stale=$$(find pkg/rt/core -name '*.lg' -newer pkg/rt/core_compiled.lgb 2>/dev/null); \
+	if [ -n "$$stale" ]; then \
+		echo "ERROR: pkg/rt/core_compiled.lgb is stale relative to:"; \
+		echo "$$stale" | sed 's/^/  /'; \
+		echo "Run 'make generate' to regenerate the bundle."; \
+		exit 1; \
+	fi
+
+# Sibling of check-bundle-fresh for the -tags gogen_ir lowered Go tree.
+# parity-full silently fails on bucket hashes if the lgb is fresh but
+# core_go_lowered/ is stale (untagged vs gogen_ir run two different
+# versions of the IR pipeline). Caught the hard way 2026-05-28.
+check-lowered-fresh:
+	@stale=$$(find pkg/rt/core -name '*.lg' -newer pkg/rt/core_go_lowered/ir/lower_go/lower_go.go 2>/dev/null); \
+	if [ -n "$$stale" ]; then \
+		echo "ERROR: pkg/rt/core_go_lowered/ is stale relative to:"; \
+		echo "$$stale" | sed 's/^/  /'; \
+		echo "Run 'go run -tags bootstrap ./cmd/lgbgen --target=go' to regenerate."; \
+		exit 1; \
+	fi
+
+generate: $(GO) generate-ir-ops generate-ir-bridge generate-ir-data pkg/rt/core_compiled.lgb pkg/rt/core_go_lowered/ir/lower_go/lower_go.go
 
 # Regenerate pkg/ir/op_generated.go from examples/go-gen/ir_ops.lg.
 # Requires ./lg to exist (built by `make build`).
@@ -57,15 +103,27 @@ generate-ir-bridge: build
 generate-ir-data: build
 	./scripts/generate-ir-data.sh
 
-$(LG): $(GO) lg.go pkg/**/*
+$(LG): $(GO) lg.go pkg/**/* pkg/rt/core_compiled.lgb
 	which go
 	go build -ldflags="-s -w" -o $@ .
 
-test: pkg/**/* $(GO)
+test: pkg/**/* pkg/rt/core_compiled.lgb $(GO)
 	$(GO-TEST-ENV) go test $(GO-TEST-FLAGS) -count=1 -v ./test
 
 clojure-compat-report: $(GO)
 	@$(REPORT-SCRIPT)
+
+# Parity checks: untagged vs -tags gogen_ir across jank + ir-stress.
+# `parity-check` is the default cadence (~3 min); `parity-quick` for
+# pre-commit smoke (~2 sec); `parity-full` for the long check (~5 min).
+parity-quick:
+	@scripts/gogen-parity.sh --quick
+
+parity-check:
+	@scripts/gogen-parity.sh
+
+parity-full:
+	@scripts/gogen-parity.sh --full
 
 clean:
 	$(RM) $(LG)
@@ -84,4 +142,4 @@ install-golangci-lint: $(GO)
 	  GO111MODULE=off go get -u $(GO111MODULE-LINT)
 
 # PHONY targets are for ones that have conflicting files/dirs present:
-.PHONY: test
+.PHONY: test check-bundle-fresh check-lowered-fresh

--- a/docs/contribution-policy.md
+++ b/docs/contribution-policy.md
@@ -1,0 +1,215 @@
+# Contribution policy
+
+This document captures the design contracts, regression checkpoints, and
+interop conventions that govern changes to `let-go`. It is the
+human-readable counterpart to the CI gates and `make` targets that
+enforce them. Source: [issue #97 — Comprehensive Go interop redesign
+roadmap](https://github.com/nooga/let-go/issues/97).
+
+Changes that conflict with anything below need explicit project-owner
+sign-off in the PR thread, not just a green CI run.
+
+---
+
+## 1. Design contracts
+
+These are load-bearing. New code is expected to fit inside them, not
+ask them to move.
+
+1. **Standalone interpreter stays portable.** REPL, nREPL, builtins,
+   and bytecode loading must work from just the interpreter binary —
+   no Go toolchain on the host. Authoring features (`lg deps`,
+   generator, walker) live behind opt-in surfaces and must not pull
+   into the minimal runtime distribution.
+2. **`let-go` is embeddable.** It must remain usable as a scripting
+   engine inside a host Go program. Public Go-side API surface (`pkg/api`,
+   `pkg/vm`, `pkg/rt`) changes are reviewed against this constraint.
+3. **Bytecode + VM are first-class.** Native/AOT lowering (`-tags
+   gogen_ir`, `lower-go`, future `lg build`) is additive. The VM still
+   powers `eval`, dynamic features, REPL workflows, embedded use, and
+   runtime compilation. No change may make any of those depend on the
+   AOT path.
+4. **Host interop is a Clojure-compatible superset.** Same spelling
+   and same semantics where they exist; Go-specific extensions are
+   purely additive. The mapping table is in §6.
+5. **Authored binaries go through generated Go.** The target for
+   `lg build` is a Go build that includes only the necessary `let-go`
+   modules and Go dependencies — not a bytecode blob appended to the
+   stock `lg` binary. The same machinery should eventually drive
+   minimal / network / full distributions.
+6. **Performance and footprint are tracked across modes.** Four
+   surfaces: interpreter, embedded, wasm, native. Per surface, per
+   program in the perf corpus we track `cold-start`, `warm-run`,
+   `peak-rss`, and `artifact-size`. The numbers live in `test/perf/`
+   so deltas are visible in PR diffs.
+
+## 2. Direction: self-host
+
+The longer arc is `let-go` implemented in `let-go` — compiler, reader,
+runtime ops, eventually the VM dispatch loop — written in `.lg` and
+lowered to Go for the shipped binary. This is the committed direction
+(issue #97, owner reply).
+
+Two consequences for sequencing PRs:
+
+- **Smart-wrapper coverage is scoped by what the compiler touches.**
+  Not "as much as we feel like." The packages `pkg/compiler/` and
+  `pkg/vm/` use directly (`reflect`, `bytes`, `unicode`, …) are the
+  reference user. Coverage gaps the self-host path doesn't need are
+  not blockers.
+- **`gogen_ir` build is the deployment path for the self-hosted
+  compiler.** Bootstrap parity (untagged vs `-tags gogen_ir`) is not
+  optional polish — it is the gate that says self-host works.
+
+## 3. Regression checkpoints
+
+A PR that trips any of these requires an explicit review checkpoint in
+the thread — not a silent override.
+
+| Checkpoint | Threshold | Enforcement |
+| --- | --- | --- |
+| Cold-start regression | > 10 % on any surface | perf corpus, `test/perf/` (in flight) |
+| Artifact-size regression | > 10 % on any surface | perf corpus, `test/perf/` (in flight) |
+| Bootstrap parity divergence | any count/bucket delta | `make parity-full` — local target, CI wiring deferred (see note below) |
+| Stale `core_compiled.lgb` | any `.lg` newer than bundle | `make check-bundle-fresh` — CI gate |
+| Stale `core_go_lowered/` | any `.lg` newer than lowered Go | `make check-lowered-fresh` — CI gate |
+| Existing test suite | any regression | `make test` — CI gate (already in place) |
+
+**Why `parity-full` isn't yet a CI gate.** Wiring it requires
+`lgbgen --target=go` to produce `pkg/rt/core_go_lowered/` cleanly from
+current `main` — and today that gen path errors on a `core.lg` reader
+EOF. The fix lands in a follow-up; until then the policy describes the
+target end-state but CI only enforces the staleness gates that protect
+the artifacts `parity-full` depends on.
+
+The two staleness gates are siblings. `core_compiled.lgb` is the bytecode
+bundle loaded by the untagged build; `core_go_lowered/` is the generated
+Go linked into `-tags gogen_ir` builds. Both derive from
+`pkg/rt/core/**/*.lg`. If either falls behind the sources, the two engines
+quietly run different versions of the IR pipeline — `parity-full` then
+diverges on bucket hashes even when pass/fail counts match. Caught the
+hard way 2026-05-28.
+
+`make parity-full` runs `scripts/gogen-parity.sh --full`, covering:
+1. clojure-test-suite (jank) — end-user-observable `clojure.core`
+2. ir-stress `lower-go` mode — AOT lowering correctness
+3. ir-stress `ir-compile` mode — eval-mode IR compile correctness
+
+Each suite runs once under the untagged build and once under
+`-tags gogen_ir`; bucket-by-symbol diffs must match.
+
+## 4. Callback error contract
+
+Signature-driven, not ambient. Decided in issue #97 and binding here.
+
+- If the Go callback type returns `error`, let-go failures route
+  through that slot and other return values are zero-valued.
+- If there is no error slot, a private panic sentinel is raised
+  inside the proxy and recovered at the outer let-go/native boundary.
+- Async escaped callbacks without an error slot need API-specific
+  policy and documented process-level behavior — they do not get a
+  default.
+
+Out of scope (rejected): sticky "next VM op" errors; ambient `*err*`
+as the primary contract.
+
+## 5. Interop schema
+
+### `:go-deps`
+
+A single ns-form key for stdlib and external Go packages.
+
+```clojure
+(ns my.app
+  (:require ...)
+  (:go-deps
+    "net/http"
+    "github.com/foo/bar@v1.2.3"
+    {:pkg "golang.org/x/sys/unix" :platform :linux}))
+```
+
+- Entries are strings (`"path"` or `"path@version"`) or maps for
+  alias / platform / explicit version metadata.
+- No `:git/url` / `:git/sha` initially — Go modules carry that via
+  `go.mod` and `replace`. Add only if a real gap appears.
+
+### Generator manifest
+
+When the generator emits binding manifests, the rule is:
+
+- **Keywords** for `let-go`/compiler-owned tags: `:kind :func`,
+  `:kind :method`, `:kind :error`, `:variadic? true`.
+- **Strings** for Go-owned identifiers: `"net/http"`,
+  `"github.com/foo/bar"`, `"ListenAndServe"`.
+
+Each binding entry carries import path, package name, generated
+alias, Go identifier, params, and results as distinct fields — not
+embedded in the let-go symbol.
+
+## 6. Host-interop syntax map
+
+The target is full Clojure compatibility on the JVM-interop surface,
+with Go-specific extensions where there is no Clojure analogue.
+
+| Clojure (JVM)              | ClojureScript      | let-go on Go                              | Status      |
+| ---                        | ---                | ---                                       | ---         |
+| `(.method obj args)`       | same               | `Boxed.InvokeMethod`                      | shipped     |
+| `(.-field obj)`            | same               | explicit field access                     | follow-up   |
+| `(set! (.-field obj) v)`   | same               | field setter                              | follow-up   |
+| `Class/staticMethod`       | `js/foo.bar`       | `net:http/Get`                            | shipped     |
+| `Class/STATIC_FIELD`       | `js/CONSTANT`      | `net:http/StatusOK`                       | shipped     |
+| `(Class. args)`            | `(js/Foo. args)`   | `(Foo. args)`                             | target      |
+| `:import` in `ns`          | `:require :refer`  | `:go-deps` ns key                         | this policy |
+| `proxy` / `reify`          | `reify`            | reify → Go structural interfaces          | follow-up   |
+| `bean`                     | —                  | `(go/bean struct)`                        | partial     |
+| `clj->js` / `js->clj`      | both               | `clj->go` / `go->clj`                     | follow-up   |
+| `clojure.java.io`          | —                  | `clojure.go.io`                           | follow-up   |
+
+Field-access semantics: `(.X obj)` falls method→field (method
+preferred when both exist); `(.-X obj)` is explicit field access.
+This matches Clojure on the JVM.
+
+Constructor syntax: prefer `(Foo. args)` (Clojure-style). `(Foo/new args)`
+is not introduced — one way to spell a constructor.
+
+## 7. WASM-specific constraints
+
+The wasm surface surfaces footprint tradeoffs earliest, so it gets
+explicit rules:
+
+- `.wasm` size and browser cold-start are first-class checkpoint
+  numbers, not derived from the artifact-size column.
+- `lg deps` carries a `js/wasm` compatibility filter with clear
+  diagnostics for packages that cannot work in wasm — fail fast at
+  resolve time, not deep in `go build`.
+- If the default binary grows to carry deps/generator machinery,
+  verify the wasm build does not pay for authoring-only code unless
+  the user opted into it.
+
+## 8. Distribution UX target
+
+The end-user authoring entry point is `lg deps`. Generator machinery
+ships in the default binary only if it does not noticeably grow size
+or startup. Otherwise it lives behind an authoring-only build path.
+
+The default `lg` binary stays lean.
+
+---
+
+## How CI enforces this today
+
+`make check-bundle-fresh` and `make parity-full` run on every PR via
+`.github/workflows/go.yml`. The bundle-staleness check is fast and
+fails the build with an explicit remediation message. The parity
+check is the longer gate (~5 min) but is what guarantees the
+self-host substrate keeps working.
+
+`make test` (the existing path) still runs as before — it does not
+go away. Parity is layered on top.
+
+## How to update this policy
+
+This document is owner-reviewed. Changes need a PR thread referencing
+the rationale, and ideally a link to a related issue discussion.
+Tightening a threshold (e.g. moving the 10 % gate to 5 %) does not
+need full review; loosening one does.

--- a/docs/els2023-ir-fixup-audit.md
+++ b/docs/els2023-ir-fixup-audit.md
@@ -1,0 +1,136 @@
+# ELS 2023 Architecture Audit (IR Branch) and Proposed IR Link/Fixup Pass
+
+Date: 2026-05-23
+Source paper reviewed: `els2023_final.pdf` ("Design of an Efficient Lisp Bytecode Machine and Compiler")
+Audit basis: isolated `jj` workspace on `lisp-ir-pipeline` (`149fa164`), then copied into default workspace.
+
+## What was verified
+
+- Default workspace is active IR development and has uncommitted changes:
+  - `pkg/rt/core/ir/lower.lg`
+  - `pkg/rt/core_compiled.lgb`
+- Isolated workspace (`.workspaces/els-audit`) was created to avoid interference.
+- On `lisp-ir-pipeline`, architecture is already IR-first:
+  - `build -> optimize-fn -> lower` pipeline exists.
+  - Lowering already has deferred patching infrastructure for control-flow offsets:
+    - lowerer state `:patches`
+    - `emit-placeholder!`
+    - `patch-branches!`
+- Test harness still marks `pendingPhase5` cases in `pkg/ir/pipeline_bench_test.go`.
+
+## Interpretation vs ELS paper
+
+The ELS paper’s key practical claim is not "just patch branch offsets", but generalizing fixups to any variable-length emission decision, allowing one-pass optimistic codegen with late resolution.
+
+Current let-go IR lower matches this direction partially:
+- Already optimistic + late patching for branch displacement.
+- Not yet generalized for optional instruction-group insertion/removal (e.g., closure-cell indirection decisions).
+
+So the architecture direction is legitimate. The main gap is generalizing the existing patch mechanism into a formal IR link/fixup phase.
+
+## What should happen first
+
+1. Finish Phase-5 IR-lower stack/branch correctness.
+2. Then expand fixups from branch offsets to generalized emission decisions.
+
+Reason: adding generalized fixups before lower correctness stabilizes increases debugging surface and masks root-cause issues.
+
+## Proposed pass: `ir.link` (or `lower/link!` subphase)
+
+## Placement
+
+Run after `optimize-fn` and after initial lowering emission, before final chunk return.
+
+Pipeline shape:
+
+`expand -> build -> optimize-fn -> lower(emit placeholders + records) -> link(resolve fixups) -> final chunk`
+
+## Core design
+
+Use a unified fixup record format in lowerer state.
+
+Suggested lowerer additions:
+
+- `:labels` — map of logical label id -> concrete IP
+- `:fixups` — vector of fixup records
+- `:decisions` — map of symbolic decision keys -> resolved policy/value
+
+### Fixup record schema (suggested)
+
+```clojure
+{:kind        :branch-offset | :emit-optional | :replace-op | :const-index
+ :site-ip      <int>          ; instruction ip or arg ip to patch
+ :site-op      <kw>           ; optional sanity check
+ :target       <label-or-id>  ; for branch/targeted fixups
+ :width        :i32           ; future-proof if encoding evolves
+ :best-size    <int>          ; optimistic assumed size
+ :worst-size   <int>          ; optional bound
+ :decision-key <kw-or-vector> ; for non-branch fixups
+ :payload      <map>}         ; kind-specific metadata
+```
+
+For current code, most entries are `:branch-offset` and map directly from existing `:patches` usage.
+
+## Resolution algorithm
+
+1. **Emit phase (optimistic):**
+   - Emit minimal/common-case instructions.
+   - Record fixups instead of fully resolving dependent bytes.
+
+2. **Decision phase:**
+   - Compute `:decisions` (e.g., which vars/tags need indirection/cell behavior).
+   - This can consult IR metadata and closure/mutation analysis artifacts.
+
+3. **Layout phase:**
+   - Recompute effective instruction positions if optional groups change size.
+   - Update label -> IP mapping.
+
+4. **Patch phase:**
+   - Apply fixups in deterministic order.
+   - Validate every fixup target and resulting displacement.
+
+5. **Validation phase:**
+   - Ensure no unresolved fixups.
+   - Assert stack/source-map invariants still hold.
+
+## Minimal incremental implementation plan
+
+### Step 1: Normalize current branch patches into generic `:fixups`
+
+- Replace ad-hoc `:patches` record shape with `:fixups` + `:kind :branch-offset`.
+- Keep behavior identical.
+
+### Step 2: Introduce explicit label table
+
+- Materialize block/branch labels into `:labels` rather than deriving only from `:block-ip` lookups.
+- Keep existing branch results unchanged.
+
+### Step 3: Add one non-branch fixup kind
+
+- Add `:emit-optional` as a no-op scaffolding kind first.
+- Exercise it in tests without changing generated semantics.
+
+### Step 4: Enable first real optional emission decision
+
+- Candidate: closure-related indirection insertion/elision at lowering boundary.
+- Gate behind feature flag to compare chunks and perf.
+
+### Step 5: Expand tests
+
+- Keep current round-trip tests.
+- Add fixup-focused tests:
+  - forward + backward jumps with nearby optional emissions
+  - nested-if join blocks
+  - loop back-edge after optional insertions
+  - source-map consistency after link
+
+## What should NOT be done yet
+
+- Bytecode encoding overhaul (LONG-prefix / compact operand format) before IR-lower correctness and generalized fixup stability.
+- Non-local-exit instruction model rewrite (ENTRY/EXIT family) before current try/catch semantics are fully stable under IR lower.
+
+## Short recommendation
+
+- Continue on `lisp-ir-pipeline` lineage.
+- Treat existing lower patching as the seed of a formal generalized link/fixup stage.
+- Make it generic in data model now, but conservative in enabled decisions until Phase-5 failures are cleared.

--- a/docs/xsofy-portability-gaps.md
+++ b/docs/xsofy-portability-gaps.md
@@ -1,0 +1,199 @@
+# let-go ↔ Clojure JVM portability gaps surfaced by xsofy
+
+Real-world portability findings from attempting to load
+[xsofy](https://github.com/nooga/xsofy) (a roguelike, ~25 .lg files,
+~5K LoC) onto Clojure 1.12.5 JVM after the 2026-05-22 let-go cleanups
+(#66 unchecked coercion, #68 destructure-shadow, #69 core-shadow
+warnings, #70 hex BigInt promotion). Every gap below was hit while
+trying to `(require 'xsofy.world)` on a stock JVM Clojure with minimal
+shimming.
+
+Companion to [jvm-compat-plan.md](jvm-compat-plan.md) and
+[clojure-compat-roadmap.md](clojure-compat-roadmap.md) — this doc is
+the *concrete user-side evidence* of what needs work, sorted by what
+let-go can fix vs. what's irreducibly let-go-specific.
+
+## Scoreboard
+
+22 xsofy modules, after applying fixes below:
+
+| State | Count | Notes |
+|---|---|---|
+| Loads cleanly | 22/22 | After fixes below |
+| Tests pass on JVM | 60/61 hash tests | 1 documented semantic divergence (see D1) |
+| Headless world-gen works | Blocked | aset on byte-array (see A2) |
+
+## A. let-go is permissive; Clojure rejects (let-go could fix)
+
+Patterns let-go accepts that Clojure JVM doesn't. Aligning let-go to
+Clojure's stricter rules would let xsofy code be portable as written.
+
+### A1. Class-less `(catch e ...)` and `(catch _ ...)`
+
+**Current let-go:** `(try ... (catch e body))` works as a catch-all.
+**Clojure JVM:** parses `e` as a class name, fails with "Unable to
+resolve classname: e".
+
+**xsofy impact:** 7 sites (check.lg×4, check_gen.lg×3). All
+straightforward catch-all error handling.
+
+**Proposal:** parse `(catch x body)` such that if `x` resolves to a
+class, use it; otherwise treat as catch-all and bind `x` to the
+exception. Matches the spirit of let-go's looser typing while still
+accepting Clojure-style class-typed catches.
+
+Alternative: align strictly to Clojure (require a class name). Worse
+for ergonomics but simpler to implement.
+
+### A2. `(aset byte-array i int-literal)` polymorphism
+
+**Current let-go:** `(aset some-byte-array 5 8)` works regardless of
+the element type — `8` is implicitly narrowed to a byte.
+**Clojure JVM:** `aset` reflects on the array type. On a `byte[]` it
+requires the value be a `Byte`, not `Integer`. Must use
+`(aset-byte arr i 8)` or `(aset arr i (byte 8))`.
+
+**xsofy impact:** 31 sites in terrain.lg (all `(aset grid i N)` where
+`grid` is a `byte-array`).
+
+**Proposal:** let-go's behavior is arguably *better* (less type tax,
+matches what users want from a Lisp). Worth keeping but documenting
+as an intentional divergence so portability-conscious code can use
+`aset-byte` / `(aset arr i (byte n))` explicitly.
+
+If let-go does want strict parity: type-check `aset` against the array
+element type and reject mismatched primitives. Costly.
+
+### A3. `(ints xs)` and `(bytes xs)` as constructors
+
+**Current let-go:** `(ints [1 -1 0 0])` constructs a primitive `int[]`
+from a vector.
+**Clojure JVM:** `ints` is a type *coercion* (hints `Object → int[]`)
+— it doesn't construct. Use `(int-array [1 -1 0 0])` and
+`(byte-array [1 2 3])`.
+
+**xsofy impact:** 4 sites in terrain.lg.
+
+**Proposal:** expose `(int-array xs)` / `(byte-array xs)` / `(long-array
+xs)` as primitive constructors with Clojure-parity semantics. Keep
+`(ints xs)` working for backward compat but document the portable
+form.
+
+This is the cheapest fix on this list — purely additive, no semantic
+change required.
+
+## B. let-go-only built-in namespaces
+
+let-go ships built-in namespaces that have no JVM equivalent. Each
+needs a shim on the JVM side.
+
+| Namespace | xsofy surface used | JVM equivalent |
+|---|---|---|
+| `math` | `sqrt`, `abs`, `exp`, `pow`, `log`, `sin`, `cos`, `floor`, `ceil`, `round`, `min`, `max`, `pi`, `e` | `java.lang.Math/*` static methods |
+| `io` | `open`, `write!`, `flush!`, `close!` | `java.io.BufferedWriter`/`FileWriter` |
+| `test` | `deftest`, `is`, `testing`, `run-tests` | `clojure.test/*` |
+| `term` | `move-cursor`, `set-fg`, `set-bg`, `write`, `clear`, `flush`, `read-key`, `size` | jline / lanterna |
+| `async` | `timeout`, `<!!`, `go` | `core.async` (overlapping API) |
+
+**Not a let-go bug**, but worth a docs section calling out:
+
+1. Which built-in namespaces are let-go-specific.
+2. For ones with direct Clojure equivalents (notably `test` →
+   `clojure.test`), consider:
+   - **(a)** auto-aliasing — `(require '[test])` on JVM transparently
+     resolves to `clojure.test`. Letting people write code that runs
+     on both with no shims.
+   - **(b)** publishing a tiny `let-go-shims` jar for JVM users that
+     provides `math`, `io`, `test`, etc. as thin aliases.
+
+Option (a) is more user-friendly but only works for the subset where
+the APIs match closely. `test` is the obvious candidate.
+
+## C. let-go-injected globals
+
+### C1. `*in-wasm*` dynamic var
+
+**Current let-go:** auto-interned at startup; user code can reference
+it for runtime-environment switching.
+**Clojure JVM:** undefined symbol unless explicitly created.
+
+**xsofy impact:** 4 sites (debug.lg, render.lg, title.lg×2).
+
+**Proposal:** document that `*in-wasm*` is let-go-specific and that
+portable code should `(def ^:dynamic *in-wasm* false)` at the top of
+namespaces that use it. Alternative: provide a portable
+`environment` ns (e.g., `(env/wasm?)` predicate) that's defined on
+both runtimes.
+
+## D. Known semantic divergences (probably stay as-is)
+
+Differences where alignment would hurt let-go more than help, or
+that are documentation-only.
+
+### D1. `(bit-shift-left x 64)`
+
+**let-go:** returns 0 (full mod-2^64 wrap on int64).
+**Clojure JVM:** returns `x` (Java `<<` masks shift count by `& 63`,
+so shift-by-64 is shift-by-0).
+
+**xsofy impact:** xsofy/hash.lg's `u64-shl` test
+(`u64-shl-wraps-at-2-to-64`) relies on let-go's behavior. One test
+fails on JVM. Not load-bearing for xxh3 correctness — the hash
+function itself never shifts by exactly 64 in practice.
+
+**Proposal:** keep let-go's behavior. It matches u64 arithmetic
+intuitions better than Java's quirk. Document under "intentional
+divergences from Clojure JVM" alongside the other primitive-int
+choices.
+
+### D2 – D5. Already fixed
+
+- **D2 hex literal BigInt promotion** — fixed by #70 (2026-05-22).
+- **D3 unchecked-* coercion family** — fixed by #66 (2026-05-22).
+- **D4 destructure-shadow-in-loop bug** — fixed by #68 (2026-05-22).
+- **D5 clojure.core shadow warnings** — added by #69 (2026-05-22).
+
+All four merged but not yet in a tagged let-go release.
+
+## Recommended action sequence
+
+In rough priority order (highest leverage first):
+
+1. **A3** — add `int-array`, `byte-array`, `long-array` constructors.
+   Purely additive, mechanical, unblocks one whole class of
+   portability complaint. ~1 hour.
+
+2. **A1** — class-less catch. Two-line reader/compiler change to
+   accept `(catch sym body)` where `sym` isn't a known class. ~2
+   hours.
+
+3. **Docs** — write a "let-go vs. Clojure JVM" page in `docs/`
+   covering Categories B/C/D. Lists every let-go-specific surface
+   xsofy hit, what to do on the JVM side, and which divergences are
+   intentional. ~2 hours.
+
+4. **B/test alias** — when `(require '[test])` is encountered on a
+   build that has `clojure.test` available, alias it. Lowest priority;
+   easiest workaround already exists (a 5-line `test.clj` shim).
+
+5. **A2** — defer or document as intentional. Cost-benefit isn't
+   favorable to fix.
+
+Total: <1 day of focused work to dramatically improve let-go's
+"can I run my Clojure code on this?" story.
+
+## Appendix: shim files used to run xsofy headlessly on JVM
+
+For reference, the JVM-side shims I wrote to get 21/22 xsofy modules
+loading on stock Clojure 1.12.5. These are what users would need to
+write if let-go doesn't grow portability features.
+
+- `src/math.clj` — 12 functions aliasing `java.lang.Math/*`.
+- `src/io.clj` — 4 functions wrapping `java.io.BufferedWriter`.
+- `src/test.clj` — 4 macros aliasing `clojure.test/*`.
+- `src/term.clj` — 13 no-op stubs (real impl needs jline/lanterna).
+- `src/async.clj` — 3 no-op stubs (real impl: core.async).
+- `src/user.clj` — interns `*in-wasm*` into `clojure.core` as dynamic.
+
+Total shim code: ~60 lines. Plus mechanical source patches (catch×7,
+ints→int-array×4, aset→aset-byte×31) on the let-go side.

--- a/scripts/gogen-parity.sh
+++ b/scripts/gogen-parity.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# gogen-parity.sh — parity benchmark for the gogen_ir bootstrap.
+#
+# Runs end-to-end correctness + perf checks under both the untagged build
+# (bytecode-replayed Lisp IR stack) and `-tags gogen_ir` (native Go IR
+# stack from pkg/rt/core_go_lowered). Prints a side-by-side summary;
+# returns non-zero if any suite diverges.
+#
+# Three suites cover different reach:
+#   1. clojure-test-suite (jank)  → end-user-observable clojure.core semantics
+#   2. ir-stress lower-go         → AOT lowering of IR → Go correctness
+#   3. ir-stress ir-compile       → eval-mode IR compile → bytecode correctness
+#
+# Usage:
+#   scripts/gogen-parity.sh             # default: jank + lower-go (~3 min)
+#   scripts/gogen-parity.sh --quick     # jank only (~2 sec, smoke check)
+#   scripts/gogen-parity.sh --full      # all three suites (~5 min)
+#   scripts/gogen-parity.sh --jank-only # just the jank suite
+#
+# Exit codes:
+#   0  all suites parity-identical (counts + buckets)
+#   1  semantic divergence detected (counts or buckets differ)
+#   2  setup error (missing submodule, no go binary, etc.)
+#
+# The wall-time delta is reported but not enforced (single-run noise is
+# typically ±2%; treat as informational unless consistently >10%).
+
+set -euo pipefail
+
+MODE="${1:-default}"
+case "$MODE" in
+    --quick)     RUN_JANK=1; RUN_LOWERGO=0; RUN_IRCOMPILE=0 ;;
+    --jank-only) RUN_JANK=1; RUN_LOWERGO=0; RUN_IRCOMPILE=0 ;;
+    --full)      RUN_JANK=1; RUN_LOWERGO=1; RUN_IRCOMPILE=1 ;;
+    default)     RUN_JANK=1; RUN_LOWERGO=1; RUN_IRCOMPILE=0 ;;
+    -h|--help)
+        sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+        exit 0
+        ;;
+    *)
+        echo "unknown mode: $MODE (try --help)" >&2
+        exit 2
+        ;;
+esac
+
+# IR corpus used by ir-stress. Order matters (data.lg must load first).
+IR_CORPUS=(
+    data.lg build.lg lower.lg lower_go.lg dump.lg
+    dominance.lg validate.lg zipper.lg passes.lg
+)
+IR_DIR=pkg/rt/core/ir
+
+LOG_DIR="${TMPDIR:-/tmp}/gogen-parity-$$"
+mkdir -p "$LOG_DIR"
+trap 'rc=$?; [ $rc -eq 0 ] && rm -rf "$LOG_DIR" || echo "logs preserved at $LOG_DIR"' EXIT
+
+# Preflight ---------------------------------------------------------------
+
+command -v go >/dev/null 2>&1 || { echo "go binary not on PATH" >&2; exit 2; }
+
+if [ "$RUN_JANK" -eq 1 ]; then
+    if [ ! -d test/clojure-test-suite/test/clojure/core_test ]; then
+        echo "clojure-test-suite submodule not initialized in this worktree." >&2
+        echo "In a jj worktree the submodule data isn't auto-populated. Either:" >&2
+        echo "  git submodule update --init                      # in a git worktree" >&2
+        echo "  ln -s <other-worktree>/test/clojure-test-suite \\" >&2
+        echo "        test/clojure-test-suite                    # in a jj worktree" >&2
+        exit 2
+    fi
+fi
+
+# Helpers -----------------------------------------------------------------
+
+# Run a command, capture stdout+stderr to $1, append wall time to log. The
+# stdout of the function itself is the recorded wall time in seconds.
+time_run() {
+    local logfile="$1"; shift
+    local start end
+    start=$(date +%s.%N)
+    "$@" >"$logfile" 2>&1
+    end=$(date +%s.%N)
+    awk -v s="$start" -v e="$end" 'BEGIN{printf "%.2f\n", e-s}'
+}
+
+# Extract the TOTALS line from a jank-suite -v log.
+jank_totals() { grep -m1 -E "TOTALS: " "$1" | sed 's/.*TOTALS: //'; }
+
+# Extract the Passed/Failed line + bucket distribution from an ir-stress log.
+ir_summary()  { grep -E "^Total fixtures:|^Passed:|^Failed:" "$1"; }
+ir_buckets()  {
+    # Scrub process-specific noise (pointer addresses in printed fn/closure
+    # values) so the bucket hash captures semantic equivalence, not memory
+    # layout. Without this, an error string containing `<fn foo 0xabc123>`
+    # produces a different md5 every run for purely cosmetic reasons.
+    awk '/^=== Failure Buckets ===/{p=1; next} p && /^=== /{exit} p' "$1" |
+        sed -E 's/0x[0-9a-fA-F]{6,}/0xXXX/g'
+}
+
+# Suites ------------------------------------------------------------------
+
+run_jank() {
+    local tag_label="$1" tag_flag="$2"
+    local log="$LOG_DIR/jank-${tag_label}.log"
+    local wall
+    wall=$(time_run "$log" go test $tag_flag ./test/ -run '^TestClojureTestSuite$' -count=1 -v -timeout 120s)
+    printf "%-10s %-50s %ss\n" "$tag_label" "$(jank_totals "$log")" "$wall"
+    echo "$wall:$(jank_totals "$log")" >"$LOG_DIR/jank-${tag_label}.summary"
+}
+
+run_ir_stress() {
+    local mode="$1" tag_label="$2" tag_flag="$3"
+    local log="$LOG_DIR/${mode}-${tag_label}.log"
+    local wall
+    wall=$(time_run "$log" go run $tag_flag . scripts/ir-stress.lg "$mode" "$IR_DIR" "${IR_CORPUS[@]}")
+    local pass fail buckets
+    pass=$(grep -m1 "^Passed:" "$log" | awk '{print $2}')
+    fail=$(grep -m1 "^Failed:" "$log" | awk '{print $2}')
+    buckets=$(ir_buckets "$log" | md5sum | cut -c1-8)
+    printf "%-10s pass=%s fail=%s buckets=%s  %ss\n" "$tag_label" "$pass" "$fail" "$buckets" "$wall"
+    echo "$wall:$pass:$fail:$buckets" >"$LOG_DIR/${mode}-${tag_label}.summary"
+}
+
+compare_summaries() {
+    local label="$1" untagged_file="$2" tagged_file="$3"
+    local u t
+    u=$(cat "$untagged_file"); t=$(cat "$tagged_file")
+    # Strip leading wall time; compare the rest.
+    local u_body t_body
+    u_body=${u#*:}; t_body=${t#*:}
+    if [ "$u_body" = "$t_body" ]; then
+        echo "  $label: PARITY"
+        return 0
+    else
+        echo "  $label: DIVERGED"
+        echo "    untagged: $u"
+        echo "    gogen_ir: $t"
+        return 1
+    fi
+}
+
+# Run --------------------------------------------------------------------
+
+divergence=0
+
+if [ "$RUN_JANK" -eq 1 ]; then
+    echo "=== clojure-test-suite (jank) ==="
+    run_jank untagged ""
+    run_jank gogen_ir "-tags gogen_ir"
+    echo
+fi
+
+if [ "$RUN_LOWERGO" -eq 1 ]; then
+    echo "=== ir-stress lower-go (IR corpus: ${#IR_CORPUS[@]} files) ==="
+    run_ir_stress lower-go untagged ""
+    run_ir_stress lower-go gogen_ir "-tags gogen_ir"
+    echo
+fi
+
+if [ "$RUN_IRCOMPILE" -eq 1 ]; then
+    echo "=== ir-stress ir-compile (IR corpus: ${#IR_CORPUS[@]} files) ==="
+    run_ir_stress ir-compile untagged ""
+    run_ir_stress ir-compile gogen_ir "-tags gogen_ir"
+    echo
+fi
+
+echo "=== Parity check ==="
+check() {
+    local label="$1" untagged="$2" tagged="$3"
+    if ! compare_summaries "$label" "$untagged" "$tagged"; then
+        divergence=$((divergence+1))
+    fi
+}
+[ "$RUN_JANK"      -eq 1 ] && check jank       "$LOG_DIR/jank-untagged.summary"       "$LOG_DIR/jank-gogen_ir.summary"
+[ "$RUN_LOWERGO"   -eq 1 ] && check lower-go   "$LOG_DIR/lower-go-untagged.summary"   "$LOG_DIR/lower-go-gogen_ir.summary"
+[ "$RUN_IRCOMPILE" -eq 1 ] && check ir-compile "$LOG_DIR/ir-compile-untagged.summary" "$LOG_DIR/ir-compile-gogen_ir.summary"
+
+if [ "$divergence" -ne 0 ]; then
+    echo "FAIL: $divergence suite(s) diverged. Logs at $LOG_DIR." >&2
+    trap - EXIT
+    exit 1
+fi
+
+echo "OK: all suites parity-identical."

--- a/scripts/ir-stress.lg
+++ b/scripts/ir-stress.lg
@@ -1,56 +1,98 @@
 ;; IR-pipeline coverage stress test — corpus-agnostic.
 ;;
-;; Usage:
-;;   go run . scripts/ir-stress.lg <mode> <dir> <file> [<file>...]
+;; Full reference: scripts/ir-stress.md
 ;;
-;;   <mode>  ir-compile  — eval each defn under (binding [*ir-compile* true])
-;;                         measures what users experience at load time
-;;           lower-go    — build IR + lower-go in :bridge mode, no eval
-;;                         measures AOT pass rate, safe to run vs live pipeline
-;;   <dir>   corpus root (absolute or relative to cwd)
-;;   <file>  one or more .lg paths relative to <dir>
+;; Usage:
+;;   go run . scripts/ir-stress.lg <mode> <args>...
+;;
+;;   <mode>:
+;;     ir-compile <dir> <file>...           eval each defn under
+;;                                          (binding [*ir-compile* true])
+;;                                          — measures user-load behavior
+;;     lower-go   <dir> <file>...           build IR + lower-go in :bridge
+;;                                          mode, no eval — AOT pass rate
+;;     trace      <dir> <file> <defn-name>  drill into ONE slow defn:
+;;                                          per-stage (expand/build/optimize/
+;;                                          lower) ms, per-pass table from
+;;                                          ir.passes.trace
+;;
+;; Env vars:
+;;   LG_STRESS_TIMEOUT_MS   per-defn timeout in ms (default 5000)
+;;   LG_STRESS_PASSES       1 = single pass; 2 = cold+warm (default 2)
+;;   LG_STRESS_LOG          path to per-defn TSV log
+;;                          (file<TAB>defn<TAB>bucket<TAB>ms)
+;;   LG_STRESS_AUTOTRACE    "1" = on each :stress/timeout, re-run that defn
+;;                          with the trace harness and emit the per-pass
+;;                          breakdown inline. Doubles work for slow defns
+;;                          but turns "X timed out" into "X timed out IN
+;;                          PASS Y".
+;;   LG_STRESS_TOPK         "1" = at run end, print top-K passes by
+;;                          cumulative ms (aggregated across all defns).
+;;                          Sampled from the auto-trace runs, so requires
+;;                          LG_STRESS_AUTOTRACE=1 to populate.
 ;;
 ;; Examples:
-;;   # xsofy IR-compile pass rate
-;;   LG_SOURCE_PATHS=/Users/ndn/development/xsofy go run . scripts/ir-stress.lg \
-;;     ir-compile /Users/ndn/development/xsofy/xsofy \
-;;     util.lg combat.lg ai.lg items.lg fov.lg fire.lg effects.lg \
-;;     bestiary.lg input.lg lighting.lg runes.lg sound.lg det.lg entities.lg check.lg
+;;   # IR-pipeline self-AOT pass rate (most common):
+;;   LG_STRESS_PASSES=1 LG_STRESS_LOG=/tmp/ir-stress.log \
+;;     go run . scripts/ir-stress.lg lower-go pkg/rt/core \
+;;       core.lg ir/build.lg ir/lower.lg ir/lower_go.lg ...
 ;;
-;;   # IR-pipeline self-AOT pass rate
-;;   go run . scripts/ir-stress.lg lower-go pkg/rt/core/ir \
-;;     data.lg zipper.lg build.lg lower.lg lower_go.lg passes.lg \
-;;     passes/constfold.lg passes/cse.lg passes/dce.lg passes/typeinfer.lg \
-;;     passes/licm.lg passes/pipeline.lg
+;;   # Drill into ONE slow defn:
+;;   go run . scripts/ir-stress.lg trace pkg/rt/core core.lg for-emit
+;;
+;;   # Auto-trace every timeout + top-K pass cost summary:
+;;   LG_STRESS_AUTOTRACE=1 LG_STRESS_TOPK=1 LG_STRESS_PASSES=1 \
+;;     go run . scripts/ir-stress.lg lower-go pkg/rt/core/ir \
+;;       data.lg build.lg lower.lg ...
 (require 'ir.data)
 (require 'ir.passes.pipeline)
+(require 'ir.passes.trace)
+(require 'ir.passes.constfold)
+(require 'ir.passes.cse)
+(require 'ir.passes.dce)
+(require 'ir.passes.licm)
+(require 'ir.passes.typeinfer)
+(require 'ir.build)
+(require 'ir.lower-go)
 
 (defn- usage-and-exit [msg]
   (println (str "ir-stress: " msg))
-  (println "Usage: go run . scripts/ir-stress.lg <mode> <dir> <file>...")
-  (println "  <mode>: ir-compile | lower-go")
-  (println "  <dir>:  corpus root")
-  (println "  <file>: one or more .lg paths relative to <dir>")
+  (println "Usage: go run . scripts/ir-stress.lg <mode> <args>")
+  (println "  ir-compile <dir> <file>...           eval-mode harness")
+  (println "  lower-go   <dir> <file>...           AOT-mode harness")
+  (println "  trace      <dir> <file> <defn-name>  drill into one defn")
+  (println "See scripts/ir-stress.md for env vars and full reference.")
   (System/exit 1))
 
 ;; os/args is [binary script user-arg user-arg...]
 (def user-args (vec (drop 2 (seq os/args))))
 (when (< (count user-args) 3)
-  (usage-and-exit "expected at least 3 args (mode, dir, file)"))
+  (usage-and-exit "expected at least 3 args (mode + per-mode args)"))
 
 (def measurement-mode
   (let [m (nth user-args 0)]
     (cond
       (= m "lower-go")   :lower-go
       (= m "ir-compile") :ir-compile
-      :else (usage-and-exit (str "<mode> must be 'ir-compile' or 'lower-go', got: " m)))))
+      (= m "trace")      :trace
+      :else (usage-and-exit (str "<mode> must be 'ir-compile', 'lower-go', or 'trace', got: " m)))))
 (def raw-dir (nth user-args 1))
 (def corpus-dir
   (let [n (count raw-dir)]
     (if (and (pos? n) (= \/ (nth raw-dir (dec n))))
       raw-dir
       (str raw-dir "/"))))
-(def files (vec (drop 2 user-args)))
+;; trace mode: args are <dir> <file> <defn-name>. ir-compile/lower-go: args
+;; are <dir> <file>....
+(def files
+  (if (= measurement-mode :trace)
+    [(nth user-args 2)]
+    (vec (drop 2 user-args))))
+(def trace-defn-name
+  (when (= measurement-mode :trace)
+    (when (< (count user-args) 4)
+      (usage-and-exit "trace mode needs <dir> <file> <defn-name>"))
+    (symbol (nth user-args 3))))
 (def stress-target (str corpus-dir " (" (count files) " files)"))
 
 (defn read-all [path]
@@ -94,36 +136,117 @@
     (subs m 0 n)))
 
 (defn classify-error [err-str]
-  "Classify error into bucket: :unresolved-symbol, :unsupported-special-form,
-   :destructure-rejection, or :other (with first 100 chars)."
-  (let [m (str err-str)
+  "Classify error into a bucket keyword.
+
+   IMPORTANT: build.lg wraps unresolved-symbol errors as
+   'ir/build: unresolved symbol X' — including special-form heads like
+   set!/var/def/trace when build-list doesn't recognize them and they
+   fall through to build-call → build-symbol. So we must check the
+   special-form patterns BEFORE the generic 'unresolved symbol' regex,
+   otherwise set!/var/def/trace failures get pooled into a single
+   :unresolved-symbol bucket and the real cause is hidden.
+
+   For genuinely-unresolved symbols (not special forms), bucket by the
+   symbol name itself so we see one row per missing dep instead of
+   one giant pile."
+  (let [;; Scrub process-specific noise before truncating. Pointer addresses
+        ;; (e.g. `<fn defn 0x2a9abf0be030>`) inside error strings push the
+        ;; subs 0 100 cutoff to a different character on each run, so two
+        ;; engines emit different `:other | ...` buckets even when the
+        ;; semantic content is identical. Normalize the address to a
+        ;; fixed marker so truncation lands at a stable spot.
+        raw (str err-str)
+        m   (clojure.string/replace raw #"0x[0-9a-fA-F]{6,}" "0xXXX")
         truncated (if (> (count m) 100) (str (subs m 0 100) "...") m)]
     (cond
-      ;; Unresolved symbol errors
-      (or (re-find #"unresolved symbol" m)
-          (re-find #"Can't resolve" m))
-        :unresolved-symbol
+      ;; Special-form heads first — these surface as 'unresolved symbol X'
+      ;; because build-list has no case for them and falls into build-call.
+      (re-find #"unresolved symbol set!" m)    :missing-form/set!
+      (re-find #"unresolved symbol var$" m)    :missing-form/var
+      (re-find #"unresolved symbol var " m)    :missing-form/var
+      (re-find #"unresolved symbol def$" m)    :missing-form/def
+      (re-find #"unresolved symbol def " m)    :missing-form/def
+      (re-find #"unresolved symbol try" m)     :missing-form/try
+      (re-find #"unresolved symbol trace" m)   :missing-form/trace
 
-      ;; Unsupported special forms
-      (or (re-find #"def\s" m)
-          (re-find #"set!" m)
-          (re-find #"\btry\b" m)
-          (re-find #"catch" m)
-          (re-find #"\bvar\b" m)
-          (re-find #"trace" m))
-        :unsupported-special-form
+      ;; Genuinely-unresolved symbol: bucket by the symbol name.
+      (re-find #"unresolved symbol" m)
+        (let [match (re-find #"unresolved symbol ([^\s,)]+)" m)]
+          (if match
+            (keyword "unresolved" (second match))
+            :unresolved-symbol))
+      (re-find #"Can't resolve" m)
+        (let [match (re-find #"Can't resolve ([^\s,)]+)" m)]
+          (if match
+            (keyword "unresolved" (second match))
+            :unresolved-symbol))
 
       ;; Destructuring issues
-      (re-find #"destructur" m)
-        :destructure-rejection
+      (re-find #"destructur" m)  :destructure-rejection
+
+      ;; Build-form errors with structural cause.
+      (re-find #"no :term" m)              :validate/no-term
+      (re-find #"cross-block ref" m)       :validate/cross-block-ref
+      (re-find #"is not a valid i" m)      :gogen/bad-identifier
+      (re-find #"nth index must be an integer" m) :gogen/nth-non-int
+      (re-find #"nested closure" m)        :lower-go/nested-closure
+      (re-find #"unrecognized form" m)     :build/unrecognized-form
 
       ;; Everything else: store the actual error message
-      :else
-        (str ":other | " truncated))))
+      :else (str ":other | " truncated))))
 
 (def per-fixture-timeout-ms
   (let [v (System/getenv "LG_STRESS_TIMEOUT_MS")]
     (if (and v (not= v "")) (parse-int v) 5000)))
+
+;; Number of passes: 2 = cold+warm (default; lets us measure cache effect),
+;; 1 = single pass (faster; sufficient for gap analysis where buckets are
+;; deterministic). Set LG_STRESS_PASSES=1 when iterating on the harness.
+(def stress-passes
+  (let [v (System/getenv "LG_STRESS_PASSES")]
+    (if (and v (not= v "")) (parse-int v) 2)))
+
+;; Optional per-defn analysis log. When LG_STRESS_LOG is set, each defn
+;; produces one TSV row: file<TAB>defn-name<TAB>bucket<TAB>time-ms.
+;; Buckets include :ok and the classify-error keys, so a single grep
+;; like `grep :missing-form ir-stress.log` answers "what's the gap?".
+(def log-path
+  (let [v (System/getenv "LG_STRESS_LOG")]
+    (if (and v (not= v "")) v nil)))
+
+(def log-entries (atom []))
+
+;; --- per-pass cost aggregation (LG_STRESS_TOPK) ---------------------------
+;;
+;; Each entry of pass-totals maps a pass name (string) → cumulative ms across
+;; every trace we ran. Populated by the auto-trace path; printed at run end
+;; when LG_STRESS_TOPK=1. Empty (and skipped) otherwise.
+(def autotrace-on?
+  (let [v (System/getenv "LG_STRESS_AUTOTRACE")] (= v "1")))
+(def topk-on?
+  (let [v (System/getenv "LG_STRESS_TOPK")] (= v "1")))
+(def pass-totals (atom {}))
+(def autotrace-rows (atom []))  ;; per-defn worst-pass summaries
+
+(defn- accumulate-pass-trace! [defn-name trace]
+  "Add the per-pass ms from one optimize-fn-traced trace into pass-totals.
+   Also remember which pass dominated this defn (worst row by ms) so the
+   top-K summary can name the offender."
+  (when (seq trace)
+    (let [worst (reduce (fn [a b] (if (> (:ms b) (:ms a)) b a))
+                       (first trace)
+                       (rest trace))]
+      (swap! autotrace-rows conj
+             {:defn defn-name :worst-pass (:pass worst) :worst-ms (:ms worst)
+              :total-ms (reduce + (map :ms trace))}))
+    (doseq [row trace]
+      (swap! pass-totals update (:pass row) (fnil + 0.0) (:ms row)))))
+
+(defn- log! [file-path defn-name bucket time-ms]
+  (when log-path
+    (swap! log-entries conj
+      (str file-path "\t" defn-name "\t" bucket "\t"
+           (format "%.1f" time-ms) "\n"))))
 
 (defn try-with-timeout [thunk timeout-ms]
   "Run thunk in a goroutine; return its result (or thrown exception) within
@@ -152,11 +275,12 @@
           ;; Single-arity success
           (and (map? result) (= :lowered (:status result)))
             :ok
-          ;; Single-arity fallback — capture reason
+          ;; Single-arity fallback — route reason through classify-error so
+          ;; gogen/lower-go fallback reasons land in the same structural
+          ;; buckets as build-side throws (e.g. :gogen/bad-identifier rather
+          ;; than a long unique 'fallback | ...' string per defn).
           (and (map? result) (= :fallback (:status result)))
-            (let [reason (or (:reason result) "no-reason")
-                  short  (if (> (count reason) 60) (str (subs reason 0 60) "...") reason)]
-              (keyword (str "fallback | " short)))
+            (classify-error (or (:reason result) "no-reason"))
           ;; Multi-arity template: succeed if every arity lowered
           (and (map? result) (= :multi-fn-template (:kind result)))
             (if (every? (fn [e] (some? (:fn e))) (:fns result))
@@ -165,11 +289,142 @@
           :else :ok)))
     (catch e (classify-error e))))
 
+(defn trace-one-defn [form]
+  "Drill into one defn: time each pipeline stage and capture the per-pass
+   trace from ir.passes.trace/optimize-fn-traced. Returns a map:
+     {:expand-ms N :build-ms N :optimize-ms N :lower-ms N
+      :pass-trace [...] :lower-status :lowered|:fallback|:throw
+      :error <str when caught>}
+   Stages mirror ir.passes.pipeline/compile-form*. Body forms are
+   macroexpanded the same way before build, so timings match the live
+   AOT pipeline."
+  (try
+    (let [name-sym    (nth form 1)
+          maybe-doc   (nth form 2)
+          has-doc?    (string? maybe-doc)
+          first-form  (if has-doc? (nth form 3) maybe-doc)
+          go-target?  true]
+      (when-not (vector? first-form)
+        (throw "trace-one-defn: multi-arity not supported"))
+      (let [args-vec   first-form
+            raw-body   (drop (if has-doc? 4 3) form)
+            _          (println "  expanding...")
+            t-expand0  (System/nanoTime)
+            body-forms (mapv (fn [b] (ir.passes.pipeline/expand-all b)) raw-body)
+            expanded   (apply list 'defn name-sym args-vec body-forms)
+            t-expand1  (System/nanoTime)
+            _          (println (format "%.1f ms" (double (/ (- t-expand1 t-expand0) 1000000.0))))
+            _          (println "  building IR...")
+            ir-fn      (ir.build/build-fn expanded)
+            t-build1   (System/nanoTime)
+            _          (println (format "%.1f ms" (double (/ (- t-build1 t-expand1) 1000000.0))))
+            _          (println "  optimizing (live, per-pass):")
+            ;; Run the passes inline so we can print each one's wall time as
+            ;; it happens. If a pass loops or quadratics on this defn, the
+            ;; hang is now visibly tied to the named pass instead of silent.
+            ;; Mirrors ir.passes.pipeline/optimize-fn structure.
+            pt         (atom [])
+            _          (let [run-pass! (fn [pass-name iter f-call]
+                                         (let [b (ir.passes.trace/live-inst-count ir-fn)
+                                               t0 (System/nanoTime)
+                                               _  (f-call)
+                                               t1 (System/nanoTime)
+                                               a (ir.passes.trace/live-inst-count ir-fn)
+                                               ms (double (/ (- t1 t0) 1000000.0))]
+                                           (println (format "    iter=%-2d  %-15s  %4d→%-4d  Δ=%+d  %7.2f ms"
+                                                            iter pass-name b a (- b a) ms))
+                                           (swap! pt conj {:pass pass-name :iter iter
+                                                           :before b :after a
+                                                           :delta (- b a) :ms ms})))]
+                         (let [ti1 (atom {})]
+                           (binding [ir.passes.typeinfer/*ti-counters* ti1]
+                             (run-pass! "typeinfer-pre" -1 #(ir.passes.typeinfer/typeinfer ir-fn)))
+                           (let [s @ti1]
+                             (println (format "      typeinfer: %d analyze-block, %d type-join, %d normalize"
+                                              (or (:analyze-block s) 0)
+                                              (or (:type-join s) 0)
+                                              (or (:normalize s) 0)))
+                             (println (format "      worklist: %d inst, %d param, %d changes, %d/%d enqueues"
+                                              (or (:process-inst s) 0)
+                                              (or (:process-param s) 0)
+                                              (or (:type-change s) 0)
+                                              (or (:enqueue s) 0)
+                                              (or (:enqueue-attempt s) 0)))
+                             (println (format "      timing: deps=%d ms, drain=%d ms"
+                                              (or (:deps-ms s) 0)
+                                              (or (:drain-ms s) 0)))))
+                         (loop [iter 0]
+                           (let [before (ir.passes.trace/live-inst-count ir-fn)]
+                             (run-pass! "constfold" iter #(ir.passes.constfold/constfold ir-fn))
+                             (run-pass! "cse"       iter #(ir.passes.cse/cse ir-fn))
+                             (run-pass! "licm"      iter #(ir.passes.licm/licm ir-fn))
+                             (run-pass! "dce"       iter #(ir.passes.dce/dce ir-fn))
+                             (let [after (ir.passes.trace/live-inst-count ir-fn)]
+                               (cond
+                                 (= before after) nil
+                                 (>= iter 15)     (println "    !! 16-iter cap hit")
+                                 :else            (recur (inc iter))))))
+                         (let [ti2 (atom {})]
+                           (binding [ir.passes.typeinfer/*ti-counters* ti2]
+                             (run-pass! "typeinfer-post" -1 #(ir.passes.typeinfer/typeinfer ir-fn)))
+                           (let [s @ti2]
+                             (println (format "      typeinfer: %d analyze-block, %d type-join, %d normalize"
+                                              (or (:analyze-block s) 0)
+                                              (or (:type-join s) 0)
+                                              (or (:normalize s) 0)))
+                             (println (format "      worklist: %d inst, %d param, %d changes, %d/%d enqueues"
+                                              (or (:process-inst s) 0)
+                                              (or (:process-param s) 0)
+                                              (or (:type-change s) 0)
+                                              (or (:enqueue s) 0)
+                                              (or (:enqueue-attempt s) 0)))
+                             (println (format "      timing: deps=%d ms, drain=%d ms"
+                                              (or (:deps-ms s) 0)
+                                              (or (:drain-ms s) 0))))))
+            pt         @pt
+            t-opt1     (System/nanoTime)
+            _          (println (format "  optimize total: %.1f ms (%d pass rows)"
+                                        (double (/ (- t-opt1 t-build1) 1000000.0))
+                                        (count pt)))
+            _          (println "  lowering...")
+            lowered    (binding [ir.passes.pipeline/*target* :go]
+                         (ir.lower-go/lower ir-fn :bridge))
+            t-lower1   (System/nanoTime)
+            _          (println (format "%.1f ms" (double (/ (- t-lower1 t-opt1) 1000000.0))))
+            ms-of      (fn [start end] (double (/ (- end start) 1000000.0)))]
+        {:expand-ms   (ms-of t-expand0 t-expand1)
+         :build-ms    (ms-of t-expand1 t-build1)
+         :optimize-ms (ms-of t-build1 t-opt1)
+         :lower-ms    (ms-of t-opt1 t-lower1)
+         :pass-trace  pt
+         :lower-status (or (:status lowered) :unknown)}))
+    (catch e
+      {:error (str e) :lower-status :throw :pass-trace []})))
+
+(defn print-trace-report [defn-name r]
+  "Pretty-print the result of trace-one-defn."
+  (println (str "\n=== trace: " defn-name " ==="))
+  (if (:error r)
+    (println (str "  ERROR: " (:error r)))
+    (do
+      (println (format "  expand:   %7.2f ms" (:expand-ms r)))
+      (println (format "  build:    %7.2f ms" (:build-ms r)))
+      (println (format "  optimize: %7.2f ms" (:optimize-ms r)))
+      (println (format "  lower:    %7.2f ms  (status=%s)"
+                       (:lower-ms r) (str (:lower-status r))))
+      (let [total (+ (:expand-ms r) (:build-ms r) (:optimize-ms r) (:lower-ms r))]
+        (println (format "  TOTAL:    %7.2f ms" total)))
+      (println "")
+      (when (seq (:pass-trace r))
+        (ir.passes.trace/print-trace (:pass-trace r))))))
+
 (defn try-ir-timed [form]
   "Per-fixture measurement, dispatched by measurement-mode.
    :ir-compile  — eval via *ir-compile* (xsofy: measures user-load behavior)
    :lower-go    — lower IR to Go via :bridge mode (ir-stack: AOT pass rate)
    Wrapped in per-fixture-timeout-ms; runaway fixtures return :stress/timeout.
+   On timeout, if LG_STRESS_AUTOTRACE=1, re-run with a longer timeout under
+   trace-one-defn to capture per-pass cost and accumulate into pass-totals.
    Returns [result-key time-ms]."
   (let [thunk (if (= measurement-mode :lower-go)
                 (fn [] (try-lower-go form))
@@ -182,6 +437,17 @@
         result (try-with-timeout thunk per-fixture-timeout-ms)
         t1 (System/nanoTime)
         ms (double (/ (- t1 t0) 1000000.0))]
+    (when (and (= result :stress/timeout) autotrace-on?
+               (= measurement-mode :lower-go)
+               (vector? (nth form 2 nil)))  ; single-arity only
+      (let [tr (try-with-timeout (fn [] (trace-one-defn form))
+                                 (* 4 per-fixture-timeout-ms))]
+        (when (map? tr)
+          (accumulate-pass-trace! (nth form 1) (:pass-trace tr))
+          (println (format "  [autotrace] %s: expand=%.0f build=%.0f optimize=%.0f lower=%.0f ms"
+                          (str (nth form 1))
+                          (:expand-ms tr) (:build-ms tr)
+                          (:optimize-ms tr) (:lower-ms tr))))))
     [result ms]))
 
 (defn stats-for [times]
@@ -211,7 +477,12 @@
             (eval (list 'in-ns (list 'quote ns-sym)))
             (catch e nil)))
         (require-deps! ns-form-)
-        (let [results (mapv (fn [d] [(nth d 1) (try-ir-timed d)]) defns)
+        (let [results (mapv (fn [d]
+                              (let [name (nth d 1)
+                                    [r ms] (try-ir-timed d)]
+                                (log! path name r ms)
+                                [name [r ms]]))
+                            defns)
               ok     (count (filter (fn [[_ [r _]]] (= :ok r)) results))
               errs   (filter (fn [[_ [r _]]] (not= :ok r)) results)
               times  (map (fn [[_ [_ t]]] t) results)
@@ -221,7 +492,35 @@
            :times times
            :error-buckets error-buckets})))))
 
+(defn trace-mode-run []
+  "Drill into one defn. Loads the corpus file like the main harness so the
+   ns + deps resolve, finds the named defn, and prints stage + per-pass
+   timings."
+  (println (str "=== ir-stress trace: " trace-defn-name
+                " in " (first files) " ===\n"))
+  (let [path (str corpus-dir (first files))
+        parsed (read-all path)]
+    (when (nil? parsed)
+      (println (str "READ-ERROR: " path)) (System/exit 1))
+    (let [ns-form- (first (filter (fn [f] (and (seq? f) (= (first f) 'ns)))
+                                  (rest parsed)))
+          ns-sym   (ns-name-from ns-form-)]
+      (when ns-sym
+        (try (eval (list 'in-ns (list 'quote ns-sym))) (catch e nil)))
+      (require-deps! ns-form-)
+      (let [defns      (vec (defn-forms parsed))
+            target     (first (filter (fn [d] (= (nth d 1) trace-defn-name)) defns))]
+        (when (nil? target)
+          (println (str "no defn named '" trace-defn-name "' in " path))
+          (println "Available defns:")
+          (doseq [d defns] (println (str "  " (nth d 1))))
+          (System/exit 1))
+        (print-trace-report trace-defn-name (trace-one-defn target))))))
+
 (defn run []
+  (when (= measurement-mode :trace)
+    (trace-mode-run)
+    (System/exit 0))
   (println (str "=== IR-pipeline stress test — target: " stress-target
                 " — mode: " measurement-mode " ===\n"))
 
@@ -249,14 +548,20 @@
         t1 (System/nanoTime)
         cold-ms (double (/ (- t1 t0) 1000000.0))]
 
-    ;; WARM pass: run again
-    (print (format "done in %.0f ms\nWarm pass (second run)... " cold-ms))
-    (let [t0 (System/nanoTime)
-          results2 (mapv (fn [f] (stress-file (str corpus-dir f))) files)
+    ;; WARM pass: run again (unless LG_STRESS_PASSES=1)
+    (let [skip-warm? (<= stress-passes 1)
+          _ (if skip-warm?
+              (print (format "done in %.0f ms\n" cold-ms))
+              (print (format "done in %.0f ms\nWarm pass (second run)... " cold-ms)))
+          t0 (System/nanoTime)
+          results2 (if skip-warm?
+                     []
+                     (mapv (fn [f] (stress-file (str corpus-dir f))) files))
           t1 (System/nanoTime)
           warm-ms (double (/ (- t1 t0) 1000000.0))]
 
-      (println (format "done in %.0f ms\n" warm-ms))
+      (when-not skip-warm?
+        (println (format "done in %.0f ms\n" warm-ms)))
 
       ;; Aggregate both passes
       (let [all-results (concat results results2)
@@ -293,6 +598,24 @@
         ;; Error buckets
         (println (str "\n=== Failure Buckets ==="))
         (doseq [[bucket count] (sort-by val (fn [a b] (compare b a)) all-errs)]
-          (println (format "  %-40s %3d" (str bucket) count)))))))
+          (println (format "  %-50s %3d" (str bucket) count)))
+
+        ;; Top-K pass cost summary (populated by auto-trace)
+        (when (and topk-on? (seq @pass-totals))
+          (println "\n=== Top passes by cumulative ms (auto-trace sample) ===")
+          (let [sorted (sort-by val (fn [a b] (compare b a)) @pass-totals)]
+            (doseq [[pass total-ms] sorted]
+              (println (format "  %-20s %8.1f ms" pass total-ms))))
+          (println "\n=== Worst-pass per traced defn ===")
+          (doseq [r (reverse (sort-by :worst-ms @autotrace-rows))]
+            (println (format "  %-35s worst=%-15s %6.1f ms  total=%6.1f ms"
+                            (str (:defn r)) (str (:worst-pass r))
+                            (:worst-ms r) (:total-ms r)))))
+
+        ;; Per-defn analysis log
+        (when log-path
+          (spit log-path (apply str @log-entries))
+          (println (str "\nPer-defn log: " log-path
+                        " (" (count @log-entries) " rows)")))))))
 
 (run)


### PR DESCRIPTION
## Summary

Lands the design contracts and regression thresholds from #97 as a binding contribution policy (`docs/contribution-policy.md`), and wires the Makefile / scripts / CI staleness gates that protect the artifacts the policy depends on.

## What lands

**Policy doc** — `docs/contribution-policy.md` (new):
- §1 Six design contracts confirmed in #97 (portable standalone, embeddable, bytecode/VM first-class, Clojure-compatible host-interop superset, generated-Go authored binaries, perf+footprint across 4 surfaces).
- §2 Self-host as the committed direction; smart-wrapper coverage scoped by what the compiler touches.
- §3 Regression checkpoint table with 10 % thresholds for cold-start and artifact-size, the two paired staleness gates, and `parity-full`'s deferred-gate status explained.
- §4 Signature-driven callback contract.
- §5 Interop schema (`:go-deps` + manifest format).
- §6 Host-interop syntax map (Clojure | ClojureScript | let-go).
- §7 WASM-specific constraints raised by @mparrett.
- §8 Distribution UX target — `lg deps`; default binary stays lean.

**CI** — `.github/workflows/go.yml`:
- `bundle-fresh` job: `make check-bundle-fresh` (~1 s) fails when any `pkg/rt/core/**/*.lg` is newer than `pkg/rt/core_compiled.lgb`.
- `lowered-fresh` step: `make check-lowered-fresh` — sibling gate for `pkg/rt/core_go_lowered/`. Trivially passes when the tree is absent (today's `main`); enforces freshness when present.
- `parity-full` is intentionally not yet wired as a CI job — the doc explains why, and the local `make parity-full` target is fully functional.

**Makefile**: targets for `core_compiled.lgb` and `core_go_lowered/`, `check-bundle-fresh`, `check-lowered-fresh`, `parity-quick` / `parity-check` / `parity-full`. `test:` and `\$(LG):` now depend on the lgb so make-driven workflows keep it fresh.

**`scripts/gogen-parity.sh`** (new): jank + ir-stress lower-go + ir-stress ir-compile, each run twice (untagged + `-tags gogen_ir`), bucket-by-symbol diff. Scrubs `0x[0-9a-fA-F]{6,}` pointer addresses before hashing to avoid false-positive divergences from process-specific memory layout.

**`scripts/ir-stress.lg`**: `classify-error` scrubs the same pointer pattern *before* the 100-char truncation, so two engines' slightly-different-length error strings don't truncate at different word boundaries (defeating the script-level scrub).

**`.gitignore`**: drops `docs/`. Brings two free-standing reference docs into tracking — `docs/els2023-ir-fixup-audit.md` (2026-05-23 audit for the IR fixup pass) and `docs/xsofy-portability-gaps.md` (let-go ↔ Clojure JVM portability findings from porting xsofy).

## Test plan

- [x] `make check-bundle-fresh` fails when `.lg` is touched, passes when fresh.
- [x] `make check-lowered-fresh` passes on current `main` (no `core_go_lowered/`), enforces freshness on a branch where the tree exists (verified on band-next worktree).
- [x] Existing `make test` continues to work (lgb prereq satisfied by tracked artifact).
- [ ] Wire `make parity-full` as a CI gate in a follow-up after the `lgbgen --target=go` reader EOF on current `main` is resolved.

## Follow-ups

- Promote `parity-full` from local target to CI gate once `lgbgen --target=go` produces `core_go_lowered/` cleanly from `main`.
- Land the perf corpus and measurement protocol called out in §6 of #97 (cold-start, warm-run, peak-rss, artifact-size across interpreter/embedded/wasm/native).