### PR TITLE
Add term/key-pending? non-blocking input peek

### DIFF
--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -125,6 +125,27 @@ func installTermNS() {
 	})
 	ns.Def("read-key", readKey)
 
+	// key-pending? — true if stdin has at least one byte buffered (the
+	// OS has received input from the TTY but read-key has not yet
+	// consumed it). Uses the FIONREAD ioctl on the stdin fd;
+	// non-consuming. fionread is defined per-OS alongside tiocswinsz.
+	//
+	// Lets animation / poll loops break out on user input without
+	// entering read-key (which would block on the underlying read).
+	// Returns false if the ioctl errors (e.g. stdin is not a TTY).
+	keyPendingFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		var n int32
+		_, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+			uintptr(os.Stdin.Fd()),
+			uintptr(fionread),
+			uintptr(unsafe.Pointer(&n)))
+		if errno != 0 || n <= 0 {
+			return vm.FALSE, nil
+		}
+		return vm.TRUE, nil
+	})
+	ns.Def("key-pending?", keyPendingFn)
+
 	// size — returns [cols rows] or nil if not a TTY
 	//   (term/size)         → stdout winsize
 	//   (term/size handle)  → arbitrary fd winsize

--- a/pkg/rt/term_pty_linux.go
+++ b/pkg/rt/term_pty_linux.go
@@ -18,6 +18,7 @@ const (
 	tiocswinsz = 0x5414
 	tiocgptn   = 0x80045430
 	tiocsptlck = 0x40045431
+	fionread   = 0x541B
 )
 
 func openPtyPair() (master *os.File, slave *os.File, slavePath string, err error) {

--- a/pkg/rt/term_pty_other.go
+++ b/pkg/rt/term_pty_other.go
@@ -15,6 +15,10 @@ import (
 // On non-Linux hosts we don't implement pty opening — lgcr targets Linux and
 // the term ns can still be used for terminal UI (raw-mode, size, colors).
 const tiocswinsz = 0x5414 // unused; placeholder so term.go compiles
+// FIONREAD on Darwin/BSD: _IOR('f', 127, int). Same value across Darwin,
+// FreeBSD, NetBSD, OpenBSD. Used by key-pending? to peek the stdin
+// buffer without consuming.
+const fionread = 0x4004667F
 
 func openPtyPair() (*os.File, *os.File, string, error) {
 	return nil, nil, "", fmt.Errorf("open-pty is only supported on Linux")

--- a/pkg/rt/term_wasm.go
+++ b/pkg/rt/term_wasm.go
@@ -76,6 +76,23 @@ func installTermNS() {
 	})
 	ns.Def("read-key", readKey)
 
+	// key-pending? — true if the key-ready flag at SAB[0] is set, i.e.
+	// the JS side has written a key that read-key has not yet consumed.
+	// Lets animation / poll loops break out on user input without
+	// entering read-key (which would Atomics.wait if no key is queued).
+	keyPendingFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		keyInt32 := js.Global().Get("_lgKeyInt32")
+		if keyInt32.IsUndefined() {
+			return vm.FALSE, nil
+		}
+		atomics := js.Global().Get("Atomics")
+		if atomics.Call("load", keyInt32, 0).Int() != 0 {
+			return vm.TRUE, nil
+		}
+		return vm.FALSE, nil
+	})
+	ns.Def("key-pending?", keyPendingFn)
+
 	// size — read from SharedArrayBuffer
 	sizeFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		keyInt32 := js.Global().Get("_lgKeyInt32")


### PR DESCRIPTION
## Summary

Adds a non-blocking `term/key-pending?` primitive that returns `true` when input is queued but `read-key` has not yet consumed it. Non-consuming — the next `read-key` still returns it normally.

```clojure
;; example: animation loop that exits early on any user input                                                                                                                                                  
(loop [frame 0]
  (when (and (< frame 60) (not (term/key-pending?)))                                                                                                                                                  
    ;; ... render this frame ...                                     
    (sleep 16)                                                                                                                                                                                        
    (recur (inc frame))))
;; key (if any) still in buffer; falls through to read-key normally                                                                                                                                   
(term/read-key)  
```

## Motivation

`term/read-key` blocks unconditionally on `Atomics.wait` (WASM) or the underlying read syscall (native), which is correct for most game-loop / REPL shapes but rules out a class of UIs that want to *poll* for input without committing to a full read on every tick:

- Title-screen animations that should bail out the moment the user presses anything.
- Auto-action loops (e.g. autoexplore, run-until-something, rest-until-X in a roguelike) that want to stay interruptible by keystroke.
- Any "do a thing per frame, exit on input" pattern.

There's currently no way to do this from let-go without entering `read-key` and being stuck on the blocking wait. `key-pending?` closes that gap with a small surface: one boolean predicate per platform.

A downstream consumer (xsofy, issue [nooga/xsofy#16](https://github.com/nooga/xsofy/issues/16)) needs this for autoexplore key-interrupt; that's the immediate driver, but the primitive is general — useful for any animation or polling loop.

## Implementation

- **WASM** (`pkg/rt/term_wasm.go`): `Atomics.load(keyInt32, 0) != 0`. Same key-ready flag that `read-key` already uses for `Atomics.wait` — no new SAB layout, no producer-side changes. Non-consuming peek.
- **Native** (`pkg/rt/term.go`): `FIONREAD` ioctl on `os.Stdin` reports buffered bytes. `fionread` const added per-OS alongside `tiocswinsz` (Linux: `0x541B`; Darwin/BSD: `0x4004667F`). Returns false on ioctl error (e.g. stdin is not a TTY).

## Test plan

- [x] `go test ./test` passes
- [x] `GOOS=js GOARCH=wasm go vet ./pkg/...` clean
- [x] Native smoke on macOS: empty stdin → `false`; `printf 'x' | lg script.lg` → `true`
- [x] End-to-end on native: xsofy autoexplore is now interruptible by keystroke when running on this binary

+43 LOC across four files.