### PR TITLE
feat(vm+rt/async): goroutine registry + cancellable, correct core.async primitives

### DIFF
--- a/pkg/rt/async.go
+++ b/pkg/rt/async.go
@@ -11,6 +11,7 @@
 package rt
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -76,10 +77,15 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("timeout expected Int milliseconds")
 		}
 		ch := make(vm.Chan)
-		go func() {
-			time.Sleep(time.Duration(int(ms)) * time.Millisecond)
+		vm.Goroutines.Go(func(ctx context.Context) {
+			t := time.NewTimer(time.Duration(int(ms)) * time.Millisecond)
+			defer t.Stop()
+			select {
+			case <-t.C:
+			case <-ctx.Done():
+			}
 			close(ch)
-		}()
+		})
 		return ch, nil
 	})
 

--- a/pkg/rt/async.go
+++ b/pkg/rt/async.go
@@ -37,6 +37,89 @@ type Pub struct {
 
 func init() { RegisterInstaller(installAsyncNS) }
 
+// PromiseChan implements clojure.core.async's promise-chan: a channel
+// that caches the FIRST value put to it and replays that value to every
+// taker, forever. Subsequent puts are dropped; closing without a value
+// makes takers receive nil; closing after a value is a no-op (the value
+// keeps being served).
+//
+// Unlike a raw vm.Chan it STORES the value rather than transferring it,
+// which is what makes the semantics correct: with a single raw channel a
+// taker parked before the first put could steal that put before it was
+// cached, so later takers would never see it. Storing the value behind a
+// latch removes that race entirely.
+//
+// Dispatched to by >! / <! / close! when they receive a boxed
+// *PromiseChan instead of a vm.Chan. Methods are unexported so the
+// reflective method-boxing in vm.NewBoxed skips them.
+type PromiseChan struct {
+	mu     sync.Mutex
+	value  vm.Value
+	set    bool
+	closed bool
+	ready  chan struct{} // closed once set or closed; latch for takers
+}
+
+func newPromiseChan() *PromiseChan {
+	return &PromiseChan{value: vm.NIL, ready: make(chan struct{})}
+}
+
+// put caches v if no value has been delivered and the chan is open;
+// otherwise it is dropped (first put wins).
+func (p *PromiseChan) put(v vm.Value) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.set || p.closed {
+		return
+	}
+	p.value = v
+	p.set = true
+	close(p.ready)
+}
+
+// take returns the cached value, blocking until one is delivered or the
+// chan is closed. ctx (the registry context) lets a blocked take be
+// drained on shutdown; cancellation returns nil.
+func (p *PromiseChan) take(ctx context.Context) vm.Value {
+	p.mu.Lock()
+	if p.set || p.closed {
+		v := p.value
+		p.mu.Unlock()
+		return v
+	}
+	p.mu.Unlock()
+	select {
+	case <-p.ready:
+	case <-ctx.Done():
+		return vm.NIL
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.value // the delivered value, or NIL if closed empty
+}
+
+// doClose marks the chan closed. No-op once a value is set, so the value
+// keeps being served to takers.
+func (p *PromiseChan) doClose() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.set || p.closed {
+		return
+	}
+	p.closed = true
+	close(p.ready)
+}
+
+// asPromiseChan returns the *PromiseChan a value wraps, if any.
+func asPromiseChan(v vm.Value) (*PromiseChan, bool) {
+	b, ok := v.(*vm.Boxed)
+	if !ok {
+		return nil, false
+	}
+	pc, ok := b.Unbox().(*PromiseChan)
+	return pc, ok
+}
+
 // ctxSend sends v on ch, aborting if ctx is cancelled (e.g. a registry
 // Drain on shutdown / between bench iterations). Returns false if the
 // send was abandoned due to cancellation.
@@ -69,6 +152,10 @@ func installAsyncNS() {
 	closeChan, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("close! expects 1 arg")
+		}
+		if pc, ok := asPromiseChan(vs[0]); ok {
+			pc.doClose()
+			return vm.NIL, nil
 		}
 		ch, ok := vs[0].(vm.Chan)
 		if !ok {
@@ -440,70 +527,15 @@ func installAsyncNS() {
 		}
 	})
 
-	// promise-chan — channel that caches and replays one value to all takers.
-	//
-	// NOTE: the replay semantics here are pre-existing and not fully
-	// correct (the put side is not wired to the returned channel). This
-	// change only brings its goroutines under the registry so they are
-	// tracked and drainable, and removes a premature close that made the
-	// replay goroutine panic on a closed channel. A proper promise-chan
-	// redesign is tracked separately.
+	// promise-chan — a channel that caches the first value put and
+	// replays it to every taker (see PromiseChan). Returned boxed; >! /
+	// <! / close! dispatch to it. No goroutine needed — the value is
+	// stored behind a latch, so there is no parked-taker steal race.
 	promiseChan, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		ch := make(vm.Chan)
-		p := vm.NewPromise()
-		// Deliver goroutine: first put delivers.
-		vm.Goroutines.Go(func(ctx context.Context) {
-			v, ok, live := ctxRecv(ctx, ch)
-			if !live {
-				return
-			}
-			if ok {
-				p.Deliver(v)
-			} else {
-				p.Deliver(vm.NIL)
-			}
-		})
-		out := make(vm.Chan)
-		// Replay goroutine: serve the delivered value to readers forever
-		// (until the registry cancels). Must NOT close(out) — that would
-		// panic this loop's send.
-		vm.Goroutines.Go(func(ctx context.Context) {
-			val := p.Deref()
-			for {
-				if !ctxSend(ctx, out, val) {
-					return
-				}
-			}
-		})
-		proxy := make(vm.Chan)
-		delivered := make(chan struct{}, 1)
-		var cached vm.Value
-		vm.Goroutines.Go(func(ctx context.Context) {
-			v, ok, live := ctxRecv(ctx, proxy)
-			if !live {
-				return
-			}
-			if ok {
-				cached = v
-			} else {
-				cached = vm.NIL
-			}
-			close(delivered)
-		})
-		vm.Goroutines.Go(func(ctx context.Context) {
-			select {
-			case <-delivered:
-			case <-ctx.Done():
-				return
-			}
-			for {
-				if !ctxSend(ctx, proxy, cached) {
-					return
-				}
-			}
-		})
-		close(ch)
-		return proxy, nil
+		if len(vs) != 0 {
+			return vm.NIL, fmt.Errorf("promise-chan expects 0 args")
+		}
+		return vm.NewBoxed(newPromiseChan()), nil
 	})
 
 	// mult — create a mult (broadcast) from a source channel

--- a/pkg/rt/async.go
+++ b/pkg/rt/async.go
@@ -37,6 +37,29 @@ type Pub struct {
 
 func init() { RegisterInstaller(installAsyncNS) }
 
+// ctxSend sends v on ch, aborting if ctx is cancelled (e.g. a registry
+// Drain on shutdown / between bench iterations). Returns false if the
+// send was abandoned due to cancellation.
+func ctxSend(ctx context.Context, ch vm.Chan, v vm.Value) bool {
+	select {
+	case ch <- v:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// ctxRecv receives from ch. ok is false when ch is closed; live is false
+// when ctx was cancelled before a value arrived (caller should return).
+func ctxRecv(ctx context.Context, ch vm.Chan) (v vm.Value, ok bool, live bool) {
+	select {
+	case rv, rok := <-ch:
+		return rv, rok, true
+	case <-ctx.Done():
+		return vm.NIL, false, false
+	}
+}
+
 // nolint
 func installAsyncNS() {
 	// Look up the core builtins to re-export
@@ -107,14 +130,23 @@ func installAsyncNS() {
 		if len(vs) == 3 {
 			shouldClose = vm.IsTruthy(vs[2])
 		}
-		go func() {
-			for v := range src {
-				dst <- v
+		vm.Goroutines.Go(func(ctx context.Context) {
+			for {
+				v, ok, live := ctxRecv(ctx, src)
+				if !live {
+					return
+				}
+				if !ok {
+					break
+				}
+				if !ctxSend(ctx, dst, v) {
+					return
+				}
 			}
 			if shouldClose {
 				close(dst)
 			}
-		}()
+		})
 		return dst, nil
 	})
 
@@ -136,14 +168,16 @@ func installAsyncNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("onto-chan! expected Sequable")
 		}
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			for s := seq.Seq(); s != nil; s = s.Next() {
-				ch <- s.First()
+				if !ctxSend(ctx, ch, s.First()) {
+					return
+				}
 			}
 			if shouldClose {
 				close(ch)
 			}
-		}()
+		})
 		return ch, nil
 	})
 
@@ -173,20 +207,37 @@ func installAsyncNS() {
 				continue
 			}
 			count++
-			go func(c vm.Chan) {
-				for v := range c {
-					out <- v
+			c := ch
+			vm.Goroutines.Go(func(ctx context.Context) {
+				for {
+					v, ok, live := ctxRecv(ctx, c)
+					if !live {
+						return
+					}
+					if !ok {
+						break
+					}
+					if !ctxSend(ctx, out, v) {
+						return
+					}
 				}
-				done <- struct{}{}
-			}(ch)
+				select {
+				case done <- struct{}{}:
+				case <-ctx.Done():
+				}
+			})
 		}
 		// Close output when all inputs are done
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			for range count {
-				<-done
+				select {
+				case <-done:
+				case <-ctx.Done():
+					return
+				}
 			}
 			close(out)
-		}()
+		})
 		return out, nil
 	})
 
@@ -205,18 +256,25 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("async/reduce expected Chan")
 		}
 		out := make(vm.Chan, 1)
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			acc := init
-			for v := range ch {
+			for {
+				v, ok, live := ctxRecv(ctx, ch)
+				if !live {
+					return
+				}
+				if !ok {
+					break
+				}
 				result, err := fn.Invoke([]vm.Value{acc, v})
 				if err != nil {
 					break
 				}
 				acc = result
 			}
-			out <- acc
+			out <- acc // out is buffered (cap 1); never blocks
 			close(out)
-		}()
+		})
 		return out, nil
 	})
 
@@ -231,16 +289,23 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("async/into expected Chan")
 		}
 		out := make(vm.Chan, 1)
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			acc := coll
-			for v := range ch {
+			for {
+				v, ok, live := ctxRecv(ctx, ch)
+				if !live {
+					return
+				}
+				if !ok {
+					break
+				}
 				if assoc, ok := acc.(vm.Collection); ok {
 					acc = assoc.Conj(v)
 				}
 			}
-			out <- acc
+			out <- acc // out is buffered (cap 1); never blocks
 			close(out)
-		}()
+		})
 		return out, nil
 	})
 
@@ -254,12 +319,14 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("to-chan! expected Sequable")
 		}
 		ch := make(vm.Chan)
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			for s := seq.Seq(); s != nil; s = s.Next() {
-				ch <- s.First()
+				if !ctxSend(ctx, ch, s.First()) {
+					return
+				}
 			}
 			close(ch)
-		}()
+		})
 		return ch, nil
 	})
 
@@ -373,55 +440,69 @@ func installAsyncNS() {
 		}
 	})
 
-	// promise-chan — channel that caches and replays one value to all takers
+	// promise-chan — channel that caches and replays one value to all takers.
+	//
+	// NOTE: the replay semantics here are pre-existing and not fully
+	// correct (the put side is not wired to the returned channel). This
+	// change only brings its goroutines under the registry so they are
+	// tracked and drainable, and removes a premature close that made the
+	// replay goroutine panic on a closed channel. A proper promise-chan
+	// redesign is tracked separately.
 	promiseChan, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		ch := make(vm.Chan)
 		p := vm.NewPromise()
-		// Deliver goroutine: first put delivers, then replay forever
-		go func() {
-			v, ok := <-ch
+		// Deliver goroutine: first put delivers.
+		vm.Goroutines.Go(func(ctx context.Context) {
+			v, ok, live := ctxRecv(ctx, ch)
+			if !live {
+				return
+			}
 			if ok {
 				p.Deliver(v)
 			} else {
 				p.Deliver(vm.NIL)
 			}
-		}()
-		// Wrap in a boxed value that acts like a channel but reads from promise
-		// Simpler approach: return a special channel that replays
+		})
 		out := make(vm.Chan)
-		go func() {
-			// Wait for the value
+		// Replay goroutine: serve the delivered value to readers forever
+		// (until the registry cancels). Must NOT close(out) — that would
+		// panic this loop's send.
+		vm.Goroutines.Go(func(ctx context.Context) {
 			val := p.Deref()
-			// Now replay it to anyone who reads
 			for {
-				out <- val
+				if !ctxSend(ctx, out, val) {
+					return
+				}
 			}
-		}()
-		// We need both ends: write to ch, read from out
-		// Package them together. Actually, simplest: use a proxy channel
+		})
 		proxy := make(vm.Chan)
 		delivered := make(chan struct{}, 1)
 		var cached vm.Value
-		go func() {
-			// First value written becomes the cached value
-			v, ok := <-proxy
+		vm.Goroutines.Go(func(ctx context.Context) {
+			v, ok, live := ctxRecv(ctx, proxy)
+			if !live {
+				return
+			}
 			if ok {
 				cached = v
 			} else {
 				cached = vm.NIL
 			}
 			close(delivered)
-		}()
-		go func() {
-			<-delivered
-			// Now serve reads forever
-			for {
-				proxy <- cached
+		})
+		vm.Goroutines.Go(func(ctx context.Context) {
+			select {
+			case <-delivered:
+			case <-ctx.Done():
+				return
 			}
-		}()
-		// Close the unused channels
+			for {
+				if !ctxSend(ctx, proxy, cached) {
+					return
+				}
+			}
+		})
 		close(ch)
-		close(out)
 		return proxy, nil
 	})
 
@@ -435,8 +516,15 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("mult expected Chan")
 		}
 		m := &Mult{src: src, taps: make(map[vm.Chan]bool)}
-		go func() {
-			for v := range src {
+		vm.Goroutines.Go(func(ctx context.Context) {
+			for {
+				v, ok, live := ctxRecv(ctx, src)
+				if !live {
+					return
+				}
+				if !ok {
+					break
+				}
 				m.mu.Lock()
 				for ch, closeCh := range m.taps {
 					select {
@@ -456,7 +544,7 @@ func installAsyncNS() {
 				}
 			}
 			m.mu.Unlock()
-		}()
+		})
 		return vm.NewBoxed(m), nil
 	})
 
@@ -543,8 +631,15 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("pub expected Fn")
 		}
 		p := &Pub{src: src, topicFn: topicFn, subs: make(map[any]vm.Chan)}
-		go func() {
-			for v := range src {
+		vm.Goroutines.Go(func(ctx context.Context) {
+			for {
+				v, ok, live := ctxRecv(ctx, src)
+				if !live {
+					return
+				}
+				if !ok {
+					break
+				}
 				topic, err := topicFn.Invoke([]vm.Value{v})
 				if err != nil {
 					continue
@@ -565,7 +660,7 @@ func installAsyncNS() {
 				close(ch)
 			}
 			p.mu.Unlock()
-		}()
+		})
 		return vm.NewBoxed(p), nil
 	})
 
@@ -628,18 +723,29 @@ func installAsyncNS() {
 		}
 		trueCh := make(vm.Chan)
 		falseCh := make(vm.Chan)
-		go func() {
-			for v := range src {
+		vm.Goroutines.Go(func(ctx context.Context) {
+			for {
+				v, ok, live := ctxRecv(ctx, src)
+				if !live {
+					return
+				}
+				if !ok {
+					break
+				}
 				result, err := pred.Invoke([]vm.Value{v})
 				if err != nil || !vm.IsTruthy(result) {
-					falseCh <- v
+					if !ctxSend(ctx, falseCh, v) {
+						return
+					}
 				} else {
-					trueCh <- v
+					if !ctxSend(ctx, trueCh, v) {
+						return
+					}
 				}
 			}
 			close(trueCh)
 			close(falseCh)
-		}()
+		})
 		return vm.NewArrayVector([]vm.Value{trueCh, falseCh}), nil
 	})
 
@@ -665,12 +771,15 @@ func installAsyncNS() {
 			chs = append(chs, ch)
 		}
 		out := make(vm.Chan)
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			for {
 				args := make([]vm.Value, len(chs))
 				allOk := true
 				for i, ch := range chs {
-					v, ok := <-ch
+					v, ok, live := ctxRecv(ctx, ch)
+					if !live {
+						return
+					}
 					if !ok {
 						allOk = false
 						break
@@ -684,10 +793,12 @@ func installAsyncNS() {
 				if err != nil {
 					break
 				}
-				out <- result
+				if !ctxSend(ctx, out, result) {
+					return
+				}
 			}
 			close(out)
-		}()
+		})
 		return out, nil
 	})
 
@@ -705,17 +816,22 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("async/take expected Chan")
 		}
 		out := make(vm.Chan)
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			count := int(n)
 			for range count {
-				v, ok := <-ch
+				v, ok, live := ctxRecv(ctx, ch)
+				if !live {
+					return
+				}
 				if !ok {
 					break
 				}
-				out <- v
+				if !ctxSend(ctx, out, v) {
+					return
+				}
 			}
 			close(out)
-		}()
+		})
 		return out, nil
 	})
 

--- a/pkg/rt/async.go
+++ b/pkg/rt/async.go
@@ -472,7 +472,20 @@ func installAsyncNS() {
 			return vm.NIL, fmt.Errorf("alts! requires at least one port")
 		}
 
+		// Append a recv on the registry context's Done channel so an
+		// alts! parked on its ports — e.g. inside a (go ...) block — is
+		// released by a CancelAll/Drain on shutdown. If that case wins,
+		// return nil (no port chosen).
+		cancelIdx := len(cases)
+		cases = append(cases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(vm.Goroutines.Context().Done()),
+		})
+
 		chosen, value, ok := reflect.Select(cases)
+		if chosen == cancelIdx {
+			return vm.NIL, nil
+		}
 		port := ports[chosen]
 
 		var result vm.Value

--- a/pkg/rt/async_test.go
+++ b/pkg/rt/async_test.go
@@ -136,3 +136,92 @@ func TestAsyncGoroutinesTrackedAndDrained(t *testing.T) {
 		t.Fatalf("expected 0 live after drain, got %d", got)
 	}
 }
+
+// --- promise-chan semantics -------------------------------------------
+
+func promiseChanOps(t *testing.T) (mk, put, take, closef vm.Fn) {
+	t.Helper()
+	return asyncFn(t, "promise-chan"), asyncFn(t, ">!"), asyncFn(t, "<!"), asyncFn(t, "close!")
+}
+
+// TestPromiseChanPutThenTake: a value put is replayed to many takers.
+func TestPromiseChanPutThenTake(t *testing.T) {
+	mk, put, take, _ := promiseChanOps(t)
+	pc := invoke(t, mk)
+	invoke(t, put, pc, vm.Int(42))
+	for i := 0; i < 3; i++ {
+		if got := invoke(t, take, pc); got != vm.Int(42) {
+			t.Fatalf("take %d: expected 42, got %v", i, got)
+		}
+	}
+}
+
+// TestPromiseChanTakeBeforePutNoStealRace: a taker parked BEFORE the put
+// must (a) receive the value and (b) NOT consume it — later takers still
+// see it. This is the race the old single-channel design lost.
+func TestPromiseChanTakeBeforePutNoStealRace(t *testing.T) {
+	mk, put, take, _ := promiseChanOps(t)
+	pc := invoke(t, mk)
+
+	got := make(chan vm.Value, 1)
+	go func() {
+		v, err := take.Invoke([]vm.Value{pc})
+		if err != nil {
+			got <- vm.NIL
+			return
+		}
+		got <- v
+	}()
+
+	// Give the taker time to park, then deliver.
+	time.Sleep(50 * time.Millisecond)
+	invoke(t, put, pc, vm.Int(7))
+
+	select {
+	case v := <-got:
+		if v != vm.Int(7) {
+			t.Fatalf("parked taker: expected 7, got %v", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("parked taker never woke after put")
+	}
+
+	// Value survived: a later taker still sees it.
+	if v := invoke(t, take, pc); v != vm.Int(7) {
+		t.Fatalf("later taker: expected 7 (replay), got %v", v)
+	}
+}
+
+// TestPromiseChanSubsequentPutsDropped: only the first put wins.
+func TestPromiseChanSubsequentPutsDropped(t *testing.T) {
+	mk, put, take, _ := promiseChanOps(t)
+	pc := invoke(t, mk)
+	invoke(t, put, pc, vm.Int(1))
+	invoke(t, put, pc, vm.Int(2)) // dropped
+	if v := invoke(t, take, pc); v != vm.Int(1) {
+		t.Fatalf("expected first put 1 to win, got %v", v)
+	}
+}
+
+// TestPromiseChanCloseEmptyYieldsNil: closing without a value → takers
+// get nil, not a hang.
+func TestPromiseChanCloseEmptyYieldsNil(t *testing.T) {
+	mk, _, take, closef := promiseChanOps(t)
+	pc := invoke(t, mk)
+	invoke(t, closef, pc)
+	if v := invoke(t, take, pc); v != vm.NIL {
+		t.Fatalf("expected nil from closed-empty promise-chan, got %v", v)
+	}
+}
+
+// TestPromiseChanValueSurvivesClose: a delivered value keeps being served
+// even after close.
+func TestPromiseChanValueSurvivesClose(t *testing.T) {
+	mk, put, take, closef := promiseChanOps(t)
+	pc := invoke(t, mk)
+	invoke(t, put, pc, vm.Int(99))
+	invoke(t, closef, pc) // no-op for the cached value
+	if v := invoke(t, take, pc); v != vm.Int(99) {
+		t.Fatalf("expected cached 99 after close, got %v", v)
+	}
+}

--- a/pkg/rt/async_test.go
+++ b/pkg/rt/async_test.go
@@ -225,3 +225,91 @@ func TestPromiseChanValueSurvivesClose(t *testing.T) {
 		t.Fatalf("expected cached 99 after close, got %v", v)
 	}
 }
+
+// --- go-block / <! / >! drainability ----------------------------------
+
+func coreOrAsyncFn(t *testing.T, name string) vm.Fn {
+	t.Helper()
+	v := NS("async").Lookup(vm.Symbol(name))
+	if v == nil {
+		t.Fatalf("%s not found", name)
+	}
+	fn, ok := v.(*vm.Var).Deref().(vm.Fn)
+	if !ok {
+		t.Fatalf("%s is not an Fn", name)
+	}
+	return fn
+}
+
+// TestGoBlockParkedInTakeIsDrainable pins the fix: a (go (<! ch)) parked
+// on an empty channel runs in a registry-tracked goroutine, but <! used
+// to block on a bare `<-ch` with no view of the registry context — so
+// Drain could not release it. After wiring <! to the registry context,
+// CancelAll/Drain unblocks the parked take and the go-block exits.
+func TestGoBlockParkedInTakeIsDrainable(t *testing.T) {
+	vm.Goroutines.Drain(2 * time.Second)
+	base := vm.Goroutines.Live()
+
+	goStar := coreOrAsyncFn(t, "go*")
+	take := asyncFn(t, "<!")
+	ch := make(vm.Chan) // nobody ever delivers
+
+	thunk, _ := vm.NativeFnType.Wrap(func(_ []vm.Value) (vm.Value, error) {
+		return take.Invoke([]vm.Value{ch})
+	})
+	invoke(t, goStar, thunk) // spawns the go-block goroutine; it parks in <!
+
+	deadline := time.Now().Add(time.Second)
+	for vm.Goroutines.Live() <= base && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if vm.Goroutines.Live() <= base {
+		t.Fatalf("go-block goroutine not tracked (live=%d base=%d)", vm.Goroutines.Live(), base)
+	}
+	// Live++ happens before the goroutine body runs; give it time to
+	// actually reach and park in the channel op (reading the current
+	// registry context) before we Drain.
+	time.Sleep(100 * time.Millisecond)
+
+	if !vm.Goroutines.Drain(3 * time.Second) {
+		t.Fatal("Drain could not release a go-block parked in <! (not ctx-aware)")
+	}
+	if got := vm.Goroutines.Live(); got != 0 {
+		t.Fatalf("expected 0 live after drain, got %d", got)
+	}
+}
+
+// TestGoBlockParkedInPutIsDrainable: same, for a put on a full/unread
+// channel.
+func TestGoBlockParkedInPutIsDrainable(t *testing.T) {
+	vm.Goroutines.Drain(2 * time.Second)
+	base := vm.Goroutines.Live()
+
+	goStar := coreOrAsyncFn(t, "go*")
+	put := asyncFn(t, ">!")
+	ch := make(vm.Chan) // unbuffered, no reader
+
+	thunk, _ := vm.NativeFnType.Wrap(func(_ []vm.Value) (vm.Value, error) {
+		return put.Invoke([]vm.Value{ch, vm.Int(1)})
+	})
+	invoke(t, goStar, thunk)
+
+	deadline := time.Now().Add(time.Second)
+	for vm.Goroutines.Live() <= base && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if vm.Goroutines.Live() <= base {
+		t.Fatalf("go-block goroutine not tracked (live=%d base=%d)", vm.Goroutines.Live(), base)
+	}
+	// Live++ happens before the goroutine body runs; give it time to
+	// actually reach and park in the channel op (reading the current
+	// registry context) before we Drain.
+	time.Sleep(100 * time.Millisecond)
+
+	if !vm.Goroutines.Drain(3 * time.Second) {
+		t.Fatal("Drain could not release a go-block parked in >! (not ctx-aware)")
+	}
+	if got := vm.Goroutines.Live(); got != 0 {
+		t.Fatalf("expected 0 live after drain, got %d", got)
+	}
+}

--- a/pkg/rt/async_test.go
+++ b/pkg/rt/async_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func asyncFn(t *testing.T, name string) vm.Fn {
+	t.Helper()
+	v := NS("async").Lookup(vm.Symbol(name))
+	if v == nil {
+		t.Fatalf("async/%s not found", name)
+	}
+	fn, ok := v.(*vm.Var).Deref().(vm.Fn)
+	if !ok {
+		t.Fatalf("async/%s is not an Fn", name)
+	}
+	return fn
+}
+
+func invoke(t *testing.T, fn vm.Fn, args ...vm.Value) vm.Value {
+	t.Helper()
+	v, err := fn.Invoke(args)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	return v
+}
+
+// drainChan reads all values from ch until it closes or timeout.
+func drainChan(t *testing.T, ch vm.Chan, timeout time.Duration) []vm.Value {
+	t.Helper()
+	var out []vm.Value
+	deadline := time.After(timeout)
+	for {
+		select {
+		case v, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, v)
+		case <-deadline:
+			t.Fatalf("drainChan timed out after %v (got %d values)", timeout, len(out))
+			return out
+		}
+	}
+}
+
+// TestAsyncToChanPipe is a correctness regression guard: to-chan! emits a
+// collection onto a channel and closes it; pipe forwards src→dst and
+// closes dst when src closes.
+func TestAsyncToChanPipe(t *testing.T) {
+	toChan := asyncFn(t, "to-chan!")
+	pipe := asyncFn(t, "pipe")
+
+	src := invoke(t, toChan, vm.NewArrayVector([]vm.Value{vm.Int(1), vm.Int(2), vm.Int(3)})).(vm.Chan)
+	dst := make(vm.Chan, 10)
+	invoke(t, pipe, src, dst)
+
+	got := drainChan(t, dst, 2*time.Second)
+	if len(got) != 3 || got[0] != vm.Int(1) || got[2] != vm.Int(3) {
+		t.Fatalf("expected [1 2 3] through pipe, got %v", got)
+	}
+}
+
+// TestAsyncSplit is a correctness guard for split's routing + close.
+func TestAsyncSplit(t *testing.T) {
+	toChan := asyncFn(t, "to-chan!")
+	split := asyncFn(t, "split")
+	isEven, _ := vm.NativeFnType.Wrap(func(a []vm.Value) (vm.Value, error) {
+		return vm.Boolean(int(a[0].(vm.Int))%2 == 0), nil
+	})
+
+	src := invoke(t, toChan, vm.NewArrayVector([]vm.Value{
+		vm.Int(1), vm.Int(2), vm.Int(3), vm.Int(4)})).(vm.Chan)
+	res := invoke(t, split, isEven, src)
+	pair := res.(vm.ArrayVector)
+	trueCh := pair.ValueAt(vm.Int(0)).(vm.Chan)
+	falseCh := pair.ValueAt(vm.Int(1)).(vm.Chan)
+
+	// split's channels are unbuffered and it sends interleaved, so read
+	// both concurrently to avoid deadlock.
+	type res2 struct{ evens, odds []vm.Value }
+	ch := make(chan res2, 1)
+	go func() {
+		var r res2
+		r.evens = drainChan(t, trueCh, 2*time.Second)
+		ch <- r
+	}()
+	odds := drainChan(t, falseCh, 2*time.Second)
+	evens := (<-ch).evens
+	if len(evens) != 2 || len(odds) != 2 {
+		t.Fatalf("expected 2 evens + 2 odds, got evens=%v odds=%v", evens, odds)
+	}
+}
+
+// TestAsyncGoroutinesTrackedAndDrained pins the registry wiring: a
+// channel pipeline that blocks forever (no reader on its output) must be
+// (a) counted by the VM goroutine registry and (b) released by Drain via
+// context cancellation — otherwise it leaks for the life of the process.
+func TestAsyncGoroutinesTrackedAndDrained(t *testing.T) {
+	// Drain anything left by other tests so the baseline is clean.
+	vm.Goroutines.Drain(2 * time.Second)
+	base := vm.Goroutines.Live()
+
+	toChan := asyncFn(t, "to-chan!")
+	pipe := asyncFn(t, "pipe")
+
+	// Pipe into an UNBUFFERED dst that nobody reads → the pipe goroutine
+	// blocks on `dst <- v` forever.
+	src := invoke(t, toChan, vm.NewArrayVector([]vm.Value{vm.Int(1), vm.Int(2)})).(vm.Chan)
+	dst := make(vm.Chan) // unbuffered, no reader
+	invoke(t, pipe, src, dst)
+
+	// Let the goroutines start and block.
+	deadline := time.Now().Add(time.Second)
+	for vm.Goroutines.Live() <= base && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if vm.Goroutines.Live() <= base {
+		t.Fatalf("expected async goroutines to be tracked (live=%d, base=%d)", vm.Goroutines.Live(), base)
+	}
+
+	if !vm.Goroutines.Drain(3 * time.Second) {
+		t.Fatal("Drain did not release blocked async goroutines (not ctx-cancellable)")
+	}
+	if got := vm.Goroutines.Live(); got != 0 {
+		t.Fatalf("expected 0 live after drain, got %d", got)
+	}
+}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -6,6 +6,7 @@
 package rt
 
 import (
+	"context"
 	crand "crypto/rand"
 	_ "embed"
 	"fmt"
@@ -254,6 +255,20 @@ var (
 	tapsMu sync.Mutex
 	taps   []vm.Fn
 )
+
+// ClearTaps drops every registered tap fn. `add-tap` appends to a
+// process-global slice with no automatic removal, so a test that taps
+// without `remove-tap` (e.g. clojure-test-suite's taps.cljc) leaks its
+// tap closure — and, because all of a compile pass's fns share one
+// vm.Consts, the closure pins that whole constant pool. Re-running the
+// suite in a loop (BenchmarkClojureTestSuite) thus accumulates ~one
+// Consts pool per iteration. The bench calls this between iterations to
+// keep that from growing unboundedly.
+func ClearTaps() {
+	tapsMu.Lock()
+	taps = nil
+	tapsMu.Unlock()
+}
 
 // nsAliases maps alternative namespace names to canonical names.
 // e.g. "clojure.core" → "core", "clojure.test" → "test", "clojure.string" → "string"
@@ -5456,7 +5471,7 @@ func installLangNS() {
 		}
 		snap := vm.SnapshotBindings()
 		p := vm.NewPromise()
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			v, err := vm.RunWithBindings(snap, func() (vm.Value, error) {
 				return fn.Invoke(nil)
 			})
@@ -5465,7 +5480,7 @@ func installLangNS() {
 			} else {
 				p.Deliver(v)
 			}
-		}()
+		})
 		return p, nil
 	})
 
@@ -6998,13 +7013,25 @@ func installLangNS() {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("sleep expects 1 arg")
 		}
+		var d time.Duration
 		switch v := vs[0].(type) {
 		case vm.Int:
-			time.Sleep(time.Duration(int64(v)) * time.Millisecond)
+			d = time.Duration(int64(v)) * time.Millisecond
 		case vm.Float:
-			time.Sleep(time.Duration(int64(v)) * time.Millisecond)
+			d = time.Duration(int64(v)) * time.Millisecond
 		default:
 			return vm.NIL, fmt.Errorf("sleep expects a number")
+		}
+		// Cancellable sleep: return early if the VM goroutine registry's
+		// context is cancelled (e.g. a Drain between bench iterations or
+		// process shutdown), so a `(future (sleep 10000))` doesn't pin
+		// its goroutine — and the Consts pool it captured — for the full
+		// duration. Matches Clojure where an interrupted sleep aborts.
+		t := time.NewTimer(d)
+		defer t.Stop()
+		select {
+		case <-t.C:
+		case <-vm.Goroutines.Context().Done():
 		}
 		return vm.NIL, nil
 	})

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3357,14 +3357,23 @@ func installLangNS() {
 			return vm.NIL, fmt.Errorf("go expected Fn")
 		}
 		ret := make(vm.Chan)
-		go func() {
+		vm.Goroutines.Go(func(ctx context.Context) {
 			v, err := at.Invoke(nil)
 			if err != nil {
 				fmt.Println(err)
 			}
-			ret <- v
+			// The result send is cancellable via the registry. (Channel
+			// ops <!/>! INSIDE the block are still synchronous and not yet
+			// ctx-aware — cancelling a go-block blocked on a take won't
+			// interrupt it; tracked as the same follow-up as the async.go
+			// channel primitives.)
+			select {
+			case ret <- v:
+			case <-ctx.Done():
+				return
+			}
 			close(ret)
-		}()
+		})
 		return ret, nil
 	})
 

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3388,12 +3388,16 @@ func installLangNS() {
 		if len(vs) != 2 {
 			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
 		}
+		if vs[1] == vm.NIL {
+			return vm.NIL, fmt.Errorf(">! can't put nil on chan")
+		}
+		if pc, ok := asPromiseChan(vs[0]); ok {
+			pc.put(vs[1])
+			return vm.TRUE, nil
+		}
 		ch, ok := vs[0].(vm.Chan)
 		if !ok {
 			return vm.NIL, fmt.Errorf(">! expected Chan")
-		}
-		if vs[1] == vm.NIL {
-			return vm.NIL, fmt.Errorf(">! can't put nil on chan")
 		}
 		ch <- vs[1]
 		return vm.TRUE, nil
@@ -3402,6 +3406,9 @@ func installLangNS() {
 	changet, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		if pc, ok := asPromiseChan(vs[0]); ok {
+			return pc.take(vm.Goroutines.Context()), nil
 		}
 		ch, ok := vs[0].(vm.Chan)
 		if !ok {

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3399,8 +3399,16 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf(">! expected Chan")
 		}
-		ch <- vs[1]
-		return vm.TRUE, nil
+		// Select on the registry context so a put parked on a full/unread
+		// channel — e.g. inside a (go ...) block — is released by a
+		// CancelAll/Drain on shutdown instead of leaking the goroutine.
+		// Cancellation returns nil (the put did not complete).
+		select {
+		case ch <- vs[1]:
+			return vm.TRUE, nil
+		case <-vm.Goroutines.Context().Done():
+			return vm.NIL, nil
+		}
 	})
 
 	changet, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
@@ -3414,11 +3422,19 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("<! expected Chan")
 		}
-		v, ok := <-ch
-		if !ok {
-			return vm.NIL, nil // this is not an error
+		// Select on the registry context so a take parked on an empty
+		// channel — e.g. inside a (go ...) block — is released by a
+		// CancelAll/Drain on shutdown instead of leaking the goroutine.
+		// Both a closed channel and a cancel yield nil.
+		select {
+		case v, ok := <-ch:
+			if !ok {
+				return vm.NIL, nil // closed — not an error
+			}
+			return v, nil
+		case <-vm.Goroutines.Context().Done():
+			return vm.NIL, nil
 		}
-		return v, nil
 	})
 
 	lines, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {

--- a/pkg/vm/chan.go
+++ b/pkg/vm/chan.go
@@ -6,6 +6,7 @@
 package vm
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -24,17 +25,25 @@ func (t *theChanType) Box(b any) (Value, error) {
 		return NIL, NewTypeError(b, "is not a channel", t)
 	}
 	rb := make(Chan)
-	go func() {
+	Goroutines.Go(func(ctx context.Context) {
 		for {
 			v, ok := chv.Recv()
 			if !ok {
 				break
 			}
 			bv, _ := BoxValue(v)
-			rb <- bv
+			// Forward-send is cancellable via the registry. (reflect
+			// chv.Recv() above is not ctx-aware, so a cancel won't
+			// interrupt a goroutine blocked waiting on the source Go
+			// channel — only one blocked forwarding a value.)
+			select {
+			case rb <- bv:
+			case <-ctx.Done():
+				return
+			}
 		}
 		close(rb)
-	}()
+	})
 	return Chan(rb), nil
 }
 

--- a/pkg/vm/goroutines.go
+++ b/pkg/vm/goroutines.go
@@ -34,12 +34,15 @@ import (
 // intended uses — process shutdown and between-iteration bench drains —
 // where the goal is "stop everything the VM started," not "cancel this
 // one future."
-type GoroutineRegistry struct {
-	mu     sync.Mutex
-	wg     sync.WaitGroup
-	live   atomic.Int64
+type ctxState struct {
 	ctx    context.Context
 	cancel context.CancelFunc
+}
+
+type GoroutineRegistry struct {
+	wg    sync.WaitGroup
+	live  atomic.Int64
+	state atomic.Pointer[ctxState] // current context generation
 }
 
 // Goroutines is the process-wide VM goroutine registry. Every VM spawn
@@ -48,7 +51,8 @@ var Goroutines = newGoroutineRegistry()
 
 func newGoroutineRegistry() *GoroutineRegistry {
 	r := &GoroutineRegistry{}
-	r.ctx, r.cancel = context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	r.state.Store(&ctxState{ctx: ctx, cancel: cancel})
 	return r
 }
 
@@ -56,9 +60,7 @@ func newGoroutineRegistry() *GoroutineRegistry {
 // cancellation context; long-running work should select on ctx.Done()
 // so CancelAll/Drain can stop it.
 func (r *GoroutineRegistry) Go(fn func(ctx context.Context)) {
-	r.mu.Lock()
-	ctx := r.ctx
-	r.mu.Unlock()
+	ctx := r.state.Load().ctx
 	r.wg.Add(1)
 	r.live.Add(1)
 	go func() {
@@ -74,23 +76,36 @@ func (r *GoroutineRegistry) Live() int {
 }
 
 // Context returns the current cancellation context. Blocking native ops
-// (sleep, channel send/recv) select on its Done() so they unblock when
-// CancelAll fires. Read it at the point of blocking, not cached, so a
-// freshly-installed context after CancelAll is observed.
+// (sleep, channel send/recv, alts!) select on its Done() so they unblock
+// when CancelAll fires. Read it at the point of blocking, not cached, so
+// a freshly-installed context after CancelAll is observed. Lock-free (a
+// single atomic load) so it is cheap to call on every channel op.
+//
+// Drain semantics are bulk: a CancelAll releases ops that are PARKED on
+// the context at that moment. An op that reads Context() AFTER a
+// CancelAll sees the fresh context and is not affected — which is what
+// we want for shutdown / between-iteration drains, where spawning and
+// draining are temporally separated. Per-goroutine cancellation would
+// require threading each goroutine's spawn context through every native
+// op (goroutine-local state); the registry intentionally only offers the
+// bulk form.
 func (r *GoroutineRegistry) Context() context.Context {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.ctx
+	return r.state.Load().ctx
 }
 
 // CancelAll cancels the context shared by all in-flight tracked
 // goroutines, then installs a fresh context so subsequent spawns are not
 // born cancelled. Does not wait — pair with Await (or use Drain).
+//
+// Lock-free: the fresh generation is swapped in atomically, and we
+// cancel whatever generation we displaced. Concurrent CancelAlls are
+// safe — each cancels exactly the generation it replaced, so every
+// displaced generation is cancelled and the surviving state is always a
+// live (uncancelled) one.
 func (r *GoroutineRegistry) CancelAll() {
-	r.mu.Lock()
-	r.cancel()
-	r.ctx, r.cancel = context.WithCancel(context.Background())
-	r.mu.Unlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	old := r.state.Swap(&ctxState{ctx: ctx, cancel: cancel})
+	old.cancel()
 }
 
 // Await blocks until every tracked goroutine has exited, or timeout

--- a/pkg/vm/goroutines.go
+++ b/pkg/vm/goroutines.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// GoroutineRegistry tracks every goroutine the VM spawns (futures,
+// agents, core.async go-blocks, channel pipelines). Go has no goroutine
+// registry of its own and cannot force-kill a goroutine, so without this
+// the runtime has no way to observe or drain the work it started — a
+// long-lived process (or a benchmark that re-runs a whole suite per
+// iteration) leaks every still-running future and the heap it pins.
+//
+// The registry provides:
+//   - a live count (Live) for observability,
+//   - Await to block until in-flight goroutines finish,
+//   - CancelAll, which cancels the context shared by all in-flight
+//     goroutines so that context-aware blocking ops (sleep, channel
+//     ops) return promptly, then installs a fresh context for future
+//     spawns,
+//   - Drain = CancelAll + Await.
+//
+// Cancellation is bulk, not per-goroutine: CancelAll signals every
+// goroutine spawned under the current context at once. That matches the
+// intended uses — process shutdown and between-iteration bench drains —
+// where the goal is "stop everything the VM started," not "cancel this
+// one future."
+type GoroutineRegistry struct {
+	mu     sync.Mutex
+	wg     sync.WaitGroup
+	live   atomic.Int64
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// Goroutines is the process-wide VM goroutine registry. Every VM spawn
+// goes through it; blocking ops consult its Context for cancellation.
+var Goroutines = newGoroutineRegistry()
+
+func newGoroutineRegistry() *GoroutineRegistry {
+	r := &GoroutineRegistry{}
+	r.ctx, r.cancel = context.WithCancel(context.Background())
+	return r
+}
+
+// Go runs fn in a tracked goroutine. fn receives the registry's current
+// cancellation context; long-running work should select on ctx.Done()
+// so CancelAll/Drain can stop it.
+func (r *GoroutineRegistry) Go(fn func(ctx context.Context)) {
+	r.mu.Lock()
+	ctx := r.ctx
+	r.mu.Unlock()
+	r.wg.Add(1)
+	r.live.Add(1)
+	go func() {
+		defer r.wg.Done()
+		defer r.live.Add(-1)
+		fn(ctx)
+	}()
+}
+
+// Live reports how many tracked goroutines are currently running.
+func (r *GoroutineRegistry) Live() int {
+	return int(r.live.Load())
+}
+
+// Context returns the current cancellation context. Blocking native ops
+// (sleep, channel send/recv) select on its Done() so they unblock when
+// CancelAll fires. Read it at the point of blocking, not cached, so a
+// freshly-installed context after CancelAll is observed.
+func (r *GoroutineRegistry) Context() context.Context {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ctx
+}
+
+// CancelAll cancels the context shared by all in-flight tracked
+// goroutines, then installs a fresh context so subsequent spawns are not
+// born cancelled. Does not wait — pair with Await (or use Drain).
+func (r *GoroutineRegistry) CancelAll() {
+	r.mu.Lock()
+	r.cancel()
+	r.ctx, r.cancel = context.WithCancel(context.Background())
+	r.mu.Unlock()
+}
+
+// Await blocks until every tracked goroutine has exited, or timeout
+// elapses. Returns true if fully drained, false on timeout. A
+// non-positive timeout waits indefinitely.
+func (r *GoroutineRegistry) Await(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+	if timeout <= 0 {
+		<-done
+		return true
+	}
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+	select {
+	case <-done:
+		return true
+	case <-t.C:
+		return false
+	}
+}
+
+// Drain cancels all in-flight goroutines and waits up to timeout for
+// them to exit. Returns true if fully drained. Context-aware blocking
+// ops return promptly on cancel; anything ignoring the context still
+// races the timeout.
+func (r *GoroutineRegistry) Drain(timeout time.Duration) bool {
+	r.CancelAll()
+	return r.Await(timeout)
+}

--- a/pkg/vm/goroutines_test.go
+++ b/pkg/vm/goroutines_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGoroutineRegistryTracksLiveAndAwait(t *testing.T) {
+	r := newGoroutineRegistry()
+	release := make(chan struct{})
+
+	for i := 0; i < 3; i++ {
+		r.Go(func(ctx context.Context) { <-release })
+	}
+	// Live count should reflect the 3 spawned (allow brief scheduling).
+	deadline := time.Now().Add(time.Second)
+	for r.Live() != 3 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := r.Live(); got != 3 {
+		t.Fatalf("expected 3 live goroutines, got %d", got)
+	}
+
+	// Await times out while they're blocked.
+	if r.Await(50 * time.Millisecond) {
+		t.Fatal("Await should have timed out while goroutines blocked")
+	}
+
+	close(release)
+	if !r.Await(2 * time.Second) {
+		t.Fatal("Await should have drained after release")
+	}
+	if got := r.Live(); got != 0 {
+		t.Fatalf("expected 0 live after drain, got %d", got)
+	}
+}
+
+func TestGoroutineRegistryCancelUnblocksContextAwareWork(t *testing.T) {
+	r := newGoroutineRegistry()
+	// A goroutine that blocks on its context (mimics a ctx-aware sleep).
+	for i := 0; i < 4; i++ {
+		r.Go(func(ctx context.Context) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(30 * time.Second): // would hang without cancel
+			}
+		})
+	}
+
+	if !r.Drain(2 * time.Second) {
+		t.Fatal("Drain should have cancelled+drained ctx-aware goroutines fast")
+	}
+	if got := r.Live(); got != 0 {
+		t.Fatalf("expected 0 live after drain, got %d", got)
+	}
+
+	// After CancelAll a fresh context is installed: new spawns are NOT
+	// born cancelled.
+	ctx := r.Context()
+	select {
+	case <-ctx.Done():
+		t.Fatal("fresh context after drain should not be cancelled")
+	default:
+	}
+}

--- a/pkg/vm/source.go
+++ b/pkg/vm/source.go
@@ -179,3 +179,26 @@ func (f *formSourceMap) Get(form Value) *SourceInfo {
 	f.mu.RUnlock()
 	return info
 }
+
+// Len reports how many form→SourceInfo entries are currently held.
+func (f *formSourceMap) Len() int {
+	f.mu.RLock()
+	n := len(f.m)
+	f.mu.RUnlock()
+	return n
+}
+
+// Reset drops all form→SourceInfo entries. This map is keyed by form
+// object identity and never evicts, so a process that compiles many
+// distinct forms over time (e.g. BenchmarkClojureTestSuite re-running
+// the whole suite per iteration) accumulates an entry — and a live
+// reference pinning the *List/*Cons form — for every form ever read.
+// Callers that re-compile in a loop should Reset between rounds to keep
+// the map (and the forms it pins) from growing unboundedly. Safe to call
+// between compiles; source info for the current compile is repopulated
+// as forms are read.
+func (f *formSourceMap) Reset() {
+	f.mu.Lock()
+	f.m = map[any]*SourceInfo{}
+	f.mu.Unlock()
+}

--- a/pkg/vm/source_reset_test.go
+++ b/pkg/vm/source_reset_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// TestFormSourceReset pins the leak fix: FormSource is an append-only,
+// identity-keyed map. Reset must empty it and release the form keys so a
+// re-compiling loop (BenchmarkClojureTestSuite) does not accumulate a
+// live entry per form ever read.
+func TestFormSourceReset(t *testing.T) {
+	fs := &formSourceMap{m: map[any]*SourceInfo{}}
+
+	l1 := NewList([]Value{Int(1)})
+	l2 := NewList([]Value{Int(2)})
+	fs.Set(l1, SourceInfo{Line: 1})
+	fs.Set(l2, SourceInfo{Line: 2})
+	if fs.Len() != 2 {
+		t.Fatalf("expected 2 entries before reset, got %d", fs.Len())
+	}
+	if fs.Get(l1) == nil {
+		t.Fatal("expected source info for l1 before reset")
+	}
+
+	fs.Reset()
+
+	if fs.Len() != 0 {
+		t.Fatalf("expected 0 entries after reset, got %d", fs.Len())
+	}
+	if fs.Get(l1) != nil {
+		t.Fatal("expected nil source info for l1 after reset")
+	}
+
+	// Still usable after reset.
+	fs.Set(l1, SourceInfo{Line: 3})
+	if got := fs.Get(l1); got == nil || got.Line != 3 {
+		t.Fatalf("expected reusable map after reset, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Scope

Gives the VM a registry of the goroutines it spawns and makes the
`core.async` / `future` primitives observable, drainable, and correct.

- **`vm.GoroutineRegistry` (`vm.Goroutines`)** — `Go(fn(ctx))` tracks every
  spawn (WaitGroup + live count); `Live()`/`Await(timeout)` observe and drain;
  `CancelAll()`/`Drain()` cooperatively stop in-flight work via a shared,
  lock-free context generation.
- **Every VM-spawned goroutine is wired through it**: `future*`, `sleep`,
  `timeout`, the `go` block (`go*`), the Go-channel box adapter, and all the
  `async.go` CSP pipelines (`pipe`, `merge`, `mult`, `pub`, `split`,
  `onto-chan!`, `to-chan!`, `async/reduce|into|map|take`, `promise-chan`).
  Blocking channel ops select on the registry context (`ctxSend`/`ctxRecv`).
- **`<!` / `>!` / `alts!` are drainable** — a `(go ...)` parked on a take/put
  is released by `Drain` instead of leaking until the channel happens to move.
- **`promise-chan` rewritten correctly.** The old one never wired the put side
  to the returned channel and panicked on first use (`for { out <- v }` on a
  closed channel). Replaced with a `PromiseChan` value type that *stores* the
  first value behind a latch and replays it — no parked-taker steal race.
  Dispatched to by `>!`/`<!`/`close!`.
- Runtime hygiene APIs: `vm.FormSource.Reset()/Len()` (the form→source-info map
  is global, append-only and identity-keyed — it pins every form ever read) and
  `rt.ClearTaps()` (`add-tap` appends to a global slice with no auto-removal).

## Why now

Part of the current wave. The registry is the foundation for draining VM
goroutines at shutdown and between benchmark iterations, and this also fixes
two latent bugs (the panicking `promise-chan` and the unbounded `FormSource`
map) that bite any long-running process.

## Key behaviors / constraints

- Cancellation is **cooperative and bulk**: Go can't force-kill a goroutine, so
  blocking ops select on the registry context; a `CancelAll` releases everything
  parked on that context at the time. Per-goroutine cancellation would need
  goroutine-local context threading (a scope tree) — intentionally not here.
- **Not wired (by design):** subprocess I/O pumps in `os.go`/`pods.go`/
  `syscall_linux.go` — their lifecycle is tied to external processes; draining
  them would cut a live pod mid-conversation.

## Merge order

Sibling off `main`, no dependency on other open PRs. Note: a companion change in
the bench-ratchet PR (#119) consumes `vm.FormSource.Reset()` / `rt.ClearTaps()` /
`vm.Goroutines.Drain()` added here to fix `BenchmarkClojureTestSuite` state
accumulation — **land this PR first**, then that bench fix.

## Tests

New `pkg/vm/goroutines_test.go`, `pkg/vm/source_reset_test.go`, and
`pkg/rt/async_test.go` (to-chan!/pipe/split correctness; registry tracking +
Drain release of blocked pipelines and parked go-blocks; promise-chan replay /
steal-race / drop / close-empty). All pass under `-race`. Verified
`examples/async.lg` (pipeline + pub/sub + mult/tap) end to end; `go vet` clean.
