### PR TITLE
fix(test): make os-cwd-test hermetic (don't assume checkout dir name)

### DIFF
--- a/test/os_test.lg
+++ b/test/os_test.lg
@@ -6,7 +6,7 @@
   (testing "cwd returns a string"
     (let [d (cwd)]
       (is (not (nil? d)))
-      (is (includes? d "let-go")))))
+      (is (string? d)))))
 
 (deftest os-ls-test
   (testing "ls returns vector of filenames"


### PR DESCRIPTION
## What

`os-cwd-test` asserted that the current working directory *string contains
`"let-go"`*:

```clojure
(is (includes? (cwd) "let-go"))
```

This couples the test to the **name of the directory the repo is checked out
into**. It passes in a normal clone (a `let-go` dir) but fails anywhere else —
for example a `git worktree` under `/tmp` — even though `cwd` itself works
perfectly. The other 11 assertions in the file are environment-portable; this
was the only non-hermetic one.

## Fix

Replace the substring check with `(is (string? d))`, which matches the test's
own intent (`testing "cwd returns a string"`) without assuming the checkout
path. The `(not (nil? d))` assertion on the line above already covers presence.

## Why it matters

It's a small thing, but it makes the suite runnable from any directory (CI
worktrees, sandboxes, contributor checkouts not named `let-go`). Verified the
file passes from `/tmp/...` after the change and still passes from a `let-go`
checkout.
