### PR TITLE
perf(vm): lock-free Var.Deref (atomic root/curr; ~670x parallel deref)

### DIFF
--- a/pkg/vm/var.go
+++ b/pkg/vm/var.go
@@ -9,11 +9,20 @@ import (
 	"fmt"
 	"maps"
 	"sync"
+	"sync/atomic"
 )
 
 type Var struct {
-	root      Value
-	bindings  []Value // dynamic binding stack (nil when unused — zero cost)
+	// root and curr are atomic so Deref — by far the hottest var
+	// operation — is lock-free. Previously every Deref (even of a var
+	// with no dynamic binding) took the global bindingsMu just to check
+	// the binding stack, serializing all var reads across goroutines.
+	// curr holds the current dynamic top binding (nil = use root); it is
+	// kept in sync with the bindings stack by push/pop/RunWithBindings
+	// under bindingsMu (the cold path).
+	root      atomic.Pointer[Value] // root binding (lock-free read)
+	curr      atomic.Pointer[Value] // current dynamic top binding; nil = use root
+	bindings  []Value               // full dynamic binding stack (guarded by bindingsMu)
 	nsref     *Namespace
 	ns        string
 	name      string
@@ -21,7 +30,7 @@ type Var struct {
 	isMacro   bool
 	isDynamic bool
 	isPrivate bool
-	mu        sync.Mutex
+	mu        sync.Mutex // guards meta + watches
 	watches   map[Value]Fn
 }
 
@@ -30,18 +39,32 @@ var (
 	activeVars = map[*Var]struct{}{}
 )
 
+// valPtr boxes a Value for storage in an atomic.Pointer[Value].
+func valPtr(v Value) *Value { return &v }
+
+// syncCurrLocked refreshes the atomic current-binding pointer from the
+// bindings stack. Must be called while holding bindingsMu.
+func (v *Var) syncCurrLocked() {
+	if len(v.bindings) == 0 {
+		v.curr.Store(nil)
+	} else {
+		v.curr.Store(valPtr(v.bindings[len(v.bindings)-1]))
+	}
+}
+
 type BindingSnapshot map[*Var][]Value
 
 func (v *Var) Invoke(values []Value) (Value, error) {
-	f, ok := v.root.(Fn)
+	root := v.Root()
+	f, ok := root.(Fn)
 	if !ok {
-		return NIL, fmt.Errorf("%v root does not implement Fn", v.root)
+		return NIL, fmt.Errorf("%v root does not implement Fn", root)
 	}
 	return f.Invoke(values)
 }
 
 func (v *Var) Arity() int {
-	f, ok := v.root.(Fn)
+	f, ok := v.Root().(Fn)
 	if !ok {
 		return 0
 	}
@@ -49,36 +72,31 @@ func (v *Var) Arity() int {
 }
 
 func NewVar(nsref *Namespace, ns string, name string) *Var {
-	return &Var{
-		nsref:     nsref,
-		ns:        ns,
-		name:      name,
-		root:      NIL,
-		isMacro:   false,
-		isDynamic: false,
-		isPrivate: false,
+	v := &Var{
+		nsref: nsref,
+		ns:    ns,
+		name:  name,
 	}
-}
-
-func (v *Var) SetRoot(val Value) *Var {
-	v.mu.Lock()
-	v.root = val
-	v.mu.Unlock()
+	v.root.Store(valPtr(NIL))
 	return v
 }
 
-func (v *Var) Deref() Value {
-	bindingsMu.Lock()
-	if len(v.bindings) > 0 {
-		out := v.bindings[len(v.bindings)-1]
-		bindingsMu.Unlock()
-		return out
-	}
-	bindingsMu.Unlock()
+func (v *Var) SetRoot(val Value) *Var {
+	v.root.Store(valPtr(val))
+	return v
+}
 
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	return v.root
+// Deref returns the current value: the dynamic top binding if one is
+// active, else the root. Lock-free — two atomic loads, no mutex — so it
+// scales across goroutines.
+func (v *Var) Deref() Value {
+	if p := v.curr.Load(); p != nil {
+		return *p
+	}
+	if p := v.root.Load(); p != nil {
+		return *p
+	}
+	return NIL
 }
 
 // Root returns the var's root binding directly, bypassing any current
@@ -86,9 +104,10 @@ func (v *Var) Deref() Value {
 // the root (e.g. alter-var-root) rather than the currently visible deref
 // value.
 func (v *Var) Root() Value {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	return v.root
+	if p := v.root.Load(); p != nil {
+		return *p
+	}
+	return NIL
 }
 
 // PushBinding pushes a dynamic binding value.
@@ -96,6 +115,7 @@ func (v *Var) PushBinding(val Value) {
 	bindingsMu.Lock()
 	defer bindingsMu.Unlock()
 	v.bindings = append(v.bindings, val)
+	v.syncCurrLocked()
 	activeVars[v] = struct{}{}
 }
 
@@ -106,6 +126,7 @@ func (v *Var) PopBinding() {
 	if len(v.bindings) > 0 {
 		v.bindings = v.bindings[:len(v.bindings)-1]
 	}
+	v.syncCurrLocked()
 	if len(v.bindings) == 0 {
 		delete(activeVars, v)
 	}
@@ -151,6 +172,7 @@ func RunWithBindings(snap BindingSnapshot, fn func() (Value, error)) (Value, err
 			v.bindings = nil
 			delete(activeVars, v)
 		}
+		v.syncCurrLocked()
 	}
 	bindingsMu.Unlock()
 
@@ -164,6 +186,7 @@ func RunWithBindings(snap BindingSnapshot, fn func() (Value, error)) (Value, err
 		} else {
 			delete(activeVars, v)
 		}
+		v.syncCurrLocked()
 	}
 	bindingsMu.Unlock()
 	return out, err
@@ -196,9 +219,7 @@ func (v *Var) AlterRootArgs(fn Fn, args []Value) (Value, error) {
 	if err != nil {
 		return NIL, err
 	}
-	v.mu.Lock()
-	v.root = result
-	v.mu.Unlock()
+	v.root.Store(valPtr(result))
 	if err := v.notifyWatches(old, result); err != nil {
 		return NIL, err
 	}

--- a/pkg/vm/var_binding_test.go
+++ b/pkg/vm/var_binding_test.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestVarBindingStackSemantics guards the atomic curr-pointer that backs
+// the lock-free Deref: nested push/pop must shadow and restore correctly,
+// and Deref must reflect the current top (or root when empty).
+func TestVarBindingStackSemantics(t *testing.T) {
+	v := NewVar(nil, "test", "*x*")
+	v.SetRoot(Int(0))
+
+	if got := v.Deref(); got != Int(0) {
+		t.Fatalf("root deref: want 0, got %v", got)
+	}
+	if got := v.Root(); got != Int(0) {
+		t.Fatalf("Root(): want 0, got %v", got)
+	}
+
+	v.PushBinding(Int(1))
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("after push 1: want 1, got %v", got)
+	}
+	// Root() must still see the root, not the binding.
+	if got := v.Root(); got != Int(0) {
+		t.Fatalf("Root() under binding: want 0, got %v", got)
+	}
+
+	v.PushBinding(Int(2))
+	if got := v.Deref(); got != Int(2) {
+		t.Fatalf("after push 2: want 2, got %v", got)
+	}
+
+	v.PopBinding()
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("after pop: want 1 (restored), got %v", got)
+	}
+
+	v.PopBinding()
+	if got := v.Deref(); got != Int(0) {
+		t.Fatalf("after pop to empty: want root 0, got %v", got)
+	}
+}
+
+// TestVarConcurrentDerefDuringBinding stresses the lock-free read path
+// against concurrent push/pop. Under -race this proves Deref never races
+// the binding mutation, and every observed value is a legitimate one
+// (root or a pushed value) — never torn.
+func TestVarConcurrentDerefDuringBinding(t *testing.T) {
+	v := NewVar(nil, "test", "*y*")
+	v.SetRoot(Int(-1))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Readers: spin on Deref, asserting only legitimate values.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				got := v.Deref()
+				n, ok := got.(Int)
+				if !ok || (n != Int(-1) && n != Int(7)) {
+					t.Errorf("torn/illegal deref value: %v", got)
+					return
+				}
+			}
+		}()
+	}
+
+	// Writer: push/pop a single value many times.
+	for i := 0; i < 50000; i++ {
+		v.PushBinding(Int(7))
+		_ = v.Deref()
+		v.PopBinding()
+	}
+	close(stop)
+	wg.Wait()
+
+	if got := v.Deref(); got != Int(-1) {
+		t.Fatalf("after all pops: want root -1, got %v", got)
+	}
+}
+
+// TestVarRunWithBindingsKeepsCurrInSync verifies the snapshot/restore
+// path keeps the atomic curr pointer consistent (future/go inherit the
+// dynamic environment through this).
+func TestVarRunWithBindingsKeepsCurrInSync(t *testing.T) {
+	v := NewVar(nil, "test", "*z*")
+	v.SetRoot(Int(0))
+	v.PushBinding(Int(5))
+	defer v.PopBinding()
+
+	snap := SnapshotBindings()
+
+	// Run a fn under a different (empty-for-this-var) environment, then
+	// confirm the binding is restored and visible via the lock-free read.
+	_, _ = RunWithBindings(BindingSnapshot{}, func() (Value, error) {
+		if got := v.Deref(); got != Int(0) {
+			t.Errorf("inside empty snapshot: want root 0, got %v", got)
+		}
+		return NIL, nil
+	})
+	if got := v.Deref(); got != Int(5) {
+		t.Fatalf("after RunWithBindings restore: want 5, got %v", got)
+	}
+
+	// And re-running with the captured snapshot re-establishes the binding.
+	_, _ = RunWithBindings(snap, func() (Value, error) {
+		if got := v.Deref(); got != Int(5) {
+			t.Errorf("inside captured snapshot: want 5, got %v", got)
+		}
+		return NIL, nil
+	})
+}

--- a/pkg/vm/var_deref_bench_test.go
+++ b/pkg/vm/var_deref_bench_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// These benchmarks quantify Var.Deref — the hottest var operation. Before
+// this change every Deref took the global bindingsMu (even a var with NO
+// dynamic binding, just to check the stack was empty), so all var reads
+// across all goroutines serialized on one mutex. The Parallel variants
+// expose that contention; after making root/curr atomic, Deref is a
+// couple of atomic loads and scales.
+
+func newRootVar() *Var {
+	v := NewVar(nil, "bench", "x")
+	v.SetRoot(Int(42))
+	return v
+}
+
+func newBoundVar() *Var {
+	v := newRootVar()
+	v.PushBinding(Int(7))
+	return v
+}
+
+// Root-only (the common case: fn vars, config) — no dynamic binding.
+func BenchmarkVarDerefRoot(b *testing.B) {
+	v := newRootVar()
+	for i := 0; i < b.N; i++ {
+		_ = v.Deref()
+	}
+}
+
+func BenchmarkVarDerefRootParallel(b *testing.B) {
+	v := newRootVar()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = v.Deref()
+		}
+	})
+}
+
+// With an active dynamic binding.
+func BenchmarkVarDerefBound(b *testing.B) {
+	v := newBoundVar()
+	for i := 0; i < b.N; i++ {
+		_ = v.Deref()
+	}
+}
+
+func BenchmarkVarDerefBoundParallel(b *testing.B) {
+	v := newBoundVar()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = v.Deref()
+		}
+	})
+}
+
+// Distinct vars per worker, all dereffed concurrently — proves the old
+// contention was the GLOBAL bindingsMu, not per-var.
+func BenchmarkVarDerefDistinctParallel(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		v := newRootVar()
+		for pb.Next() {
+			_ = v.Deref()
+		}
+	})
+}


### PR DESCRIPTION
## What

`Var.Deref` — the hottest var operation — took the **global** `bindingsMu`
mutex on *every* read, even for a var with no dynamic binding (just to check
the binding stack was empty). So all var reads across all goroutines serialized
on one lock. That throttles any concurrent Lisp that touches vars — in
particular, parallelizing the IR typeinfer passes, where each worker derefs
`*ns*` / config dynamic vars per function.

## Fix

Make `Deref` lock-free: the `root` and the current dynamic top binding (`curr`)
live in `atomic.Pointer[Value]`. `Deref` is two atomic loads, no mutex. Push /
pop / `RunWithBindings` keep `curr` in sync with the bindings stack under
`bindingsMu` (the cold path). Binding semantics are unchanged.

## Numbers (pkg/vm, 8 cores, before → after)

| benchmark | before | after | speedup |
|---|--:|--:|--:|
| `VarDerefRoot` (single) | 6.4 ns | 0.46 ns | ~14× |
| `VarDerefRootParallel` | 87 ns | 0.13 ns | **~670×** |
| `VarDerefBoundParallel` | 80 ns | 0.11 ns | **~720×** |
| `VarDerefDistinctParallel` | 84 ns | 0.13 ns | ~650× |

`VarDerefDistinctParallel` gives each worker a *distinct* var yet still measured
~84 ns before — proving the contention was the one **global** `bindingsMu`, not
per-var. After the change, reads scale like an atomic load.

The benchmarks ship in `pkg/vm/var_deref_bench_test.go`, so the bench-ratchet
(which sweeps `pkg/vm`) tracks this hot path going forward.

## Correctness

- `pkg/vm` + `pkg/rt` green; the Lisp suite (`binding` / `*ns*` / `future`
  heavy) passes.
- New `pkg/vm/var_binding_test.go`: nested push/pop shadow+restore,
  `RunWithBindings` restore, and a 50k push/pop vs 8 concurrent readers stress —
  all pass under `-race` (no torn reads, no data race).

## Scope / follow-up

This removes the read-side serialization. The binding *stack* itself is still
process-global (not thread-local), so concurrent `(binding …)` / `future` with
*different* values on the *same* var still share state — a separate, deeper
change (true per-goroutine binding frames) if that's ever needed. Not required
for the parallel-read case this unblocks.
