### PR TITLE
perf(rt): atomic gensym + pmapv (eager parallel map) + design note

### DIFF
--- a/docs/parallel-lowering-and-type-cache.md
+++ b/docs/parallel-lowering-and-type-cache.md
@@ -1,0 +1,148 @@
+# Parallel IR lowering, and a mergeable type-discovery cache
+
+Status: design note / findings. Captures the 2026-05-30 investigation into
+parallelizing the IR lowering passes, what blocked it, and the proposed
+architecture (a mergeable type cache) for making parallel lowering both fast
+*and* reproducible.
+
+## Goal
+
+`lgbgen --target=go` lowers every core namespace's defns to Go. It is the
+slowest step in the bootstrap (~3 min). The per-defn work (expand → build IR →
+optimize → typeinfer → lower) is embarrassingly parallel across defns, so the
+question was whether we can lower a namespace's defns concurrently.
+
+## What blocked it, and what we fixed
+
+### 1. The future-spawn binding cost (fixed)
+
+The obvious move — `pmap` over the defns — gave **zero** speedup (actually
+slightly slower than sequential), even after fixing the gensym race below.
+
+Cause: `pmap` is built on `future`, and every `future` calls
+`SnapshotBindings` + `RunWithBindings`, which take the global `bindingsMu`
+**and copy every active dynamic binding** per spawn. A future is *async* — it
+may run after the caller's `binding` scope has unwound — so it must capture and
+reinstate that scope. That spawn cost serializes the work.
+
+Two prerequisites made a real fix possible:
+
+- **Lock-free `Var.Deref`** (atomic `root`/`curr` instead of the global
+  `bindingsMu`): dynamic-var *reads* no longer serialize. ~670–720× faster
+  parallel deref. (Landed separately.)
+- **`pmapv`** — an eager, order-preserving, *synchronous* parallel map. Because
+  it blocks until every element finishes, the caller's `binding` scope is still
+  live, so workers just **read** the caller's global bindings via the lock-free
+  Deref. No snapshot, no `RunWithBindings`, no `bindingsMu` on spawn.
+
+Result on the `core` lowering: future-`pmap` 213 s (0.90× — slower than
+sequential 193 s), **`pmapv` 155 s (1.24×, ~1.9 effective cores)**. The win is
+the binding fix; gensym was a red herring for *speed*.
+
+Caveat: `pmapv` is not Clojure `pmap`. Clojure's `pmap` is a *lazy, chunked*
+seq with bounded lookahead; `pmapv` is eager and shares the caller's dynamic
+bindings — correct for "do all of these in parallel and collect," not a drop-in
+for lazy chunked semantics.
+
+### 2. Non-deterministic output (partially fixed)
+
+Two parallel runs produced semantically-identical but textually-different Go.
+Sources, in order of discovery:
+
+- **gensym counter** — a global `int` incremented per `gensym`. Made it
+  `atomic.Int64` (fixes the data race). But atomicity alone leaves the absolute
+  numbers scheduling-dependent.
+- **gensym numbers in emitted names** — `value-name` builds `<src>_<nid>` where
+  `nid` (the IR instruction id) is already deterministic and unique per
+  function, so the gensym digits in `<src>` (e.g. `doseq_seq__10369`) are pure
+  non-determinism. Stripping the `__<digits>` tail makes names reproducible
+  (`doseq_seq_23`). `build-args` likewise names arg temps by inst-id, not
+  gensym.
+- **import grouping/order** — minor; sort the import set.
+- **the wall-clock typeinfer budget** — the deep one (below). *Not yet fixed.*
+
+`order-defn-forms` was already deterministic (function order is stable).
+
+### 3. The wall-clock typeinfer budget (root cause of the remaining non-determinism)
+
+`typeinfer` bails when it exceeds `*typeinfer-budget-ms*` (2000 ms), returning a
+**sound partial** result (a lower bound in the type lattice). Under parallel
+load, N workers contend for CPU, so a given typeinfer call gets less wall-time,
+hits the budget sooner, and bails with *less* type information. A call that
+qualified for direct native (`corefns.X`) dispatch sequentially falls back to
+generic dispatch in parallel — so even the *imports* differ run-to-run.
+
+**A time-based budget is inherently non-deterministic under variable CPU load.**
+This is the one source the per-site fixes can't reach.
+
+## Proposed fix: a mergeable type-discovery cache
+
+Rather than a deterministic *iteration* budget (which gives determinism but
+permanently caps precision on hard functions), cache the type discoveries and
+**merge** them across runs.
+
+### Why it's sound
+
+typeinfer is **monotone**: `set-type-if-changed!` is a lattice *join* — types
+only move up (`:unknown → :int → :number → :any`), never down. The budget bails
+with a lower bound. So:
+
+- A cache entry is a point in the type lattice.
+- Merging two entries is the **least upper bound** (join).
+- Join is commutative, associative, idempotent ⇒ **merge order is irrelevant**.
+
+Two runs that each got partway merge to a result at least as precise as either,
+deterministically. Parallel workers can contribute discoveries to a shared
+cache and the converged result is independent of scheduling. That removes the
+budget-vs-load non-determinism: lowering decisions become a function of the
+*converged cache*, not of who-won-the-CPU.
+
+### Shape
+
+- **Key:** a content hash of the function's IR (stable across runs;
+  auto-invalidates when the source changes). This is the same
+  "deterministic hash for elements" idea, reused as a cache key.
+- **Value:** inferred signature (arg types, result type) ± per-inst types.
+- **Merge:** per-field lattice join; parallel writers compare-and-join per key.
+- **Convergence:** interprocedural — F's inference improves when its callees'
+  cached signatures improve, so iterate to a whole-program fixpoint. Monotone +
+  finite lattice height ⇒ it terminates; the cache makes re-inference
+  incremental (only functions whose callees moved).
+- **Committed artifact:** like the `.lgb` bundle and the lowered tree, commit
+  the converged cache. A "warm to fixpoint" step (sequential, unbudgeted —
+  correctness over speed) produces it; `make generate` runs it; the staleness
+  manifest covers it. Lowering then *reads* the cache — fast, parallel,
+  reproducible — and the wall-clock budget can be dropped from the hot path.
+
+### Comparison
+
+| | wall-clock budget (today) | deterministic iteration budget | mergeable type cache |
+|---|---|---|---|
+| deterministic | no | yes | yes (once converged) |
+| reaches full precision | sometimes | no (capped) | yes (accumulates) |
+| parallel-safe | — | yes | yes (join is order-free) |
+| decouples discovery from use | no | no | yes |
+
+### Honest caveats
+
+1. **Warmup is non-deterministic until converged** — same contract as the
+   committed lowered tree: deterministic *given* a committed, complete cache.
+   A cache miss in CI should hard-fail (force a regen) rather than silently
+   fall back to bounded inference.
+2. **Invalidation is interprocedural** — keying by IR hash handles edited
+   functions; a callee signature change must invalidate its callers. That's the
+   fixpoint dependency tracking — real work, well-trodden.
+3. **It's a feature, not a tweak** — cache structure, hashing, join, fixpoint
+   driver, commit + staleness. The payoff (determinism + full precision + drops
+   the budget + makes parallel lowering usable) is large.
+
+## Sequencing
+
+1. Land the keepers from the experiment — **atomic gensym** and **pmapv** — they
+   are correct independent of any of this.
+2. Land the deterministic naming (build-args inst-id, gensym-suffix strip,
+   import sort) with the lowering work; regenerates the tree once.
+3. Prototype the type cache: content-key + join-merge + a fixpoint driver;
+   measure convergence on `core`.
+4. If it converges cheaply, wire lowering to read it, drop the wall-clock
+   budget, and turn on `pmapv` lowering for the speedup — now reproducible.

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -548,11 +549,13 @@ const NameCoreNS = "core"
 var CoreNS *vm.Namespace
 var CurrentNS *vm.Var
 
-var gensymID = 0
+// gensymID backs gensym. Atomic so concurrent gensym calls (e.g. lowering
+// namespaces' defns in parallel) don't race the counter. Single-threaded
+// the sequence is unchanged.
+var gensymID atomic.Int64
 
 func nextID() int {
-	gensymID++
-	return gensymID
+	return int(gensymID.Add(1))
 }
 
 // mapLike is any map type with Lookup + Counted + Sequable
@@ -5837,6 +5840,8 @@ func installLangNS() {
 
 	ns.Def("map*", mapf)
 	ns.Def("mapv", mapv)
+	parMapV, _ := vm.NativeFnType.Wrap(parallelMapV)
+	ns.Def("pmapv", parMapV)
 	ns.Def("chunk-first", chunkFirst)
 	ns.Def("chunk-rest", chunkRest)
 	ns.Def("chunk-next", chunkNext)

--- a/pkg/rt/parallel.go
+++ b/pkg/rt/parallel.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// parallelMapV is `pmapv` — an EAGER, ordered parallel map that shares
+// the caller's dynamic-var bindings rather than snapshotting them.
+//
+// `pmap` (the Lisp one) is built on `future`, and every future pays the
+// global bindings mutex twice plus an O(active-bindings) copy in
+// SnapshotBindings + RunWithBindings — because a future is async and may
+// run after the caller's `binding` scope has unwound, so it must capture
+// and reinstate that scope. That spawn cost serializes parallel work.
+//
+// pmapv is *synchronous*: it blocks until every element is done, so the
+// caller's `binding` scope is still live throughout. The worker
+// goroutines therefore just read the current global dynamic bindings via
+// the (lock-free) Var.Deref — no snapshot, no per-task bindings mutex.
+//
+// Caveat: because workers share the caller's binding stack, a worker fn
+// that PUSHES its own dynamic binding (a `binding` form) on a var would
+// race the shared global stack. pmapv is for read-only-binding workloads
+// (e.g. lowering a namespace's defns, which only read *ns*/*target*).
+func parallelMapV(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 2 {
+		return vm.NIL, fmt.Errorf("pmapv expects 2 args (fn coll)")
+	}
+	fn, ok := vs[0].(vm.Fn)
+	if !ok {
+		return vm.NIL, fmt.Errorf("pmapv expected Fn as first arg")
+	}
+	if vs[1] == vm.NIL {
+		return vm.NewArrayVector(nil), nil
+	}
+	seq, ok := vs[1].(vm.Sequable)
+	if !ok {
+		return vm.NIL, fmt.Errorf("pmapv expected a seqable second arg")
+	}
+
+	var items []vm.Value
+	for s := seq.Seq(); s != nil; s = s.Next() {
+		items = append(items, s.First())
+	}
+	n := len(items)
+	if n == 0 {
+		return vm.NewArrayVector(nil), nil
+	}
+
+	results := make([]vm.Value, n)
+	errs := make([]error, n)
+
+	workers := runtime.NumCPU()
+	if workers > n {
+		workers = n
+	}
+
+	var next int64 = -1
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(atomic.AddInt64(&next, 1))
+				if i >= n {
+					return
+				}
+				r, err := fn.Invoke([]vm.Value{items[i]})
+				results[i] = r
+				errs[i] = err
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			return vm.NIL, err
+		}
+	}
+	return vm.NewArrayVector(results), nil
+}

--- a/pkg/rt/parallel_test.go
+++ b/pkg/rt/parallel_test.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func TestPmapvPreservesOrder(t *testing.T) {
+	sq, _ := vm.NativeFnType.Wrap(func(a []vm.Value) (vm.Value, error) {
+		n := int(a[0].(vm.Int))
+		return vm.Int(n * n), nil
+	})
+	coll := vm.NewArrayVector([]vm.Value{vm.Int(1), vm.Int(2), vm.Int(3), vm.Int(4), vm.Int(5)})
+	r, err := parallelMapV([]vm.Value{sq, coll})
+	if err != nil {
+		t.Fatalf("pmapv: %v", err)
+	}
+	got := r.(vm.ArrayVector)
+	want := []int{1, 4, 9, 16, 25}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d results, got %d", len(want), len(got))
+	}
+	for i, w := range want {
+		if int(got[i].(vm.Int)) != w {
+			t.Fatalf("at %d: want %d, got %v", i, w, got[i])
+		}
+	}
+}
+
+// TestPmapvSharesCallerBindings: the workers run synchronously while the
+// caller's dynamic binding is live, so they read it via Var.Deref without
+// any per-task snapshot.
+func TestPmapvSharesCallerBindings(t *testing.T) {
+	v := vm.NewVar(nil, "test", "*scale*")
+	v.SetRoot(vm.Int(1))
+	v.PushBinding(vm.Int(10))
+	defer v.PopBinding()
+
+	mul, _ := vm.NativeFnType.Wrap(func(a []vm.Value) (vm.Value, error) {
+		return vm.Int(int(a[0].(vm.Int)) * int(v.Deref().(vm.Int))), nil
+	})
+	r, err := parallelMapV([]vm.Value{mul, vm.NewArrayVector([]vm.Value{vm.Int(1), vm.Int(2), vm.Int(3)})})
+	if err != nil {
+		t.Fatalf("pmapv: %v", err)
+	}
+	got := r.(vm.ArrayVector)
+	want := []int{10, 20, 30}
+	for i, w := range want {
+		if int(got[i].(vm.Int)) != w {
+			t.Fatalf("worker did not see caller binding at %d: want %d, got %v", i, w, got[i])
+		}
+	}
+}
+
+func TestPmapvEmpty(t *testing.T) {
+	id, _ := vm.NativeFnType.Wrap(func(a []vm.Value) (vm.Value, error) { return a[0], nil })
+	r, err := parallelMapV([]vm.Value{id, vm.NIL})
+	if err != nil {
+		t.Fatalf("pmapv nil: %v", err)
+	}
+	if got := r.(vm.ArrayVector); len(got) != 0 {
+		t.Fatalf("expected empty result for nil coll, got %d", len(got))
+	}
+}
+
+// TestNextIDConcurrentUnique pins the atomic gensym counter: concurrent
+// callers must each get a distinct id and there must be no data race
+// (run under -race). The old non-atomic gensymID++ both raced and could
+// hand out duplicates.
+func TestNextIDConcurrentUnique(t *testing.T) {
+	const n = 2000
+	out := make([]int, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			out[i] = nextID()
+		}(i)
+	}
+	wg.Wait()
+	seen := make(map[int]struct{}, n)
+	for _, x := range out {
+		if _, dup := seen[x]; dup {
+			t.Fatalf("duplicate gensym id %d under concurrency", x)
+		}
+		seen[x] = struct{}{}
+	}
+}


### PR DESCRIPTION
Two independent keepers from the parallel-IR-lowering investigation, plus a
design note capturing the findings and the proposed path forward.

## 1. Atomic gensym (a real data-race fix)

`gensymID` was a plain `int` bumped with `++`. Concurrent `gensym` calls — e.g.
lowering a namespace's defns in parallel — race it (and `go test -race` flags
it), and could even hand out duplicate ids. Now `atomic.Int64`. Single-threaded
the sequence is identical, so no generated output changes.

## 2. `pmapv` — eager, synchronous, binding-sharing parallel map

The future-based `pmap` is unusable for parallel compiler work: every `future`
calls `SnapshotBindings`+`RunWithBindings`, which take the global bindings mutex
and copy the whole dynamic-binding environment **per spawn** (a future is async,
so it must capture/reinstate the caller's `binding` scope). That spawn cost
serializes the work — in the lowering experiment, future-`pmap` was *slower*
than sequential.

`pmapv` is **synchronous**: it blocks until every element finishes, so the
caller's `binding` scope is still live and workers just **read** the caller's
dynamic bindings via `Var.Deref` — no snapshot, no per-task mutex. Worker pool
sized to `NumCPU`, order-preserving, returns a vector.

In the (separate) lowering experiment this took the `core` lowering from
~193 s sequential to ~155 s (1.24×), where future-`pmap` made it *worse*.

**Not** Clojure `pmap`: Clojure's is a lazy, chunked seq; `pmapv` is eager and
shares the caller's bindings — right for "do all of these in parallel and
collect," not a lazy drop-in. Noted on the primitive.

## 3. Design note

`docs/parallel-lowering-and-type-cache.md` records the full investigation (the
future-snapshot bottleneck, the gensym + wall-clock-typeinfer-budget
determinism issues) and proposes a **mergeable type-discovery cache**: because
typeinfer is monotone (types only join *up* the lattice), cached type results
merge by least-upper-bound — order-free and parallel-safe — which makes parallel
lowering both fast and reproducible. Forward-looking; references the lock-free
`Var.Deref` change (separate PR) for context.

## Tests

`pkg/rt/parallel_test.go`, all under `-race`: `pmapv` order preservation,
sharing the caller's dynamic binding, empty coll; and concurrent `nextID`
uniqueness (data-races without the atomic).
