### PR TITLE
feat(vm): surface Go panic origin in crash reports

### DIFF
--- a/pkg/vm/errfmt.go
+++ b/pkg/vm/errfmt.go
@@ -35,6 +35,7 @@ func FormatError(err error) string {
 	}
 
 	var frames []frame
+	var goStack string
 	current := err
 	for current != nil {
 		switch e := current.(type) {
@@ -45,6 +46,13 @@ func FormatError(err error) string {
 		case *TypeError:
 			frames = append(frames, frame{msg: current.Error()})
 			current = e.cause
+		case *GoPanicError:
+			// An unexpected Go panic (e.g. syscall/js under WASM, nil deref in
+			// a builtin). Carries the Go stack — the only traceback that pins
+			// the actual crash site, since native fns have no .lg source.
+			goStack = e.GoStack()
+			frames = append(frames, frame{msg: e.Error()})
+			current = nil
 		default:
 			frames = append(frames, frame{msg: current.Error()})
 			current = nil
@@ -89,7 +97,46 @@ func FormatError(err error) string {
 		}
 	}
 
+	// For an unexpected Go panic, surface the let-go-relevant Go frames so the
+	// real crash site (the .go file:line) is visible — otherwise the only
+	// traceback is the source-less let-go frames above.
+	if origin := letGoStackFrames(goStack); origin != "" {
+		b.WriteString("\n" + ansiBold + "go panic origin:" + ansiReset + "\n")
+		b.WriteString(origin)
+	}
+
 	return b.String()
+}
+
+// letGoStackFrames extracts the let-go-relevant func+location pairs from a
+// debug.Stack() dump (those inside this repo), skipping the panic-recover
+// machinery, so a Go panic's actual origin (e.g. term_wasm.go:91) is shown.
+// Returns "" when there are no in-repo frames (or no stack at all).
+func letGoStackFrames(stack string) string {
+	if stack == "" {
+		return ""
+	}
+	const repo = "nooga/let-go/"
+	lines := strings.Split(stack, "\n")
+	var out strings.Builder
+	shown := 0
+	for i := 0; i+1 < len(lines) && shown < 8; i++ {
+		fn := strings.TrimSpace(lines[i])
+		if !strings.Contains(fn, repo) || strings.Contains(fn, "recoverThrownPanic") {
+			continue
+		}
+		loc := strings.TrimSpace(lines[i+1])
+		if idx := strings.Index(loc, repo); idx >= 0 {
+			loc = loc[idx+len(repo):]
+		}
+		if sp := strings.IndexByte(loc, ' '); sp >= 0 {
+			loc = loc[:sp]
+		}
+		fmt.Fprintf(&out, "  %s\n     %s\n", fn, loc)
+		shown++
+		i++ // consume the location line
+	}
+	return out.String()
 }
 
 func formatCompileError(ce compileErrorLike) string {

--- a/pkg/vm/errfmt_origin_test.go
+++ b/pkg/vm/errfmt_origin_test.go
@@ -1,0 +1,33 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatErrorSurfacesGoPanicOrigin(t *testing.T) {
+	fakeStack := `goroutine 1 [running]:
+runtime/debug.Stack()
+	/usr/lib/go/src/runtime/debug/stack.go:26 +0x5e
+github.com/nooga/let-go/pkg/vm.recoverThrownPanic(0x1)
+	/repo/pkg/vm/errors.go:181 +0x44
+panic({0x1, 0x2})
+	/usr/lib/go/src/runtime/panic.go:770 +0x132
+github.com/nooga/let-go/pkg/rt.installTermNS.func7()
+	/repo/pkg/rt/term_wasm.go:91 +0x88
+github.com/nooga/let-go/pkg/vm.(*NativeFn).Invoke(...)
+	/repo/pkg/vm/native_func.go:200 +0x40`
+	gpe := &GoPanicError{value: "syscall/js: call of Value.Int on undefined", stack: []byte(fakeStack)}
+	wrapped := &ExecutionError{message: "calling require", cause: gpe}
+	out := FormatError(wrapped)
+	if !strings.Contains(out, "go panic origin") {
+		t.Fatalf("expected 'go panic origin' section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "pkg/rt/term_wasm.go:91") {
+		t.Fatalf("expected the crash site term_wasm.go:91, got:\n%s", out)
+	}
+	if strings.Contains(out, "recoverThrownPanic") {
+		t.Fatalf("recover machinery should be filtered, got:\n%s", out)
+	}
+	t.Logf("\n%s", out)
+}

--- a/pkg/vm/errors.go
+++ b/pkg/vm/errors.go
@@ -164,6 +164,23 @@ type thrownPanic struct {
 	err error
 }
 
+// GoPanicError wraps an unexpected Go panic (one that is NOT a let-go thrown
+// error) together with the Go stack captured at the recover site. Native-fn
+// crashes — e.g. a `syscall/js: Value.Int on undefined` under WASM, or a nil
+// dereference in a Go builtin — have no let-go source location, so without this
+// the only traceback was an unhelpful `at <fn> (<unknown>)`. The captured Go
+// stack pins the actual crash site (the .go file:line) and FormatError surfaces
+// the let-go-relevant frames.
+type GoPanicError struct {
+	value any
+	stack []byte
+}
+
+func (e *GoPanicError) Error() string { return fmt.Sprintf("%v", e.value) }
+
+// GoStack returns the raw Go stack trace captured when the panic was recovered.
+func (e *GoPanicError) GoStack() string { return string(e.stack) }
+
 // recoverThrownPanic catches a thrownPanic and converts it back to an error return.
 // It also catches arbitrary Go panics and converts them to ExecutionErrors so that
 // they produce let-go errors instead of crashing with Go stack traces.
@@ -173,14 +190,16 @@ func recoverThrownPanic(errp *error) {
 		if tp, ok := r.(*thrownPanic); ok {
 			*errp = tp.err
 		} else {
-			// Convert arbitrary Go panics to let-go errors. When
-			// LG_PANIC_STACK=1, also dump the Go stack trace so
-			// gogen_ir self-host bugs surface their actual location
-			// instead of being lost behind a wrapped error.
+			// Convert arbitrary Go panics to let-go errors, capturing the Go
+			// stack so the crash site is reportable instead of lost behind a
+			// `%v`-wrapped error. FormatError prints the let-go-relevant
+			// frames; LG_PANIC_STACK=1 additionally dumps the full stack to
+			// stderr at the recover site.
+			stack := debug.Stack()
 			if os.Getenv("LG_PANIC_STACK") != "" {
-				fmt.Fprintf(os.Stderr, "[panic-recover] %v\n%s\n", r, debug.Stack())
+				fmt.Fprintf(os.Stderr, "[panic-recover] %v\n%s\n", r, stack)
 			}
-			*errp = fmt.Errorf("%v", r)
+			*errp = &GoPanicError{value: r, stack: stack}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

An unexpected Go panic in a native fn — e.g. `syscall/js: call of Value.Int on undefined` under WASM, or a nil deref in a Go builtin — was recovered and wrapped via `fmt.Errorf("%v", r)`, **discarding the Go stack**. Since native fns have no `.lg` source, the only traceback was:

```
error: syscall/js: call of Value.Int on undefined
stack trace:
  at require (<unknown>)
```

— useless for finding the crash site.

## Change

- New `GoPanicError` captures the Go stack (`debug.Stack()`) at the recover site instead of throwing it away.
- `FormatError` adds a **`go panic origin:`** section listing the let-go-relevant Go frames (filtering the panic-recover machinery), so the actual `.go` crash site is shown:

```
error: syscall/js: call of Value.Int on undefined

stack trace:
  at require (<unknown>)

go panic origin:
  github.com/nooga/let-go/pkg/rt.installTermNS.func7()
     pkg/rt/term_wasm.go:91
  github.com/nooga/let-go/pkg/vm.(*NativeFn).Invoke(...)
     pkg/vm/native_func.go:200
```

`LG_PANIC_STACK=1` still dumps the full stack to stderr. Especially valuable under WASM, where there's otherwise no usable traceback. Test in `errfmt_origin_test.go`.