### PR TITLE
chore: prepare v1.9.0 release

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     paths:
       - .*_test\.go
       - ^wasm/
+      - ^pkg/rt/core_go_lowered/
       - third_party$
       - builtin$
       - ^examples/
@@ -48,6 +49,7 @@ formatters:
     paths:
       - .*_test\.go
       - ^wasm/
+      - ^pkg/rt/core_go_lowered/
       - third_party$
       - builtin$
       - ^examples/

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.26
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/stretchr/testify v1.8.4
+	github.com/zeebo/xxh3 v1.1.0
+	golang.org/x/perf v0.0.0-20260512194132-3cf34090a3db
 )
 
 require (
 	github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
-	github.com/zeebo/xxh3 v1.1.0 // indirect
-	golang.org/x/perf v0.0.0-20260512194132-3cf34090a3db // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -27,14 +27,14 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/bencode v1.0.0 h1:zgop0Wu1nu4IexAZeCZ5qbsjU4O1vMrfCrVgUjbHVuA=
 github.com/zeebo/bencode v1.0.0/go.mod h1:Ct7CkrWIQuLWAy9M3atFHYq4kG9Ao/SsY5cdtCXmp9Y=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 golang.org/x/perf v0.0.0-20260512194132-3cf34090a3db h1:1EdY5INjhh724sLDk1O/nIzRZ8wmHbmiF8K2cK/mNLw=
 golang.org/x/perf v0.0.0-20260512194132-3cf34090a3db/go.mod h1:vtQ1uZI2nWugeUDAr4i3qjU4fqZ0yZYuruCC4FKahWE=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=


### PR DESCRIPTION
## Summary
- refresh module metadata with go mod tidy for the v1.9.0 release

## Verification
- go mod tidy
- go generate ./pkg/rt/
- go test -timeout 60s ./... -count=1