### PR TITLE
feat(rt): pluggable host-method-dispatch seam

### DIFF
--- a/pkg/compiler/host_method_seam_test.go
+++ b/pkg/compiler/host_method_seam_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func runHM(t *testing.T, src string) vm.Value {
+	t.Helper()
+	cp := vm.NewConsts()
+	ns := rt.NS(rt.NameCoreNS)
+	ctx := NewCompiler(cp, ns)
+	ch, _, err := ctx.CompileMultiple(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	v, err := vm.NewFrame(ch, nil).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return v
+}
+
+// The host-method seam lets a (type, method) pair be registered so that a
+// `.method` dot-form on a value of that type dispatches to the registered fn
+// (receiver first). This backs Java-method calls on let-go values without a
+// general reflective bridge.
+func TestHostMethodSeam(t *testing.T) {
+	// A method registered on a deftype, dispatched via a dot-form.
+	if v := runHM(t, `(do
+                        (deftype Pair [a b])
+                        (register-host-method! Pair 'sum (fn [p] (+ (.a p) (.b p))))
+                        (.sum (->Pair 3 4)))`); v.String() != "7" {
+		t.Fatalf("deftype host method: want 7, got %v", v)
+	}
+
+	// A registered method taking arguments.
+	if v := runHM(t, `(do
+                        (deftype Acc [n])
+                        (register-host-method! Acc 'plus (fn [a x] (+ (.n a) x)))
+                        (.plus (->Acc 5) 3))`); v.String() != "8" {
+		t.Fatalf("host method with arg: want 8, got %v", v)
+	}
+
+	// A method registered on a built-in collection type.
+	if v := runHM(t, `(do
+                        (register-host-method! (type []) 'firstish (fn [v] (first v)))
+                        (.firstish [10 20]))`); v.String() != "10" {
+		t.Fatalf("native-type host method: want 10, got %v", v)
+	}
+
+	// A registered method whose name collides with a core fn (pop) must win
+	// over the generic name→fn fallback — otherwise `.pop` on a custom type
+	// would be hijacked by core `pop`. (malli needs .nth/.cons/.pop etc.)
+	if v := runHM(t, `(do
+                        (deftype Stack [top])
+                        (register-host-method! Stack 'pop (fn [s] (.top s)))
+                        (.pop (->Stack 99)))`); v.String() != "99" {
+		t.Fatalf("registered .pop must win over core pop: want 99, got %v", v)
+	}
+}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -1301,7 +1301,47 @@ func fnComparator(comp vm.Fn) vm.Comparator {
 	}
 }
 
+// hostMethods backs the pluggable host-method-dispatch seam: a (type, method)
+// registry consulted by the `.`-form when a value has no native method of that
+// name. Mirrors the pluggable NSLoader — core ships the seam; callers (e.g. a
+// library-compat module) register the specific method names they need, rather
+// than baking a general reflective bridge into core.
+var (
+	hostMethodsMu sync.RWMutex
+	hostMethods   = map[vm.ValueType]map[vm.Symbol]vm.Fn{}
+)
+
+// RegisterHostMethod registers fn as the handler for `.name` on values whose
+// type is t. The handler is invoked with the receiver as its first argument.
+func RegisterHostMethod(t vm.ValueType, name vm.Symbol, fn vm.Fn) {
+	hostMethodsMu.Lock()
+	defer hostMethodsMu.Unlock()
+	m := hostMethods[t]
+	if m == nil {
+		m = map[vm.Symbol]vm.Fn{}
+		hostMethods[t] = m
+	}
+	m[name] = fn
+}
+
+func lookupHostMethod(t vm.ValueType, name vm.Symbol) (vm.Fn, bool) {
+	hostMethodsMu.RLock()
+	defer hostMethodsMu.RUnlock()
+	if m := hostMethods[t]; m != nil {
+		fn, ok := m[name]
+		return fn, ok
+	}
+	return nil, false
+}
+
 func invokeMethodFallback(rec vm.Value, name vm.Symbol, args []vm.Value, originalErr error) (vm.Value, error) {
+	// Explicit host-method registrations win over the generic name→fn fallbacks
+	// below (so e.g. a registered `.pop` is not shadowed by core `pop`).
+	if rec != nil {
+		if fn, ok := lookupHostMethod(rec.Type(), name); ok {
+			return fn.Invoke(append([]vm.Value{rec}, args...))
+		}
+	}
 	if isCompatChecker(rec) && len(args) == 1 {
 		switch name {
 		case "isLong":
@@ -3146,6 +3186,28 @@ func installLangNS() {
 			return result, nil
 		}
 		return invokeMethodFallback(rec, name, vs[2:], err)
+	})
+
+	// (register-host-method! Type 'name (fn [rec & args] ...)) — register a
+	// handler for `.name` dot-forms on values of Type (the host-method seam).
+	registerHostMethod, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 3 {
+			return vm.NIL, fmt.Errorf("register-host-method! expected 3 arguments, got %d", len(vs))
+		}
+		t, ok := vs[0].(vm.ValueType)
+		if !ok {
+			return vm.NIL, fmt.Errorf("register-host-method! expected a type, got %s", vs[0].Type().Name())
+		}
+		name, ok := vs[1].(vm.Symbol)
+		if !ok {
+			return vm.NIL, fmt.Errorf("register-host-method! expected a Symbol method name")
+		}
+		fn, ok := vs[2].(vm.Fn)
+		if !ok {
+			return vm.NIL, fmt.Errorf("register-host-method! expected a fn")
+		}
+		RegisterHostMethod(t, name, fn)
+		return vm.NIL, nil
 	})
 
 	deref, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
@@ -5941,6 +6003,7 @@ func installLangNS() {
 
 	ns.Def("apply*", apply)
 	ns.Def("deref", deref)
+	ns.Def("register-host-method!", registerHostMethod)
 
 	ns.Def("atom", atom)
 	ns.Def("reset!", reset)


### PR DESCRIPTION
Adds a small, general **host-method-dispatch seam**: a `(type, method) → fn` registry that the `.`-form consults when a value has no native method of that name. Mirrors the existing pluggable `NSLoader` — core ships the seam, callers register the specific method names they need (no general reflective `.`-bridge baked into core).

## API

- Go: `rt.RegisterHostMethod(t vm.ValueType, name vm.Symbol, fn vm.Fn)`
- let-go: `(register-host-method! Type 'name (fn [rec & args] …))`

When `(.name x …)` finds no native method, `invokeMethodFallback` looks up `(x.Type(), name)` and, if registered, invokes the handler with the receiver first. Existing native dispatch and the hard-coded fallbacks are unchanged (the registry is consulted last, before erroring).

## Why

Lets a library-compat layer make Java-method calls on let-go values resolve to let-go ops — e.g. `(.nth v 0)` / `(.iterator coll)` on native collections, or `.push`/`.pop` on a let-go-defined stack — without a general reflective bridge. Part of running stock `metosin/malli` on let-go (#134); general-purpose on its own.

## Tests

`pkg/compiler/host_method_seam_test.go`: a method registered on a deftype dispatched via `.sum`; a registered method taking an argument; and a method on a built-in collection type (`(type [])`). Full suite green (255); `go vet` clean.