### PR TITLE
feat(rt): 3-arg deref (blocking deref with timeout) for promises/futures

### DIFF
--- a/pkg/compiler/deref_timeout_test.go
+++ b/pkg/compiler/deref_timeout_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func runDT(t *testing.T, src string) vm.Value {
+	t.Helper()
+	cp := vm.NewConsts()
+	ns := rt.NS(rt.NameCoreNS)
+	ctx := NewCompiler(cp, ns)
+	ch, _, err := ctx.CompileMultiple(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	v, err := vm.NewFrame(ch, nil).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return v
+}
+
+// 3-arg deref: (deref blocking-ref timeout-ms timeout-val) blocks up to ms for
+// a promise/future, returning timeout-val on timeout.
+func TestDerefTimeout(t *testing.T) {
+	// Undelivered promise → timeout value.
+	if v := runDT(t, `(deref (promise) 20 :timed-out)`); v.String() != ":timed-out" {
+		t.Fatalf("undelivered: want :timed-out, got %v", v)
+	}
+	// Already-delivered promise → value (immediately).
+	if v := runDT(t, `(let [p (promise)] (deliver p 42) (deref p 1000 :to))`); v.String() != "42" {
+		t.Fatalf("delivered: want 42, got %v", v)
+	}
+	// future delivers within the timeout window.
+	if v := runDT(t, `(deref (future 7) 2000 :to)`); v.String() != "7" {
+		t.Fatalf("future: want 7, got %v", v)
+	}
+	// 1-arg deref still works.
+	if v := runDT(t, `(let [p (promise)] (deliver p 5) (deref p))`); v.String() != "5" {
+		t.Fatalf("1-arg deref: want 5, got %v", v)
+	}
+}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3149,14 +3149,28 @@ func installLangNS() {
 	})
 
 	deref, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		if len(vs) != 1 {
-			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		switch len(vs) {
+		case 1:
+			ref, ok := vs[0].(vm.Reference)
+			if !ok {
+				return vm.NIL, fmt.Errorf("deref expected Reference")
+			}
+			return ref.Deref(), nil
+		case 3:
+			// (deref blocking-ref timeout-ms timeout-val): block up to ms for a
+			// promise/future's value, else return timeout-val.
+			bref, ok := vs[0].(vm.BlockingDeref)
+			if !ok {
+				return vm.NIL, fmt.Errorf("deref with timeout expects a blocking ref (promise or future)")
+			}
+			ms, ok := vs[1].(vm.Int)
+			if !ok {
+				return vm.NIL, fmt.Errorf("deref timeout must be an integer number of milliseconds")
+			}
+			return bref.DerefTimeout(int64(ms), vs[2]), nil
+		default:
+			return vm.NIL, fmt.Errorf("deref: wrong number of arguments %d (expected 1 or 3)", len(vs))
 		}
-		ref, ok := vs[0].(vm.Reference)
-		if !ok {
-			return vm.NIL, fmt.Errorf("deref expected Reference")
-		}
-		return ref.Deref(), nil
 	})
 
 	concat, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
 // Promise is a write-once, read-many synchronization primitive.
@@ -42,6 +43,25 @@ func (p *Promise) Deref() Value {
 	p.mu.Unlock()
 	<-p.ch // block until delivered
 	return p.value
+}
+
+// DerefTimeout blocks until the promise is delivered or timeoutMs elapses,
+// returning timeoutVal on timeout. Backs Clojure's 3-arg deref for blocking
+// refs (promises/futures).
+func (p *Promise) DerefTimeout(timeoutMs int64, timeoutVal Value) Value {
+	p.mu.Lock()
+	if p.delivered {
+		v := p.value
+		p.mu.Unlock()
+		return v
+	}
+	p.mu.Unlock()
+	select {
+	case <-p.ch:
+		return p.value
+	case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
+		return timeoutVal
+	}
 }
 
 func (p *Promise) IsRealized() bool {

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -96,6 +96,13 @@ type Reference interface {
 	Deref() Value
 }
 
+// BlockingDeref is a reference whose value may not be available yet (promise,
+// future). DerefTimeout blocks up to timeoutMs for the value, returning
+// timeoutVal on timeout. Backs Clojure's 3-arg deref.
+type BlockingDeref interface {
+	DerefTimeout(timeoutMs int64, timeoutVal Value) Value
+}
+
 type theTypeType struct{}
 
 var TypeType *theTypeType = &theTypeType{}


### PR DESCRIPTION
Adds Clojure's **3-arg `deref`** — `(deref blocking-ref timeout-ms timeout-val)` — a standard `clojure.core` form that was missing.

It blocks up to `timeout-ms` for a **blocking** reference (`promise`/`future`) to be delivered, returning `timeout-val` on timeout:

```clojure
(deref (promise) 20 :timed-out)              ;; => :timed-out
(let [p (promise)] (deliver p 42) (deref p 1000 :to))  ;; => 42
(deref (future 7) 2000 :to)                  ;; => 7
```

## Implementation

- `Promise.DerefTimeout(ms, timeoutVal)` — a `select` on the existing deliver channel vs. `time.After` (promises/futures are the same `*Promise`).
- A `vm.BlockingDeref` interface (`DerefTimeout`), mirroring `vm.Reference`.
- `deref` now dispatches on arity: 1-arg unchanged; 3-arg requires a `BlockingDeref` (errors clearly on atoms/refs/vars, which aren't blocking). Other arities error.

## Why

General-purpose (like `compare-and-set!` was). It's also the clean primitive for timeout-bounded waits — e.g. running work with a deadline maps directly onto `(deref (future …) ms :timeout)` instead of hand-rolled `chan`/`alts!`. Part of running stock `metosin/malli` on let-go (#134), whose `-run` helper is exactly this shape.

## Tests

`pkg/compiler/deref_timeout_test.go`: undelivered→timeout, delivered→value, future-within-window, and 1-arg deref unchanged. vm+rt suites green (245); `go vet` clean.