### PR TITLE
feat(reader+compiler): preserve type-hint tags instead of failing to resolve them

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1040,6 +1040,15 @@ func compileBindings(c *Context, binds []vm.Value, opName string) (int, error) {
 	bindn := 0
 	for i := 0; i < len(binds); i += 2 {
 		name := binds[i]
+		// Strip a metadata wrapper from the binding name: `^long x` is read as
+		// `(with-meta x {:tag long})`. As with fn params, we don't yet attach
+		// the tag to the local (a future hook for the IR typeinfer pass), just
+		// unwrap to the bare symbol so the check below succeeds.
+		if lst, ok := name.(*vm.List); ok && lst.First() == vm.Symbol("with-meta") {
+			if rest := lst.Next(); rest != nil {
+				name = rest.First()
+			}
+		}
 		if name.Type() != vm.SymbolType {
 			return 0, NewCompileError(fmt.Sprintf("%s binding name must be a symbol: %v", opName, name))
 		}

--- a/pkg/compiler/reader.go
+++ b/pkg/compiler/reader.go
@@ -1275,7 +1275,12 @@ func readMeta(r *LispReader, _ rune) (vm.Value, error) {
 		case vm.Keyword:
 			m = m.(*vm.PersistentMap).Assoc(v, vm.TRUE).(*vm.PersistentMap)
 		case vm.Symbol:
-			m = m.(*vm.PersistentMap).Assoc(tagKey, v).(*vm.PersistentMap)
+			// A bare-symbol tag (`^Iterable x`) is a type hint. Preserve it as
+			// :tag metadata (the IR's typeinfer/lowering passes can use it), but
+			// quote it so the (often host-class) symbol is a datum, not an
+			// evaluated var reference that won't resolve.
+			quotedTag := vm.NewList([]vm.Value{vm.Symbol("quote"), v})
+			m = m.(*vm.PersistentMap).Assoc(tagKey, quotedTag).(*vm.PersistentMap)
 		case vm.String:
 			m = m.(*vm.PersistentMap).Assoc(tagKey, v).(*vm.PersistentMap)
 		default:

--- a/pkg/compiler/type_hint_test.go
+++ b/pkg/compiler/type_hint_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func runTH(t *testing.T, src string) vm.Value {
+	t.Helper()
+	cp := vm.NewConsts()
+	ns := rt.NS(rt.NameCoreNS)
+	ctx := NewCompiler(cp, ns)
+	ch, _, err := ctx.CompileMultiple(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	v, err := vm.NewFrame(ch, nil).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return v
+}
+
+// A type hint naming a host class (`^Iterable`, `^String`, …) must not require
+// that symbol to resolve as a var — let-go ignores type hints, but they appear
+// throughout real Clojure source.
+func TestTypeHint_UnresolvedTagIsIgnored(t *testing.T) {
+	// Hint on an expression whose tag (Iterable) is undefined.
+	if v := runTH(t, `(count ^Iterable [1 2 3])`); v.String() != "3" {
+		t.Fatalf("^Iterable hint: want 3, got %v", v)
+	}
+	// Hint on a fn parameter.
+	if v := runTH(t, `((fn [^String s] (str s "!")) "hi")`); v.String() != `"hi!"` {
+		t.Fatalf("^String param hint: want \"hi!\", got %v", v)
+	}
+	// Hint on a let binding name (unwrapped, like fn params).
+	if v := runTH(t, `(let [^CharSequence x "ok"] x)`); v.String() != `"ok"` {
+		t.Fatalf("^CharSequence let-name hint: want \"ok\", got %v", v)
+	}
+	// Hint on a let binding value (expression position).
+	if v := runTH(t, `(let [x ^Iterable [1 2]] (count x))`); v.String() != "2" {
+		t.Fatalf("^Iterable let-value hint: want 2, got %v", v)
+	}
+}
+
+// Expression-position type hints are PRESERVED as :tag metadata (the symbol
+// datum), so the IR/typeinfer can use them — they are not discarded.
+func TestTypeHint_PreservedAsTagMetadata(t *testing.T) {
+	if v := runTH(t, `(:tag (meta ^Foo [1 2 3]))`); v.String() != "Foo" {
+		t.Fatalf("expected :tag metadata Foo to be preserved, got %v", v)
+	}
+}


### PR DESCRIPTION
Type hints (`^Iterable os`, `^long x`, `^objects arr`) appear throughout real Clojure source. Previously a bare-symbol tag was stored as an **evaluated** metadata value, so `^Iterable os` → `(with-meta os {:tag Iterable})` failed with *"Can't resolve Iterable"* (it names a host class). And a tag on a `let`/`loop` binding *name* hit *"binding name must be a symbol"*.

## What

- **Reader:** a bare-symbol tag is now stored **quoted** (`{:tag (quote Iterable)}`), so it's preserved as a `:tag` datum rather than evaluated as a var reference. Type hints in **expression position** now compile, and the tag survives in metadata: `(:tag (meta ^Foo [1 2 3]))` → `Foo`.
- **Compiler (`let`/`loop` bindings):** unwrap a `(with-meta sym …)` binding **name** to the bare symbol — matching what `fn` params already do (`compiler.go:196`, *"we don't yet attach meta to locals"*).

## Why preserve (not drop)

Type hints are advisory, so dropping them is behavior-safe — but it would discard the `^long`/`^double`/`^objects` signal the IR's `typeinfer`/`lower_go` passes can use for unboxing and specialization. Preserving them on values keeps that information available; attaching binding-name tags to locals for the IR is the natural follow-up (the existing fn-param comment already flags it). Part of loading stock `metosin/malli`, which is densely type-hinted (#134).

## Tests

`pkg/compiler/type_hint_test.go`: `^Iterable`/`^String`/`^CharSequence` in expression, fn-param, and let-binding positions; and `:tag` metadata preservation. Full suite green (256); `go vet` clean.