### PR TITLE
docs: add Matt Parrett to CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,6 +7,7 @@ first change.
 
   Marcin Gasperowicz <xnooga@gmail.com>
   Norman Nunley, Jr <nnunley@gmail.com>
+  Matt Parrett <matt.parrett@gmail.com>
 
 The phrase "let-go contributors" in any header refers to the people
 listed here.


### PR DESCRIPTION
Adds me to CONTRIBUTORS after #43 (Safari / Firefox COI bootstrap fix)
and #118 (term/key-pending? non-blocking input peek). Late on the
"alongside your first change" convention noted in the file — figured
a standalone catch-up was cleaner than tacking it onto an unrelated
future PR.