### PR TITLE
fix(compiler): correct lexical binding resolution

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -217,17 +217,12 @@ func (c *Context) enterFn(args []vm.Value) (*Context, error) {
 			}
 			i = i - 1
 		}
-		// Clojure allows `_` to appear multiple times in a parameter list
-		// as the conventional "ignored" placeholder. Multiple `_`s would
-		// collide in formalArgs (a Symbol-keyed map), so we simply don't
-		// register `_` for name lookup — but the slot still exists and
-		// the corresponding argument is still evaluated and passed (Clojure
-		// is strict; the caller's side effects must happen). argCount tracks
-		// the total slot count, including `_`s, for arity checks.
+		// `_` is the conventional "ignored" placeholder but is still an ordinary
+		// symbol in Clojure: it IS bound and may be referenced. When `_` repeats,
+		// the last occurrence wins, which the Symbol-keyed map gives us for free
+		// by overwriting on assignment. argCount tracks the total slot count,
+		// including `_`s, for arity checks.
 		fc.argCount++
-		if s == "_" {
-			continue
-		}
 		fc.formalArgs[s] = i
 	}
 	return fc, nil
@@ -255,12 +250,10 @@ func (c *Context) leaveFn(ctx *Context) {
 }
 
 func (c *Context) symbolLookup(s vm.Symbol) cell {
-	if c.isClosure {
-		clo := c.closedOvers[s]
-		if clo != nil {
-			return clo
-		}
-	}
+	// Locals and args in the current scope shadow a closed-over variable of the
+	// same name: `(let [v (f v)] v)` where v is also captured from an enclosing
+	// scope must see the NEW binding in the body, not the captured value.
+	// Checking closedOvers first (as before) made the let binding a no-op.
 	local := c.lookupLocal(s)
 	if local >= 0 {
 		// we have a local symbol in scope
@@ -274,6 +267,12 @@ func (c *Context) symbolLookup(s vm.Symbol) cell {
 		return &argCell{
 			scope: c,
 			arg:   arg,
+		}
+	}
+	if c.isClosure {
+		clo := c.closedOvers[s]
+		if clo != nil {
+			return clo
 		}
 	}
 	if c.parent == nil {
@@ -515,9 +514,10 @@ func (c *Context) compileForm(o vm.Value) error {
 				return c.compileForm(newform)
 			}
 
-			// Locals shadow macros: skip macro expansion if name is bound locally.
+			// Locals shadow macros: skip macro expansion if name is bound in the
+			// enclosing lexical scope (local, arg, or captured by a closure).
 			fvar := vm.Value(vm.NIL)
-			if c.lookupLocal(fnsym) < 0 {
+			if !c.resolvesAsLexical(fnsym) {
 				fvar = c.CurrentNS().Lookup(fnsym)
 			}
 			if fvar != vm.NIL && fvar.(*vm.Var).IsMacro() {
@@ -707,6 +707,28 @@ func (c *Context) lookupLocal(symbol vm.Symbol) int {
 		}
 	}
 	return -1
+}
+
+// resolvesAsLexical reports whether symbol is bound as a local, formal arg, or
+// closed-over variable anywhere in the enclosing lexical scope, WITHOUT the
+// capture side effects of symbolLookup. Used to decide head-position macro
+// shadowing: a lexical binding named like a macro/special form (e.g. a local
+// `fn`) must shadow it even when the use site is inside a nested fn/closure
+// that captures it. lookupLocal alone only sees the current frame, so a
+// captured binding would otherwise be mistaken for the macro.
+func (c *Context) resolvesAsLexical(symbol vm.Symbol) bool {
+	for ctx := c; ctx != nil; ctx = ctx.parent {
+		if ctx.isClosure && ctx.closedOvers[symbol] != nil {
+			return true
+		}
+		if ctx.lookupLocal(symbol) >= 0 {
+			return true
+		}
+		if ctx.arg(symbol) >= 0 {
+			return true
+		}
+	}
+	return false
 }
 
 type recurPoint struct {

--- a/test/lexical_binding_test.lg
+++ b/test/lexical_binding_test.lg
@@ -1,0 +1,58 @@
+(ns test.lexical-binding-test
+  (:require [test :refer :all]))
+
+;; Regression tests for lexical binding resolution in the compiler.
+;;
+;; Three related correctness fixes:
+;;  1. A let/loop binding that SHADOWS a captured variable must take effect in
+;;     the body. symbolLookup used to consult closed-over variables BEFORE
+;;     locals/args, so the shadowing binding was silently ignored.
+;;  2. `_` parameters are ordinary bound symbols (last-wins on repeat), not
+;;     unbindable placeholders.
+;;  3. A lexical binding named like a macro/special form must shadow it in head
+;;     position even when the use site is inside a closure that captures it.
+
+;; --- 1. value shadowing (symbolLookup: locals/args before closed-overs) ---
+
+(deftest let-binding-shadows-captured-variable
+  (testing "a let binding shadows a variable captured by an inner fn"
+    ;; the inner (fn []) captures v; the let must rebind it for the body
+    (is (= 6 ((fn [v] ((fn [] (let [v (inc v)] v)))) 5)))
+    (is (= 60 ((fn [v] ((fn [] (let [v (inc v)] (* v 10))))) 5)))
+    ;; nested lets each shadow the same captured name
+    (is (= 7 ((fn [v] ((fn [] (let [v (inc v)] (let [v (inc v)] v))))) 5)))))
+
+(deftest loop-binding-shadows-captured-variable
+  (testing "a loop binding shadows a variable captured by an inner fn"
+    (is (= 6 ((fn [v] ((fn [] (loop [v (inc v)] v)))) 5)))))
+
+(deftest self-referential-let-over-captured-variable
+  (testing "(let [v (f v)] v) where v is captured: RHS sees the captured value, body the new binding"
+    ;; RHS reads the captured value, body returns the freshly-bound one
+    (is (= "outer->5" ((fn [v] ((fn [] (let [v (str "outer->" v)] v)))) 5)))
+    ;; the reduce shape: the reduce fn captures `base`, a let in its body
+    ;; shadows it; the RHS reads the captured `base`, the body the new binding.
+    ;; With the bug the body returned the captured value, so reduce yielded "init".
+    (is (= "init2" ((fn [base]
+                      (reduce (fn [acc x] (let [base (str base x)] base)) base [0 1 2]))
+                    "init")))))
+
+;; --- 2. `_` is an ordinary bound parameter (last-wins on repeat) ---
+
+(deftest underscore-param-is-bound
+  (testing "a single `_` parameter is bound and referenceable"
+    (is (= 5 ((fn [_] _) 5))))
+  (testing "repeated `_` parameters bind last-wins, and all arg slots still pass"
+    (is (= 2 ((fn [_ _] _) 1 2)))
+    (is (= 3 ((fn [_ _ _] _) 1 2 3)))))
+
+;; --- 3. lexical binding shadows a macro in head position, through a closure ---
+
+(deftest local-shadows-macro-in-head-position-through-closure
+  (testing "a param shadowing a core macro is called as a fn, even when captured by an inner closure"
+    ;; `or` the macro on (or 42) yields 42; the shadowing fn doubles it to 84.
+    ;; The use site is inside (fn []) which CAPTURES `or` — lookupLocal alone
+    ;; would miss the capture and wrongly expand the `or` macro.
+    (is (= 84 ((fn [or] ((fn [] (or 42)))) (fn [x] (* x 2)))))
+    ;; same, with `when`: the macro (when 42) with no body is nil; the fn returns 42.
+    (is (= 42 ((fn [when] ((fn [] (when 42)))) (fn [x] x))))))


### PR DESCRIPTION
Three related lexical-binding correctness fixes in the compiler, grouped as one concern.

## Fixes

1. **Bind `_` parameters** (last-wins on repeat) instead of skipping them. `_` is an ordinary symbol in Clojure — it is bound and may be referenced (e.g. as the `this` arg of a method whose body refers back to it). When `_` repeats, the last occurrence wins.

2. **`symbolLookup` resolves locals/args before closed-overs.** A `let`/`loop` binding that shadows a variable captured from an enclosing scope must take effect in the body. Checking `closedOvers` first made the shadowing binding a silent no-op:
   ```clojure
   ((fn [v] ((fn [] (let [v (inc v)] v)))) 5)  ;; was 5, now 6
   ```

3. **`resolvesAsLexical` gates head-position macro shadowing.** A lexical binding named like a macro/special form must shadow it even when the use site is inside a closure that captures it — `lookupLocal` alone only sees the current frame:
   ```clojure
   ((fn [or] ((fn [] (or 42)))) (fn [x] (* x 2)))  ;; was 42 (macro), now 84 (the fn)
   ```

## Tests

Adds `test/lexical_binding_test.lg` (5 deftests, 11 assertions) covering all three. Each sub-fix was verified to fail without its specific change (`_` → compile error; shadowing → captured value; macro-shadow → wrong `42`/`nil`). Full suite green (145 tests).