### PR TITLE
fix(reader): fully skip non-matching reader-conditional branches

### DIFF
--- a/pkg/compiler/reader.go
+++ b/pkg/compiler/reader.go
@@ -1197,6 +1197,21 @@ func skipReaderForm(r *LispReader) {
 				continue
 			}
 			switch c {
+			case '\\':
+				// Character literal (e.g. \), \", \(): skip the next char so a
+				// delimiter or quote in a char literal doesn't corrupt the count.
+				if _, err := r.next(); err != nil {
+					return
+				}
+			case ';':
+				// Line comment: skip to end of line so a delimiter inside a
+				// comment isn't counted.
+				for c != '\n' && c != '\r' {
+					c, err = r.next()
+					if err != nil {
+						return
+					}
+				}
 			case '"':
 				inString = true
 			case '(', '[', '{':
@@ -1225,22 +1240,70 @@ func skipReaderForm(r *LispReader) {
 		if err != nil {
 			return
 		}
-		if c == '(' || c == '{' {
+		switch {
+		case c == '(' || c == '{':
+			// #(...) anon fn or #{...} set — balanced delimiters.
 			r.unread()
 			skipReaderForm(r)
-		} else {
-			// #something — skip to whitespace/delimiter
+		case c == '"':
+			// #"regex" — a string literal; skip to its closing quote.
 			for {
-				c, err := r.next()
+				cc, err := r.next()
 				if err != nil {
 					return
 				}
-				if isWhitespace(c) || isTerminatingMacro(c) {
-					r.unread()
-					return
+				if cc == '\\' {
+					r.next()
+				} else if cc == '"' {
+					break
 				}
 			}
+		case c == '\'' || c == '_':
+			// #'var-quote or #_discard — applies to the single next form.
+			skipReaderForm(r)
+		case c == '?':
+			// Nested reader conditional #?(...) / #?@(...) inside a skipped
+			// branch — skip the whole (list) (consume the optional @ first).
+			cc, err := r.next()
+			if err != nil {
+				return
+			}
+			if cc != '@' {
+				r.unread()
+			}
+			skipReaderForm(r)
+		default:
+			// Tagged literal #tag form (e.g. #js [], #inst "..."): skip the tag
+			// token, THEN the form it tags. Skipping only the tag would leave
+			// the tagged collection/value behind and desync the surrounding
+			// reader-conditional, swallowing the rest of the file.
+			for {
+				cc, err := r.next()
+				if err != nil {
+					return
+				}
+				if isWhitespace(cc) || isTerminatingMacro(cc) {
+					r.unread()
+					break
+				}
+			}
+			skipReaderForm(r)
 		}
+	case '^':
+		// Metadata prefix (`^number x`, `^{:k v} x`, `^:kw x`): the metadata
+		// form and the form it attaches to are ONE logical value. Skip BOTH,
+		// or the trailing target (e.g. `size` in `^number size`) is left
+		// behind and desyncs the surrounding reader-conditional key/value
+		// pairing — which then consumes the closing `)` and swallows the
+		// rest of the file.
+		skipReaderForm(r) // the metadata form
+		skipReaderForm(r) // the form it attaches to
+	case '\'', '`', '~', '@':
+		// Quote / syntax-quote / unquote / deref prefixes each apply to the
+		// single following form. Skip that form so the prefix doesn't leave
+		// its target dangling. (`~@` composes: `~` skips a form starting with
+		// `@`, which in turn skips one more.)
+		skipReaderForm(r)
 	default:
 		// Atom (symbol, number, keyword, etc.) — skip to whitespace/delimiter
 		for {

--- a/pkg/compiler/reader.go
+++ b/pkg/compiler/reader.go
@@ -1240,12 +1240,12 @@ func skipReaderForm(r *LispReader) {
 		if err != nil {
 			return
 		}
-		switch {
-		case c == '(' || c == '{':
+		switch c {
+		case '(', '{':
 			// #(...) anon fn or #{...} set — balanced delimiters.
 			r.unread()
 			skipReaderForm(r)
-		case c == '"':
+		case '"':
 			// #"regex" — a string literal; skip to its closing quote.
 			for {
 				cc, err := r.next()
@@ -1258,10 +1258,10 @@ func skipReaderForm(r *LispReader) {
 					break
 				}
 			}
-		case c == '\'' || c == '_':
+		case '\'', '_':
 			// #'var-quote or #_discard — applies to the single next form.
 			skipReaderForm(r)
-		case c == '?':
+		case '?':
 			// Nested reader conditional #?(...) / #?@(...) inside a skipped
 			// branch — skip the whole (list) (consume the optional @ first).
 			cc, err := r.next()

--- a/pkg/compiler/reader_conditional_skip_test.go
+++ b/pkg/compiler/reader_conditional_skip_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Norman Nunley, Jr <nnunley@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+// A non-matching reader-conditional branch must be skipped in its entirety,
+// whatever syntax it contains. skipReaderForm used to under-skip several form
+// shapes (metadata prefixes, tagged literals, regex, quote prefixes, nested
+// conditionals, char literals/comments inside a list), leaving tokens behind
+// that desynced the surrounding conditional and swallowed following forms.
+//
+// Each case reads TWO forms: the conditional's :default value, then the form
+// immediately after the conditional. If the gnarly :clj branch is mis-skipped,
+// the trailing form is corrupted or never reached.
+func TestReaderConditionalSkipsGnarlyBranches(t *testing.T) {
+	type twoForms struct{ first, second vm.Value }
+	cases := map[string]twoForms{
+		"#?(:clj ^long size :default 1) 2":            {vm.Int(1), vm.Int(2)},   // metadata prefix
+		"#?(:clj #js [1 2] :default 3) 4":             {vm.Int(3), vm.Int(4)},   // tagged literal
+		"#?(:clj #\"a)b\" :default 5) 6":              {vm.Int(5), vm.Int(6)},   // regex containing )
+		"#?(:clj 'foo :default 7) 8":                  {vm.Int(7), vm.Int(8)},   // quote prefix
+		"#?(:clj #?(:bb 1 :default 2) :default 9) 10": {vm.Int(9), vm.Int(10)},  // nested conditional
+		"#?(:clj #'foo :default 11) 12":               {vm.Int(11), vm.Int(12)}, // var-quote
+		"#?(:clj #_ x :default 13) 14":                {vm.Int(13), vm.Int(14)}, // discard
+		"#?(:clj (a \\) b) :default 15) 16":           {vm.Int(15), vm.Int(16)}, // char literal ) inside list
+		"#?(:clj (a ; )\n b) :default 17) 18":         {vm.Int(17), vm.Int(18)}, // comment ) inside list
+	}
+	for p, e := range cases {
+		r := NewLispReader(strings.NewReader(p), "<reader>")
+		first, err := r.Read()
+		assert.NoErrorf(t, err, "first form of %q", p)
+		assert.Equalf(t, e.first, first, "first form of %q", p)
+		second, err := r.Read()
+		assert.NoErrorf(t, err, "second form of %q", p)
+		assert.Equalf(t, e.second, second, "second form of %q", p)
+	}
+}


### PR DESCRIPTION
`readConditional` skips a non-matching `#?(...)` branch with `skipReaderForm`, which consumes the value form without parsing it (the branch may contain dialect syntax the reader can't parse). `skipReaderForm` under-skipped several form shapes, leaving tokens behind that desynced the surrounding conditional and swallowed following forms — e.g. a `^long size` branch left `size` dangling, which was then mis-read as the next branch key and consumed the rest of the file.

## Forms now fully skipped

- **char literals (`\)`) and line comments (`;`) inside a balanced `(...)` form** — a `)` in a char literal or comment no longer corrupts the depth count
- **`#`-dispatch variants**: `#(`/`#{` anon-fn/set, `#"regex"` (closing quote, with `)` inside ignored), `#'var-quote`, `#_discard`, and nested `#?(...)` / `#?@(...)`
- **metadata prefixes `^...`** — skips both the metadata form and the form it attaches to (stacked `^:a ^:b x` resolves recursively)
- **quote-family prefixes `'` `` ` `` `~` `@`** — skips the following form

## Tests

Adds `TestReaderConditionalSkipsGnarlyBranches`, which reads two forms per case — the conditional's `:default` value and the form immediately after — so any desync from mis-skipping is caught. Covers metadata, tagged literals, regex-with-paren, quote, nested conditional, var-quote, discard, and char-literal/comment inside a list. Verified to fail without the change; full suite green (324 tests).