### PR TITLE
fix(vm): type dispatch — Object default, instance? on protocols, deftype fields, re-pattern

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3861,6 +3861,11 @@ func installLangNS() {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
 		}
+		// (re-pattern p) on an already-compiled regex returns it unchanged,
+		// matching Clojure where re-pattern accepts a Pattern, not only a String.
+		if r, ok := vs[0].(*vm.Regex); ok {
+			return r, nil
+		}
 		if s, ok := vs[0].(vm.String); ok {
 			return vm.NewRegex(string(s))
 		}
@@ -5782,6 +5787,12 @@ func installLangNS() {
 		// We accept type objects (e.g. IntType) and check if the value's type matches
 		if t, ok := vs[0].(vm.ValueType); ok {
 			return vm.Boolean(vs[1].Type() == t), nil
+		}
+		// A protocol behaves like an interface: (instance? SomeProtocol x) is a
+		// membership test, matching Clojure where defprotocol generates a host
+		// interface.
+		if p, ok := vs[0].(*vm.Protocol); ok {
+			return vm.Boolean(p.Satisfies(vs[1])), nil
 		}
 		return vm.FALSE, nil
 	})

--- a/pkg/vm/deftype.go
+++ b/pkg/vm/deftype.go
@@ -97,9 +97,17 @@ func (d *DTypeInstance) Hash() uint32 {
 }
 
 // InvokeMethod implements Receiver so (.fieldname instance) returns the field.
+// Both (.field x) and the explicit field-access form (.-field x) are accepted:
+// the reader hands the latter through as the member symbol "-field", so a
+// leading "-" is stripped before the field lookup (Clojure's .-field syntax).
 func (d *DTypeInstance) InvokeMethod(name Symbol, args []Value) (Value, error) {
 	if idx, ok := d.dtype.fieldIdx[name]; ok {
 		return d.fields[idx], nil
+	}
+	if len(name) > 1 && name[0] == '-' {
+		if idx, ok := d.dtype.fieldIdx[name[1:]]; ok {
+			return d.fields[idx], nil
+		}
 	}
 	return NIL, fmt.Errorf("no field %s on deftype %s", name, d.dtype.typeName)
 }

--- a/pkg/vm/protocol.go
+++ b/pkg/vm/protocol.go
@@ -57,27 +57,43 @@ func (p *Protocol) Lookup(methodName Symbol, target Value) (Fn, bool) {
 	}
 
 	vt := target.Type()
-	implMap, ok := p.impls[vt]
-	if !ok {
+	if fn, ok := p.lookupIn(p.impls[vt], key); ok {
+		return fn, true
+	}
+	// Fall back to a default extended onto Object (AnyType) — Clojure's
+	// (extend-type Object ...) universal default. Also covers a partial impl
+	// that is missing this particular method.
+	if vt != AnyType {
+		if fn, ok := p.lookupIn(p.impls[AnyType], key); ok {
+			return fn, true
+		}
+	}
+	return nil, false
+}
+
+// lookupIn pulls a method fn out of one type's impl map, if present.
+func (p *Protocol) lookupIn(implMap *PersistentMap, key Value) (Fn, bool) {
+	if implMap == nil {
 		return nil, false
 	}
-
 	v := implMap.ValueAt(key)
 	if v == NIL {
 		return nil, false
 	}
-
 	fn, ok := v.(Fn)
 	return fn, ok
 }
 
-// Satisfies returns true if the given value's type has an implementation.
+// Satisfies returns true if the given value's type has an implementation, or a
+// universal default was extended onto Object (AnyType).
 func (p *Protocol) Satisfies(target Value) bool {
 	if target == NIL {
-		return p.nilImpl != nil
+		return p.nilImpl != nil || p.impls[AnyType] != nil
 	}
-	_, ok := p.impls[target.Type()]
-	return ok
+	if _, ok := p.impls[target.Type()]; ok {
+		return ok
+	}
+	return p.impls[AnyType] != nil
 }
 
 // ProtocolFn is a function that dispatches on the first arg's type via a protocol.

--- a/test/type_dispatch_test.lg
+++ b/test/type_dispatch_test.lg
@@ -1,0 +1,60 @@
+;; Type-dispatch regression tests: protocol Object/universal default,
+;; instance? on a protocol, deftype .-field access, re-pattern idempotence.
+(ns test.type-dispatch-test
+  (:require [test :refer :all]))
+
+;; --- 1. protocol Object/universal default (extend-type Object) ---
+
+(defprotocol Describable
+  (describe [this]))
+
+(extend-type (type "")
+  Describable
+  (describe [s] (str "string:" s)))
+
+;; a universal default extended onto Object answers for every other type
+(extend-type Object
+  Describable
+  (describe [_] "default"))
+
+(deftest protocol-object-default
+  (testing "an explicit impl is used when present"
+    (is (= "string:hi" (describe "hi"))))
+  (testing "types without an explicit impl fall back to the Object default"
+    (is (= "default" (describe 42)))
+    (is (= "default" (describe :kw)))
+    (is (= "default" (describe [1 2])))))
+
+;; --- 2. instance? on a protocol is a membership test ---
+
+(defprotocol OnlyStrings
+  (only-str [this]))
+
+(extend-type (type "")
+  OnlyStrings
+  (only-str [s] s))
+
+(deftest instance-on-protocol
+  (testing "(instance? Protocol x) reflects protocol membership"
+    (is (instance? OnlyStrings "hi"))
+    (is (not (instance? OnlyStrings 42)))))
+
+;; --- 3. deftype .-field access ---
+
+(deftype Point [x y])
+
+(deftest deftype-field-access
+  (testing "both (.field p) and (.-field p) read the field"
+    (let [p (->Point 3 4)]
+      (is (= 3 (.x p)))
+      (is (= 4 (.y p)))
+      (is (= 3 (.-x p)))
+      (is (= 4 (.-y p))))))
+
+;; --- 4. re-pattern is idempotent on an already-compiled pattern ---
+
+(deftest re-pattern-idempotent
+  (testing "(re-pattern p) returns p unchanged when p is already a regex"
+    (is (= "42" (re-find (re-pattern #"\d+") "abc42def"))))
+  (testing "(re-pattern s) still compiles a string"
+    (is (= "42" (re-find (re-pattern "\\d+") "abc42def")))))


### PR DESCRIPTION
Four small, related type-dispatch correctness fixes.

## Fixes

1. **Protocol `Object`/universal default** (`protocol.go`). `Protocol.Lookup`/`Satisfies` now fall back to the impl extended onto `Object` (which maps to `AnyType`) when the target type has no explicit impl — enabling Clojure's `(extend-type Object ...)` universal default. The fallback also covers a *partial* impl that is missing the dispatched method. A `lookupIn` helper is extracted; the `vt != AnyType` guard avoids a redundant second lookup.

2. **`instance?` on a protocol** (`lang.go`). `(instance? SomeProtocol x)` is treated as a membership test (`protocol.Satisfies`), matching Clojure where `defprotocol` generates a host interface.

3. **`re-pattern` idempotence** (`lang.go`). `(re-pattern p)` returns `p` unchanged when it is already a compiled regex, matching Clojure where `re-pattern` accepts a `Pattern`, not only a `String`.

4. **deftype `.-field` access** (`deftype.go`). `InvokeMethod` strips a leading `-` so `(.-field x)` reads the field alongside `(.field x)` (exact match takes precedence).

## Tests

Adds `test/type_dispatch_test.lg` covering all four. Each was verified to fail without its specific fix (`describe` on a non-extended type errored; `instance?` returned false; `.-x` errored "no field -x"; `re-pattern` errored "regex expected String"). Full suite green (393 tests).