### PR TITLE
feat(os): add os/exec* — run a command with inherited stdio

### DIFF
--- a/pkg/rt/os.go
+++ b/pkg/rt/os.go
@@ -157,6 +157,40 @@ func installOsNS() {
 		}), nil
 	})
 
+	// os/exec* — (os/exec* cmd & args) → exit code (Int). Unlike os/sh, the
+	// child inherits the parent's stdin/stdout/stderr, so output streams and the
+	// child stays interactive (e.g. launching a REPL). Returns the exit code.
+	execStar, err := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) < 1 {
+			return vm.NIL, fmt.Errorf("os/exec* expects at least 1 arg")
+		}
+		cmdName, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("os/exec* expected String command")
+		}
+		cmdArgs := make([]string, len(vs)-1)
+		for i := 1; i < len(vs); i++ {
+			if s, ok := vs[i].(vm.String); ok {
+				cmdArgs[i-1] = string(s)
+			} else {
+				cmdArgs[i-1] = vs[i].String()
+			}
+		}
+		cmd := exec.Command(string(cmdName), cmdArgs...)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		exitCode := 0
+		if runErr := cmd.Run(); runErr != nil {
+			if exitErr, ok := runErr.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			} else {
+				return vm.NIL, runErr
+			}
+		}
+		return vm.Int(exitCode), nil
+	})
+
 	if err != nil {
 		panic(fmt.Sprintf("os NS init failed: %e", err))
 	}
@@ -174,6 +208,7 @@ func installOsNS() {
 	ns.Def("ls", ls)
 	ns.Def("stat", stat)
 	ns.Def("sh", sh)
+	ns.Def("exec*", execStar)
 
 	// os/os-name — (os/os-name) → "linux", "darwin", "windows", ...
 	ns.Def("os-name", mustWrap(func(vs []vm.Value) (vm.Value, error) {

--- a/test/os_exec_star_test.lg
+++ b/test/os_exec_star_test.lg
@@ -1,0 +1,12 @@
+;; os/exec* runs a command with inherited stdio and returns its exit code.
+(ns test.os-exec-star-test
+  (:require [test :refer :all]))
+
+(deftest exec-star-exit-codes
+  (testing "returns 0 for a successful command"
+    (is (= 0 (os/exec* "true"))))
+  (testing "returns the non-zero exit code of a failing command"
+    (is (= 1 (os/exec* "false")))
+    (is (= 3 (os/exec* "sh" "-c" "exit 3"))))
+  (testing "coerces non-string args to strings"
+    (is (= 0 (os/exec* "sh" "-c" "exit 0")))))


### PR DESCRIPTION
`os/sh` captures stdout/stderr into a result map and gives the child a dead stdin — so it can't stream output and can't run anything interactive (a child REPL gets immediate EOF and exits). There was no way to launch an interactive subprocess from let-go.

`os/exec*` fills that gap: it runs a command with the parent's **stdin/stdout/stderr inherited**, and returns the child's exit code.

```clojure
(os/exec* "true")              ;=> 0
(os/exec* "false")             ;=> 1
(os/exec* "sh" "-c" "exit 3")  ;=> 3
(os/exec* "lg" "-r" "app.lg")  ; drops you into an interactive REPL
```

Arg handling mirrors `os/sh` (first arg the command String, rest coerced to strings); a non-`ExitError` failure (e.g. command not found) surfaces as a let-go error.

This is the primitive an inherited-stdio process runner needs — e.g. lgx's runner, whose own TODO reads *"stdin is dead (so -r REPL will not work). Replace with an inherited-stdio runner once let-go ships one."*

## Tests

Adds `test/os_exec_star_test.lg` (exit-code propagation for success/failure/explicit codes; verified to fail with "Can't resolve os/exec*" without the change). Full suite green (193 tests in rt + test).