### PR TITLE
feat(math): expose the math namespace as clojure.math too

### DIFF
--- a/pkg/rt/math.go
+++ b/pkg/rt/math.go
@@ -75,9 +75,19 @@ func mathFn2(f func(float64, float64) float64) vm.Value {
 
 func init() { RegisterInstaller(installMathNS) }
 
-// nolint
+// installMathNS registers the math functions under both "math" (let-go's
+// historical name) and "clojure.math" (the namespace Clojure actually uses, so
+// stock libraries that (require 'clojure.math) load). The contents are
+// identical; each name gets its own namespace object.
 func installMathNS() {
-	ns := vm.NewNamespace("math")
+	for _, name := range []string{"math", "clojure.math"} {
+		installMathInto(name)
+	}
+}
+
+// nolint
+func installMathInto(nsName string) {
+	ns := vm.NewNamespace(nsName)
 	ns.Refer(CoreNS, "", true)
 
 	// Intentional shadows of clojure.core names — suppress warn-on-shadow.

--- a/test/clojure_math_test.lg
+++ b/test/clojure_math_test.lg
@@ -1,0 +1,19 @@
+;; clojure.math is available under its real Clojure name (not only `math`).
+(ns test.clojure-math-test
+  (:require [clojure.math :as m]
+            [test :refer :all]))
+
+(deftest clojure-math-is-requirable
+  (testing "(require 'clojure.math) works and its functions behave"
+    (is (= 3 (m/round 2.7)))          ; round -> long
+    (is (= 4.0 (m/sqrt 16)))
+    (is (= 1024.0 (m/pow 2 10)))
+    (is (= 1.0 (m/floor 1.9)))
+    (is (= 2.0 (m/ceil 1.1)))
+    (is (< 3.14 m/PI 3.15))
+    (is (= 7 (m/floor-div 15 2)))))
+
+(deftest math-alias-still-works
+  (testing "the historical `math` namespace is unchanged"
+    (is (= 5 (math/round 5.2)))
+    (is (= 3.0 (math/sqrt 9)))))


### PR DESCRIPTION
let-go already implements the **full** `clojure.math` API in `pkg/rt/math.go` — trig, hyperbolic, exp/log, `pow`/`sqrt`/`cbrt`, `round`/`floor`/`ceil`/`rint`, the exact-arithmetic family, `floor-div`/`floor-mod`, `hypot`, `signum`, `ulp`, angle conversion, `PI`/`E`, and so on. It was just registered under the name **`math`**, while Clojure's actual namespace is **`clojure.math`** (added in Clojure 1.11). So stock libraries that `(require 'clojure.math)` — e.g. `malli.transform`, which uses `clojure.math/round` — couldn't load on let-go.

This registers the identical contents under **both** `math` and `clojure.math`:

```clojure
(require 'clojure.math)
(clojure.math/round 2.7)   ;=> 3
(clojure.math/sqrt 16)     ;=> 4.0
clojure.math/PI            ;=> 3.141592653589793
(clojure.math/floor-div 15 2) ;=> 7
```

The function-defining body is factored into `installMathInto(nsName)` and run for each name; each gets its own namespace object. `math` is unchanged (regression-tested).

## Tests

Adds `test/clojure_math_test.lg` covering `clojure.math` (round/sqrt/pow/floor/ceil/PI/floor-div) and a regression check that `math` still works. Verified to fail ("unable to load namespace clojure.math") without the change. Full suite green (193 tests). No bundle regeneration — this is a Go-registered namespace.