### PR TITLE
docs(readme): document :lg reader-conditional portability convention (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,38 @@ It shares `~/.babashka/pods/` with `bb`, so install pods with babashka and use
 them from `lg`. See the [pod registry](https://github.com/babashka/pod-registry)
 for what's available.
 
+### Portable code (`:lg` reader conditionals)
+
+let-go ships some namespaces of its own — e.g. `let-go.semver` — that JVM
+Clojure can't load. To keep shared code loadable on both, guard the let-go-only
+parts behind `:lg` reader conditionals. The reader always matches `:lg` and
+`:default`, and matches `:clj` / `:bb` only when opted in. JVM Clojure has no
+idea what `:lg` is, so it skips those branches entirely — the same way it skips
+a `:cljs` branch:
+
+```clojure
+(ns my.app
+  ;; only let-go reads the :lg branch; Clojure never tries to load let-go.semver
+  #?(:lg (:require [let-go.semver :as semver])))
+
+(defn normalize [s]
+  ;; the semver alias appears only inside the :lg branch, so a non-let-go reader
+  ;; never sees an unresolved symbol
+  #?(:lg (semver/render (semver/version s))
+     :default s))
+```
+
+This has to be guarded at **read** time: a missing namespace or an unresolved
+symbol fails at compile time, before any `when`/`if` could intervene. Two
+things to know:
+
+- **Use `.cljc`.** Clojure only honors `#?` in `.cljc` files. let-go reads `#?`
+  in any file and its loader resolves `.lg` → `.cljc` → `.clj`, so a shared file
+  should just be `.cljc`.
+- **Put `:lg` before `:clj`.** First match wins. If a let-go user opted into
+  `:clj` matching to consume a Clojure library, then in `#?(:clj … :lg …)`
+  let-go would take the `:clj` branch.
+
 ## Known limitations
 
 ### Not implemented


### PR DESCRIPTION
Documents the `:lg` reader-conditional convention for keeping let-go-specific code (e.g. `let-go.semver`, and the future `require-letgo`) from breaking JVM Clojure when shared code is loaded there — the portability concern raised in #132.

Adds a **Portable code (`:lg` reader conditionals)** subsection under Compatibility covering:
- `:lg` is always matched by let-go and never by JVM Clojure (which skips it like a `:cljs` branch), so it's the guard marker.
- The idiom: guard both the `:require` and the body so a non-let-go reader never sees the require or an unresolved alias.
- Why it must be a **read-time** guard (eval-time is too late).
- Two gotchas: use `.cljc` (Clojure only honors `#?` there; let-go's loader resolves `.lg`→`.cljc`→`.clj`), and put `:lg` before `:clj` (first match wins).

Docs-only. The runnable regression guard for this behavior already landed with #160 (`test/portable-consumer.cljc`, `test/portable-foreign.cljc`, `test/lg_portability_test.lg`).