### PR TITLE
docs: README index + status frontmatter (#159)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,60 @@
+# let-go docs
+
+Design plans, execution roadmaps, and policy for the let-go implementation. Each doc carries a `status:` frontmatter line indicating whether it's the current authority or has been superseded. See "What's current" below.
+
+## What's current
+
+`contribution-policy.md` is the most authoritative doc on overall direction (self-host as committed direction, `gogen_ir` deployment path, CI gates, callback error contract, `:go-deps` interop schema). Where it disagrees with older docs on direction, it wins.
+
+`master-plan.md` is still the useful phase skeleton (Phases 0–9 covering semantics, VM perf, collections, transducers, runtime images). Read it for the staging structure; cross-reference `contribution-policy.md` for any direction question.
+
+## Topical map
+
+| Concern | Doc(s) |
+|---|---|
+| Design contracts, CI gates, interop schema | `contribution-policy.md` |
+| Phase skeleton, success metrics | `master-plan.md` |
+| Calling convention, allocation, TCO | `vm-performance-optimization.md` |
+| Numeric/value representation | `value-representation-and-numeric-performance.md` |
+| Persistent collections, seq tower, transients | `clojurelike-refactor-plan.md` |
+| Equality/hashing across types | `clojurelike-refactor-plan.md` (Phase 3) |
+| Transducers, reduction fast paths | `clojurelike-refactor-plan.md` (Phase 4) |
+| Runtime image / stdlib precompile | `runtime-image-and-stdlib-cache.md` |
+| Go AOT / self-host deployment | `go-aot-backend.md` + `contribution-policy.md` §2–3 |
+| JVM-shape interop (strategy) | `jvm-compat-plan.md` |
+| JVM-shape interop (execution) | `clojure-compat-roadmap.md` |
+| Real-world Clojure compat findings | `xsofy-portability-gaps.md` |
+| Clojure-test-suite (jank) workflow | `clojure-test-suite.md` |
+| Testing strategy, conformance | `testing-and-conformance.md` |
+| Perf ratchet, regression checkpoints, historical baselines | `perf/ratchet.md` |
+| Babashka pod support | `pods.md` |
+| IR fixup / link pass | `els2023-ir-fixup-audit.md` |
+| Parallel IR lowering + determinism | `parallel-lowering-and-type-cache.md` |
+
+## Reading order if starting cold
+
+1. **`contribution-policy.md`** — current commitments, design contracts, interop schema, CI gates.
+2. **`master-plan.md`** — the phased skeleton.
+3. **`clojurelike-refactor-plan.md`** — semantic foundation under most of the collections/perf work.
+4. Pick concerns from the topical map as needed.
+5. **`clojure-compat-roadmap.md`** — only if working on Clojure-library compat specifically.
+
+## Status conventions
+
+Every doc carries frontmatter:
+
+```yaml
+---
+status: planning | active | shipped | superseded | archived
+last-verified: YYYY-MM-DD
+supersedes: [...]       # optional
+superseded-by: [...]    # optional
+shipped: [...]          # optional, for partial-shipped docs
+remaining-open: [...]   # optional, for partial-shipped docs
+authoritative-for: [...]  # optional, used by this index
+---
+```
+
+`status` describes the *doc*, not the underlying work. A doc that proposed a feature can stay `active` after the feature ships if it's still the authority on the design rationale; the shipped items move to a `shipped:` list and the doc itself carries forward.
+
+When a feature ships, add a dated `Shipped:` annotation in the relevant section of the doc body, pointing at the commit or PR. The doc stays in place; the status updates. When a newer doc takes over on a topic, link the supersession in both directions via the frontmatter rather than deleting the older doc.

--- a/docs/contribution-policy.md
+++ b/docs/contribution-policy.md
@@ -1,3 +1,17 @@
+---
+status: active
+last-verified: 2026-06-01
+authoritative-for:
+  - design-contracts
+  - regression-checkpoints
+  - callback-error-contract
+  - go-deps-schema
+  - host-interop-syntax-map
+  - wasm-constraints
+supersedes:
+  - master-plan.md (on direction — self-host as committed direction, gogen_ir as deployment path)
+---
+
 # Contribution policy
 
 This document captures the design contracts, regression checkpoints, and

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -1,3 +1,14 @@
+---
+status: active
+last-verified: 2026-06-01
+authoritative-for:
+  - phase-skeleton
+  - success-metrics
+  - cross-cutting-benchmarks-and-ci
+superseded-by:
+  - contribution-policy.md (on direction — Phase 7 Go AOT is the committed deployment path, not optional)
+---
+
 ## let-go master plan — fastest and most useful Clojure-on-Go
 
 This roadmap consolidates our existing plans for VM performance, Clojure-like collections, numeric and value representation, and runtime images. It defines staged milestones, success criteria, and dependencies to make let-go the fastest and most useful Clojure-on-Go implementation.

--- a/docs/xsofy-portability-gaps.md
+++ b/docs/xsofy-portability-gaps.md
@@ -1,3 +1,20 @@
+---
+status: active
+last-verified: 2026-06-01
+authoritative-for:
+  - xsofy-side-clojure-compat-evidence
+  - intentional-jvm-divergences
+shipped:
+  - A1 (class-less catch — pkg/compiler/compiler.go:799-820)
+  - A3 (int-array / byte-array / long-array constructors — pkg/rt/lang.go:6738-6760)
+  - D2 (hex BigInt promotion — #70, in v1.8.0+)
+  - D3 (unchecked-* coercion — #66, in v1.8.0+)
+  - D4 (destructure-shadow-in-loop bug — #68, in v1.8.0+)
+  - D5 (clojure.core shadow warnings — #69, in v1.8.0+)
+remaining-open:
+  - A2 aset polymorphism (recommendation in doc: keep behavior, document as intentional divergence)
+---
+
 # let-go ↔ Clojure JVM portability gaps surfaced by xsofy
 
 Real-world portability findings from attempting to load


### PR DESCRIPTION
Implements the proposal in #159 — `docs/README.md` orientation index plus status frontmatter applied to three representative docs as worked examples.

## What's in the PR

- **`docs/README.md`** — "what's current" callout, topical map across the corpus, reading order for newcomers, frontmatter convention spec.
- **Frontmatter on three worked examples:**
  - `contribution-policy.md` — `active`, authoritative on multiple topics, supersedes `master-plan.md` on direction.
  - `master-plan.md` — `active`, superseded-on-direction by `contribution-policy.md`, still the useful phase skeleton.
  - `xsofy-portability-gaps.md` — `active` for evidence/divergences, with `shipped:` and `remaining-open:` lists naming items that have landed (A1, A3, D2–D5) and what hasn't (A2).

Retrofit of the remaining ~12 docs is deliberately out of scope here — second pass if the pattern lands.

## Open discussion

#159 has the design conversation, including @nnunley's three follow-on proposals (frontmatter-maintenance pre-commit hook, deletion-tombstone slice, `human-verified:` attestation field). The frontmatter shape may evolve before merge depending on consensus there — happy to update this PR with any changes that land.

## Explicit non-goals

Folder reorg, full ADR system, broader archival/deletion policy — deferred.