### PR TITLE
test(bench): fixed-workload program benchmark from benchmark/*.clj

### DIFF
--- a/pkg/compiler/programs_bench_test.go
+++ b/pkg/compiler/programs_bench_test.go
@@ -1,0 +1,48 @@
+package compiler
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// BenchmarkPrograms runs the fixed Clojure programs under benchmark/*.clj as
+// end-to-end workloads. Each program is compiled ONCE (outside the timer); the
+// timed loop only executes the compiled chunk, so this measures execution speed
+// of the compiled output — the axis the IR-optimization pipeline affects. The
+// .clj files are committed and identical across versions, so this is a stable
+// cross-version comparison (unlike BenchmarkClojureTestSuite, whose workload is
+// the evolving test suite).
+func BenchmarkPrograms(b *testing.B) {
+	dir := filepath.Join("..", "..", "benchmark")
+	files, err := filepath.Glob(filepath.Join(dir, "*.clj"))
+	if err != nil || len(files) == 0 {
+		b.Skipf("no benchmark programs found in %s", dir)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".clj")
+		src, err := os.ReadFile(f)
+		if err != nil {
+			b.Fatalf("read %s: %v", f, err)
+		}
+		b.Run(name, func(b *testing.B) {
+			consts := vm.NewConsts()
+			ctx := NewCompiler(consts, rt.NS(rt.NameCoreNS))
+			chunk, _, err := ctx.CompileMultiple(strings.NewReader(string(src)))
+			if err != nil {
+				b.Skipf("compile %s: %v", name, err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				fr := vm.NewFrame(chunk, nil)
+				fr.Run()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #97. Adds `BenchmarkPrograms` (pkg/compiler) — a fixed-workload, end-to-end benchmark driven by the committed `benchmark/*.clj` programs (fib, tak, map-filter, reduce, persistent-map, loop-recur, transducers).

Each program is compiled **once** (outside the timer); the timed loop executes the compiled chunk, so it measures **execution speed of the compiled output** — the axis the IR-optimization pipeline affects. Unlike `BenchmarkClojureTestSuite` (whose workload is the evolving test suite), the `.clj` files are committed and identical across versions, making this a stable cross-version gate.

## Why

Used it to answer "are the compiled IR optimizations better or worse than v1.8.0?" — measured against the v1.8.0 release (same M3, identical workloads, benchstat, n=6):

| program | v1.8.0 | current | Δ |
|---|---|---|---|
| map-filter | 165µs | 69µs | −58% |
| reduce | 54.3ms | 39.3ms | −28% |
| transducers | 34.1ms | 25.3ms | −26% |
| persistent-map | 8.5ms | 6.6ms | −23% |
| tak | 1.92s | 1.65s | −14% |
| fib | 1.86s | 1.65s | −11% |
| loop-recur | 42.5ms | 46.3ms | +9% |
| **geomean** | **45.4ms** | **34.4ms** | **−24%** |

Net ~24% faster execution vs v1.8.0; one regression (`loop-recur` +9%, p=0.002) noted for follow-up.

No production code; benchmark only.