### PR TITLE
feat(tooling): fanout-ratchet — generated-code-size gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,5 +213,20 @@ check-generated: $(GO)
 		exit 1; \
 	fi
 
+# Fanout ratchet: gate on the size of the generated -tags gogen_ir lowered tree.
+# Gates the byte-sum of ALREADY-TRACKED modules against a percent band; new
+# modules are exempt. Baseline is docs/perf/fanout-baseline.edn (committed).
+#   fanout-ratchet         regenerate tree, fail on tracked-module bloat > band
+#   fanout-ratchet-update  recompute + MIN-merge the baseline (tighten-only)
+#   fanout-ratchet-show    print current metrics, write nothing
+fanout-ratchet: build
+	./lg scripts/fanout-ratchet.lg check --go "$$(command -v go)"
+
+fanout-ratchet-update: build
+	./lg scripts/fanout-ratchet.lg update --go "$$(command -v go)"
+
+fanout-ratchet-show: build
+	./lg scripts/fanout-ratchet.lg show --go "$$(command -v go)"
+
 # PHONY targets are for ones that have conflicting files/dirs present:
-.PHONY: test bench-ratchet bench-ratchet-update bench-ratchet-show install-hooks check-generated
+.PHONY: test bench-ratchet bench-ratchet-update bench-ratchet-show install-hooks check-generated fanout-ratchet fanout-ratchet-update fanout-ratchet-show

--- a/docs/perf/fanout-baseline.edn
+++ b/docs/perf/fanout-baseline.edn
@@ -1,0 +1,26 @@
+{:total-bytes 1283546
+ :total-loc 49593
+ :files 25
+ :modules {"_wireup" {:bytes 4585 :loc 90 :files 3}
+           "edn" {:bytes 774 :loc 30 :files 1}
+           "hash" {:bytes 1826 :loc 62 :files 1}
+           "io" {:bytes 1069 :loc 39 :files 1}
+           "ir_build" {:bytes 322345 :loc 11968 :files 1}
+           "ir_data_generated" {:bytes 33347 :loc 922 :files 1}
+           "ir_dominance" {:bytes 23479 :loc 986 :files 1}
+           "ir_dump" {:bytes 54076 :loc 1933 :files 1}
+           "ir_lower" {:bytes 109950 :loc 4438 :files 1}
+           "ir_lower_go" {:bytes 321768 :loc 13510 :files 1}
+           "ir_passes" {:bytes 2454 :loc 67 :files 1}
+           "ir_passes_constfold" {:bytes 18681 :loc 914 :files 1}
+           "ir_passes_cse" {:bytes 8275 :loc 313 :files 1}
+           "ir_passes_dce" {:bytes 7161 :loc 277 :files 1}
+           "ir_passes_infer_arg_types" {:bytes 7424 :loc 339 :files 1}
+           "ir_passes_licm" {:bytes 70743 :loc 2410 :files 1}
+           "ir_passes_mutability" {:bytes 11699 :loc 465 :files 1}
+           "ir_passes_pipeline" {:bytes 97217 :loc 3220 :files 1}
+           "ir_passes_trace" {:bytes 23302 :loc 682 :files 1}
+           "ir_passes_typeinfer" {:bytes 106481 :loc 4861 :files 1}
+           "ir_validate" {:bytes 34102 :loc 1267 :files 1}
+           "test" {:bytes 3026 :loc 80 :files 1}
+           "walk" {:bytes 19762 :loc 720 :files 1}}}

--- a/scripts/fanout-ratchet.lg
+++ b/scripts/fanout-ratchet.lg
@@ -148,7 +148,39 @@
         (do (println "FANOUT REGRESSION: tracked modules grew beyond band.") (os/exit 1))
         (do (println "OK: tracked fanout within band.") (os/exit 0))))))
 
+;; MIN-merge current into baseline: existing modules tighten (MIN per metric),
+;; new modules added at current size, removed modules drop. :total-bytes is
+;; DERIVED from the merged module map (never MIN'd independently), so total and
+;; modules can never disagree.
+(defn merge-baseline [current baseline]
+  (let [base-mods (:modules baseline)
+        merged (reduce
+                 (fn [acc pair]
+                   (let [m (first pair) cur-e (second pair)
+                         base-e (get base-mods m)]
+                     (assoc acc m
+                       (if base-e
+                         {:bytes (min (:bytes base-e) (:bytes cur-e))
+                          :loc   (min (:loc base-e) (:loc cur-e))
+                          :files (:files cur-e)}
+                         cur-e))))
+                 {} (:modules current))]
+    {:total-bytes (reduce + 0 (map :bytes (vals merged)))
+     :total-loc   (reduce + 0 (map :loc   (vals merged)))
+     :files       (reduce + 0 (map :files (vals merged)))
+     :modules     merged}))
+
+(defn do-update []
+  (regen!)
+  (let [current  (collect-metrics tree-dir wireup-files)
+        baseline (read-baseline baseline-path)
+        merged   (if baseline (merge-baseline current baseline) current)]
+    (spit baseline-path (metrics->edn merged))
+    (println (str "wrote " baseline-path " (total-bytes " (:total-bytes merged) ")"))
+    (os/exit 0)))
+
 (cond
-  (= subcommand "show")  (do-show)
-  (= subcommand "check") (do-check)
+  (= subcommand "show")   (do-show)
+  (= subcommand "check")  (do-check)
+  (= subcommand "update") (do-update)
   :else (die (str "unknown subcommand " (pr-str subcommand) " — use check|update|show")))

--- a/scripts/fanout-ratchet.lg
+++ b/scripts/fanout-ratchet.lg
@@ -63,6 +63,33 @@
 (defn module-bytes [metrics m]
   (let [e (get (:modules metrics) m)] (if e (:bytes e) 0)))
 
+(defn read-baseline [path]
+  (when (file-exists? path) (read-string (slurp path))))
+
+;; items in seq `a` not present in seq `b`
+(defn set-diff [a b]
+  (let [bset (set b)]
+    (vec (filter (fn [x] (not (contains? bset x))) a))))
+
+;; sum of CURRENT bytes over only the modules present in the baseline (tracked set)
+(defn gated-total [current baseline]
+  (reduce + 0 (map (fn [m] (module-bytes current m)) (keys (:modules baseline)))))
+
+(defn limit-for [baseline-bytes]
+  (quot (* baseline-bytes (+ 100 threshold-pct)) 100))
+
+(defn compare-result [current baseline]
+  (let [base-mods (keys (:modules baseline))
+        cur-mods  (keys (:modules current))
+        gated     (gated-total current baseline)
+        limit     (limit-for (:total-bytes baseline))]
+    {:status   (if (> gated limit) :regression :ok)
+     :gated    gated
+     :baseline (:total-bytes baseline)
+     :limit    limit
+     :new      (sort (set-diff cur-mods base-mods))
+     :removed  (sort (set-diff base-mods cur-mods))}))
+
 ;; Build {module {:bytes :loc :files}} + totals over the tree + present wireup files.
 (defn collect-metrics [tree-dir wireup]
   (let [tree-files (list-go-files tree-dir)
@@ -107,6 +134,21 @@
   (print (metrics->edn (collect-metrics tree-dir wireup-files)))
   (os/exit 0))
 
+(defn do-check []
+  (regen!)
+  (let [current  (collect-metrics tree-dir wireup-files)
+        baseline (read-baseline baseline-path)]
+    (when-not baseline (die (str "no baseline at " baseline-path " — run 'update' first")))
+    (let [r (compare-result current baseline)]
+      (println (str "tracked gated bytes: " (:gated r) " / limit " (:limit r)
+                    " (baseline " (:baseline r) " +" threshold-pct "%)"))
+      (when (seq (:new r))     (println (str "NEW modules (exempt): " (:new r))))
+      (when (seq (:removed r)) (println (str "removed modules: " (:removed r))))
+      (if (= :regression (:status r))
+        (do (println "FANOUT REGRESSION: tracked modules grew beyond band.") (os/exit 1))
+        (do (println "OK: tracked fanout within band.") (os/exit 0))))))
+
 (cond
-  (= subcommand "show") (do-show)
+  (= subcommand "show")  (do-show)
+  (= subcommand "check") (do-check)
   :else (die (str "unknown subcommand " (pr-str subcommand) " — use check|update|show")))

--- a/scripts/fanout-ratchet.lg
+++ b/scripts/fanout-ratchet.lg
@@ -1,0 +1,112 @@
+;; scripts/fanout-ratchet.lg — generated-code-size gate (the "fanout ratchet").
+;;
+;; Measures the -tags gogen_ir lowered tree (pkg/rt/core_go_lowered/**/*.go plus
+;; the three wireup files) and compares its size against a committed EDN
+;; baseline, failing when ALREADY-TRACKED modules bloat beyond a percent band.
+;; New modules are exempt (adding an IR module is an expected addition, not a
+;; regression). The ratchet only tightens.
+;;
+;; Subcommands:  check | update | show
+;; Flags:
+;;   --go <path>        go binary for regeneration    (default "go")
+;;   --tree-dir <dir>   lowered tree root             (default "pkg/rt/core_go_lowered")
+;;   --baseline <path>  baseline EDN                  (default "docs/perf/fanout-baseline.edn")
+;;   --threshold <pct>  allowed growth, integer pct   (default "5")
+;;   --no-regen         skip regeneration (use tree as-is; for tests/fixtures)
+
+(defn flag [argv name default]
+  (loop [xs argv]
+    (cond
+      (empty? xs)         default
+      (= (first xs) name) (second xs)
+      :else               (recur (rest xs)))))
+
+(defn has-flag? [argv name]
+  (loop [xs argv]
+    (cond
+      (empty? xs)         false
+      (= (first xs) name) true
+      :else               (recur (rest xs)))))
+
+(def argv          (drop 2 os/args))
+(def subcommand    (first argv))
+(def go-bin        (flag argv "--go" "go"))
+(def tree-dir      (flag argv "--tree-dir" "pkg/rt/core_go_lowered"))
+(def baseline-path (flag argv "--baseline" "docs/perf/fanout-baseline.edn"))
+(def threshold-pct (read-string (flag argv "--threshold" "5")))
+(def no-regen?     (has-flag? argv "--no-regen"))
+(def no-wireup?    (has-flag? argv "--no-wireup"))
+
+;; The three gogen_ir wireup files live OUTSIDE the tree dir. Counted under a
+;; synthetic "_wireup" module; missing ones are skipped (fixtures lack them).
+(def wireup-files
+  ["lg_gogen_ir.go" "cmd/lgbgen/main_gogen_ir.go" "pkg/ir/zz_gogen_ir_wire_test.go"])
+
+(defn die [msg] (println "fanout-ratchet ERROR:" msg) (os/exit 2))
+
+(defn file-exists? [path] (= 0 (:exit (os/sh "test" "-f" path))))
+
+;; List *.go files under dir (recursive). Empty vec if dir missing.
+(defn list-go-files [dir]
+  (let [r (os/sh "find" dir "-name" "*.go" "-type" "f")]
+    (if (= 0 (:exit r)) (vec (re-seq #"[^\n]+" (:out r))) [])))
+
+;; Size in chars (== bytes for the ASCII gofmt'd corpus). Deterministic; no
+;; per-file subprocess.
+(defn file-size [path] (count (slurp path)))
+(defn file-loc  [path] (count (re-seq #"\n" (slurp path))))
+
+;; Parent-directory name: ".../ir_lower_go/ir_lower_go.go" -> "ir_lower_go".
+(defn parent-dir [path]
+  (let [m (re-find #"([^/]+)/[^/]+$" path)] (if m (second m) "_root")))
+
+(defn module-bytes [metrics m]
+  (let [e (get (:modules metrics) m)] (if e (:bytes e) 0)))
+
+;; Build {module {:bytes :loc :files}} + totals over the tree + present wireup files.
+(defn collect-metrics [tree-dir wireup]
+  (let [tree-files (list-go-files tree-dir)
+        wf         (if no-wireup? [] (filter file-exists? wireup))
+        entries    (concat (map (fn [p] [(parent-dir p) p]) tree-files)
+                           (map (fn [p] ["_wireup" p]) wf))
+        modules    (reduce
+                     (fn [acc pair]
+                       (let [m (first pair) p (second pair)
+                             b (file-size p) l (file-loc p)
+                             cur (get acc m {:bytes 0 :loc 0 :files 0})]
+                         (assoc acc m {:bytes (+ (:bytes cur) b)
+                                       :loc   (+ (:loc cur) l)
+                                       :files (+ (:files cur) 1)})))
+                     {} entries)]
+    {:total-bytes (reduce + 0 (map :bytes (vals modules)))
+     :total-loc   (reduce + 0 (map :loc   (vals modules)))
+     :files       (reduce + 0 (map :files (vals modules)))
+     :modules     modules}))
+
+;; --- deterministic, diff-friendly EDN emission (sorted module keys) ---
+(defn module->edn [m e]
+  (str "            \"" m "\" {:bytes " (:bytes e) " :loc " (:loc e) " :files " (:files e) "}"))
+
+(defn metrics->edn [metrics]
+  (let [mods  (sort (keys (:modules metrics)))
+        lines (map (fn [m] (module->edn m (get (:modules metrics) m))) mods)]
+    (str "{:total-bytes " (:total-bytes metrics) "\n"
+         " :total-loc " (:total-loc metrics) "\n"
+         " :files " (:files metrics) "\n"
+         " :modules {\n"
+         (reduce (fn [a l] (str a l "\n")) "" lines)
+         "           }}\n")))
+
+(defn regen! []
+  (when-not no-regen?
+    (let [r (os/sh go-bin "run" "-tags" "bootstrap" "./cmd/lgbgen" "--target=go")]
+      (when-not (= 0 (:exit r)) (die (str "regeneration failed: " (:err r)))))))
+
+(defn do-show []
+  (regen!)
+  (print (metrics->edn (collect-metrics tree-dir wireup-files)))
+  (os/exit 0))
+
+(cond
+  (= subcommand "show") (do-show)
+  :else (die (str "unknown subcommand " (pr-str subcommand) " — use check|update|show")))

--- a/test/fanout_ratchet_test.go
+++ b/test/fanout_ratchet_test.go
@@ -1,0 +1,89 @@
+package test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// lgBin is the lg binary built once for all fanout-ratchet integration tests.
+var lgBin string
+
+// repoRoot is the absolute path to the repository root (tests run from test/).
+var repoRoot string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "lg-fanout-*")
+	if err != nil {
+		panic(err)
+	}
+	lgBin = filepath.Join(tmp, "lg-bin")
+	build := exec.Command("go", "build", "-o", lgBin, "../")
+	build.Dir = "."
+	if out, err := build.CombinedOutput(); err != nil {
+		panic("build lg: " + err.Error() + "\n" + string(out))
+	}
+	repoRoot, _ = filepath.Abs("..")
+	code := m.Run()
+	os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
+// runRatchet runs scripts/fanout-ratchet.lg with args from repo root; returns
+// combined output and exit code.
+func runRatchet(t *testing.T, args ...string) (string, int) {
+	t.Helper()
+	full := append([]string{"scripts/fanout-ratchet.lg"}, args...)
+	cmd := exec.Command(lgBin, full...)
+	cmd.Dir = repoRoot
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run ratchet: %v\noutput:\n%s", err, out.String())
+	}
+	return out.String(), code
+}
+
+// writeModule writes <dir>/<module>/<module>.go with exactly `size` bytes
+// (size-1 'a's + trailing newline). file-size in the script == chars == bytes.
+func writeModule(t *testing.T, treeDir, module string, size int) {
+	t.Helper()
+	d := filepath.Join(treeDir, module)
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Repeat("a", size-1) + "\n"
+	if err := os.WriteFile(filepath.Join(d, module+".go"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeBaseline(t *testing.T, path, edn string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(edn), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFanoutShow(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "a", 1000)
+	out, code := runRatchet(t, "show", "--no-regen", "--no-wireup", "--tree-dir", tree)
+	if code != 0 {
+		t.Fatalf("show exit=%d, want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, ":total-bytes 1000") {
+		t.Errorf("expected :total-bytes 1000 in output:\n%s", out)
+	}
+	if !strings.Contains(out, "\"a\"") {
+		t.Errorf("expected module \"a\" in output:\n%s", out)
+	}
+}

--- a/test/fanout_ratchet_test.go
+++ b/test/fanout_ratchet_test.go
@@ -144,3 +144,65 @@ func TestFanoutCheckNewModuleExempt(t *testing.T) {
 		t.Errorf("expected NEW module c reported:\n%s", out)
 	}
 }
+
+func TestFanoutUpdateTightens(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "a", 800) // shrank from 1000
+	writeModule(t, tree, "b", 1000)
+	bl := filepath.Join(t.TempDir(), "base.edn")
+	writeBaseline(t, bl, fixtureBaseline)
+	_, code := runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	if code != 0 {
+		t.Fatalf("update exit=%d, want 0", code)
+	}
+	got, _ := os.ReadFile(bl)
+	s := string(got)
+	if !strings.Contains(s, ":total-bytes 1800") {
+		t.Errorf("expected total-bytes tightened to 1800:\n%s", s)
+	}
+	if !strings.Contains(s, "\"a\" {:bytes 800") {
+		t.Errorf("expected a tightened to 800:\n%s", s)
+	}
+}
+
+func TestFanoutUpdateFoldsNewModule(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "a", 1000)
+	writeModule(t, tree, "b", 1000)
+	writeModule(t, tree, "c", 500) // new module
+	bl := filepath.Join(t.TempDir(), "base.edn")
+	writeBaseline(t, bl, fixtureBaseline)
+	_, code := runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	if code != 0 {
+		t.Fatalf("update exit=%d, want 0", code)
+	}
+	got, _ := os.ReadFile(bl)
+	s := string(got)
+	if !strings.Contains(s, "\"c\" {:bytes 500") {
+		t.Errorf("expected new module c folded in:\n%s", s)
+	}
+	if !strings.Contains(s, ":total-bytes 2500") {
+		t.Errorf("expected total-bytes 2500 (1000+1000+500):\n%s", s)
+	}
+}
+
+func TestFanoutUpdateDeterministic(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "b", 1000)
+	writeModule(t, tree, "a", 1000)
+	writeModule(t, tree, "c", 1000)
+	bl := filepath.Join(t.TempDir(), "base.edn")
+	writeBaseline(t, bl, fixtureBaseline)
+	runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	first, _ := os.ReadFile(bl)
+	runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	second, _ := os.ReadFile(bl)
+	if string(first) != string(second) {
+		t.Errorf("update output not byte-stable:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	s := string(first)
+	ia, ib, ic := strings.Index(s, "\"a\""), strings.Index(s, "\"b\""), strings.Index(s, "\"c\"")
+	if !(ia < ib && ib < ic) {
+		t.Errorf("modules not sorted a<b<c:\n%s", s)
+	}
+}

--- a/test/fanout_ratchet_test.go
+++ b/test/fanout_ratchet_test.go
@@ -87,3 +87,60 @@ func TestFanoutShow(t *testing.T) {
 		t.Errorf("expected module \"a\" in output:\n%s", out)
 	}
 }
+
+// baseline: a=1000, b=1000, total 2000.
+const fixtureBaseline = `{:total-bytes 2000
+ :total-loc 2
+ :files 2
+ :modules {
+            "a" {:bytes 1000 :loc 1 :files 1}
+            "b" {:bytes 1000 :loc 1 :files 1}
+           }}
+`
+
+func TestFanoutCheckWithinBand(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "a", 1000)
+	writeModule(t, tree, "b", 1020) // +2% on b; gated 2020 <= limit 2100
+	bl := filepath.Join(t.TempDir(), "base.edn")
+	writeBaseline(t, bl, fixtureBaseline)
+	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	if code != 0 {
+		t.Fatalf("check exit=%d, want 0 (within band)\n%s", code, out)
+	}
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK in output:\n%s", out)
+	}
+}
+
+func TestFanoutCheckOverBand(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "a", 1000)
+	writeModule(t, tree, "b", 1200) // gated 2200 > limit 2100
+	bl := filepath.Join(t.TempDir(), "base.edn")
+	writeBaseline(t, bl, fixtureBaseline)
+	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	if code != 1 {
+		t.Fatalf("check exit=%d, want 1 (over band)\n%s", code, out)
+	}
+	if !strings.Contains(out, "REGRESSION") {
+		t.Errorf("expected REGRESSION in output:\n%s", out)
+	}
+}
+
+// The key requirement: a new module never causes failure, even when large.
+func TestFanoutCheckNewModuleExempt(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "a", 1000)
+	writeModule(t, tree, "b", 1000)
+	writeModule(t, tree, "c", 50000) // brand new, huge — must NOT fail
+	bl := filepath.Join(t.TempDir(), "base.edn")
+	writeBaseline(t, bl, fixtureBaseline)
+	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	if code != 0 {
+		t.Fatalf("check exit=%d, want 0 (new module exempt)\n%s", code, out)
+	}
+	if !strings.Contains(out, "NEW") || !strings.Contains(out, "c") {
+		t.Errorf("expected NEW module c reported:\n%s", out)
+	}
+}


### PR DESCRIPTION
Part of #97. Adds a CI-gateable ratchet on the size of the generated `-tags gogen_ir` lowered tree, so codegen changes (e.g. the direct-call lowering) are measured against a committed, tighten-only baseline.

## What

`scripts/fanout-ratchet.lg` (let-go script) with `check`/`update`/`show` subcommands + an EDN baseline `docs/perf/fanout-baseline.edn`:
- Measures total bytes of the lowered tree (+ wireup files), per-module + totals.
- **`check`** fails when the byte-sum of *already-tracked* modules exceeds baseline by >5% (band absorbs codegen non-determinism). **New modules are exempt** (adding an IR module isn't a regression). Removed modules just shrink it.
- **`update`** MIN-merges (tighten-only; total derived from the merged module map). **`show`** prints, writes nothing.
- Three `make` targets (`fanout-ratchet{,-update,-show}`), decoupled from `check-generated` (self-regenerates).

## Tests

`test/fanout_ratchet_test.go` — Go integration tests at the CLI seam (build lg, run script vs temp fixtures): within-band pass, over-band fail, **new-module-exempt**, MIN-merge tighten, fold-new-module, deterministic byte-stable output.

Note: the committed baseline is an initial capture; it's tighten-only, and the first `make fanout-ratchet-update` after merge refreshes it to the current tree.