### PR TITLE
perf: add timeline page and main snapshots

### DIFF
--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -1,0 +1,77 @@
+name: Perf Timeline
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/perf/index.html'
+      - 'docs/perf/timeline/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: perf-timeline-main
+  cancel-in-progress: false
+
+jobs:
+  profile:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate lowered runtime
+        run: make lowered
+
+      - name: Capture full perf snapshot
+        id: perf
+        run: |
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          commit_epoch="$(git show -s --format=%ct HEAD)"
+          stamp="$(date -u -d "@${commit_epoch}" +%Y%m%dT%H%M%SZ)"
+          snapshot_name="${stamp}-${short_sha}.json"
+          snapshot_tmp="${RUNNER_TEMP}/${snapshot_name}"
+          raw_tmp="${RUNNER_TEMP}/${snapshot_name%.json}.jsonl"
+
+          go run ./cmd/bench-ratchet \
+            -full \
+            -count 3 \
+            -benchtime 2s \
+            -timeout 30m \
+            -out "${raw_tmp}" \
+            -baseline "${snapshot_tmp}" \
+            snapshot
+
+          echo "snapshot_name=${snapshot_name}" >> "${GITHUB_OUTPUT}"
+          echo "snapshot_tmp=${snapshot_tmp}" >> "${GITHUB_OUTPUT}"
+
+      - name: Commit perf snapshot and page
+        run: |
+          git checkout -B main origin/main
+          git pull --rebase origin main
+          mkdir -p docs/perf/timeline
+          cp "${{ steps.perf.outputs.snapshot_tmp }}" "docs/perf/timeline/${{ steps.perf.outputs.snapshot_name }}"
+          go run ./cmd/perf-page -out docs/perf/index.html
+
+          git add docs/perf/timeline docs/perf/index.html
+          if git diff --cached --quiet; then
+            echo "No perf changes to commit."
+            exit 0
+          fi
+          git commit -m "perf: record timeline snapshot for ${{ github.sha }}"
+          git push origin HEAD:main

--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -56,6 +56,7 @@ jobs:
             -out "${raw_tmp}" \
             -baseline "${snapshot_tmp}" \
             snapshot
+          # The committed snapshot embeds the per-run samples from raw_tmp.
 
           echo "snapshot_name=${snapshot_name}" >> "${GITHUB_OUTPUT}"
           echo "snapshot_tmp=${snapshot_tmp}" >> "${GITHUB_OUTPUT}"

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,8 @@ generate: build
 # `version` deliberately stays "dev" (no honest release version on an untagged
 # build). Falls back to "none" outside a git checkout.
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+PERF-TIMELINE-DIR ?= docs/perf/timeline
+PERF-SNAPSHOT ?= $(PERF-TIMELINE-DIR)/$(shell date -u +%Y%m%dT%H%M%SZ)-$(COMMIT).json
 
 $(LG): $(GO) lg.go pkg/**/* pkg/rt/core_compiled.lgb
 	which go
@@ -100,6 +102,13 @@ clojure-compat-report: $(GO)
 #
 # All three are anchor-normalized — see cmd/bench-ratchet/main.go
 # and docs/perf/ratchet.md.
+perf-page:
+	go run ./cmd/perf-page -out docs/perf/index.html
+
+perf-snapshot: lowered
+	mkdir -p $(PERF-TIMELINE-DIR)
+	go run ./cmd/bench-ratchet -full -baseline $(PERF-SNAPSHOT) snapshot
+
 # Regenerate the gitignored gogen_ir lowered tree (a build artifact, not
 # committed — see check-generated). Any target that builds -tags gogen_ir
 # depends on this. Cheap relative to the runs that follow.
@@ -130,9 +139,9 @@ parity-check:
 parity-full:
 	@scripts/gogen-parity.sh --full
 
-# Manual deep-dive (~25 min): the entire pkg/vm micro-benchmark fleet plus the
-# suite under -tags. Not gated in CI — run by hand when investigating a specific
-# regression. Pair with `update` to refresh the full baseline.
+# Manual deep-dive (~25 min): the pkg/vm fleet plus suite/IR variants. Not
+# gated in PR CI — run by hand when investigating a specific regression. Pair
+# with `update` to refresh the full baseline.
 bench-ratchet-full: lowered
 	go run ./cmd/bench-ratchet -full check
 
@@ -229,4 +238,4 @@ fanout-ratchet-show: build
 	./lg scripts/fanout-ratchet.lg show --go "$$(command -v go)"
 
 # PHONY targets are for ones that have conflicting files/dirs present:
-.PHONY: test bench-ratchet bench-ratchet-update bench-ratchet-show install-hooks check-generated fanout-ratchet fanout-ratchet-update fanout-ratchet-show
+.PHONY: test bench-ratchet bench-ratchet-update bench-ratchet-show perf-page perf-snapshot install-hooks check-generated fanout-ratchet fanout-ratchet-update fanout-ratchet-show

--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -26,10 +26,12 @@
 //	bench-ratchet show                  capture, aggregate, print baseline
 //	bench-ratchet capture               capture only, write .jsonl
 //	bench-ratchet aggregate             aggregate prior .jsonl(s) into baseline
+//	bench-ratchet snapshot              capture, aggregate, write immutable snapshot
 //
 // Flags:
 //
-//	-baseline string    baseline JSON path (default docs/perf/baseline.json)
+//	-baseline string    baseline JSON path; with snapshot, snapshot output path
+//	                    (default docs/perf/baseline.json)
 //	-budget float       fractional regression tolerated (default 0.05)
 //	-packages string    space-sep go packages to bench (default: discover)
 //	-count int          go test -count (default 1)
@@ -78,9 +80,10 @@ const (
 	anchorPackage       = "github.com/nooga/let-go/pkg/vm"
 	schemaVersion       = 1
 
-	// The default (CI-gating) scope: the end-to-end jank suite measured under
-	// both VM variants, plus the calibration anchor. This is deliberately tiny
-	// (~1 min) — the pkg/vm micro-benchmark fleet is only run under -full.
+	// The default (CI-gating) scope: the end-to-end jank suite and targeted
+	// IR compile benchmark measured under both VM variants, plus the
+	// calibration anchor. This is deliberately tiny (~1 min) — the pkg/vm
+	// micro-benchmark fleet is only run under -full.
 	suitePackage = "github.com/nooga/let-go/test"
 	suiteFilter  = "^BenchmarkClojureTestSuite$"
 	anchorFilter = "^BenchmarkRatchetAnchor$"
@@ -216,7 +219,7 @@ func main() {
 		shaOverride  = flag.String("sha", "", "override the SHA recorded for this run (default: git rev-parse HEAD of cwd). Use when aggregating a capture from a worktree that differs from cwd.")
 		tags         = flag.String("tags", defaultTags, "go test -tags. Default 'gogen_ir' so the lowered-to-Go VM is compiled into the test binary alongside the bytecode VM. Has no effect on releases that pre-date the lowered-Go work (the build tag matches no files there).")
 		format       = flag.String("format", "text", "report format: text (default, ANSI terminal), markdown (GitHub/Slack-friendly table), json (the raw baseline)")
-		full         = flag.Bool("full", false, "run the FULL benchmark fleet (all default packages, every benchmark) under -tags. Slow (~25 min) — for manual deep-dives. Default gate runs only the jank suite under both VM variants + anchor (~1 min).")
+		full         = flag.Bool("full", false, "run the FULL benchmark profile: pkg/vm fleet under -tags plus jank + IR compile under both VM variants. Slow (~25 min) — for mainline profiling and manual deep-dives.")
 	)
 	flag.Parse()
 
@@ -225,13 +228,13 @@ func main() {
 		mode = flag.Arg(0)
 	}
 	switch mode {
-	case "check", "update", "show", "capture", "aggregate":
+	case "check", "update", "show", "capture", "aggregate", "snapshot":
 	default:
-		die("unknown mode %q (want check / update / show / capture / aggregate)", mode)
+		die("unknown mode %q (want check / update / show / capture / aggregate / snapshot)", mode)
 	}
 
 	// aggregate-only mode reads an existing .jsonl, no benchmarks run.
-	if mode == "aggregate" {
+	if mode == "aggregate" || (mode == "snapshot" && *inPath != "") {
 		path := *inPath
 		if path == "" {
 			var err error
@@ -248,11 +251,15 @@ func main() {
 		if *shaOverride != "" {
 			current.CapturedAtSHA = *shaOverride
 		}
-		writeOrCheck(*baselinePath, current, "update", *budget, *force, *format)
+		if mode == "snapshot" {
+			writeSnapshot(*baselinePath, current)
+		} else {
+			writeOrCheck(*baselinePath, current, "update", *budget, *force, *format)
+		}
 		return
 	}
 
-	// check / update / show / capture all need a capture phase.
+	// check / update / show / capture / snapshot all need a capture phase.
 	manual := *packages != "" || *filter != ""
 	filterRE, err := compileFilter(*filter)
 	if err != nil {
@@ -303,7 +310,27 @@ func main() {
 		current.CapturedAtSHA = *shaOverride
 	}
 
-	writeOrCheck(*baselinePath, current, mode, *budget, *force, *format)
+	if mode == "snapshot" {
+		writeSnapshot(*baselinePath, current)
+	} else {
+		writeOrCheck(*baselinePath, current, mode, *budget, *force, *format)
+	}
+}
+
+func writeSnapshot(path string, current Baseline) {
+	if path == defaultBaselinePath {
+		die("snapshot mode needs -baseline <snapshot.json>; refusing to write %s", defaultBaselinePath)
+	}
+	if _, err := os.Stat(path); err == nil {
+		die("snapshot %s already exists; refusing to overwrite immutable perf history", path)
+	} else if err != nil && !os.IsNotExist(err) {
+		die("stat snapshot %s: %v", path, err)
+	}
+	stampAll(&current)
+	if err := writeBaseline(path, current); err != nil {
+		die("write snapshot: %v", err)
+	}
+	fmt.Printf("\nwrote snapshot → %s (%d benchmarks)\n", path, len(current.Benchmarks))
 }
 
 // writeOrCheck dispatches the post-aggregate action.
@@ -562,8 +589,10 @@ type captureJob struct {
 //
 //   - manual (-packages or -filter given): honor them verbatim across the
 //     selected packages under -tags. Power-user escape hatch.
-//   - -full: the entire default fleet (pkg/vm micro-benches + the suite) under
-//     -tags. Slow; for deep-dives, not the CI gate.
+//   - -full: the broad profile used for timeline snapshots: pkg/vm
+//     micro-benches under -tags, plus the suite and IR compile benchmark
+//     under both bytecode and gogen_ir variants. Slow; for deep-dives and
+//     scheduled/mainline profiling, not the PR gate.
 //   - default: the fast gate — the calibration anchor plus the end-to-end jank
 //     suite measured under BOTH VM variants (bytecode and gogen_ir-lowered),
 //     which is the only thing the ratchet needs to catch a real regression.
@@ -580,11 +609,22 @@ func buildJobs(packages, tags string, full, manual bool, filterRE *regexp.Regexp
 		}
 		return jobs, "manual scope", nil
 	case full:
-		var jobs []captureJob
-		for _, p := range defaultPackages {
-			jobs = append(jobs, captureJob{pkg: p, tags: tags, filter: filterRE})
+		suiteRE, err := regexp.Compile(suiteFilter)
+		if err != nil {
+			return nil, "", fmt.Errorf("suite filter: %w", err)
 		}
-		return jobs, "full fleet", nil
+		irCompileRE, err := regexp.Compile(irCompileFilter)
+		if err != nil {
+			return nil, "", fmt.Errorf("ir-compile filter: %w", err)
+		}
+		jobs := []captureJob{
+			{pkg: anchorPackage, tags: tags, filter: filterRE},
+			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "bytecode"},
+			{pkg: suitePackage, tags: "gogen_ir", filter: suiteRE, variant: "gogen_ir"},
+			{pkg: irCompilePackage, tags: "", filter: irCompileRE, variant: "bytecode"},
+			{pkg: irCompilePackage, tags: "gogen_ir", filter: irCompileRE, variant: "gogen_ir"},
+		}
+		return jobs, "full profile (vm fleet + jank ×2 + ir-compile ×2)", nil
 	default:
 		anchorRE, err := regexp.Compile(anchorFilter)
 		if err != nil {

--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -65,6 +65,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nooga/let-go/pkg/perfdata"
 	"golang.org/x/perf/benchfmt"
 )
 
@@ -122,59 +123,12 @@ var defaultPackages = []string{
 	"github.com/nooga/let-go/test",
 }
 
-// Baseline is the on-disk format. Keep field tags stable.
-type Baseline struct {
-	Version       int                       `json:"version"`
-	CapturedAt    string                    `json:"captured_at"`
-	CapturedAtSHA string                    `json:"captured_at_sha"`
-	Machine       Machine                   `json:"machine"`
-	Anchor        AnchorRecord              `json:"anchor"`
-	Benchmarks    map[string]BenchmarkEntry `json:"benchmarks"`
-}
-
-// Machine fingerprint. Anything that affects benchmark numbers in a
-// way an anchor can't fully normalize (architecture, cpu model,
-// frequency scaling defaults, go runtime version).
-type Machine struct {
-	OS        string `json:"os"`
-	Arch      string `json:"arch"`
-	NumCPU    int    `json:"num_cpu"`
-	CPUModel  string `json:"cpu_model"`
-	GoVersion string `json:"go_version"`
-}
-
-// AnchorRecord captures the absolute speed of the anchor benchmark on
-// the machine where the baseline was taken. Useful for sanity-checking
-// that the anchor itself hasn't drifted (e.g. a new Go release that
-// compiles it differently).
-type AnchorRecord struct {
-	Name       string  `json:"name"`
-	Package    string  `json:"package"`
-	NSPerOp    float64 `json:"ns_per_op"`
-	Iterations int64   `json:"iterations,omitempty"`
-}
-
-// BenchmarkEntry is one benchmark's current best. ratio_to_anchor is
-// the load-bearing field for comparisons; ns_per_op is for context.
-//
-// BestSinceSHA / BestSinceAt record the most recent ratchet tighten
-// for this entry — the commit and timestamp that set the current bar.
-// When ratchetMerge tightens any metric, both stamps move forward to
-// the run's commit/time. When nothing tightens, the stamps stay put.
-// New benchmarks get the run's stamp; missing-from-current benchmarks
-// keep their prior stamp.
-//
-// The fields are additive (omitempty) so this struct still loads old
-// baselines that pre-date the provenance work — they just come back
-// with empty stamps and get filled in on the next ratchet.
-type BenchmarkEntry struct {
-	NSPerOp       float64 `json:"ns_per_op"`
-	AllocsPerOp   int64   `json:"allocs_per_op"`
-	BytesPerOp    int64   `json:"bytes_per_op"`
-	RatioToAnchor float64 `json:"ratio_to_anchor"`
-	BestSinceSHA  string  `json:"best_since_sha,omitempty"`
-	BestSinceAt   string  `json:"best_since_at,omitempty"`
-}
+type Baseline = perfdata.Baseline
+type Machine = perfdata.Machine
+type AnchorRecord = perfdata.Anchor
+type BenchmarkEntry = perfdata.BenchmarkEntry
+type BenchmarkSample = perfdata.BenchmarkSample
+type StreamRecord = perfdata.StreamRecord
 
 // Result is the in-memory parse of one benchmark line.
 type Result struct {
@@ -184,24 +138,12 @@ type Result struct {
 	NSPerOp     float64
 	BytesPerOp  int64
 	AllocsPerOp int64
+	Samples     []BenchmarkSample
 }
 
 // FullName is "<package>.<benchmark name without -N suffix>".
 func (r Result) FullName() string {
 	return r.Package + "." + r.Name
-}
-
-// StreamRecord is one .jsonl line. The capture phase appends one of
-// these per benchmark per `go test -count` repetition; the aggregate
-// phase reads them back and averages by (package, name).
-type StreamRecord struct {
-	Package     string  `json:"package"`
-	Name        string  `json:"name"`
-	Iterations  int64   `json:"iterations"`
-	NSPerOp     float64 `json:"ns_per_op"`
-	BytesPerOp  int64   `json:"bytes_per_op"`
-	AllocsPerOp int64   `json:"allocs_per_op"`
-	CapturedAt  string  `json:"captured_at"`
 }
 
 func main() {
@@ -449,10 +391,12 @@ func ratchetMerge(existing, current Baseline) (Baseline, RatchetSummary) {
 		if tightened {
 			merged.BestSinceSHA = current.CapturedAtSHA
 			merged.BestSinceAt = current.CapturedAt
+			merged.Samples = cur.Samples
 			summary.Tightened = append(summary.Tightened, SummaryEntry{Name: name, NSPerOp: merged.NSPerOp})
 		} else {
 			merged.BestSinceSHA = base.BestSinceSHA
 			merged.BestSinceAt = base.BestSinceAt
+			merged.Samples = base.Samples
 		}
 		out.Benchmarks[name] = merged
 		if regressedOnSome {
@@ -792,6 +736,7 @@ func aggregateFromFile(path string) (Baseline, error) {
 		count                     int
 		nsSum, bytesSum, allocSum float64
 		iters                     int64
+		samples                   []BenchmarkSample
 	}
 	byName := map[string]*accum{}
 	dec := json.NewDecoder(f)
@@ -813,6 +758,7 @@ func aggregateFromFile(path string) (Baseline, error) {
 		if rec.Iterations > a.iters {
 			a.iters = rec.Iterations
 		}
+		a.samples = append(a.samples, rec.Sample())
 	}
 
 	var results []Result
@@ -824,6 +770,7 @@ func aggregateFromFile(path string) (Baseline, error) {
 			NSPerOp:     a.nsSum / float64(a.count),
 			BytesPerOp:  int64(a.bytesSum / float64(a.count)),
 			AllocsPerOp: int64(a.allocSum / float64(a.count)),
+			Samples:     append([]BenchmarkSample(nil), a.samples...),
 		})
 	}
 	sort.Slice(results, func(i, j int) bool { return results[i].FullName() < results[j].FullName() })
@@ -854,11 +801,16 @@ func buildCurrentBaseline(results []Result, anchor Result) Baseline {
 		if r.Name == anchorName {
 			continue
 		}
+		samples := append([]BenchmarkSample(nil), r.Samples...)
+		for i := range samples {
+			samples[i].RatioToAnchor = samples[i].NSPerOp / anchor.NSPerOp
+		}
 		bm[r.FullName()] = BenchmarkEntry{
 			NSPerOp:       r.NSPerOp,
 			AllocsPerOp:   r.AllocsPerOp,
 			BytesPerOp:    r.BytesPerOp,
 			RatioToAnchor: r.NSPerOp / anchor.NSPerOp,
+			Samples:       samples,
 		}
 	}
 	return Baseline{
@@ -871,6 +823,7 @@ func buildCurrentBaseline(results []Result, anchor Result) Baseline {
 			Package:    anchor.Package,
 			NSPerOp:    anchor.NSPerOp,
 			Iterations: anchor.Iterations,
+			Samples:    append([]BenchmarkSample(nil), anchor.Samples...),
 		},
 		Benchmarks: bm,
 	}
@@ -929,7 +882,31 @@ func writeBaseline(path string, b Baseline) error {
 		return err
 	}
 	body = append(body, '\n')
-	return os.WriteFile(path, body, 0o644)
+	dir := filepath.Dir(path)
+	if dir == "" {
+		dir = "."
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 func readBaseline(path string) (Baseline, error) {

--- a/cmd/bench-ratchet/main_test.go
+++ b/cmd/bench-ratchet/main_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAggregateFromFileRetainsSamples(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	records := []StreamRecord{
+		{Package: anchorPackage, Name: anchorName, Iterations: 100, NSPerOp: 10, CapturedAt: "2026-06-01T00:00:00Z"},
+		{Package: anchorPackage, Name: anchorName, Iterations: 90, NSPerOp: 20, CapturedAt: "2026-06-01T00:00:01Z"},
+		{Package: "pkg", Name: "BenchmarkA", Iterations: 50, NSPerOp: 30, BytesPerOp: 100, AllocsPerOp: 1, CapturedAt: "2026-06-01T00:00:02Z"},
+		{Package: "pkg", Name: "BenchmarkA", Iterations: 60, NSPerOp: 60, BytesPerOp: 200, AllocsPerOp: 3, CapturedAt: "2026-06-01T00:00:03Z"},
+	}
+	for _, rec := range records {
+		if err := enc.Encode(rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	baseline, err := aggregateFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(baseline.Anchor.Samples) != 2 {
+		t.Fatalf("anchor samples = %d, want 2", len(baseline.Anchor.Samples))
+	}
+	entry := baseline.Benchmarks["pkg.BenchmarkA"]
+	if entry.NSPerOp != 45 {
+		t.Fatalf("ns/op = %v, want 45", entry.NSPerOp)
+	}
+	if entry.BytesPerOp != 150 {
+		t.Fatalf("bytes/op = %d, want 150", entry.BytesPerOp)
+	}
+	if entry.AllocsPerOp != 2 {
+		t.Fatalf("allocs/op = %d, want 2", entry.AllocsPerOp)
+	}
+	if len(entry.Samples) != 2 {
+		t.Fatalf("samples = %d, want 2", len(entry.Samples))
+	}
+	if entry.Samples[0].RatioToAnchor != 2 {
+		t.Fatalf("first sample ratio = %v, want 2", entry.Samples[0].RatioToAnchor)
+	}
+	if entry.Samples[1].RatioToAnchor != 4 {
+		t.Fatalf("second sample ratio = %v, want 4", entry.Samples[1].RatioToAnchor)
+	}
+}
+
+func TestWriteBaselineWritesAtomicallyReadableJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	baseline := Baseline{
+		Version:       schemaVersion,
+		CapturedAt:    "2026-06-01T00:00:00Z",
+		CapturedAtSHA: "abc",
+		Benchmarks: map[string]BenchmarkEntry{
+			"pkg.BenchmarkA": {NSPerOp: 1, RatioToAnchor: 2},
+		},
+	}
+	if err := writeBaseline(path, baseline); err != nil {
+		t.Fatal(err)
+	}
+	read, err := readBaseline(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Benchmarks["pkg.BenchmarkA"].RatioToAnchor != 2 {
+		t.Fatalf("ratio = %v, want 2", read.Benchmarks["pkg.BenchmarkA"].RatioToAnchor)
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), ".*.tmp-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("left temporary files: %v", matches)
+	}
+}

--- a/cmd/perf-page/main.go
+++ b/cmd/perf-page/main.go
@@ -1,0 +1,1313 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"html/template"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const modulePrefix = "github.com/nooga/let-go/"
+
+type Baseline struct {
+	Version       int                       `json:"version"`
+	CapturedAt    string                    `json:"captured_at"`
+	CapturedAtSHA string                    `json:"captured_at_sha"`
+	Machine       Machine                   `json:"machine"`
+	Anchor        Anchor                    `json:"anchor"`
+	Benchmarks    map[string]BenchmarkEntry `json:"benchmarks"`
+}
+
+type Machine struct {
+	OS        string `json:"os"`
+	Arch      string `json:"arch"`
+	NumCPU    int    `json:"num_cpu"`
+	CPUModel  string `json:"cpu_model"`
+	GoVersion string `json:"go_version"`
+}
+
+type Anchor struct {
+	Name       string  `json:"name"`
+	Package    string  `json:"package"`
+	NSPerOp    float64 `json:"ns_per_op"`
+	Iterations int64   `json:"iterations"`
+}
+
+type BenchmarkEntry struct {
+	NSPerOp      float64 `json:"ns_per_op"`
+	AllocsPerOp  float64 `json:"allocs_per_op"`
+	BytesPerOp   float64 `json:"bytes_per_op"`
+	Ratio        float64 `json:"ratio_to_anchor"`
+	BestSinceSHA string  `json:"best_since_sha"`
+	BestSinceAt  string  `json:"best_since_at"`
+}
+
+type BenchmarkRow struct {
+	FullName     string
+	Package      string
+	Name         string
+	NSPerOp      float64
+	AllocsPerOp  float64
+	BytesPerOp   float64
+	Ratio        float64
+	BestSinceSHA string
+	BestSinceAt  string
+	Delta        *float64
+	BarWidth     float64
+}
+
+type ChangeRow struct {
+	BenchmarkRow
+	OldRatio float64
+	NewRatio float64
+}
+
+type Snapshot struct {
+	Name     string
+	Baseline Baseline
+	Captured time.Time
+}
+
+type Chart struct {
+	Title    string
+	Subtitle string
+	Unit     string
+	Series   []ChartSeries
+	YMin     float64
+	YMax     float64
+	YMinText string
+	YMaxText string
+}
+
+type ChartSeries struct {
+	Label  string
+	Color  string
+	Path   string
+	Points []ChartPoint
+}
+
+type ChartPoint struct {
+	X     float64
+	Y     float64
+	Index int
+	Date  string
+	SHA   string
+	Value float64
+	Text  string
+}
+
+type Summary struct {
+	BenchmarkCount int
+	PackageCount   int
+	ZeroAllocs     int
+	Common         int
+	New            int
+	Missing        int
+	Faster         int
+	Slower         int
+	MedianDelta    float64
+}
+
+type PageData struct {
+	Title             string
+	LogoDataURI       template.URL
+	Current           Baseline
+	ReferenceName     string
+	Summary           Summary
+	Timeline          []Snapshot
+	Charts            []Chart
+	Rows              []BenchmarkRow
+	TopImprovements   []ChangeRow
+	TopSlowdowns      []ChangeRow
+	RecentlyTightened []BenchmarkRow
+}
+
+func main() {
+	var (
+		baselinePath   = flag.String("baseline", "docs/perf/baseline.json", "current baseline JSON")
+		historicalPath = flag.String("historical", "docs/perf/historical", "historical baseline directory")
+		timelinePath   = flag.String("timeline", "docs/perf/timeline", "timeline snapshot directory")
+		outPath        = flag.String("out", "docs/perf/index.html", "HTML output path")
+		logoPath       = flag.String("logo", "meta/logo.svg", "logo SVG to embed")
+	)
+	flag.Parse()
+
+	current, err := loadBaseline(*baselinePath)
+	if err != nil {
+		die("load baseline: %v", err)
+	}
+	reference, referenceName, err := loadLatestHistorical(*historicalPath)
+	if err != nil {
+		die("load historical baseline: %v", err)
+	}
+	timeline, err := loadTimeline(*timelinePath, *historicalPath, current)
+	if err != nil {
+		die("load timeline: %v", err)
+	}
+	logo, err := logoDataURI(*logoPath)
+	if err != nil {
+		die("load logo: %v", err)
+	}
+
+	page := buildPage(current, reference, referenceName, timeline, logo)
+	html, err := renderPage(page)
+	if err != nil {
+		die("render page: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(*outPath), 0o755); err != nil {
+		die("create output directory: %v", err)
+	}
+	if err := os.WriteFile(*outPath, html, 0o644); err != nil {
+		die("write %s: %v", *outPath, err)
+	}
+	fmt.Printf("wrote %s (%d benchmarks)\n", *outPath, len(current.Benchmarks))
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "perf-page: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func loadBaseline(path string) (Baseline, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Baseline{}, err
+	}
+	var baseline Baseline
+	if err := json.Unmarshal(b, &baseline); err != nil {
+		return Baseline{}, err
+	}
+	if len(baseline.Benchmarks) == 0 {
+		return Baseline{}, fmt.Errorf("%s has no benchmarks", path)
+	}
+	return baseline, nil
+}
+
+func loadLatestHistorical(dir string) (Baseline, string, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return Baseline{}, "", err
+	}
+	if len(matches) == 0 {
+		return Baseline{}, "", nil
+	}
+
+	type historical struct {
+		path     string
+		name     string
+		baseline Baseline
+		captured time.Time
+	}
+	var all []historical
+	for _, match := range matches {
+		baseline, err := loadBaseline(match)
+		if err != nil {
+			return Baseline{}, "", err
+		}
+		captured, _ := time.Parse(time.RFC3339, baseline.CapturedAt)
+		name := strings.TrimSuffix(filepath.Base(match), filepath.Ext(match))
+		all = append(all, historical{
+			path:     match,
+			name:     name,
+			baseline: baseline,
+			captured: captured,
+		})
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if !all[i].captured.Equal(all[j].captured) {
+			return all[i].captured.After(all[j].captured)
+		}
+		return all[i].path > all[j].path
+	})
+	return all[0].baseline, all[0].name, nil
+}
+
+func loadTimeline(timelineDir, historicalDir string, current Baseline) ([]Snapshot, error) {
+	var snapshots []Snapshot
+	matches, err := filepath.Glob(filepath.Join(timelineDir, "*.json"))
+	if err != nil {
+		return nil, err
+	}
+	for _, match := range matches {
+		baseline, err := loadBaseline(match)
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, makeSnapshot(strings.TrimSuffix(filepath.Base(match), filepath.Ext(match)), baseline))
+	}
+	if len(snapshots) == 0 {
+		historical, err := filepath.Glob(filepath.Join(historicalDir, "*.json"))
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range historical {
+			baseline, err := loadBaseline(match)
+			if err != nil {
+				return nil, err
+			}
+			snapshots = append(snapshots, makeSnapshot(strings.TrimSuffix(filepath.Base(match), filepath.Ext(match)), baseline))
+		}
+		snapshots = append(snapshots, makeSnapshot("current-ratchet", current))
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		if !snapshots[i].Captured.Equal(snapshots[j].Captured) {
+			return snapshots[i].Captured.Before(snapshots[j].Captured)
+		}
+		if snapshots[i].Baseline.CapturedAtSHA != snapshots[j].Baseline.CapturedAtSHA {
+			return snapshots[i].Baseline.CapturedAtSHA < snapshots[j].Baseline.CapturedAtSHA
+		}
+		return snapshots[i].Name < snapshots[j].Name
+	})
+	return snapshots, nil
+}
+
+func makeSnapshot(name string, baseline Baseline) Snapshot {
+	captured, _ := time.Parse(time.RFC3339, baseline.CapturedAt)
+	return Snapshot{Name: name, Baseline: baseline, Captured: captured}
+}
+
+func logoDataURI(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.StdEncoding.EncodeToString(b)
+	return "data:image/svg+xml;base64," + encoded, nil
+}
+
+func buildPage(current, reference Baseline, referenceName string, timeline []Snapshot, logo string) PageData {
+	rows := benchmarkRows(current)
+	changes, summary := compare(current, reference)
+	maxRatio := 0.0
+	packageSet := map[string]struct{}{}
+	for i := range rows {
+		if rows[i].Ratio > maxRatio {
+			maxRatio = rows[i].Ratio
+		}
+		packageSet[rows[i].Package] = struct{}{}
+		if delta, ok := changes[rows[i].FullName]; ok {
+			rows[i].Delta = &delta
+		}
+		if rows[i].AllocsPerOp == 0 {
+			summary.ZeroAllocs++
+		}
+	}
+	for i := range rows {
+		rows[i].BarWidth = barWidth(rows[i].Ratio, maxRatio)
+	}
+	summary.BenchmarkCount = len(rows)
+	summary.PackageCount = len(packageSet)
+
+	recent := append([]BenchmarkRow(nil), rows...)
+	sort.Slice(recent, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, recent[i].BestSinceAt)
+		tj, _ := time.Parse(time.RFC3339, recent[j].BestSinceAt)
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return recent[i].FullName < recent[j].FullName
+	})
+	if len(recent) > 8 {
+		recent = recent[:8]
+	}
+
+	improvements, slowdowns := topChanges(current, reference, 8)
+	return PageData{
+		Title:             "Are we fast yet?",
+		LogoDataURI:       template.URL(logo),
+		Current:           current,
+		ReferenceName:     referenceName,
+		Summary:           summary,
+		Timeline:          timeline,
+		Charts:            buildCharts(timeline),
+		Rows:              rows,
+		TopImprovements:   improvements,
+		TopSlowdowns:      slowdowns,
+		RecentlyTightened: recent,
+	}
+}
+
+func buildCharts(timeline []Snapshot) []Chart {
+	specs := []struct {
+		title    string
+		subtitle string
+		unit     string
+		metric   func(BenchmarkEntry) float64
+		format   func(float64) string
+		series   []chartSeriesSpec
+	}{
+		{
+			title:    "End-to-end suite",
+			subtitle: "Anchor-normalized jank clojure-test-suite wall time. Lower is better.",
+			unit:     "anchors",
+			metric:   func(entry BenchmarkEntry) float64 { return entry.Ratio },
+			format:   formatRatio,
+			series: []chartSeriesSpec{
+				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]"},
+				{label: "gogen_ir", color: "#167a48", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [gogen_ir]"},
+			},
+		},
+		{
+			title:    "IR compile",
+			subtitle: "Anchor-normalized IR compile benchmark variants. Lower is better.",
+			unit:     "anchors",
+			metric:   func(entry BenchmarkEntry) float64 { return entry.Ratio },
+			format:   formatRatio,
+			series: []chartSeriesSpec{
+				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [bytecode]"},
+				{label: "gogen_ir", color: "#167a48", name: "github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [gogen_ir]"},
+			},
+		},
+		{
+			title:    "Suite allocations",
+			subtitle: "allocs/op for the full suite benchmark variants. Lower is better.",
+			unit:     "allocs/op",
+			metric:   func(entry BenchmarkEntry) float64 { return entry.AllocsPerOp },
+			format:   formatCount,
+			series: []chartSeriesSpec{
+				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]"},
+				{label: "gogen_ir", color: "#167a48", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [gogen_ir]"},
+			},
+		},
+		{
+			title:    "Suite memory",
+			subtitle: "bytes/op for the full suite benchmark variants. Lower is better.",
+			unit:     "B/op",
+			metric:   func(entry BenchmarkEntry) float64 { return entry.BytesPerOp },
+			format:   formatBytes,
+			series: []chartSeriesSpec{
+				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]"},
+				{label: "gogen_ir", color: "#167a48", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [gogen_ir]"},
+			},
+		},
+	}
+
+	charts := make([]Chart, 0, len(specs))
+	for _, spec := range specs {
+		chart := buildChart(timeline, spec.title, spec.subtitle, spec.unit, spec.metric, spec.format, spec.series)
+		if len(chart.Series) > 0 {
+			charts = append(charts, chart)
+		}
+	}
+	return charts
+}
+
+type chartSeriesSpec struct {
+	label string
+	color string
+	name  string
+}
+
+func buildChart(timeline []Snapshot, title, subtitle, unit string, metric func(BenchmarkEntry) float64, format func(float64) string, specs []chartSeriesSpec) Chart {
+	const (
+		left   = 46.0
+		right  = 18.0
+		top    = 22.0
+		bottom = 34.0
+		width  = 520.0
+		height = 210.0
+	)
+	plotW := width - left - right
+	plotH := height - top - bottom
+	yMin := math.Inf(1)
+	yMax := math.Inf(-1)
+	series := make([]ChartSeries, 0, len(specs))
+
+	for _, spec := range specs {
+		var raw []struct {
+			index int
+			snap  Snapshot
+			value float64
+		}
+		for i, snap := range timeline {
+			entry, ok := snap.Baseline.Benchmarks[spec.name]
+			if !ok {
+				continue
+			}
+			value := metric(entry)
+			if value <= 0 {
+				continue
+			}
+			raw = append(raw, struct {
+				index int
+				snap  Snapshot
+				value float64
+			}{index: i, snap: snap, value: value})
+			if value < yMin {
+				yMin = value
+			}
+			if value > yMax {
+				yMax = value
+			}
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		series = append(series, ChartSeries{
+			Label:  spec.label,
+			Color:  spec.color,
+			Points: make([]ChartPoint, 0, len(raw)),
+		})
+		for _, item := range raw {
+			series[len(series)-1].Points = append(series[len(series)-1].Points, ChartPoint{
+				Index: item.index,
+				Date:  formatDate(item.snap.Baseline.CapturedAt),
+				SHA:   shortSHA(item.snap.Baseline.CapturedAtSHA),
+				Value: item.value,
+				Text:  format(item.value),
+			})
+		}
+	}
+
+	if len(series) == 0 {
+		return Chart{}
+	}
+	if yMin == yMax {
+		yMin *= 0.95
+		yMax *= 1.05
+		if yMin == yMax {
+			yMin = 0
+			yMax = 1
+		}
+	}
+	if yMin > 0 {
+		padding := (yMax - yMin) * 0.08
+		yMin -= padding
+		yMax += padding
+	}
+	for si := range series {
+		pathParts := make([]string, 0, len(series[si].Points))
+		for pi := range series[si].Points {
+			point := &series[si].Points[pi]
+			denom := float64(maxInt(len(timeline)-1, 1))
+			point.X = left + (float64(point.Index)/denom)*plotW
+			point.Y = top + ((yMax-point.Value)/(yMax-yMin))*plotH
+			cmd := "L"
+			if pi == 0 {
+				cmd = "M"
+			}
+			pathParts = append(pathParts, fmt.Sprintf("%s %.2f %.2f", cmd, point.X, point.Y))
+		}
+		series[si].Path = strings.Join(pathParts, " ")
+	}
+	return Chart{
+		Title:    title,
+		Subtitle: subtitle,
+		Unit:     unit,
+		Series:   series,
+		YMin:     yMin,
+		YMax:     yMax,
+		YMinText: format(yMin),
+		YMaxText: format(yMax),
+	}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func benchmarkRows(baseline Baseline) []BenchmarkRow {
+	rows := make([]BenchmarkRow, 0, len(baseline.Benchmarks))
+	for fullName, entry := range baseline.Benchmarks {
+		pkg, name := splitBenchmarkName(fullName)
+		rows = append(rows, BenchmarkRow{
+			FullName:     fullName,
+			Package:      pkg,
+			Name:         name,
+			NSPerOp:      entry.NSPerOp,
+			AllocsPerOp:  entry.AllocsPerOp,
+			BytesPerOp:   entry.BytesPerOp,
+			Ratio:        entry.Ratio,
+			BestSinceSHA: entry.BestSinceSHA,
+			BestSinceAt:  entry.BestSinceAt,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Package != rows[j].Package {
+			return rows[i].Package < rows[j].Package
+		}
+		return rows[i].Name < rows[j].Name
+	})
+	return rows
+}
+
+func splitBenchmarkName(fullName string) (string, string) {
+	name := strings.TrimPrefix(fullName, modulePrefix)
+	idx := strings.Index(name, ".Benchmark")
+	if idx < 0 {
+		return "", name
+	}
+	return name[:idx], name[idx+1:]
+}
+
+func compare(current, reference Baseline) (map[string]float64, Summary) {
+	changes := make(map[string]float64)
+	if len(reference.Benchmarks) == 0 {
+		return changes, Summary{New: len(current.Benchmarks)}
+	}
+	var deltas []float64
+	var summary Summary
+	for name, cur := range current.Benchmarks {
+		ref, ok := reference.Benchmarks[name]
+		if !ok {
+			summary.New++
+			continue
+		}
+		if ref.Ratio == 0 {
+			continue
+		}
+		delta := cur.Ratio/ref.Ratio - 1
+		changes[name] = delta
+		deltas = append(deltas, delta)
+		summary.Common++
+		if delta <= -0.05 {
+			summary.Faster++
+		} else if delta >= 0.05 {
+			summary.Slower++
+		}
+	}
+	for name := range reference.Benchmarks {
+		if _, ok := current.Benchmarks[name]; !ok {
+			summary.Missing++
+		}
+	}
+	summary.MedianDelta = median(deltas)
+	return changes, summary
+}
+
+func topChanges(current, reference Baseline, limit int) ([]ChangeRow, []ChangeRow) {
+	if len(reference.Benchmarks) == 0 {
+		return nil, nil
+	}
+	var rows []ChangeRow
+	for _, row := range benchmarkRows(current) {
+		cur := current.Benchmarks[row.FullName]
+		ref, ok := reference.Benchmarks[row.FullName]
+		if !ok || ref.Ratio == 0 {
+			continue
+		}
+		delta := cur.Ratio/ref.Ratio - 1
+		row.Delta = &delta
+		rows = append(rows, ChangeRow{
+			BenchmarkRow: row,
+			OldRatio:     ref.Ratio,
+			NewRatio:     cur.Ratio,
+		})
+	}
+
+	improvements := append([]ChangeRow(nil), rows...)
+	sort.Slice(improvements, func(i, j int) bool {
+		return *improvements[i].Delta < *improvements[j].Delta
+	})
+	slowdowns := append([]ChangeRow(nil), rows...)
+	sort.Slice(slowdowns, func(i, j int) bool {
+		return *slowdowns[i].Delta > *slowdowns[j].Delta
+	})
+
+	return takeSignificant(improvements, limit, true), takeSignificant(slowdowns, limit, false)
+}
+
+func takeSignificant(rows []ChangeRow, limit int, faster bool) []ChangeRow {
+	out := make([]ChangeRow, 0, limit)
+	for _, row := range rows {
+		if row.Delta == nil {
+			continue
+		}
+		if faster && *row.Delta >= -0.01 {
+			continue
+		}
+		if !faster && *row.Delta <= 0.01 {
+			continue
+		}
+		out = append(out, row)
+		if len(out) == limit {
+			return out
+		}
+	}
+	return out
+}
+
+func median(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	values = append([]float64(nil), values...)
+	sort.Float64s(values)
+	mid := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[mid]
+	}
+	return (values[mid-1] + values[mid]) / 2
+}
+
+func barWidth(ratio, maxRatio float64) float64 {
+	if maxRatio <= 0 || ratio <= 0 {
+		return 0
+	}
+	return math.Log1p(ratio) / math.Log1p(maxRatio) * 100
+}
+
+func renderPage(page PageData) ([]byte, error) {
+	funcs := template.FuncMap{
+		"date":       formatDate,
+		"shortSHA":   shortSHA,
+		"ns":         formatNS,
+		"bytes":      formatBytes,
+		"count":      formatCount,
+		"ratio":      formatRatio,
+		"pct":        formatPct,
+		"deltaClass": deltaClass,
+		"deltaText":  deltaText,
+		"bar":        formatBar,
+	}
+	tmpl, err := template.New("page").Funcs(funcs).Parse(pageTemplate)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, page); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func formatDate(value string) string {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return value
+	}
+	return t.UTC().Format("2006-01-02 15:04 UTC")
+}
+
+func shortSHA(value string) string {
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
+}
+
+func formatNS(value float64) string {
+	switch {
+	case value < 1_000:
+		return fmt.Sprintf("%.2f ns", value)
+	case value < 1_000_000:
+		return fmt.Sprintf("%.2f us", value/1_000)
+	case value < 1_000_000_000:
+		return fmt.Sprintf("%.2f ms", value/1_000_000)
+	default:
+		return fmt.Sprintf("%.2f s", value/1_000_000_000)
+	}
+}
+
+func formatBytes(value float64) string {
+	switch {
+	case value < 1024:
+		return fmt.Sprintf("%.0f B", value)
+	case value < 1024*1024:
+		return fmt.Sprintf("%.1f KiB", value/1024)
+	default:
+		return fmt.Sprintf("%.1f MiB", value/(1024*1024))
+	}
+}
+
+func formatCount(value float64) string {
+	return formatCompact(value)
+}
+
+func formatRatio(value float64) string {
+	if math.Abs(value) >= 1_000 {
+		return formatCompact(value)
+	}
+	if value >= 10 {
+		return fmt.Sprintf("%.1f", value)
+	}
+	return fmt.Sprintf("%.2f", value)
+}
+
+func formatCompact(value float64) string {
+	abs := math.Abs(value)
+	switch {
+	case abs >= 1_000_000_000:
+		return fmt.Sprintf("%.2fB", value/1_000_000_000)
+	case abs >= 1_000_000:
+		return fmt.Sprintf("%.2fM", value/1_000_000)
+	case abs >= 1_000:
+		return fmt.Sprintf("%.1fk", value/1_000)
+	default:
+		return fmt.Sprintf("%.0f", value)
+	}
+}
+
+func formatPct(value float64) string {
+	return fmt.Sprintf("%+.1f%%", value*100)
+}
+
+func deltaClass(value *float64) string {
+	if value == nil {
+		return "muted"
+	}
+	if *value <= -0.05 {
+		return "good"
+	}
+	if *value >= 0.05 {
+		return "bad"
+	}
+	return "flat"
+}
+
+func deltaText(value *float64) string {
+	if value == nil {
+		return "new"
+	}
+	return formatPct(*value)
+}
+
+func formatBar(value float64) string {
+	return fmt.Sprintf("%.2f", value)
+}
+
+const pageTemplate = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.Title}} - let-go perf</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f7f4;
+      --paper: #ffffff;
+      --ink: #171717;
+      --muted: #65645f;
+      --line: #deddd6;
+      --soft: #eeede7;
+      --green: #167a48;
+      --green-bg: #e4f3ea;
+      --red: #aa2e2e;
+      --red-bg: #f8e3e0;
+      --amber: #8b5e12;
+      --amber-bg: #f4ead2;
+      --accent: #245c73;
+      --shadow: 0 18px 50px rgba(23, 23, 23, 0.08);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+    .wrap {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+    }
+    header {
+      padding: 34px 0 24px;
+      border-bottom: 1px solid var(--line);
+      background:
+        linear-gradient(90deg, rgba(36, 92, 115, 0.12), transparent 42%),
+        linear-gradient(180deg, #ffffff, var(--bg));
+    }
+    .topline {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      margin-bottom: 28px;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+      font-weight: 750;
+      letter-spacing: 0;
+    }
+    .brand img {
+      width: 42px;
+      height: 42px;
+      display: block;
+    }
+    .brand span {
+      white-space: nowrap;
+    }
+    .links {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+    .links a {
+      color: var(--ink);
+      text-decoration: none;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.7);
+      border-radius: 7px;
+      padding: 7px 10px;
+      font-size: 13px;
+      font-weight: 650;
+    }
+    h1 {
+      margin: 0;
+      font-size: clamp(42px, 7vw, 86px);
+      line-height: 0.94;
+      letter-spacing: 0;
+      max-width: 820px;
+    }
+    .lede {
+      margin: 18px 0 0;
+      max-width: 760px;
+      color: var(--muted);
+      font-size: 18px;
+    }
+    .meta {
+      margin-top: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      min-height: 30px;
+      padding: 5px 9px;
+      border-radius: 7px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.72);
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 620;
+    }
+    main { padding: 28px 0 54px; }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 30px;
+    }
+    .card {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 16px;
+      min-height: 116px;
+    }
+    .label {
+      margin: 0 0 8px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 760;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .value {
+      margin: 0;
+      font-size: 32px;
+      line-height: 1;
+      font-weight: 820;
+      letter-spacing: 0;
+    }
+    .note {
+      margin: 9px 0 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    section {
+      margin-top: 34px;
+    }
+    .section-head {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 12px;
+    }
+    h2 {
+      margin: 0;
+      font-size: 24px;
+      line-height: 1.15;
+      letter-spacing: 0;
+    }
+    .section-head p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .grid-2 {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .chart {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 14px;
+      min-width: 0;
+    }
+    .chart h3 {
+      margin: 0;
+      font-size: 16px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+    .chart p {
+      margin: 5px 0 12px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .chart svg {
+      width: 100%;
+      height: auto;
+      display: block;
+      overflow: visible;
+    }
+    .axis {
+      stroke: var(--line);
+      stroke-width: 1;
+    }
+    .axis-label {
+      fill: var(--muted);
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+    }
+    .chart-line {
+      fill: none;
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .point {
+      stroke: var(--paper);
+      stroke-width: 2;
+    }
+    .legend {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 650;
+    }
+    .legend span {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .swatch {
+      width: 16px;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--series);
+      display: inline-block;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+    th, td {
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--soft);
+      text-align: left;
+      vertical-align: middle;
+    }
+    th {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 780;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      background: #fbfbf9;
+    }
+    tr:last-child td { border-bottom: 0; }
+    .bench {
+      min-width: 260px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 13px;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+    .pkg {
+      display: block;
+      color: var(--muted);
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 12px;
+      margin-bottom: 2px;
+    }
+    .num {
+      white-space: nowrap;
+      font-variant-numeric: tabular-nums;
+    }
+    .delta {
+      display: inline-flex;
+      justify-content: center;
+      min-width: 72px;
+      padding: 4px 7px;
+      border-radius: 6px;
+      font-weight: 760;
+      font-variant-numeric: tabular-nums;
+    }
+    .good { color: var(--green); background: var(--green-bg); }
+    .bad { color: var(--red); background: var(--red-bg); }
+    .flat { color: var(--amber); background: var(--amber-bg); }
+    .muted { color: var(--muted); background: var(--soft); }
+    .barcell {
+      min-width: 170px;
+    }
+    .bartrack {
+      height: 9px;
+      border-radius: 999px;
+      background: var(--soft);
+      overflow: hidden;
+    }
+    .barfill {
+      display: block;
+      height: 100%;
+      width: calc(var(--w) * 1%);
+      min-width: 3px;
+      background: linear-gradient(90deg, var(--accent), #6a9c7d);
+      border-radius: inherit;
+    }
+    .empty {
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--paper);
+      color: var(--muted);
+    }
+    footer {
+      padding: 22px 0 38px;
+      color: var(--muted);
+      border-top: 1px solid var(--line);
+      font-size: 13px;
+    }
+    @media (max-width: 860px) {
+      .cards, .grid-2, .chart-grid { grid-template-columns: 1fr; }
+      .section-head { display: block; }
+      .section-head p { margin-top: 6px; }
+      table { display: block; overflow-x: auto; }
+      .topline { align-items: flex-start; }
+    }
+    @media (max-width: 560px) {
+      .wrap { width: min(100% - 22px, 1180px); }
+      header { padding-top: 20px; }
+      .topline { flex-direction: column; }
+      .links { justify-content: flex-start; }
+      h1 { font-size: 42px; }
+      .lede { font-size: 16px; }
+      th, td { padding: 9px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <div class="topline">
+        <div class="brand">
+          {{if .LogoDataURI}}<img alt="" src="{{.LogoDataURI}}">{{end}}
+          <span>let-go perf</span>
+        </div>
+        <nav class="links" aria-label="Links">
+          <a href="../">WASM repl</a>
+          <a href="https://github.com/nooga/let-go">GitHub</a>
+          <a href="https://github.com/nooga/let-go/blob/main/docs/perf/ratchet.md">Ratchet docs</a>
+        </nav>
+      </div>
+      <h1>{{.Title}}</h1>
+      <p class="lede">Committed benchmark ratchet data, rendered as a static page. Ratios are normalized to {{.Current.Anchor.Name}}, so lower is better and cross-machine drift is less noisy.</p>
+      <div class="meta">
+        <span class="chip">captured {{date .Current.CapturedAt}}</span>
+        <span class="chip">sha {{shortSHA .Current.CapturedAtSHA}}</span>
+        <span class="chip">{{.Current.Machine.CPUModel}}</span>
+        <span class="chip">{{.Current.Machine.GoVersion}}</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <div class="cards" aria-label="Summary">
+      <article class="card">
+        <p class="label">Tracked benches</p>
+        <p class="value">{{.Summary.BenchmarkCount}}</p>
+        <p class="note">{{.Summary.PackageCount}} packages in the current baseline</p>
+      </article>
+      <article class="card">
+        <p class="label">Zero allocs</p>
+        <p class="value">{{.Summary.ZeroAllocs}}</p>
+        <p class="note">benchmarks currently at 0 allocs/op</p>
+      </article>
+      <article class="card">
+        <p class="label">Since {{.ReferenceName}}</p>
+        <p class="value">{{pct .Summary.MedianDelta}}</p>
+        <p class="note">median anchor-relative delta across {{.Summary.Common}} shared benches</p>
+      </article>
+      <article class="card">
+        <p class="label">Movement</p>
+        <p class="value">{{.Summary.Faster}} / {{.Summary.Slower}}</p>
+        <p class="note">faster / slower by at least 5 percent</p>
+      </article>
+    </div>
+
+    <section>
+      <div class="section-head">
+        <h2>Timeline</h2>
+        <p>{{len .Timeline}} snapshot(s). CI snapshots graph real runs; seed points use committed historical/current JSON until the timeline fills in.</p>
+      </div>
+      {{if .Charts}}
+      <div class="chart-grid">
+        {{range .Charts}}
+        <article class="chart">
+          <h3>{{.Title}}</h3>
+          <p>{{.Subtitle}}</p>
+          <svg viewBox="0 0 520 210" role="img" aria-label="{{.Title}} trend chart">
+            <line class="axis" x1="46" y1="22" x2="46" y2="176"></line>
+            <line class="axis" x1="46" y1="176" x2="502" y2="176"></line>
+            <text class="axis-label" x="4" y="29">{{.YMaxText}}</text>
+            <text class="axis-label" x="4" y="176">{{.YMinText}}</text>
+            <text class="axis-label" x="4" y="194">{{.Unit}}</text>
+            <text class="axis-label" x="46" y="204">older</text>
+            <text class="axis-label" x="461" y="204">newer</text>
+            {{range .Series}}
+            {{$color := .Color}}
+            <path class="chart-line" stroke="{{$color}}" d="{{.Path}}"></path>
+            {{range .Points}}
+            <circle class="point" fill="{{$color}}" cx="{{printf "%.2f" .X}}" cy="{{printf "%.2f" .Y}}" r="4">
+              <title>{{.Date}} @ {{.SHA}}: {{.Text}}</title>
+            </circle>
+            {{end}}
+            {{end}}
+          </svg>
+          <div class="legend">
+            {{range .Series}}<span><i class="swatch" style="--series: {{.Color}}"></i>{{.Label}}</span>{{end}}
+          </div>
+        </article>
+        {{end}}
+      </div>
+      {{else}}
+      <div class="empty">No timeline-capable benchmarks found yet.</div>
+      {{end}}
+    </section>
+
+    <section>
+      <div class="section-head">
+        <h2>Largest changes</h2>
+        <p>Current ratchet compared with {{.ReferenceName}}.</p>
+      </div>
+      <div class="grid-2">
+        {{if .TopImprovements}}
+        <table>
+          <thead><tr><th>Improved</th><th>Delta</th><th>Now</th></tr></thead>
+          <tbody>
+            {{range .TopImprovements}}
+            <tr>
+              <td class="bench"><span class="pkg">{{.Package}}</span>{{.Name}}</td>
+              <td><span class="delta good">{{deltaText .Delta}}</span></td>
+              <td class="num">{{ratio .NewRatio}} anchors</td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+        {{else}}<div class="empty">No historical improvements found.</div>{{end}}
+
+        {{if .TopSlowdowns}}
+        <table>
+          <thead><tr><th>Slower</th><th>Delta</th><th>Now</th></tr></thead>
+          <tbody>
+            {{range .TopSlowdowns}}
+            <tr>
+              <td class="bench"><span class="pkg">{{.Package}}</span>{{.Name}}</td>
+              <td><span class="delta bad">{{deltaText .Delta}}</span></td>
+              <td class="num">{{ratio .NewRatio}} anchors</td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+        {{else}}<div class="empty">No historical slowdowns found.</div>{{end}}
+      </div>
+    </section>
+
+    <section>
+      <div class="section-head">
+        <h2>Recently tightened</h2>
+        <p>Most recent per-benchmark bars in the ratchet.</p>
+      </div>
+      <table>
+        <thead><tr><th>Benchmark</th><th>Bar set</th><th>Wall</th><th>Allocs</th></tr></thead>
+        <tbody>
+          {{range .RecentlyTightened}}
+          <tr>
+            <td class="bench"><span class="pkg">{{.Package}}</span>{{.Name}}</td>
+            <td class="num">{{date .BestSinceAt}} @ {{shortSHA .BestSinceSHA}}</td>
+            <td class="num">{{ns .NSPerOp}}</td>
+            <td class="num">{{count .AllocsPerOp}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <div class="section-head">
+        <h2>Current baseline</h2>
+        <p>Sorted by package and benchmark. Lower anchor ratio is faster.</p>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Benchmark</th>
+            <th>Ratio</th>
+            <th>Wall</th>
+            <th>Alloc</th>
+            <th>Bytes</th>
+            <th>Delta</th>
+            <th>Scale</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .Rows}}
+          <tr>
+            <td class="bench"><span class="pkg">{{.Package}}</span>{{.Name}}</td>
+            <td class="num">{{ratio .Ratio}}</td>
+            <td class="num">{{ns .NSPerOp}}</td>
+            <td class="num">{{count .AllocsPerOp}}</td>
+            <td class="num">{{bytes .BytesPerOp}}</td>
+            <td><span class="delta {{deltaClass .Delta}}">{{deltaText .Delta}}</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: {{bar .BarWidth}}"></span></div></td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap">Source data: docs/perf/baseline.json, docs/perf/historical/*.json, and docs/perf/timeline/*.json. Page generation does not run benchmarks.</div>
+  </footer>
+</body>
+</html>
+`

--- a/cmd/perf-page/main.go
+++ b/cmd/perf-page/main.go
@@ -13,42 +13,19 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/nooga/let-go/pkg/perfdata"
+	"golang.org/x/perf/benchunit"
 )
 
 const modulePrefix = "github.com/nooga/let-go/"
 
-type Baseline struct {
-	Version       int                       `json:"version"`
-	CapturedAt    string                    `json:"captured_at"`
-	CapturedAtSHA string                    `json:"captured_at_sha"`
-	Machine       Machine                   `json:"machine"`
-	Anchor        Anchor                    `json:"anchor"`
-	Benchmarks    map[string]BenchmarkEntry `json:"benchmarks"`
-}
-
-type Machine struct {
-	OS        string `json:"os"`
-	Arch      string `json:"arch"`
-	NumCPU    int    `json:"num_cpu"`
-	CPUModel  string `json:"cpu_model"`
-	GoVersion string `json:"go_version"`
-}
-
-type Anchor struct {
-	Name       string  `json:"name"`
-	Package    string  `json:"package"`
-	NSPerOp    float64 `json:"ns_per_op"`
-	Iterations int64   `json:"iterations"`
-}
-
-type BenchmarkEntry struct {
-	NSPerOp      float64 `json:"ns_per_op"`
-	AllocsPerOp  float64 `json:"allocs_per_op"`
-	BytesPerOp   float64 `json:"bytes_per_op"`
-	Ratio        float64 `json:"ratio_to_anchor"`
-	BestSinceSHA string  `json:"best_since_sha"`
-	BestSinceAt  string  `json:"best_since_at"`
-}
+type Baseline = perfdata.Baseline
+type Machine = perfdata.Machine
+type Anchor = perfdata.Anchor
+type BenchmarkEntry = perfdata.BenchmarkEntry
 
 type BenchmarkRow struct {
 	FullName     string
@@ -210,7 +187,8 @@ func loadLatestHistorical(dir string) (Baseline, string, error) {
 	for _, match := range matches {
 		baseline, err := loadBaseline(match)
 		if err != nil {
-			return Baseline{}, "", err
+			warnSkipBaseline(match, err)
+			continue
 		}
 		captured, _ := time.Parse(time.RFC3339, baseline.CapturedAt)
 		name := strings.TrimSuffix(filepath.Base(match), filepath.Ext(match))
@@ -220,6 +198,9 @@ func loadLatestHistorical(dir string) (Baseline, string, error) {
 			baseline: baseline,
 			captured: captured,
 		})
+	}
+	if len(all) == 0 {
+		return Baseline{}, "", nil
 	}
 	sort.Slice(all, func(i, j int) bool {
 		if !all[i].captured.Equal(all[j].captured) {
@@ -239,7 +220,8 @@ func loadTimeline(timelineDir, historicalDir string, current Baseline) ([]Snapsh
 	for _, match := range matches {
 		baseline, err := loadBaseline(match)
 		if err != nil {
-			return nil, err
+			warnSkipBaseline(match, err)
+			continue
 		}
 		snapshots = append(snapshots, makeSnapshot(strings.TrimSuffix(filepath.Base(match), filepath.Ext(match)), baseline))
 	}
@@ -251,7 +233,8 @@ func loadTimeline(timelineDir, historicalDir string, current Baseline) ([]Snapsh
 		for _, match := range historical {
 			baseline, err := loadBaseline(match)
 			if err != nil {
-				return nil, err
+				warnSkipBaseline(match, err)
+				continue
 			}
 			snapshots = append(snapshots, makeSnapshot(strings.TrimSuffix(filepath.Base(match), filepath.Ext(match)), baseline))
 		}
@@ -267,6 +250,10 @@ func loadTimeline(timelineDir, historicalDir string, current Baseline) ([]Snapsh
 		return snapshots[i].Name < snapshots[j].Name
 	})
 	return snapshots, nil
+}
+
+func warnSkipBaseline(path string, err error) {
+	fmt.Fprintf(os.Stderr, "perf-page: warning: skipping %s: %v\n", path, err)
 }
 
 func makeSnapshot(name string, baseline Baseline) Snapshot {
@@ -348,7 +335,7 @@ func buildCharts(timeline []Snapshot) []Chart {
 			title:    "End-to-end suite",
 			subtitle: "Anchor-normalized jank clojure-test-suite wall time. Lower is better.",
 			unit:     "anchors",
-			metric:   func(entry BenchmarkEntry) float64 { return entry.Ratio },
+			metric:   func(entry BenchmarkEntry) float64 { return entry.RatioToAnchor },
 			format:   formatRatio,
 			series: []chartSeriesSpec{
 				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]"},
@@ -359,7 +346,7 @@ func buildCharts(timeline []Snapshot) []Chart {
 			title:    "IR compile",
 			subtitle: "Anchor-normalized IR compile benchmark variants. Lower is better.",
 			unit:     "anchors",
-			metric:   func(entry BenchmarkEntry) float64 { return entry.Ratio },
+			metric:   func(entry BenchmarkEntry) float64 { return entry.RatioToAnchor },
 			format:   formatRatio,
 			series: []chartSeriesSpec{
 				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [bytecode]"},
@@ -370,7 +357,7 @@ func buildCharts(timeline []Snapshot) []Chart {
 			title:    "Suite allocations",
 			subtitle: "allocs/op for the full suite benchmark variants. Lower is better.",
 			unit:     "allocs/op",
-			metric:   func(entry BenchmarkEntry) float64 { return entry.AllocsPerOp },
+			metric:   func(entry BenchmarkEntry) float64 { return float64(entry.AllocsPerOp) },
 			format:   formatCount,
 			series: []chartSeriesSpec{
 				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]"},
@@ -381,7 +368,7 @@ func buildCharts(timeline []Snapshot) []Chart {
 			title:    "Suite memory",
 			subtitle: "bytes/op for the full suite benchmark variants. Lower is better.",
 			unit:     "B/op",
-			metric:   func(entry BenchmarkEntry) float64 { return entry.BytesPerOp },
+			metric:   func(entry BenchmarkEntry) float64 { return float64(entry.BytesPerOp) },
 			format:   formatBytes,
 			series: []chartSeriesSpec{
 				{label: "bytecode", color: "#245c73", name: "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]"},
@@ -526,9 +513,9 @@ func benchmarkRows(baseline Baseline) []BenchmarkRow {
 			Package:      pkg,
 			Name:         name,
 			NSPerOp:      entry.NSPerOp,
-			AllocsPerOp:  entry.AllocsPerOp,
-			BytesPerOp:   entry.BytesPerOp,
-			Ratio:        entry.Ratio,
+			AllocsPerOp:  float64(entry.AllocsPerOp),
+			BytesPerOp:   float64(entry.BytesPerOp),
+			Ratio:        entry.RatioToAnchor,
 			BestSinceSHA: entry.BestSinceSHA,
 			BestSinceAt:  entry.BestSinceAt,
 		})
@@ -564,10 +551,10 @@ func compare(current, reference Baseline) (map[string]float64, Summary) {
 			summary.New++
 			continue
 		}
-		if ref.Ratio == 0 {
+		if ref.RatioToAnchor == 0 {
 			continue
 		}
-		delta := cur.Ratio/ref.Ratio - 1
+		delta := cur.RatioToAnchor/ref.RatioToAnchor - 1
 		changes[name] = delta
 		deltas = append(deltas, delta)
 		summary.Common++
@@ -594,15 +581,15 @@ func topChanges(current, reference Baseline, limit int) ([]ChangeRow, []ChangeRo
 	for _, row := range benchmarkRows(current) {
 		cur := current.Benchmarks[row.FullName]
 		ref, ok := reference.Benchmarks[row.FullName]
-		if !ok || ref.Ratio == 0 {
+		if !ok || ref.RatioToAnchor == 0 {
 			continue
 		}
-		delta := cur.Ratio/ref.Ratio - 1
+		delta := cur.RatioToAnchor/ref.RatioToAnchor - 1
 		row.Delta = &delta
 		rows = append(rows, ChangeRow{
 			BenchmarkRow: row,
-			OldRatio:     ref.Ratio,
-			NewRatio:     cur.Ratio,
+			OldRatio:     ref.RatioToAnchor,
+			NewRatio:     cur.RatioToAnchor,
 		})
 	}
 
@@ -698,31 +685,68 @@ func shortSHA(value string) string {
 }
 
 func formatNS(value float64) string {
-	switch {
-	case value < 1_000:
-		return fmt.Sprintf("%.2f ns", value)
-	case value < 1_000_000:
-		return fmt.Sprintf("%.2f us", value/1_000)
-	case value < 1_000_000_000:
-		return fmt.Sprintf("%.2f ms", value/1_000_000)
-	default:
-		return fmt.Sprintf("%.2f s", value/1_000_000_000)
-	}
+	return formatScaledUnit(value, "ns")
 }
 
 func formatBytes(value float64) string {
-	switch {
-	case value < 1024:
-		return fmt.Sprintf("%.0f B", value)
-	case value < 1024*1024:
-		return fmt.Sprintf("%.1f KiB", value/1024)
-	default:
-		return fmt.Sprintf("%.1f MiB", value/(1024*1024))
-	}
+	return formatScaledUnit(value, "B")
 }
 
 func formatCount(value float64) string {
-	return formatCompact(value)
+	number, prefix := splitBenchunitScale(benchunit.Scale(value, benchunit.Decimal))
+	return trimScaledNumber(number) + prefix
+}
+
+func formatScaledUnit(value float64, unit string) string {
+	tidiedValue, tidiedUnit := benchunit.Tidy(value, unit)
+	number, prefix := splitBenchunitScale(benchunit.Scale(tidiedValue, benchunit.ClassOf(tidiedUnit)))
+	return trimScaledNumber(number) + " " + displayUnit(prefix, tidiedUnit)
+}
+
+func splitBenchunitScale(value string) (string, string) {
+	idx := len(value)
+	for idx > 0 {
+		r, size := utf8.DecodeLastRuneInString(value[:idx])
+		if r == '.' || r == '-' || r == '+' || unicode.IsDigit(r) {
+			break
+		}
+		idx -= size
+	}
+	return value[:idx], value[idx:]
+}
+
+func trimScaledNumber(value string) string {
+	if !strings.Contains(value, ".") {
+		return value
+	}
+	value = strings.TrimRight(value, "0")
+	value = strings.TrimRight(value, ".")
+	if value == "-0" {
+		return "0"
+	}
+	return value
+}
+
+func displayUnit(prefix, unit string) string {
+	switch unit {
+	case "sec":
+		switch prefix {
+		case "n":
+			return "ns"
+		case "µ":
+			return "us"
+		case "m":
+			return "ms"
+		case "":
+			return "s"
+		default:
+			return prefix + "s"
+		}
+	case "B":
+		return prefix + "B"
+	default:
+		return prefix + unit
+	}
 }
 
 func formatRatio(value float64) string {

--- a/cmd/perf-page/main_test.go
+++ b/cmd/perf-page/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import "testing"
+
+func TestSplitBenchmarkName(t *testing.T) {
+	pkg, name := splitBenchmarkName("github.com/nooga/let-go/pkg/vm.BenchmarkFuncInvoke/Direct")
+	if pkg != "pkg/vm" {
+		t.Fatalf("package = %q, want pkg/vm", pkg)
+	}
+	if name != "BenchmarkFuncInvoke/Direct" {
+		t.Fatalf("name = %q, want BenchmarkFuncInvoke/Direct", name)
+	}
+
+	pkg, name = splitBenchmarkName("github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [gogen_ir]")
+	if pkg != "pkg/ir" {
+		t.Fatalf("package = %q, want pkg/ir", pkg)
+	}
+	if name != "BenchmarkIRCompile [gogen_ir]" {
+		t.Fatalf("name = %q, want BenchmarkIRCompile [gogen_ir]", name)
+	}
+}
+
+func TestCompareWithHistorical(t *testing.T) {
+	current := Baseline{Benchmarks: map[string]BenchmarkEntry{
+		"pkg.BenchmarkA": {Ratio: 80},
+		"pkg.BenchmarkB": {Ratio: 120},
+		"pkg.BenchmarkC": {Ratio: 50},
+	}}
+	reference := Baseline{Benchmarks: map[string]BenchmarkEntry{
+		"pkg.BenchmarkA": {Ratio: 100},
+		"pkg.BenchmarkB": {Ratio: 100},
+		"pkg.BenchmarkD": {Ratio: 10},
+	}}
+
+	changes, summary := compare(current, reference)
+	if summary.Common != 2 {
+		t.Fatalf("common = %d, want 2", summary.Common)
+	}
+	if summary.New != 1 {
+		t.Fatalf("new = %d, want 1", summary.New)
+	}
+	if summary.Missing != 1 {
+		t.Fatalf("missing = %d, want 1", summary.Missing)
+	}
+	if summary.Faster != 1 {
+		t.Fatalf("faster = %d, want 1", summary.Faster)
+	}
+	if summary.Slower != 1 {
+		t.Fatalf("slower = %d, want 1", summary.Slower)
+	}
+	if summary.MedianDelta != 0 {
+		t.Fatalf("median delta = %v, want 0", summary.MedianDelta)
+	}
+	if got := changes["pkg.BenchmarkA"]; !near(got, -0.2) {
+		t.Fatalf("BenchmarkA delta = %v, want -0.2", got)
+	}
+	if got := changes["pkg.BenchmarkB"]; !near(got, 0.2) {
+		t.Fatalf("BenchmarkB delta = %v, want 0.2", got)
+	}
+}
+
+func TestBuildCharts(t *testing.T) {
+	timeline := []Snapshot{
+		makeSnapshot("a", Baseline{
+			CapturedAt:    "2026-06-01T00:00:00Z",
+			CapturedAtSHA: "aaaaaaaaaaaa",
+			Benchmarks: map[string]BenchmarkEntry{
+				"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]": {Ratio: 100, AllocsPerOp: 10, BytesPerOp: 1000},
+			},
+		}),
+		makeSnapshot("b", Baseline{
+			CapturedAt:    "2026-06-02T00:00:00Z",
+			CapturedAtSHA: "bbbbbbbbbbbb",
+			Benchmarks: map[string]BenchmarkEntry{
+				"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]": {Ratio: 80, AllocsPerOp: 9, BytesPerOp: 900},
+			},
+		}),
+	}
+
+	charts := buildCharts(timeline)
+	if len(charts) != 3 {
+		t.Fatalf("chart count = %d, want 3", len(charts))
+	}
+	if charts[0].Title != "End-to-end suite" {
+		t.Fatalf("first chart = %q, want End-to-end suite", charts[0].Title)
+	}
+	if len(charts[0].Series) != 1 {
+		t.Fatalf("series count = %d, want 1", len(charts[0].Series))
+	}
+	if len(charts[0].Series[0].Points) != 2 {
+		t.Fatalf("point count = %d, want 2", len(charts[0].Series[0].Points))
+	}
+	if charts[0].Series[0].Path == "" {
+		t.Fatal("expected SVG path")
+	}
+	if charts[0].Series[0].Points[1].X <= charts[0].Series[0].Points[0].X {
+		t.Fatalf("x coordinates did not advance: %#v", charts[0].Series[0].Points)
+	}
+}
+
+func near(got, want float64) bool {
+	diff := got - want
+	return diff < 0.0000001 && diff > -0.0000001
+}
+
+func TestFormatNS(t *testing.T) {
+	tests := map[float64]string{
+		12.345:         "12.35 ns",
+		12_345:         "12.35 us",
+		12_345_000:     "12.35 ms",
+		12_345_000_000: "12.35 s",
+	}
+	for input, want := range tests {
+		if got := formatNS(input); got != want {
+			t.Fatalf("formatNS(%v) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestFormatRatioCompactsLargeValues(t *testing.T) {
+	tests := map[float64]string{
+		1_124_520_183: "1.12B",
+		8_519_621:     "8.52M",
+		66_309:        "66.3k",
+		16.209:        "16.2",
+		4.688:         "4.69",
+	}
+	for input, want := range tests {
+		if got := formatRatio(input); got != want {
+			t.Fatalf("formatRatio(%v) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/cmd/perf-page/main_test.go
+++ b/cmd/perf-page/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestSplitBenchmarkName(t *testing.T) {
 	pkg, name := splitBenchmarkName("github.com/nooga/let-go/pkg/vm.BenchmarkFuncInvoke/Direct")
@@ -22,14 +28,14 @@ func TestSplitBenchmarkName(t *testing.T) {
 
 func TestCompareWithHistorical(t *testing.T) {
 	current := Baseline{Benchmarks: map[string]BenchmarkEntry{
-		"pkg.BenchmarkA": {Ratio: 80},
-		"pkg.BenchmarkB": {Ratio: 120},
-		"pkg.BenchmarkC": {Ratio: 50},
+		"pkg.BenchmarkA": {RatioToAnchor: 80},
+		"pkg.BenchmarkB": {RatioToAnchor: 120},
+		"pkg.BenchmarkC": {RatioToAnchor: 50},
 	}}
 	reference := Baseline{Benchmarks: map[string]BenchmarkEntry{
-		"pkg.BenchmarkA": {Ratio: 100},
-		"pkg.BenchmarkB": {Ratio: 100},
-		"pkg.BenchmarkD": {Ratio: 10},
+		"pkg.BenchmarkA": {RatioToAnchor: 100},
+		"pkg.BenchmarkB": {RatioToAnchor: 100},
+		"pkg.BenchmarkD": {RatioToAnchor: 10},
 	}}
 
 	changes, summary := compare(current, reference)
@@ -65,14 +71,14 @@ func TestBuildCharts(t *testing.T) {
 			CapturedAt:    "2026-06-01T00:00:00Z",
 			CapturedAtSHA: "aaaaaaaaaaaa",
 			Benchmarks: map[string]BenchmarkEntry{
-				"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]": {Ratio: 100, AllocsPerOp: 10, BytesPerOp: 1000},
+				"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]": {RatioToAnchor: 100, AllocsPerOp: 10, BytesPerOp: 1000},
 			},
 		}),
 		makeSnapshot("b", Baseline{
 			CapturedAt:    "2026-06-02T00:00:00Z",
 			CapturedAtSHA: "bbbbbbbbbbbb",
 			Benchmarks: map[string]BenchmarkEntry{
-				"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]": {Ratio: 80, AllocsPerOp: 9, BytesPerOp: 900},
+				"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]": {RatioToAnchor: 80, AllocsPerOp: 9, BytesPerOp: 900},
 			},
 		}),
 	}
@@ -114,6 +120,48 @@ func TestFormatNS(t *testing.T) {
 		if got := formatNS(input); got != want {
 			t.Fatalf("formatNS(%v) = %q, want %q", input, got, want)
 		}
+	}
+}
+
+func TestLoadTimelineSkipsCorruptSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	timelineDir := filepath.Join(dir, "timeline")
+	historicalDir := filepath.Join(dir, "historical")
+	if err := os.MkdirAll(timelineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(historicalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := `{"version":1,"captured_at":"2026-06-01T00:00:00Z","captured_at_sha":"abc","benchmarks":{"pkg.BenchmarkA":{"ns_per_op":1,"ratio_to_anchor":2}}}`
+	if err := os.WriteFile(filepath.Join(timelineDir, "good.json"), []byte(good), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(timelineDir, "bad.json"), []byte(`{"version":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr strings.Builder
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	snapshots, err := loadTimeline(timelineDir, historicalDir, Baseline{})
+	_ = w.Close()
+	os.Stderr = oldStderr
+	if _, copyErr := io.Copy(&stderr, r); copyErr != nil {
+		t.Fatal(copyErr)
+	}
+	if err != nil {
+		t.Fatalf("loadTimeline returned error: %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("snapshot count = %d, want 1", len(snapshots))
+	}
+	if !strings.Contains(stderr.String(), "skipping") {
+		t.Fatalf("stderr = %q, want skip warning", stderr.String())
 	}
 }
 

--- a/docs/perf/index.html
+++ b/docs/perf/index.html
@@ -477,7 +477,7 @@
             <line class="axis" x1="46" y1="22" x2="46" y2="176"></line>
             <line class="axis" x1="46" y1="176" x2="502" y2="176"></line>
             <text class="axis-label" x="4" y="29">8.52M</text>
-            <text class="axis-label" x="4" y="176">8.44M</text>
+            <text class="axis-label" x="4" y="176">8.441M</text>
             <text class="axis-label" x="4" y="194">allocs/op</text>
             <text class="axis-label" x="46" y="204">older</text>
             <text class="axis-label" x="461" y="204">newer</text>
@@ -486,7 +486,7 @@
             <path class="chart-line" stroke="#245c73" d="M 502.00 165.38"></path>
             
             <circle class="point" fill="#245c73" cx="502.00" cy="165.38" r="4">
-              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 8.45M</title>
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 8.446M</title>
             </circle>
             
             
@@ -494,7 +494,7 @@
             <path class="chart-line" stroke="#167a48" d="M 502.00 32.62"></path>
             
             <circle class="point" fill="#167a48" cx="502.00" cy="32.62" r="4">
-              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 8.51M</title>
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 8.514M</title>
             </circle>
             
             
@@ -580,42 +580,42 @@
           <tr>
             <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [bytecode]</td>
             <td class="num">2026-05-30 21:01 UTC @ c4623afd0ef6</td>
-            <td class="num">1.91 s</td>
-            <td class="num">8.45M</td>
+            <td class="num">1.909 s</td>
+            <td class="num">8.446M</td>
           </tr>
           
           <tr>
             <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [gogen_ir]</td>
             <td class="num">2026-05-30 21:01 UTC @ c4623afd0ef6</td>
-            <td class="num">2.07 s</td>
-            <td class="num">8.51M</td>
+            <td class="num">2.075 s</td>
+            <td class="num">8.514M</td>
           </tr>
           
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/ArrayVector</td>
             <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
-            <td class="num">9.19 us</td>
+            <td class="num">9.193 us</td>
             <td class="num">216</td>
           </tr>
           
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/List</td>
             <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
-            <td class="num">1.98 us</td>
+            <td class="num">1.981 us</td>
             <td class="num">100</td>
           </tr>
           
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/Map</td>
             <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
-            <td class="num">168.50 us</td>
+            <td class="num">168.5 us</td>
             <td class="num">659</td>
           </tr>
           
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConsCreation/ListCons</td>
             <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
-            <td class="num">0.32 ns</td>
+            <td class="num">0.3166 ns</td>
             <td class="num">0</td>
           </tr>
           
@@ -647,7 +647,7 @@
             <td class="num">23.66M</td>
             <td class="num">23.97 ms</td>
             <td class="num">306.9k</td>
-            <td class="num">9.9 MiB</td>
+            <td class="num">9.891 MiB</td>
             <td><span class="delta muted">new</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 81.50"></span></div></td>
           </tr>
@@ -657,7 +657,7 @@
             <td class="num">23.56M</td>
             <td class="num">23.87 ms</td>
             <td class="num">306.9k</td>
-            <td class="num">9.9 MiB</td>
+            <td class="num">9.891 MiB</td>
             <td><span class="delta muted">new</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 81.48"></span></div></td>
           </tr>
@@ -665,9 +665,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/ArrayVector</td>
             <td class="num">8.5k</td>
-            <td class="num">9.19 us</td>
+            <td class="num">9.193 us</td>
             <td class="num">216</td>
-            <td class="num">33.7 KiB</td>
+            <td class="num">33.73 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 43.40"></span></div></td>
           </tr>
@@ -675,9 +675,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/List</td>
             <td class="num">1.8k</td>
-            <td class="num">1.98 us</td>
+            <td class="num">1.981 us</td>
             <td class="num">100</td>
-            <td class="num">6.2 KiB</td>
+            <td class="num">6.25 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.04"></span></div></td>
           </tr>
@@ -685,7 +685,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/Map</td>
             <td class="num">155.0k</td>
-            <td class="num">168.50 us</td>
+            <td class="num">168.5 us</td>
             <td class="num">659</td>
             <td class="num">307.8 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -695,7 +695,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConsCreation/ListCons</td>
             <td class="num">0.29</td>
-            <td class="num">0.32 ns</td>
+            <td class="num">0.3166 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -705,7 +705,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConsCreation/NewCons</td>
             <td class="num">0.27</td>
-            <td class="num">0.29 ns</td>
+            <td class="num">0.2888 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -735,7 +735,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFrameDispatch</td>
             <td class="num">454.5</td>
-            <td class="num">494.20 ns</td>
+            <td class="num">494.2 ns</td>
             <td class="num">2</td>
             <td class="num">416 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -765,7 +765,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFuncInvoke/Native</td>
             <td class="num">4.69</td>
-            <td class="num">5.10 ns</td>
+            <td class="num">5.098 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -775,7 +775,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/false</td>
             <td class="num">2.23</td>
-            <td class="num">2.42 ns</td>
+            <td class="num">2.422 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -785,7 +785,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/int</td>
             <td class="num">0.79</td>
-            <td class="num">0.86 ns</td>
+            <td class="num">0.8641 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -795,7 +795,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/nil</td>
             <td class="num">0.55</td>
-            <td class="num">0.59 ns</td>
+            <td class="num">0.5933 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -805,7 +805,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/string</td>
             <td class="num">0.80</td>
-            <td class="num">0.87 ns</td>
+            <td class="num">0.8711 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -815,7 +815,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/true</td>
             <td class="num">2.22</td>
-            <td class="num">2.41 ns</td>
+            <td class="num">2.413 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -825,8 +825,8 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkLazySeqRealize/Realize/01000</td>
             <td class="num">96.9k</td>
-            <td class="num">105.42 us</td>
-            <td class="num">4.7k</td>
+            <td class="num">105.4 us</td>
+            <td class="num">4.747k</td>
             <td class="num">201.2 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 55.11"></span></div></td>
@@ -835,9 +835,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkLazySeqRealize/Realize/10</td>
             <td class="num">995.2</td>
-            <td class="num">1.08 us</td>
+            <td class="num">1.082 us</td>
             <td class="num">43</td>
-            <td class="num">2.1 KiB</td>
+            <td class="num">2.062 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 33.14"></span></div></td>
           </tr>
@@ -847,7 +847,7 @@
             <td class="num">9.8k</td>
             <td class="num">10.68 us</td>
             <td class="num">403</td>
-            <td class="num">19.6 KiB</td>
+            <td class="num">19.64 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 44.12"></span></div></td>
           </tr>
@@ -855,7 +855,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Assoc/01000</td>
             <td class="num">66.3k</td>
-            <td class="num">72.10 us</td>
+            <td class="num">72.1 us</td>
             <td class="num">20</td>
             <td class="num">156.2 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -865,7 +865,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Assoc/10</td>
             <td class="num">415.7</td>
-            <td class="num">451.98 ns</td>
+            <td class="num">452 ns</td>
             <td class="num">3</td>
             <td class="num">616 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -875,9 +875,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Assoc/100</td>
             <td class="num">4.2k</td>
-            <td class="num">4.53 us</td>
+            <td class="num">4.533 us</td>
             <td class="num">9</td>
-            <td class="num">8.8 KiB</td>
+            <td class="num">8.82 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 40.01"></span></div></td>
           </tr>
@@ -915,9 +915,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Assoc/01000</td>
             <td class="num">408.7</td>
-            <td class="num">444.44 ns</td>
+            <td class="num">444.4 ns</td>
             <td class="num">6</td>
-            <td class="num">2.0 KiB</td>
+            <td class="num">2.048 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 28.87"></span></div></td>
           </tr>
@@ -925,7 +925,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Assoc/10</td>
             <td class="num">113.3</td>
-            <td class="num">123.22 ns</td>
+            <td class="num">123.2 ns</td>
             <td class="num">4</td>
             <td class="num">353 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -935,9 +935,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Assoc/100</td>
             <td class="num">244.4</td>
-            <td class="num">265.80 ns</td>
+            <td class="num">265.8 ns</td>
             <td class="num">6</td>
-            <td class="num">1.2 KiB</td>
+            <td class="num">1.235 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 26.41"></span></div></td>
           </tr>
@@ -945,9 +945,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Dissoc/01000</td>
             <td class="num">424.6</td>
-            <td class="num">461.74 ns</td>
+            <td class="num">461.7 ns</td>
             <td class="num">5</td>
-            <td class="num">2.0 KiB</td>
+            <td class="num">2.047 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 29.06"></span></div></td>
           </tr>
@@ -955,7 +955,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Dissoc/10</td>
             <td class="num">136.5</td>
-            <td class="num">148.44 ns</td>
+            <td class="num">148.4 ns</td>
             <td class="num">3</td>
             <td class="num">320 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -965,9 +965,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Dissoc/100</td>
             <td class="num">232.4</td>
-            <td class="num">252.76 ns</td>
+            <td class="num">252.8 ns</td>
             <td class="num">5</td>
-            <td class="num">1.2 KiB</td>
+            <td class="num">1.203 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 26.17"></span></div></td>
           </tr>
@@ -975,7 +975,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Lookup/01000</td>
             <td class="num">24.9</td>
-            <td class="num">27.10 ns</td>
+            <td class="num">27.1 ns</td>
             <td class="num">1</td>
             <td class="num">8 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1046,8 +1046,8 @@
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/ArrayVector/01000</td>
             <td class="num">13.7k</td>
             <td class="num">14.89 us</td>
-            <td class="num">1.0k</td>
-            <td class="num">31.2 KiB</td>
+            <td class="num">1k</td>
+            <td class="num">31.25 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 45.72"></span></div></td>
           </tr>
@@ -1055,7 +1055,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/ArrayVector/10</td>
             <td class="num">148.2</td>
-            <td class="num">161.20 ns</td>
+            <td class="num">161.2 ns</td>
             <td class="num">10</td>
             <td class="num">320 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1065,9 +1065,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/ArrayVector/100</td>
             <td class="num">1.4k</td>
-            <td class="num">1.51 us</td>
+            <td class="num">1.513 us</td>
             <td class="num">100</td>
-            <td class="num">3.1 KiB</td>
+            <td class="num">3.125 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 34.74"></span></div></td>
           </tr>
@@ -1075,7 +1075,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/List/01000</td>
             <td class="num">1.8k</td>
-            <td class="num">1.94 us</td>
+            <td class="num">1.935 us</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1095,7 +1095,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/List/100</td>
             <td class="num">183.2</td>
-            <td class="num">199.26 ns</td>
+            <td class="num">199.3 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1106,8 +1106,8 @@
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/PersistentVector/01000</td>
             <td class="num">18.9k</td>
             <td class="num">20.57 us</td>
-            <td class="num">1.0k</td>
-            <td class="num">47.0 KiB</td>
+            <td class="num">1.001k</td>
+            <td class="num">46.95 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 47.27"></span></div></td>
           </tr>
@@ -1115,7 +1115,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/PersistentVector/10</td>
             <td class="num">206.9</td>
-            <td class="num">224.94 ns</td>
+            <td class="num">224.9 ns</td>
             <td class="num">11</td>
             <td class="num">560 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1125,9 +1125,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/PersistentVector/100</td>
             <td class="num">2.0k</td>
-            <td class="num">2.16 us</td>
+            <td class="num">2.163 us</td>
             <td class="num">101</td>
-            <td class="num">4.8 KiB</td>
+            <td class="num">4.766 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.46"></span></div></td>
           </tr>
@@ -1135,7 +1135,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkStackOps/Push</td>
             <td class="num">0.72</td>
-            <td class="num">0.78 ns</td>
+            <td class="num">0.7809 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1145,7 +1145,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkStackOps/PushPop</td>
             <td class="num">0.74</td>
-            <td class="num">0.81 ns</td>
+            <td class="num">0.8081 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1175,7 +1175,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVariadicInvoke/5Args</td>
             <td class="num">227.4</td>
-            <td class="num">247.26 ns</td>
+            <td class="num">247.3 ns</td>
             <td class="num">6</td>
             <td class="num">344 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1185,7 +1185,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/10</td>
             <td class="num">0.43</td>
-            <td class="num">0.47 ns</td>
+            <td class="num">0.4728 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1195,7 +1195,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/100</td>
             <td class="num">0.41</td>
-            <td class="num">0.45 ns</td>
+            <td class="num">0.4468 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1205,7 +1205,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/1000</td>
             <td class="num">0.42</td>
-            <td class="num">0.45 ns</td>
+            <td class="num">0.4524 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1215,7 +1215,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/10000</td>
             <td class="num">0.42</td>
-            <td class="num">0.46 ns</td>
+            <td class="num">0.4568 ns</td>
             <td class="num">0</td>
             <td class="num">0 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1267,7 +1267,7 @@
             <td class="num">1.3k</td>
             <td class="num">1.42 us</td>
             <td class="num">20</td>
-            <td class="num">1.1 KiB</td>
+            <td class="num">1.094 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 34.44"></span></div></td>
           </tr>
@@ -1285,8 +1285,8 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/ArrayVector/1000</td>
             <td class="num">97.6k</td>
-            <td class="num">106.16 us</td>
-            <td class="num">2.9k</td>
+            <td class="num">106.2 us</td>
+            <td class="num">2.899k</td>
             <td class="num">382.7 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 55.14"></span></div></td>
@@ -1295,9 +1295,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/PersistentVector/10</td>
             <td class="num">2.0k</td>
-            <td class="num">2.19 us</td>
+            <td class="num">2.186 us</td>
             <td class="num">22</td>
-            <td class="num">2.2 KiB</td>
+            <td class="num">2.164 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.51"></span></div></td>
           </tr>
@@ -1307,7 +1307,7 @@
             <td class="num">9.9k</td>
             <td class="num">10.82 us</td>
             <td class="num">216</td>
-            <td class="num">35.4 KiB</td>
+            <td class="num">35.41 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 44.18"></span></div></td>
           </tr>
@@ -1315,7 +1315,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/PersistentVector/1000</td>
             <td class="num">98.1k</td>
-            <td class="num">106.67 us</td>
+            <td class="num">106.7 us</td>
             <td class="num">2.9k</td>
             <td class="num">384.4 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1335,9 +1335,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/ArrayVector/100</td>
             <td class="num">286.7</td>
-            <td class="num">311.72 ns</td>
+            <td class="num">311.7 ns</td>
             <td class="num">1</td>
-            <td class="num">1.8 KiB</td>
+            <td class="num">1.75 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 27.18"></span></div></td>
           </tr>
@@ -1345,9 +1345,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/ArrayVector/1000</td>
             <td class="num">2.0k</td>
-            <td class="num">2.16 us</td>
+            <td class="num">2.163 us</td>
             <td class="num">1</td>
-            <td class="num">16.0 KiB</td>
+            <td class="num">16 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.46"></span></div></td>
           </tr>
@@ -1357,7 +1357,7 @@
             <td class="num">23.6k</td>
             <td class="num">25.63 us</td>
             <td class="num">1</td>
-            <td class="num">160.0 KiB</td>
+            <td class="num">160 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 48.32"></span></div></td>
           </tr>
@@ -1365,7 +1365,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/PersistentVector/10</td>
             <td class="num">206.5</td>
-            <td class="num">224.52 ns</td>
+            <td class="num">224.5 ns</td>
             <td class="num">4</td>
             <td class="num">776 B</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1375,9 +1375,9 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/PersistentVector/100</td>
             <td class="num">642.0</td>
-            <td class="num">698.08 ns</td>
+            <td class="num">698.1 ns</td>
             <td class="num">10</td>
-            <td class="num">1.8 KiB</td>
+            <td class="num">1.781 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 31.04"></span></div></td>
           </tr>
@@ -1385,7 +1385,7 @@
           <tr>
             <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/PersistentVector/1000</td>
             <td class="num">3.7k</td>
-            <td class="num">4.08 us</td>
+            <td class="num">4.076 us</td>
             <td class="num">67</td>
             <td class="num">17.2 KiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
@@ -1405,8 +1405,8 @@
           <tr>
             <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite</td>
             <td class="num">599.52M</td>
-            <td class="num">651.91 ms</td>
-            <td class="num">9.01M</td>
+            <td class="num">651.9 ms</td>
+            <td class="num">9.014M</td>
             <td class="num">368.2 MiB</td>
             <td><span class="delta flat">&#43;0.0%</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 97.01"></span></div></td>
@@ -1415,8 +1415,8 @@
           <tr>
             <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [bytecode]</td>
             <td class="num">1.03B</td>
-            <td class="num">1.91 s</td>
-            <td class="num">8.45M</td>
+            <td class="num">1.909 s</td>
+            <td class="num">8.446M</td>
             <td class="num">367.4 MiB</td>
             <td><span class="delta muted">new</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 99.60"></span></div></td>
@@ -1425,8 +1425,8 @@
           <tr>
             <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [gogen_ir]</td>
             <td class="num">1.12B</td>
-            <td class="num">2.07 s</td>
-            <td class="num">8.51M</td>
+            <td class="num">2.075 s</td>
+            <td class="num">8.514M</td>
             <td class="num">370.1 MiB</td>
             <td><span class="delta muted">new</span></td>
             <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 100.00"></span></div></td>

--- a/docs/perf/index.html
+++ b/docs/perf/index.html
@@ -1,0 +1,1444 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Are we fast yet? - let-go perf</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f7f4;
+      --paper: #ffffff;
+      --ink: #171717;
+      --muted: #65645f;
+      --line: #deddd6;
+      --soft: #eeede7;
+      --green: #167a48;
+      --green-bg: #e4f3ea;
+      --red: #aa2e2e;
+      --red-bg: #f8e3e0;
+      --amber: #8b5e12;
+      --amber-bg: #f4ead2;
+      --accent: #245c73;
+      --shadow: 0 18px 50px rgba(23, 23, 23, 0.08);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+    .wrap {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+    }
+    header {
+      padding: 34px 0 24px;
+      border-bottom: 1px solid var(--line);
+      background:
+        linear-gradient(90deg, rgba(36, 92, 115, 0.12), transparent 42%),
+        linear-gradient(180deg, #ffffff, var(--bg));
+    }
+    .topline {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      margin-bottom: 28px;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+      font-weight: 750;
+      letter-spacing: 0;
+    }
+    .brand img {
+      width: 42px;
+      height: 42px;
+      display: block;
+    }
+    .brand span {
+      white-space: nowrap;
+    }
+    .links {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+    .links a {
+      color: var(--ink);
+      text-decoration: none;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.7);
+      border-radius: 7px;
+      padding: 7px 10px;
+      font-size: 13px;
+      font-weight: 650;
+    }
+    h1 {
+      margin: 0;
+      font-size: clamp(42px, 7vw, 86px);
+      line-height: 0.94;
+      letter-spacing: 0;
+      max-width: 820px;
+    }
+    .lede {
+      margin: 18px 0 0;
+      max-width: 760px;
+      color: var(--muted);
+      font-size: 18px;
+    }
+    .meta {
+      margin-top: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      min-height: 30px;
+      padding: 5px 9px;
+      border-radius: 7px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.72);
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 620;
+    }
+    main { padding: 28px 0 54px; }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 30px;
+    }
+    .card {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 16px;
+      min-height: 116px;
+    }
+    .label {
+      margin: 0 0 8px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 760;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .value {
+      margin: 0;
+      font-size: 32px;
+      line-height: 1;
+      font-weight: 820;
+      letter-spacing: 0;
+    }
+    .note {
+      margin: 9px 0 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    section {
+      margin-top: 34px;
+    }
+    .section-head {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 12px;
+    }
+    h2 {
+      margin: 0;
+      font-size: 24px;
+      line-height: 1.15;
+      letter-spacing: 0;
+    }
+    .section-head p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .grid-2 {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .chart {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 14px;
+      min-width: 0;
+    }
+    .chart h3 {
+      margin: 0;
+      font-size: 16px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+    .chart p {
+      margin: 5px 0 12px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .chart svg {
+      width: 100%;
+      height: auto;
+      display: block;
+      overflow: visible;
+    }
+    .axis {
+      stroke: var(--line);
+      stroke-width: 1;
+    }
+    .axis-label {
+      fill: var(--muted);
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+    }
+    .chart-line {
+      fill: none;
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .point {
+      stroke: var(--paper);
+      stroke-width: 2;
+    }
+    .legend {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 650;
+    }
+    .legend span {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .swatch {
+      width: 16px;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--series);
+      display: inline-block;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+    th, td {
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--soft);
+      text-align: left;
+      vertical-align: middle;
+    }
+    th {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 780;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      background: #fbfbf9;
+    }
+    tr:last-child td { border-bottom: 0; }
+    .bench {
+      min-width: 260px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 13px;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+    .pkg {
+      display: block;
+      color: var(--muted);
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 12px;
+      margin-bottom: 2px;
+    }
+    .num {
+      white-space: nowrap;
+      font-variant-numeric: tabular-nums;
+    }
+    .delta {
+      display: inline-flex;
+      justify-content: center;
+      min-width: 72px;
+      padding: 4px 7px;
+      border-radius: 6px;
+      font-weight: 760;
+      font-variant-numeric: tabular-nums;
+    }
+    .good { color: var(--green); background: var(--green-bg); }
+    .bad { color: var(--red); background: var(--red-bg); }
+    .flat { color: var(--amber); background: var(--amber-bg); }
+    .muted { color: var(--muted); background: var(--soft); }
+    .barcell {
+      min-width: 170px;
+    }
+    .bartrack {
+      height: 9px;
+      border-radius: 999px;
+      background: var(--soft);
+      overflow: hidden;
+    }
+    .barfill {
+      display: block;
+      height: 100%;
+      width: calc(var(--w) * 1%);
+      min-width: 3px;
+      background: linear-gradient(90deg, var(--accent), #6a9c7d);
+      border-radius: inherit;
+    }
+    .empty {
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--paper);
+      color: var(--muted);
+    }
+    footer {
+      padding: 22px 0 38px;
+      color: var(--muted);
+      border-top: 1px solid var(--line);
+      font-size: 13px;
+    }
+    @media (max-width: 860px) {
+      .cards, .grid-2, .chart-grid { grid-template-columns: 1fr; }
+      .section-head { display: block; }
+      .section-head p { margin-top: 6px; }
+      table { display: block; overflow-x: auto; }
+      .topline { align-items: flex-start; }
+    }
+    @media (max-width: 560px) {
+      .wrap { width: min(100% - 22px, 1180px); }
+      header { padding-top: 20px; }
+      .topline { flex-direction: column; }
+      .links { justify-content: flex-start; }
+      h1 { font-size: 42px; }
+      .lede { font-size: 16px; }
+      th, td { padding: 9px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <div class="topline">
+        <div class="brand">
+          <img alt="" src="data:image/svg&#43;xml;base64,PCEtLQogIC0gQ29weXJpZ2h0IChjKSAyMDIxIE1hcmNpbiBHYXNwZXJvd2ljeiA8eG5vb2dhQGdtYWlsLmNvbT4KICAtIFNQRFgtTGljZW5zZS1JZGVudGlmaWVyOiBNSVQKICAtLT4KCjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMzk1Ljg1MiIgaGVpZ2h0PSI1NjUiIHZpZXdCb3g9IjAgMCAzOTUuODUyIDU2NSI&#43;PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTc2Mi4xMDIgLTIyMikiPjxwYXRoIGQ9Ik0tMjgyMC4xNzcsMjc0LjUyYTIyLjUsMjIuNSwwLDAsMS03LjE1OC00LjY0MywyMS4wMjMsMjEuMDIzLDAsMCwxLTYuMjU2LTExLjc0MXEtMTEuMzYxLTEuNDk1LTIxLjk2My0zLjgzYy0xOC4xNzgtNC4wMDgtMzQuMzE4LTkuOC00Ny45NzItMTcuMjA3YTExOC4yMTQsMTE4LjIxNCwwLDAsMS0xNy41ODMtMTEuNTcxLDg1Ljg0NSw4NS44NDUsMCwwLDEtMTMuMTI5LTEyLjk1Myw2My4yNDQsNjMuMjQ0LDAsMCwxLTguNi0xMy44ODYsNTAuNjU2LDUwLjY1NiwwLDAsMS00LjA2MS0xNC40NDZjLS43NjItNi4yMzktMS40MjctMTEuODY5LTEuODMyLTE3LjYwOHEtLjAxMy0uMTgzLS4wMjUtLjM2NWE2NS4zNTYsNjUuMzU2LDAsMCwxLTEuMTEzLTEyLjA0MSw2NSw2NSwwLDAsMSw2NS02NSw2NC43NzMsNjQuNzczLDAsMCwxLDQ0LjY5LDE3LjhsNDcuOC0xMTAuMzczTC0yODExLjgxNi00OS44cS00Ljc0LTEwLjktMTIuNTYtMTMuOTgzQTUxLjA3Niw1MS4wNzYsMCwwLDAtMjg0My4xLTY2Ljg2YTg1Ljg5NCw4NS44OTQsMCwwLDAtMjMuMjI1LDMuMzE4di01MC4yNDRhMTA2LjUwOSwxMDYuNTA5LDAsMCwxLDIyLjA0MS00LjI2NnExMS4xMzktLjk0OCwyMS4wOTItLjk0OCwxNi41OSwwLDI4LjQ0LDMuNTU1YTU1Ljg3Nyw1NS44NzcsMCwwLDEsMjAuODU2LDExLjM3Niw3Ny44NjgsNzcuODY4LDAsMCwxLDE2LjExNSwyMC4xNDUsMTk4LjgsMTk4LjgsMCwwLDEsMTMuNzQ3LDMwLjMzNmw1Mi42NzQsMTM4LjY3OGE2NS4wNTQsNjUuMDU0LDAsMCwxLDM2LjU0OSwyNC4yMTJxLjg3MS41NDIsMS43NTgsMS4xMDZjMy45MTYsMi40ODksOC42MTcsNy41MjMsMTMuNiwxNC41NmExODUuMjM0LDE4NS4yMzQsMCwwLDEsMTMuODExLDIzLjQ2MywyMTEuODIyLDIxMS44MjIsMCwwLDEsMTAuNDA5LDI0LjI4OSwxMDEuNTMsMTAxLjUzLDAsMCwxLDIuOTYxLDkuOTEyLDMwLjcwNiwzMC43MDYsMCwwLDEsMSw2Ljc1MVYxOTEuNmwxLjg3NiwxLjE3NWM2LjM2MywzLjk4OSwxMC44MTgsNy45MjEsMTMuMjM5LDExLjY4OCwxLjk3NiwzLjA3NCwyLjU0LDUuOTQ5LDEuNzIzLDguNzg5LS44MjksMi44ODMtMy4wODMsNS44Ny02LjcsOC44NzhhNzEuMjY5LDcxLjI2OSwwLDAsMS0xNS40MTksOS4yMzEsMTgzLjk4NywxODMuOTg3LDAsMCwxLTIyLjQwNiw4LjQxNmMtOC4yMzYsMi41NjItMTcuNDgxLDQuOTkyLTI3LjQ4LDcuMjIyYTU4Ni4xNDQsNTg2LjE0NCwwLDAsMS02Mi40MzMsMTAuMTA2LDIxLjI0MywyMS4yNDMsMCwwLDEtNS41MzQsOC43NzQsMjIuNTE3LDIyLjUxNywwLDAsMS03LjE1OCw0LjY0MiwyMy4yNiwyMy4yNiwwLDAsMS04LjgwNiwxLjcwOCwyMy4zNTEsMjMuMzUxLDAsMCwxLTEwLjc0Mi0yLjYsMjIuMzYzLDIyLjM2MywwLDAsMS03LjkxMy02Ljg3MmwtMS4yNzctMS44LTIuMjA3LjEyMWMtMS45My4xMDYtMy45LjE1OS01Ljg2MS4xNTktMi44MTEsMC01LjYyNy0uMTEtOC4zNzItLjMyOGwtMS44MDktLjE0My0xLjAzMi4wMDYtMS4xMiwyLjQ3OGEyMS43OTEsMjEuNzkxLDAsMCwxLTguMTIzLDkuMzM4LDIzLjEzMSwyMy4xMzEsMCwwLDEtMTIuNTQ0LDMuNjQ5QTIzLjI2NCwyMy4yNjQsMCwwLDEtMjgyMC4xNzcsMjc0LjUyWm00MC4wMjQtMTU4Ljk4NmM0Ljk0NC0yLjk4NCw5LjgtNS42OTMsMTQuNS04LjEsNC44MTYtMi40NTgsOS41NzYtNC42NDQsMTQuMjIyLTYuNTMzbC4zNDItLjMyLTEwLjQ4NC0zMy4zaC0xLjQyMloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM3MzEuOTcyIDQ2MS4zODYpIiBmaWxsPSIjZmZmIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iNDAiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSg0NTcuMSAxMTkpIj48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzMjQgNDIxKSIgZmlsbD0iIzhiZGJmZiI&#43;PHBhdGggZD0iTSAxNTkuMjcxMTMzNDIyODUxNiAxODEuNTQwMzI4OTc5NDkyMiBDIDEzNi4yODY4NjUyMzQzNzUgMTgxLjU0MDMyODk3OTQ5MjIgMTE0Ljc2OTI0ODk2MjQwMjMgMTc5LjM2NTk4MjA1NTY2NDEgOTUuMzE2MDI0NzgwMjczNDQgMTc1LjA3Nzc1ODc4OTA2MjUgQyA3Ny4xMzc1Mjc0NjU4MjAzMSAxNzEuMDcwNTQxMzgxODM1OSA2MC45OTczNjAyMjk0OTIxOSAxNjUuMjgxMzcyMDcwMzEyNSA0Ny4zNDM3NSAxNTcuODcxMTU0Nzg1MTU2MiBDIDQwLjg1ODU4MTU0Mjk2ODc1IDE1NC4zNTE0ODYyMDYwNTQ3IDM0Ljk0MjgwNjI0Mzg5NjQ4IDE1MC40NTgxNjA0MDAzOTA2IDI5Ljc2MDY5NDUwMzc4NDE4IDE0Ni4yOTkzMTY0MDYyNSBDIDI0LjcwNDg2MDY4NzI1NTg2IDE0Mi4yNDE4MjEyODkwNjI1IDIwLjI4NzM2MTE0NTAxOTUzIDEzNy44ODM4MTk1ODAwNzgxIDE2LjYzMDk3MTkwODU2OTM0IDEzMy4zNDYzNzQ1MTE3MTg4IEMgMTMuMDQ0ODU5ODg2MTY5NDMgMTI4Ljg5NjE0ODY4MTY0MDYgMTAuMTUxMzA0MjQ0OTk1MTIgMTI0LjIyNDI2NjA1MjI0NjEgOC4wMzA2OTQwMDc4NzM1MzUgMTE5LjQ2MDM4MDU1NDE5OTIgQyA1LjkzMjI0OTA2OTIxMzg2NyAxMTQuNzQ2MzIyNjMxODM1OSA0LjU2NjE5MzU4MDYyNzQ0MSAxMDkuODg2MDQ3MzYzMjgxMiAzLjk3MDQ3MTM4MjE0MTExMyAxMDUuMDE0NDM0ODE0NDUzMSBDIDMuMjA3NTgyNDczNzU0ODgzIDk4Ljc3NjE1MzU2NDQ1MzEyIDIuNTQzMTkzNTc4NzIwMDkzIDkzLjE0NTMyNDcwNzAzMTI1IDIuMTM4OTcxMzI4NzM1MzUyIDg3LjQwNjA0NDAwNjM0NzY2IEMgMS42ODE5MTU3NjAwNDAyODMgODAuOTE2NzA5ODk5OTAyMzQgMS42NTI5MTU4MzUzODA1NTQgNzUuMzQwODIwMzEyNSAyLjA1MDMwNDY1MTI2MDM3NiA3MC4zNTk4MjUxMzQyNzczNCBDIDIuNTE3MTkzNTU1ODMxOTA5IDY0LjUwODM3NzA3NTE5NTMxIDMuNTYxNjM4MTE2ODM2NTQ4IDU5LjQyMjc2NzYzOTE2MDE2IDUuMjQzNDE1ODMyNTE5NTMxIDU0LjgxMjQzMTMzNTQ0OTIyIEMgNy4xMDQ4MDQ1MTU4Mzg2MjMgNDkuNzA5NTk4NTQxMjU5NzcgOS42OTI2OTM3MTAzMjcxNDggNDUuMzI3NTk4NTcxNzc3MzQgMTMuMTU1MDI2NDM1ODUyMDUgNDEuNDE2MDk5NTQ4MzM5ODQgQyAxNi4xMzgzMDM3NTY3MTM4NyAzOC4wNDU3NjQ5MjMwOTU3IDE5LjgxODg2MTAwNzY5MDQzIDM1LjAyNDkzMjg2MTMyODEyIDI0LjA5NDQxNTY2NDY3Mjg1IDMyLjQzNzQzMTMzNTQ0OTIyIEMgMjguNzI1MjQ4MzM2NzkxOTkgMjkuNjM0OTMzNDcxNjc5NjkgMzQuMjE3MDI1NzU2ODM1OTQgMjcuMjM5ODc3NzAwODA1NjYgNDAuNDE3MDgzNzQwMjM0MzggMjUuMzE4OTMzNDg2OTM4NDggQyA0Ny4wNTQyNDg4MDk4MTQ0NSAyMy4yNjI0ODc0MTE0OTkwMiA1NC43MTAwMjU3ODczNTM1MiAyMS42ODQ3MDk1NDg5NTAyIDYzLjE3MTY5MTg5NDUzMTI1IDIwLjYyOTM3NzM2NTExMjMgQyA3Mi4xMTYzMDI0OTAyMzQzOCAxOS41MTM4MjA2NDgxOTMzNiA4Mi4yMzMwMjQ1OTcxNjc5NyAxOC45NDgyMDk3NjI1NzMyNCA5My4yNDA4MDY1Nzk1ODk4NCAxOC45NDgyMDk3NjI1NzMyNCBDIDkzLjQ3ODI0ODU5NjE5MTQxIDE4Ljk0ODIwOTc2MjU3MzI0IDkzLjY5OTg1OTYxOTE0MDYyIDE4Ljk0ODQzMjkyMjM2MzI4IDkzLjkzODQ2ODkzMzEwNTQ3IDE4Ljk0ODkzMjY0NzcwNTA4IEMgOTYuOTUwMDgwODcxNTgyMDMgMTguOTU1MzIyMjY1NjI1IDk4LjgwNzgwNzkyMjM2MzI4IDIwLjA4MDQzMjg5MTg0NTcgMTAwLjM1MDU4NTkzNzUgMjIuODMyMzc2NDgwMTAyNTQgQyAxMDIuMDUwNDY4NDQ0ODI0MiAyNS44NjQ3MDk4NTQxMjU5OCAxMDIuOTg2Njk0MzM1OTM3NSAzMC4yMjgyNjU3NjIzMjkxIDEwMy45Nzc4NTk0OTcwNzAzIDM0Ljg0ODA0NTM0OTEyMTA5IEMgMTA1LjExNDU4NTg3NjQ2NDggNDAuMTQ1OTMxMjQzODk2NDggMTA2LjI4OTk3MDM5Nzk0OTIgNDUuNjI0MjEwMzU3NjY2MDIgMTA4Ljg1NTMwMDkwMzMyMDMgNTAuMDIwMDk5NjM5ODkyNTggQyAxMTIuMTExOTY4OTk0MTQwNiA1NS42MDA1OTczODE1OTE4IDExNy4wNzg4NTc0MjE4NzUgNTguNDMwMTUyODkzMDY2NDEgMTIzLjYxODA4MDEzOTE2MDIgNTguNDMwMTUyODkzMDY2NDEgQyAxMjguMDI3Njk0NzAyMTQ4NCA1OC40MzAxNTI4OTMwNjY0MSAxMzMuMTQ3ODU3NjY2MDE1NiA1Ny4xNjIyNjU3Nzc1ODc4OSAxMzkuMjcxMTMzNDIyODUxNiA1NC41NTQwNDI4MTYxNjIxMSBDIDE0NS42MTEyNTE4MzEwNTQ3IDUxLjg1MzQzMTcwMTY2MDE2IDE1Mi44NzIxMzEzNDc2NTYyIDQ3Ljc5Mjc2NjU3MTA0NDkyIDE2MS40Njg4MTEwMzUxNTYyIDQyLjEzOTg3NzMxOTMzNTk0IEMgMTY5LjYxNjQ3MDMzNjkxNDEgMzYuNzgyMjY0NzA5NDcyNjYgMTc3LjYwNzAyNTE0NjQ4NDQgMzIuMDk1OTMyMDA2ODM1OTQgMTg1LjIxODUyMTExODE2NDEgMjguMjEwOTg4OTk4NDEzMDkgQyAxOTIuNDY3MDI1NzU2ODM1OSAyNC41MTEzMjIwMjE0ODQzOCAxOTkuNTg3NTI0NDE0MDYyNSAyMS40Mjg0MzI0NjQ1OTk2MSAyMDYuMzgyMjQ3OTI0ODA0NyAxOS4wNDgwNDQyMDQ3MTE5MSBDIDIxMi44MDk5NjcwNDEwMTU2IDE2Ljc5NjIxMTI0MjY3NTc4IDIxOS4xNDM3OTg4MjgxMjUgMTUuMTA0MDQzOTYwNTcxMjkgMjI1LjIwNzc0ODQxMzA4NTkgMTQuMDE4NTk5NTEwMTkyODcgQyAyMzAuOTA0MzEyMTMzNzg5MSAxMi45OTg5MzI4Mzg0Mzk5NCAyMzYuNTQ4MTg3MjU1ODU5NCAxMi40ODE4NzczMjY5NjUzMyAyNDEuOTgyNTg5NzIxNjc5NyAxMi40ODE4NzczMjY5NjUzMyBDIDI1Mi4zMDI4NTY0NDUzMTI1IDEyLjQ4MTg3NzMyNjk2NTMzIDI2Mi4xODQ5MDYwMDU4NTk0IDE0LjI4MzgyMTEwNTk1NzAzIDI3Mi4xOTM0ODE0NDUzMTI1IDE3Ljk5MDcxMTIxMjE1ODIgQyAyODAuMTUzODA4NTkzNzUgMjAuOTM4OTg3NzMxOTMzNTkgMjg4LjI5NTg2NzkxOTkyMTkgMjUuMTMwMjEwODc2NDY0ODQgMjk3LjgxNzA3NzYzNjcxODggMzEuMTgwODc3Njg1NTQ2ODggQyAzMDEuNzMzMTg0ODE0NDUzMSAzMy42Njk0ODY5OTk1MTE3MiAzMDYuNDM0NjMxMzQ3NjU2MiAzOC43MDQwOTc3NDc4MDI3MyAzMTEuNDEzMTQ2OTcyNjU2MiA0NS43NDAzNzU1MTg3OTg4MyBDIDMxNi4wMDk0Mjk5MzE2NDA2IDUyLjIzNjQ4ODM0MjI4NTE2IDMyMC43ODUwOTUyMTQ4NDM4IDYwLjM1MDA5NzY1NjI1IDMyNS4yMjM5Njg1MDU4NTk0IDY5LjIwNDEwMTU2MjUgQyAzMjkuMzQxODU3OTEwMTU2MiA3Ny40MTc5OTE2MzgxODM1OSAzMzMuMDM4NjM1MjUzOTA2MiA4Ni4wNDM5OTEwODg4NjcxOSAzMzUuNjMzMzAwNzgxMjUgOTMuNDkzMTAzMDI3MzQzNzUgQyAzMzYuOTE5ODYwODM5ODQzOCA5Ny4xODY3Njc1NzgxMjUgMzM3LjkxNjM1MTMxODM1OTQgMTAwLjUyMTU5ODgxNTkxOCAzMzguNTk1MDkyNzczNDM3NSAxMDMuNDA0ODc2NzA4OTg0NCBDIDMzOS40MjIwMjc1ODc4OTA2IDEwNi45MTc5MzA2MDMwMjczIDMzOS41OTU2NDIwODk4NDM4IDEwOS4wMTUyMTMwMTI2OTUzIDMzOS41OTU2NDIwODk4NDM4IDExMC4xNTU5OTA2MDA1ODU5IEwgMzM5LjU5NTY0MjA4OTg0MzggMTEyLjM2OTgxOTY0MTExMzMgTCAzNDEuNDcxNTg4MTM0NzY1NiAxMTMuNTQ1NDMzMDQ0NDMzNiBDIDM0Ny44MzUyOTY2MzA4NTk0IDExNy41MzMzNzg2MDEwNzQyIDM1Mi4yODk3OTQ5MjE4NzUgMTIxLjQ2NTg3MzcxODI2MTcgMzU0LjcxMTMwMzcxMDkzNzUgMTI1LjIzMzU5NjgwMTc1NzggQyAzNTYuNjg2OTgxMjAxMTcxOSAxMjguMzA3NjQ3NzA1MDc4MSAzNTcuMjUwNTE4Nzk4ODI4MSAxMzEuMTgyNjAxOTI4NzEwOSAzNTYuNDM0MjA0MTAxNTYyNSAxMzQuMDIyNTk4MjY2NjAxNiBDIDM1NS42MDU2NTE4NTU0Njg4IDEzNi45MDUxNTEzNjcxODc1IDM1My4zNTIxNDIzMzM5ODQ0IDEzOS44OTIwNDQwNjczODI4IDM0OS43MzYzNTg2NDI1NzgxIDE0Mi45MDAzMTQzMzEwNTQ3IEMgMzQ1Ljk4MTk2NDExMTMyODEgMTQ2LjAyMzg4MDAwNDg4MjggMzQwLjc5NDMxMTUyMzQzNzUgMTQ5LjEyOTgyMTc3NzM0MzggMzM0LjMxNzQxMzMzMDA3ODEgMTUyLjEzMTg4MTcxMzg2NzIgQyAzMjguMDMwNDI2MDI1MzkwNiAxNTUuMDQ1OTI4OTU1MDc4MSAzMjAuNDkxOTczODc2OTUzMSAxNTcuODc3MjEyNTI0NDE0MSAzMTEuOTExNDY4NTA1ODU5NCAxNjAuNTQ3MDQyODQ2Njc5NyBDIDMwMy42NzU3NTA3MzI0MjE5IDE2My4xMDk2MDM4ODE4MzU5IDI5NC40MzAyOTc4NTE1NjI1IDE2NS41MzkzODI5MzQ1NzAzIDI4NC40MzE5NzYzMTgzNTk0IDE2Ny43Njg4NzUxMjIwNzAzIEMgMjY1LjQxNDA5MzAxNzU3ODEgMTcyLjAwOTU5Nzc3ODMyMDMgMjQzLjYyMTM1MzE0OTQxNDEgMTc1LjUyNjMyMTQxMTEzMjggMjIxLjQwOTgwNTI5Nzg1MTYgMTc3LjkzODg3MzI5MTAxNTYgQyAxOTkuNzE3ODAzOTU1MDc4MSAxODAuMjk0OTM3MTMzNzg5MSAxNzguMjMwNTc1NTYxNTIzNCAxODEuNTQwMzI4OTc5NDkyMiAxNTkuMjcxMTMzNDIyODUxNiAxODEuNTQwMzI4OTc5NDkyMiBaIiBzdHJva2U9Im5vbmUiLz48cGF0aCBkPSJNIDI0MS45ODI2MjAyMzkyNTc4IDguNDgxOTE4MzM0OTYwOTM4IEwgMjQxLjk4MzI0NTg0OTYwOTQgMTYuNDgxOTE4MzM0OTYwOTQgQyAyMTguOTU3NzQ4NDEzMDg1OSAxNi40ODM3Nzk5MDcyMjY1NiAxOTMuMzQwMDU3MzczMDQ2OSAyNS45Njk4NDg2MzI4MTI1IDE2My42NjY0ODg2NDc0NjA5IDQ1LjQ4MjEwMTQ0MDQyOTY5IEMgMTQ2LjA4MjI0NDg3MzA0NjkgNTcuMDQ0Nzg0NTQ1ODk4NDQgMTMzLjM1NjU2NzM4MjgxMjUgNjIuNDMwMTYwNTIyNDYwOTQgMTIzLjYxODA0MTk5MjE4NzUgNjIuNDMwMTYwNTIyNDYwOTQgQyAxMDUuODA0Njg3NSA2Mi40MzAxNjA1MjI0NjA5NCAxMDIuMjEyODYwMTA3NDIxOSA0NS42ODk0MDczNDg2MzI4MSAxMDAuMDY2ODY0MDEzNjcxOSAzNS42ODcxNjQzMDY2NDA2MiBDIDk3LjcxMjEyNzY4NTU0Njg4IDI0LjcxMTkxNDA2MjUgOTYuNTI2Nzk0NDMzNTkzNzUgMjIuOTU0NDA2NzM4MjgxMjUgOTMuMjQwODE0MjA4OTg0MzggMjIuOTQ4MTY1ODkzNTU0NjkgQyA1NC40OTE2MDc2NjYwMTU2MiAyMi45NDgxNjU4OTM1NTQ2OSAyOC41NTQ1NjU0Mjk2ODc1IDMwLjA1MzY2NTE2MTEzMjgxIDE2LjE1MDIzODAzNzEwOTM4IDQ0LjA2NzI5MTI1OTc2NTYyIEMgMi40NDExMzE1OTE3OTY4NzUgNTkuNTU0OTc3NDE2OTkyMTkgNS4zNjI5MTUwMzkwNjI1IDgzLjQ0ODI4Nzk2Mzg2NzE5IDcuOTQwODU2OTMzNTkzNzUgMTA0LjUyODkxNTQwNTI3MzQgQyAxMi4zNzc2MjQ1MTE3MTg3NSAxNDAuODEwOTc0MTIxMDkzOCA2NS43ODMyMzM2NDI1NzgxMiAxNzcuNTQwMzQ0MjM4MjgxMiAxNTkuMjcxMTE4MTY0MDYyNSAxNzcuNTQwMzQ0MjM4MjgxMiBDIDI0NS4zMDAxMDk4NjMyODEyIDE3Ny41NDAzNDQyMzgyODEyIDM0Ni40NzYyNTczMjQyMTg4IDE1NC4xODYzNTU1OTA4MjAzIDM1Mi41ODk4NzQyNjc1NzgxIDEzMi45MTc1NDE1MDM5MDYyIEMgMzU0LjI3OTExMzc2OTUzMTIgMTI3LjA0MDc4Njc0MzE2NDEgMzQzLjg5MTgxNTE4NTU0NjkgMTE5Ljc4MjY2MTQzNzk4ODMgMzM5LjM0NzUwMzY2MjEwOTQgMTE2LjkzNDg0NDk3MDcwMzEgTCAzMzUuNTk1NjExNTcyMjY1NiAxMTQuNTgzNzI0OTc1NTg1OSBMIDMzNS41OTU2MTE1NzIyNjU2IDExMC4xNTU5NzUzNDE3OTY5IEMgMzM1LjU5NTYxMTU3MjI2NTYgOTUuNTkwODUwODMwMDc4MTIgMzExLjU0MjExNDI1NzgxMjUgNDQuNjQyMjI3MTcyODUxNTYgMjk1LjY3MTYzMDg1OTM3NSAzNC41NTY3OTMyMTI4OTA2MiBDIDI4MS42MDcwNTU2NjQwNjI1IDI1LjYxODkxMTc0MzE2NDA2IDI2NC4yMzA2MjEzMzc4OTA2IDE2LjQ4MTkxODMzNDk2MDk0IDI0MS45OTAyNDk2MzM3ODkxIDE2LjQ4MTkxODMzNDk2MDk0IEwgMjQxLjk4MjYyMDIzOTI1NzggOC40ODE5MTgzMzQ5NjA5MzggTSAyNDEuOTgyNjA0OTgwNDY4OCA4LjQ4MTg4NzgxNzM4MjgxMiBDIDI2NS4zMjM4NTI1MzkwNjI1IDguNDc5OTY1MjA5OTYwOTM4IDI4My41ODE2NjUwMzkwNjI1IDE3LjM5NTAzNDc5MDAzOTA2IDI5OS45NjI0MzI4NjEzMjgxIDI3LjgwNDg1NTM0NjY3OTY5IEMgMzE4LjY4NDI5NTY1NDI5NjkgMzkuNzAyMjg1NzY2NjAxNTYgMzQzLjU5NTYxMTU3MjI2NTYgOTQuMDc0NjAwMjE5NzI2NTYgMzQzLjU5NTYxMTU3MjI2NTYgMTEwLjE1NTk3NTM0MTc5NjkgQyA0MTMuMTQ3Njc0NTYwNTQ2OSAxNTMuNzQxOTEyODQxNzk2OSAyNTUuNjQ0ODA1OTA4MjAzMSAxODUuNTQwMzQ0MjM4MjgxMiAxNTkuMjcxMTE4MTY0MDYyNSAxODUuNTQwMzQ0MjM4MjgxMiBDIDYyLjg5NzQzMDQxOTkyMTg4IDE4NS41NDAzNDQyMzgyODEyIDUuMTc0MDQxNzQ4MDQ2ODc1IDE0Ny44MTA5MTMwODU5Mzc1IDAgMTA1LjQ5OTk3NzExMTgxNjQgQyAtNS4xNjIwNzg4NTc0MjE4NzUgNjMuMjg3MjMxNDQ1MzEyNSAtMTAuMTMzMjcwMjYzNjcxODggMTQuOTQ4MTY1ODkzNTU0NjkgOTMuMjQwODE0MjA4OTg0MzggMTQuOTQ4MTY1ODkzNTU0NjkgQyA5My40ODExNDAxMzY3MTg3NSAxNC45NDgxNjU4OTM1NTQ2OSA5My43MDUzODMzMDA3ODEyNSAxNC45NDgzOTQ3NzUzOTA2MiA5My45NDY4Njg4OTY0ODQzOCAxNC45NDg5MTM1NzQyMTg3NSBDIDExNC4xMzYzNTI1MzkwNjI1IDE0Ljk5MTY1MzQ0MjM4MjgxIDEwMS40NDQ1ODAwNzgxMjUgNTQuNDMwMTQ1MjYzNjcxODggMTIzLjYxODA3MjUwOTc2NTYgNTQuNDMwMTQ1MjYzNjcxODggQyAxMzAuOTE4MDkwODIwMzEyNSA1NC40MzAxNDUyNjM2NzE4OCAxNDEuOTk1MDg2NjY5OTIxOSA1MC4xNTc4MjE2NTUyNzM0NCAxNTkuMjcxMTE4MTY0MDYyNSAzOC43OTc3Mjk0OTIxODc1IEMgMTkzLjIwMTYyOTYzODY3MTkgMTYuNDg2MjY3MDg5ODQzNzUgMjE5Ljg3MzA0Njg3NSA4LjQ4MzcwMzYxMzI4MTI1IDI0MS45ODI2MDQ5ODA0Njg4IDguNDgxODg3ODE3MzgyODEyIFoiIHN0cm9rZT0ibm9uZSIgZmlsbD0iIzAwMCIvPjwvZz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMjQyIDYpIj48dGV4dCB0cmFuc2Zvcm09InRyYW5zbGF0ZSg2MjQgNTU5KSIgZm9udC1zaXplPSI0NzQiIGZvbnQtZmFtaWx5PSJIZWx2ZXRpY2FOZXVlLUJvbGQsIEhlbHZldGljYSBOZXVlIiBmb250LXdlaWdodD0iNzAwIj48dHNwYW4geD0iMCIgeT0iMCI&#43;zrs8L3RzcGFuPjwvdGV4dD48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSg3NDEgNDE1KSIgZmlsbD0iI2ZmZiIgc3Ryb2tlPSIjMDAwIiBzdHJva2Utd2lkdGg9IjgiPjxjaXJjbGUgY3g9IjY5IiBjeT0iNjkiIHI9IjY5IiBzdHJva2U9Im5vbmUiLz48Y2lyY2xlIGN4PSI2OSIgY3k9IjY5IiByPSI2NSIgZmlsbD0ibm9uZSIvPjwvZz48Y2lyY2xlIGN4PSIyOSIgY3k9IjI5IiByPSIyOSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNzk5IDQ0MSkiLz48Y2lyY2xlIGN4PSIxMS41IiBjeT0iMTEuNSIgcj0iMTEuNSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoODEwIDQ2MSkiIGZpbGw9IiNmZmYiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSg1NjMgNDIxKSIgZmlsbD0iI2ZmZiIgc3Ryb2tlPSIjMDAwIiBzdHJva2Utd2lkdGg9IjgiPjxjaXJjbGUgY3g9IjY5IiBjeT0iNjkiIHI9IjY5IiBzdHJva2U9Im5vbmUiLz48Y2lyY2xlIGN4PSI2OSIgY3k9IjY5IiByPSI2NSIgZmlsbD0ibm9uZSIvPjwvZz48Y2lyY2xlIGN4PSIyOSIgY3k9IjI5IiByPSIyOSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNTg2IDQ0MykiLz48Y2lyY2xlIGN4PSIxMS41IiBjeT0iMTEuNSIgcj0iMTEuNSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNjAxIDQ2NykiIGZpbGw9IiNmZmYiLz48L2c&#43;PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNDM3IDU3MSkiIGZpbGw9IiNmZmVkYTMiIHN0cm9rZT0iIzAwMCIgc3Ryb2tlLXdpZHRoPSI4Ij48ZWxsaXBzZSBjeD0iMjYuNSIgY3k9IjI1LjUiIHJ4PSIyNi41IiByeT0iMjUuNSIgc3Ryb2tlPSJub25lIi8&#43;PGVsbGlwc2UgY3g9IjI2LjUiIGN5PSIyNS41IiByeD0iMjIuNSIgcnk9IjIxLjUiIGZpbGw9Im5vbmUiLz48L2c&#43;PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNDk4IDU2NykiIGZpbGw9IiNmZmVkYTMiIHN0cm9rZT0iIzAwMCIgc3Ryb2tlLXdpZHRoPSI4Ij48ZWxsaXBzZSBjeD0iMjYuNSIgY3k9IjI1LjUiIHJ4PSIyNi41IiByeT0iMjUuNSIgc3Ryb2tlPSJub25lIi8&#43;PGVsbGlwc2UgY3g9IjI2LjUiIGN5PSIyNS41IiByeD0iMjIuNSIgcnk9IjIxLjUiIGZpbGw9Im5vbmUiLz48L2c&#43;PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNDQ1IDU1OSkiIGZpbGw9IiNkOGIzNGYiIHN0cm9rZT0iIzAwMCIgc3Ryb2tlLXdpZHRoPSI4Ij48ZWxsaXBzZSBjeD0iNTEuNSIgY3k9IjI0IiByeD0iNTEuNSIgcnk9IjI0IiBzdHJva2U9Im5vbmUiLz48ZWxsaXBzZSBjeD0iNTEuNSIgY3k9IjI0IiByeD0iNDcuNSIgcnk9IjIwIiBmaWxsPSJub25lIi8&#43;PC9nPjxlbGxpcHNlIGN4PSIyNy41IiBjeT0iMTgiIHJ4PSIyNy41IiByeT0iMTgiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQ2OSA1NDEpIi8&#43;PC9nPjwvZz48L3N2Zz4=">
+          <span>let-go perf</span>
+        </div>
+        <nav class="links" aria-label="Links">
+          <a href="../">WASM repl</a>
+          <a href="https://github.com/nooga/let-go">GitHub</a>
+          <a href="https://github.com/nooga/let-go/blob/main/docs/perf/ratchet.md">Ratchet docs</a>
+        </nav>
+      </div>
+      <h1>Are we fast yet?</h1>
+      <p class="lede">Committed benchmark ratchet data, rendered as a static page. Ratios are normalized to BenchmarkRatchetAnchor, so lower is better and cross-machine drift is less noisy.</p>
+      <div class="meta">
+        <span class="chip">captured 2026-05-30 21:01 UTC</span>
+        <span class="chip">sha c4623afd0ef6</span>
+        <span class="chip">Apple M3</span>
+        <span class="chip">go1.26.3</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <div class="cards" aria-label="Summary">
+      <article class="card">
+        <p class="label">Tracked benches</p>
+        <p class="value">79</p>
+        <p class="note">3 packages in the current baseline</p>
+      </article>
+      <article class="card">
+        <p class="label">Zero allocs</p>
+        <p class="value">30</p>
+        <p class="note">benchmarks currently at 0 allocs/op</p>
+      </article>
+      <article class="card">
+        <p class="label">Since v1.8.0</p>
+        <p class="value">&#43;0.0%</p>
+        <p class="note">median anchor-relative delta across 75 shared benches</p>
+      </article>
+      <article class="card">
+        <p class="label">Movement</p>
+        <p class="value">0 / 0</p>
+        <p class="note">faster / slower by at least 5 percent</p>
+      </article>
+    </div>
+
+    <section>
+      <div class="section-head">
+        <h2>Timeline</h2>
+        <p>2 snapshot(s). CI snapshots graph real runs; seed points use committed historical/current JSON until the timeline fills in.</p>
+      </div>
+      
+      <div class="chart-grid">
+        
+        <article class="chart">
+          <h3>End-to-end suite</h3>
+          <p>Anchor-normalized jank clojure-test-suite wall time. Lower is better.</p>
+          <svg viewBox="0 0 520 210" role="img" aria-label="End-to-end suite trend chart">
+            <line class="axis" x1="46" y1="22" x2="46" y2="176"></line>
+            <line class="axis" x1="46" y1="176" x2="502" y2="176"></line>
+            <text class="axis-label" x="4" y="29">1.12B</text>
+            <text class="axis-label" x="4" y="176">1.02B</text>
+            <text class="axis-label" x="4" y="194">anchors</text>
+            <text class="axis-label" x="46" y="204">older</text>
+            <text class="axis-label" x="461" y="204">newer</text>
+            
+            
+            <path class="chart-line" stroke="#245c73" d="M 502.00 165.38"></path>
+            
+            <circle class="point" fill="#245c73" cx="502.00" cy="165.38" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 1.03B</title>
+            </circle>
+            
+            
+            
+            <path class="chart-line" stroke="#167a48" d="M 502.00 32.62"></path>
+            
+            <circle class="point" fill="#167a48" cx="502.00" cy="32.62" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 1.12B</title>
+            </circle>
+            
+            
+          </svg>
+          <div class="legend">
+            <span><i class="swatch" style="--series: #245c73"></i>bytecode</span><span><i class="swatch" style="--series: #167a48"></i>gogen_ir</span>
+          </div>
+        </article>
+        
+        <article class="chart">
+          <h3>IR compile</h3>
+          <p>Anchor-normalized IR compile benchmark variants. Lower is better.</p>
+          <svg viewBox="0 0 520 210" role="img" aria-label="IR compile trend chart">
+            <line class="axis" x1="46" y1="22" x2="46" y2="176"></line>
+            <line class="axis" x1="46" y1="176" x2="502" y2="176"></line>
+            <text class="axis-label" x="4" y="29">23.67M</text>
+            <text class="axis-label" x="4" y="176">23.56M</text>
+            <text class="axis-label" x="4" y="194">anchors</text>
+            <text class="axis-label" x="46" y="204">older</text>
+            <text class="axis-label" x="461" y="204">newer</text>
+            
+            
+            <path class="chart-line" stroke="#245c73" d="M 502.00 32.62"></path>
+            
+            <circle class="point" fill="#245c73" cx="502.00" cy="32.62" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 23.66M</title>
+            </circle>
+            
+            
+            
+            <path class="chart-line" stroke="#167a48" d="M 502.00 165.38"></path>
+            
+            <circle class="point" fill="#167a48" cx="502.00" cy="165.38" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 23.56M</title>
+            </circle>
+            
+            
+          </svg>
+          <div class="legend">
+            <span><i class="swatch" style="--series: #245c73"></i>bytecode</span><span><i class="swatch" style="--series: #167a48"></i>gogen_ir</span>
+          </div>
+        </article>
+        
+        <article class="chart">
+          <h3>Suite allocations</h3>
+          <p>allocs/op for the full suite benchmark variants. Lower is better.</p>
+          <svg viewBox="0 0 520 210" role="img" aria-label="Suite allocations trend chart">
+            <line class="axis" x1="46" y1="22" x2="46" y2="176"></line>
+            <line class="axis" x1="46" y1="176" x2="502" y2="176"></line>
+            <text class="axis-label" x="4" y="29">8.52M</text>
+            <text class="axis-label" x="4" y="176">8.44M</text>
+            <text class="axis-label" x="4" y="194">allocs/op</text>
+            <text class="axis-label" x="46" y="204">older</text>
+            <text class="axis-label" x="461" y="204">newer</text>
+            
+            
+            <path class="chart-line" stroke="#245c73" d="M 502.00 165.38"></path>
+            
+            <circle class="point" fill="#245c73" cx="502.00" cy="165.38" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 8.45M</title>
+            </circle>
+            
+            
+            
+            <path class="chart-line" stroke="#167a48" d="M 502.00 32.62"></path>
+            
+            <circle class="point" fill="#167a48" cx="502.00" cy="32.62" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 8.51M</title>
+            </circle>
+            
+            
+          </svg>
+          <div class="legend">
+            <span><i class="swatch" style="--series: #245c73"></i>bytecode</span><span><i class="swatch" style="--series: #167a48"></i>gogen_ir</span>
+          </div>
+        </article>
+        
+        <article class="chart">
+          <h3>Suite memory</h3>
+          <p>bytes/op for the full suite benchmark variants. Lower is better.</p>
+          <svg viewBox="0 0 520 210" role="img" aria-label="Suite memory trend chart">
+            <line class="axis" x1="46" y1="22" x2="46" y2="176"></line>
+            <line class="axis" x1="46" y1="176" x2="502" y2="176"></line>
+            <text class="axis-label" x="4" y="29">370.3 MiB</text>
+            <text class="axis-label" x="4" y="176">367.1 MiB</text>
+            <text class="axis-label" x="4" y="194">B/op</text>
+            <text class="axis-label" x="46" y="204">older</text>
+            <text class="axis-label" x="461" y="204">newer</text>
+            
+            
+            <path class="chart-line" stroke="#245c73" d="M 502.00 165.38"></path>
+            
+            <circle class="point" fill="#245c73" cx="502.00" cy="165.38" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 367.4 MiB</title>
+            </circle>
+            
+            
+            
+            <path class="chart-line" stroke="#167a48" d="M 502.00 32.62"></path>
+            
+            <circle class="point" fill="#167a48" cx="502.00" cy="32.62" r="4">
+              <title>2026-05-30 21:01 UTC @ c4623afd0ef6: 370.1 MiB</title>
+            </circle>
+            
+            
+          </svg>
+          <div class="legend">
+            <span><i class="swatch" style="--series: #245c73"></i>bytecode</span><span><i class="swatch" style="--series: #167a48"></i>gogen_ir</span>
+          </div>
+        </article>
+        
+      </div>
+      
+    </section>
+
+    <section>
+      <div class="section-head">
+        <h2>Largest changes</h2>
+        <p>Current ratchet compared with v1.8.0.</p>
+      </div>
+      <div class="grid-2">
+        <div class="empty">No historical improvements found.</div>
+
+        <div class="empty">No historical slowdowns found.</div>
+      </div>
+    </section>
+
+    <section>
+      <div class="section-head">
+        <h2>Recently tightened</h2>
+        <p>Most recent per-benchmark bars in the ratchet.</p>
+      </div>
+      <table>
+        <thead><tr><th>Benchmark</th><th>Bar set</th><th>Wall</th><th>Allocs</th></tr></thead>
+        <tbody>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/ir</span>BenchmarkIRCompile [bytecode]</td>
+            <td class="num">2026-05-31 19:19 UTC @ d7b70df596cd</td>
+            <td class="num">23.97 ms</td>
+            <td class="num">306.9k</td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/ir</span>BenchmarkIRCompile [gogen_ir]</td>
+            <td class="num">2026-05-31 19:19 UTC @ d7b70df596cd</td>
+            <td class="num">23.87 ms</td>
+            <td class="num">306.9k</td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [bytecode]</td>
+            <td class="num">2026-05-30 21:01 UTC @ c4623afd0ef6</td>
+            <td class="num">1.91 s</td>
+            <td class="num">8.45M</td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [gogen_ir]</td>
+            <td class="num">2026-05-30 21:01 UTC @ c4623afd0ef6</td>
+            <td class="num">2.07 s</td>
+            <td class="num">8.51M</td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/ArrayVector</td>
+            <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
+            <td class="num">9.19 us</td>
+            <td class="num">216</td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/List</td>
+            <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
+            <td class="num">1.98 us</td>
+            <td class="num">100</td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/Map</td>
+            <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
+            <td class="num">168.50 us</td>
+            <td class="num">659</td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConsCreation/ListCons</td>
+            <td class="num">2026-05-29 20:22 UTC @ 3d5af1c49b87</td>
+            <td class="num">0.32 ns</td>
+            <td class="num">0</td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <div class="section-head">
+        <h2>Current baseline</h2>
+        <p>Sorted by package and benchmark. Lower anchor ratio is faster.</p>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Benchmark</th>
+            <th>Ratio</th>
+            <th>Wall</th>
+            <th>Alloc</th>
+            <th>Bytes</th>
+            <th>Delta</th>
+            <th>Scale</th>
+          </tr>
+        </thead>
+        <tbody>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/ir</span>BenchmarkIRCompile [bytecode]</td>
+            <td class="num">23.66M</td>
+            <td class="num">23.97 ms</td>
+            <td class="num">306.9k</td>
+            <td class="num">9.9 MiB</td>
+            <td><span class="delta muted">new</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 81.50"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/ir</span>BenchmarkIRCompile [gogen_ir]</td>
+            <td class="num">23.56M</td>
+            <td class="num">23.87 ms</td>
+            <td class="num">306.9k</td>
+            <td class="num">9.9 MiB</td>
+            <td><span class="delta muted">new</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 81.48"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/ArrayVector</td>
+            <td class="num">8.5k</td>
+            <td class="num">9.19 us</td>
+            <td class="num">216</td>
+            <td class="num">33.7 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 43.40"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/List</td>
+            <td class="num">1.8k</td>
+            <td class="num">1.98 us</td>
+            <td class="num">100</td>
+            <td class="num">6.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.04"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConj/Map</td>
+            <td class="num">155.0k</td>
+            <td class="num">168.50 us</td>
+            <td class="num">659</td>
+            <td class="num">307.8 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 57.36"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConsCreation/ListCons</td>
+            <td class="num">0.29</td>
+            <td class="num">0.32 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 1.23"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkConsCreation/NewCons</td>
+            <td class="num">0.27</td>
+            <td class="num">0.29 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 1.13"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFrameAlloc/3Args</td>
+            <td class="num">63.5</td>
+            <td class="num">69.07 ns</td>
+            <td class="num">2</td>
+            <td class="num">224 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 20.00"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFrameAlloc/NoArgs</td>
+            <td class="num">58.8</td>
+            <td class="num">63.99 ns</td>
+            <td class="num">2</td>
+            <td class="num">224 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 19.64"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFrameDispatch</td>
+            <td class="num">454.5</td>
+            <td class="num">494.20 ns</td>
+            <td class="num">2</td>
+            <td class="num">416 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 29.38"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFuncInvoke/Closure</td>
+            <td class="num">16.2</td>
+            <td class="num">17.63 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 13.66"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFuncInvoke/Direct</td>
+            <td class="num">15.9</td>
+            <td class="num">17.25 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 13.56"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkFuncInvoke/Native</td>
+            <td class="num">4.69</td>
+            <td class="num">5.10 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 8.34"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/false</td>
+            <td class="num">2.23</td>
+            <td class="num">2.42 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 5.62"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/int</td>
+            <td class="num">0.79</td>
+            <td class="num">0.86 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 2.81"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/nil</td>
+            <td class="num">0.55</td>
+            <td class="num">0.59 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 2.09"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/string</td>
+            <td class="num">0.80</td>
+            <td class="num">0.87 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 2.82"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkIsTruthy/true</td>
+            <td class="num">2.22</td>
+            <td class="num">2.41 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 5.61"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkLazySeqRealize/Realize/01000</td>
+            <td class="num">96.9k</td>
+            <td class="num">105.42 us</td>
+            <td class="num">4.7k</td>
+            <td class="num">201.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 55.11"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkLazySeqRealize/Realize/10</td>
+            <td class="num">995.2</td>
+            <td class="num">1.08 us</td>
+            <td class="num">43</td>
+            <td class="num">2.1 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 33.14"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkLazySeqRealize/Realize/100</td>
+            <td class="num">9.8k</td>
+            <td class="num">10.68 us</td>
+            <td class="num">403</td>
+            <td class="num">19.6 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 44.12"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Assoc/01000</td>
+            <td class="num">66.3k</td>
+            <td class="num">72.10 us</td>
+            <td class="num">20</td>
+            <td class="num">156.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 53.29"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Assoc/10</td>
+            <td class="num">415.7</td>
+            <td class="num">451.98 ns</td>
+            <td class="num">3</td>
+            <td class="num">616 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 28.95"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Assoc/100</td>
+            <td class="num">4.2k</td>
+            <td class="num">4.53 us</td>
+            <td class="num">9</td>
+            <td class="num">8.8 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 40.01"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Lookup/01000</td>
+            <td class="num">9.33</td>
+            <td class="num">10.14 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 11.21"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Lookup/10</td>
+            <td class="num">9.97</td>
+            <td class="num">10.84 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 11.50"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/GoMap-Lookup/100</td>
+            <td class="num">10.1</td>
+            <td class="num">10.98 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 11.55"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Assoc/01000</td>
+            <td class="num">408.7</td>
+            <td class="num">444.44 ns</td>
+            <td class="num">6</td>
+            <td class="num">2.0 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 28.87"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Assoc/10</td>
+            <td class="num">113.3</td>
+            <td class="num">123.22 ns</td>
+            <td class="num">4</td>
+            <td class="num">353 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 22.75"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Assoc/100</td>
+            <td class="num">244.4</td>
+            <td class="num">265.80 ns</td>
+            <td class="num">6</td>
+            <td class="num">1.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 26.41"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Dissoc/01000</td>
+            <td class="num">424.6</td>
+            <td class="num">461.74 ns</td>
+            <td class="num">5</td>
+            <td class="num">2.0 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 29.06"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Dissoc/10</td>
+            <td class="num">136.5</td>
+            <td class="num">148.44 ns</td>
+            <td class="num">3</td>
+            <td class="num">320 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 23.63"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Dissoc/100</td>
+            <td class="num">232.4</td>
+            <td class="num">252.76 ns</td>
+            <td class="num">5</td>
+            <td class="num">1.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 26.17"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Lookup/01000</td>
+            <td class="num">24.9</td>
+            <td class="num">27.10 ns</td>
+            <td class="num">1</td>
+            <td class="num">8 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 15.62"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Lookup/10</td>
+            <td class="num">16.3</td>
+            <td class="num">17.68 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 13.67"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMapAssoc/HAMT-Lookup/100</td>
+            <td class="num">14.8</td>
+            <td class="num">16.12 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 13.26"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMultiArity/1Arg</td>
+            <td class="num">18.7</td>
+            <td class="num">20.36 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 14.31"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkMultiArity/2Args</td>
+            <td class="num">18.4</td>
+            <td class="num">20.02 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 14.24"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkRecordToStructFastPath</td>
+            <td class="num">11.4</td>
+            <td class="num">12.38 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 12.08"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkRecordToStructSlowPath</td>
+            <td class="num">19.0</td>
+            <td class="num">20.65 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 14.38"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/ArrayVector/01000</td>
+            <td class="num">13.7k</td>
+            <td class="num">14.89 us</td>
+            <td class="num">1.0k</td>
+            <td class="num">31.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 45.72"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/ArrayVector/10</td>
+            <td class="num">148.2</td>
+            <td class="num">161.20 ns</td>
+            <td class="num">10</td>
+            <td class="num">320 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 24.03"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/ArrayVector/100</td>
+            <td class="num">1.4k</td>
+            <td class="num">1.51 us</td>
+            <td class="num">100</td>
+            <td class="num">3.1 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 34.74"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/List/01000</td>
+            <td class="num">1.8k</td>
+            <td class="num">1.94 us</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 35.93"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/List/10</td>
+            <td class="num">20.4</td>
+            <td class="num">22.14 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 14.69"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/List/100</td>
+            <td class="num">183.2</td>
+            <td class="num">199.26 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 25.04"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/PersistentVector/01000</td>
+            <td class="num">18.9k</td>
+            <td class="num">20.57 us</td>
+            <td class="num">1.0k</td>
+            <td class="num">47.0 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 47.27"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/PersistentVector/10</td>
+            <td class="num">206.9</td>
+            <td class="num">224.94 ns</td>
+            <td class="num">11</td>
+            <td class="num">560 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 25.62"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkSeqIteration/PersistentVector/100</td>
+            <td class="num">2.0k</td>
+            <td class="num">2.16 us</td>
+            <td class="num">101</td>
+            <td class="num">4.8 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.46"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkStackOps/Push</td>
+            <td class="num">0.72</td>
+            <td class="num">0.78 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 2.60"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkStackOps/PushPop</td>
+            <td class="num">0.74</td>
+            <td class="num">0.81 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 2.67"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkStructToRecord</td>
+            <td class="num">81.2</td>
+            <td class="num">88.35 ns</td>
+            <td class="num">4</td>
+            <td class="num">160 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 21.17"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVariadicInvoke/1Arg</td>
+            <td class="num">76.0</td>
+            <td class="num">82.65 ns</td>
+            <td class="num">2</td>
+            <td class="num">88 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 20.85"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVariadicInvoke/5Args</td>
+            <td class="num">227.4</td>
+            <td class="num">247.26 ns</td>
+            <td class="num">6</td>
+            <td class="num">344 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 26.07"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/10</td>
+            <td class="num">0.43</td>
+            <td class="num">0.47 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 1.73"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/100</td>
+            <td class="num">0.41</td>
+            <td class="num">0.45 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 1.65"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/1000</td>
+            <td class="num">0.42</td>
+            <td class="num">0.45 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 1.67"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/ArrayVector/10000</td>
+            <td class="num">0.42</td>
+            <td class="num">0.46 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 1.68"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/PersistentVector/10</td>
+            <td class="num">12.5</td>
+            <td class="num">13.54 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 12.48"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/PersistentVector/100</td>
+            <td class="num">14.7</td>
+            <td class="num">16.02 ns</td>
+            <td class="num">0</td>
+            <td class="num">0 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 13.23"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/PersistentVector/1000</td>
+            <td class="num">26.1</td>
+            <td class="num">28.36 ns</td>
+            <td class="num">2</td>
+            <td class="num">16 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 15.83"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorAccess/PersistentVector/10000</td>
+            <td class="num">29.8</td>
+            <td class="num">32.46 ns</td>
+            <td class="num">2</td>
+            <td class="num">16 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 16.46"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/ArrayVector/10</td>
+            <td class="num">1.3k</td>
+            <td class="num">1.42 us</td>
+            <td class="num">20</td>
+            <td class="num">1.1 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 34.44"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/ArrayVector/100</td>
+            <td class="num">9.5k</td>
+            <td class="num">10.29 us</td>
+            <td class="num">215</td>
+            <td class="num">33.7 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 43.94"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/ArrayVector/1000</td>
+            <td class="num">97.6k</td>
+            <td class="num">106.16 us</td>
+            <td class="num">2.9k</td>
+            <td class="num">382.7 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 55.14"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/PersistentVector/10</td>
+            <td class="num">2.0k</td>
+            <td class="num">2.19 us</td>
+            <td class="num">22</td>
+            <td class="num">2.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.51"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/PersistentVector/100</td>
+            <td class="num">9.9k</td>
+            <td class="num">10.82 us</td>
+            <td class="num">216</td>
+            <td class="num">35.4 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 44.18"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorConj/PersistentVector/1000</td>
+            <td class="num">98.1k</td>
+            <td class="num">106.67 us</td>
+            <td class="num">2.9k</td>
+            <td class="num">384.4 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 55.17"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/ArrayVector/10</td>
+            <td class="num">50.7</td>
+            <td class="num">55.17 ns</td>
+            <td class="num">1</td>
+            <td class="num">160 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 18.94"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/ArrayVector/100</td>
+            <td class="num">286.7</td>
+            <td class="num">311.72 ns</td>
+            <td class="num">1</td>
+            <td class="num">1.8 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 27.18"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/ArrayVector/1000</td>
+            <td class="num">2.0k</td>
+            <td class="num">2.16 us</td>
+            <td class="num">1</td>
+            <td class="num">16.0 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 36.46"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/ArrayVector/10000</td>
+            <td class="num">23.6k</td>
+            <td class="num">25.63 us</td>
+            <td class="num">1</td>
+            <td class="num">160.0 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 48.32"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/PersistentVector/10</td>
+            <td class="num">206.5</td>
+            <td class="num">224.52 ns</td>
+            <td class="num">4</td>
+            <td class="num">776 B</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 25.61"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/PersistentVector/100</td>
+            <td class="num">642.0</td>
+            <td class="num">698.08 ns</td>
+            <td class="num">10</td>
+            <td class="num">1.8 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 31.04"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/PersistentVector/1000</td>
+            <td class="num">3.7k</td>
+            <td class="num">4.08 us</td>
+            <td class="num">67</td>
+            <td class="num">17.2 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 39.50"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">pkg/vm</span>BenchmarkVectorCreation/PersistentVector/10000</td>
+            <td class="num">40.2k</td>
+            <td class="num">43.75 us</td>
+            <td class="num">650</td>
+            <td class="num">171.6 KiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 50.89"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite</td>
+            <td class="num">599.52M</td>
+            <td class="num">651.91 ms</td>
+            <td class="num">9.01M</td>
+            <td class="num">368.2 MiB</td>
+            <td><span class="delta flat">&#43;0.0%</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 97.01"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [bytecode]</td>
+            <td class="num">1.03B</td>
+            <td class="num">1.91 s</td>
+            <td class="num">8.45M</td>
+            <td class="num">367.4 MiB</td>
+            <td><span class="delta muted">new</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 99.60"></span></div></td>
+          </tr>
+          
+          <tr>
+            <td class="bench"><span class="pkg">test</span>BenchmarkClojureTestSuite [gogen_ir]</td>
+            <td class="num">1.12B</td>
+            <td class="num">2.07 s</td>
+            <td class="num">8.51M</td>
+            <td class="num">370.1 MiB</td>
+            <td><span class="delta muted">new</span></td>
+            <td class="barcell"><div class="bartrack"><span class="barfill" style="--w: 100.00"></span></div></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap">Source data: docs/perf/baseline.json, docs/perf/historical/*.json, and docs/perf/timeline/*.json. Page generation does not run benchmarks.</div>
+  </footer>
+</body>
+</html>

--- a/docs/perf/ratchet.md
+++ b/docs/perf/ratchet.md
@@ -19,6 +19,9 @@ Two phases, separately invokable:
    single test from blocking the whole sweep forever.
 2. **aggregate** — reads one or more `.jsonl` files, normalizes
    against the anchor, emits the consolidated `baseline.json`.
+3. **snapshot** — captures and aggregates like `show`, then writes
+   the current run as an immutable JSON snapshot. This is for timeline
+   graphs and does not ratchet or update `baseline.json`.
 
 The one-shot `check` / `update` / `show` modes are just wrappers:
 capture-then-aggregate-then-(compare|write|print).
@@ -32,21 +35,28 @@ capture-then-aggregate-then-(compare|write|print).
 | `test/zz_bench_test.go` | `BenchmarkClojureTestSuite` — end-to-end wall time of the full clojure-test-suite (jank) corpus. Catches compile + run regressions that pkg/vm micro-benches don't see. |
 | `docs/perf/baseline.json` | The current committed baseline. |
 | `docs/perf/historical/*.json` | Frozen historical snapshots (e.g. `v1.8.0.json`). Captured against the same anchor so any current run can `-baseline docs/perf/historical/v1.8.0.json check` and see "how much have we drifted since release N." |
+| `docs/perf/timeline/*.json` | Append-only full perf snapshots captured on pushes to `main`. These drive trend charts and record actual runs over time. |
+| `docs/perf/index.html` | Static "Are we fast yet?" page generated from the committed baseline, historical snapshots, and timeline snapshots. |
+| `cmd/perf-page/main.go` | Static page generator. It renders HTML only; it never runs benchmarks. |
 | `docs/perf/.runs/*.jsonl` | Raw capture output. Gitignored; recreated on each run. |
-| `Makefile` targets | `bench-ratchet`, `bench-ratchet-update`, `bench-ratchet-show`. |
+| `.github/workflows/perf-timeline.yml` | Main-only CI job that records timeline snapshots and commits the regenerated static page. |
+| `Makefile` targets | `bench-ratchet`, `bench-ratchet-update`, `bench-ratchet-show`, `perf-snapshot`, `perf-page`. |
 
 ## Scope
 
-Default packages: `pkg/vm` (VM-runtime micro-benchmarks + the anchor)
-and `./test` (BenchmarkClojureTestSuite — the end-to-end "real Lisp at
-scale" wall time over the full clojure-test-suite corpus, 232 files,
-5621 assertions, 100% pass rate).
+Default gate: calibration anchor, BenchmarkClojureTestSuite under both
+bytecode and `gogen_ir`, and the targeted `pkg/ir` BenchmarkIRCompile
+under both bytecode and `gogen_ir`.
+
+Full profile (`-full`): the broad timeline/deep-dive profile. It runs
+the full `pkg/vm` benchmark fleet under `-tags gogen_ir`, plus the
+suite and IR compile benchmark under both bytecode and `gogen_ir`.
 
 Deliberately out of scope: `pkg/compiler` (compile time — measured by
-parity scripts), `pkg/bytecode` (decode time — measured at `make build`),
-`pkg/ir` (IR pipeline internals — measured by ir-stress). Keeping the
-ratchet narrow means a slow compiler change doesn't trip a runtime gate
-AND each in-scope bench gets more of the sample budget.
+parity scripts) and `pkg/bytecode` (decode time — measured at `make
+build`). Keeping the ratchet narrow means a slow compiler change
+doesn't trip a runtime gate AND each in-scope bench gets more of the
+sample budget.
 
 Override via `-packages "github.com/nooga/let-go/pkg/X github.com/.../Y"`.
 
@@ -69,6 +79,8 @@ One-shot (Makefile):
 make bench-ratchet           # check current vs baseline (CI mode)
 make bench-ratchet-update    # overwrite baseline with current numbers
 make bench-ratchet-show      # capture & print, write nothing
+make perf-page               # refresh docs/perf/index.html from committed JSON
+make perf-snapshot           # full capture into docs/perf/timeline/<ts>-<sha>.json
 ```
 
 Explicit two-phase (useful when you want progress visibility, or are
@@ -79,6 +91,8 @@ capturing on one machine and aggregating on another):
 go run ./cmd/bench-ratchet -out /tmp/run.jsonl capture
 # Aggregate to a baseline
 go run ./cmd/bench-ratchet -in /tmp/run.jsonl -baseline /tmp/b.json aggregate
+# Aggregate to an immutable timeline snapshot
+go run ./cmd/bench-ratchet -in /tmp/run.jsonl -baseline docs/perf/timeline/<ts>-<sha>.json snapshot
 ```
 
 Finer control on either phase:

--- a/pkg/perfdata/perfdata.go
+++ b/pkg/perfdata/perfdata.go
@@ -1,0 +1,73 @@
+// Package perfdata defines the JSON schema shared by the perf tools.
+package perfdata
+
+// Baseline is the on-disk format. Keep field tags stable.
+type Baseline struct {
+	Version       int                       `json:"version"`
+	CapturedAt    string                    `json:"captured_at"`
+	CapturedAtSHA string                    `json:"captured_at_sha"`
+	Machine       Machine                   `json:"machine"`
+	Anchor        Anchor                    `json:"anchor"`
+	Benchmarks    map[string]BenchmarkEntry `json:"benchmarks"`
+}
+
+// Machine fingerprints the host that captured a baseline.
+type Machine struct {
+	OS        string `json:"os"`
+	Arch      string `json:"arch"`
+	NumCPU    int    `json:"num_cpu"`
+	CPUModel  string `json:"cpu_model"`
+	GoVersion string `json:"go_version"`
+}
+
+// Anchor captures the absolute speed of the calibration benchmark.
+type Anchor struct {
+	Name       string            `json:"name"`
+	Package    string            `json:"package"`
+	NSPerOp    float64           `json:"ns_per_op"`
+	Iterations int64             `json:"iterations,omitempty"`
+	Samples    []BenchmarkSample `json:"samples,omitempty"`
+}
+
+// BenchmarkEntry is one benchmark's current summary plus optional raw samples.
+type BenchmarkEntry struct {
+	NSPerOp       float64           `json:"ns_per_op"`
+	AllocsPerOp   int64             `json:"allocs_per_op"`
+	BytesPerOp    int64             `json:"bytes_per_op"`
+	RatioToAnchor float64           `json:"ratio_to_anchor"`
+	BestSinceSHA  string            `json:"best_since_sha,omitempty"`
+	BestSinceAt   string            `json:"best_since_at,omitempty"`
+	Samples       []BenchmarkSample `json:"samples,omitempty"`
+}
+
+// BenchmarkSample is one raw benchmark measurement retained for statistics.
+type BenchmarkSample struct {
+	Iterations    int64   `json:"iterations"`
+	NSPerOp       float64 `json:"ns_per_op"`
+	BytesPerOp    int64   `json:"bytes_per_op"`
+	AllocsPerOp   int64   `json:"allocs_per_op"`
+	RatioToAnchor float64 `json:"ratio_to_anchor,omitempty"`
+	CapturedAt    string  `json:"captured_at,omitempty"`
+}
+
+// StreamRecord is one .jsonl line emitted by bench-ratchet capture.
+type StreamRecord struct {
+	Package     string  `json:"package"`
+	Name        string  `json:"name"`
+	Iterations  int64   `json:"iterations"`
+	NSPerOp     float64 `json:"ns_per_op"`
+	BytesPerOp  int64   `json:"bytes_per_op"`
+	AllocsPerOp int64   `json:"allocs_per_op"`
+	CapturedAt  string  `json:"captured_at"`
+}
+
+// Sample returns the record's benchmark measurement without identity fields.
+func (r StreamRecord) Sample() BenchmarkSample {
+	return BenchmarkSample{
+		Iterations:  r.Iterations,
+		NSPerOp:     r.NSPerOp,
+		BytesPerOp:  r.BytesPerOp,
+		AllocsPerOp: r.AllocsPerOp,
+		CapturedAt:  r.CapturedAt,
+	}
+}

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -8,6 +8,7 @@ build:
 pages: build
 	mkdir -p static
 	cp index.html letgo.wasm wasm_exec.js logo.svg static
+	cd .. && go run ./cmd/perf-page -out wasm/static/perf/index.html
 
 clean:
 	rm -f letgo.wasm wasm_exec.js logo.svg


### PR DESCRIPTION
## What

This adds a static "Are we fast yet?" perf page and a main-only CI job that records full perf snapshots after merges to main. Quick and dirty!

## How It Works

- `bench-ratchet` gets a new `snapshot` mode. It captures and aggregates benchmark output like the existing modes, but writes the current run as an immutable JSON snapshot instead of ratcheting `docs/perf/baseline.json`.
- Snapshots are written under `docs/perf/timeline/<commit-time>-<sha>.json`.
- `.github/workflows/perf-timeline.yml` runs on pushes to `main` except perf-artifact-only commits. It measures the post-merge tip once, regenerates the static page, and commits the snapshot plus `docs/perf/index.html` back to `main`.
- `cmd/perf-page` renders `docs/perf/baseline.json`, `docs/perf/historical/*.json`, and `docs/perf/timeline/*.json` into a self-contained static HTML page with SVG trend charts.
- The existing Pages workflow already uploads `wasm/static`; `wasm/Makefile` now also generates `wasm/static/perf/index.html`, so the page deploys at `/perf/`.

## Open Questions / Risks

- The current ratchet baseline was captured on an Apple M3. The timeline workflow will run on GitHub-hosted Linux runners, so the displayed machine metadata and absolute `ns/op` values will change after the first CI snapshot.
- GitHub-hosted runners are noisy and may vary by CPU model. The page graphs `ratio_to_anchor` for the main timing charts, but we should merge this after review and observe how stable the data looks after the first main merge.
- If the runner noise is too high, the next step is likely a self-hosted stable runner or more grouping/filtering by machine fingerprint.

## Verification

- `GOCACHE=/private/tmp/let-go-gocache go test ./... -count=1 -skip TestClojureTestSuite`
- `GOCACHE=/private/tmp/let-go-gocache make perf-page`
- Validated `bench-ratchet snapshot` from an existing raw `.jsonl` capture.
- Render-checked the generated page in local headless Chrome at desktop and mobile widths.

## Proposal

Merge after review and see how the first post-merge main snapshot behaves in CI before tuning runner selection, benchmark duration, or chart grouping.