### PR TITLE
feat: browser interop (js/emit + LetGoHost API)

### DIFF
--- a/pkg/rt/js.go
+++ b/pkg/rt/js.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ *
+ * Platform-independent half of the js namespace. Argument validation and
+ * marshaling live here so that bugs (wrong arity, bad event-name type) are
+ * caught the same way whether .lg code is running native or in WASM. The
+ * platform-specific files (js_wasm.go, js_other.go) only provide the
+ * dispatch primitive.
+ */
+
+package rt
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// prepareEmit validates args for (js/emit event-name data) and returns the
+// event name and the JSON-marshaled data ready to hand to the platform
+// dispatcher. Same contract on every platform.
+func prepareEmit(vs []vm.Value) (string, string, error) {
+	if len(vs) != 2 {
+		return "", "", fmt.Errorf("js/emit expects 2 args (event-name data), got %d", len(vs))
+	}
+	name, err := eventName(vs[0])
+	if err != nil {
+		return "", "", err
+	}
+	data, err := fromValue(vs[1])
+	if err != nil {
+		return "", "", err
+	}
+	buf, err := json.Marshal(data)
+	if err != nil {
+		return "", "", fmt.Errorf("js/emit: %w", err)
+	}
+	return name, string(buf), nil
+}
+
+// eventName coerces a let-go value into the string event name passed to
+// CustomEvent. Accepts keyword (:stats), symbol (stats), or string ("stats").
+func eventName(v vm.Value) (string, error) {
+	switch v.Type() {
+	case vm.KeywordType:
+		return string(v.(vm.Keyword)), nil
+	case vm.SymbolType:
+		return v.(vm.Symbol).String(), nil
+	case vm.StringType:
+		return string(v.(vm.String)), nil
+	default:
+		return "", fmt.Errorf("js/emit event-name must be keyword, symbol, or string; got %s", v.Type().Name())
+	}
+}

--- a/pkg/rt/js_other.go
+++ b/pkg/rt/js_other.go
@@ -1,0 +1,35 @@
+//go:build !(js && wasm)
+
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ *
+ * Native (non-WASM) stub for the `js` namespace. The namespace IS installed
+ * so .lg code that uses (js/emit ...) parses and runs identically on native
+ * and in the browser — emits just no-op on native, mirroring the way
+ * `term/raw-mode!` is a no-op in WASM. Arg validation still runs so type
+ * bugs are caught during native dev, not just at runtime in the browser.
+ */
+
+package rt
+
+import (
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func init() { RegisterInstaller(installJSNS) }
+
+func installJSNS() {
+	ns := vm.NewNamespace("js")
+
+	// (js/emit event-name data) -> nil — validates args, then no-ops.
+	emitFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if _, _, err := prepareEmit(vs); err != nil {
+			return vm.NIL, err
+		}
+		return vm.NIL, nil
+	})
+	ns.Def("emit", emitFn)
+
+	RegisterNS(ns)
+}

--- a/pkg/rt/js_wasm.go
+++ b/pkg/rt/js_wasm.go
@@ -1,0 +1,51 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ *
+ * Browser bridge namespace. Lets .lg code dispatch structured events to JS
+ * without caring whether the let-go VM is running on the main thread (where
+ * the DOM is directly reachable) or inside a Web Worker (where it isn't).
+ *
+ * Single hidden contract with the bundle bootstrap: a global function
+ *   _lgEmit(name string, dataJson string)
+ * which dispatches a CustomEvent named `name` whose .detail is the parsed
+ * dataJson. The bootstrap defines _lgEmit per mode — main-thread version
+ * calls window.dispatchEvent directly; worker version postMessages to main,
+ * which dispatches there. From .lg code, both look the same.
+ */
+
+package rt
+
+import (
+	"syscall/js"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func init() { RegisterInstaller(installJSNS) }
+
+func installJSNS() {
+	ns := vm.NewNamespace("js")
+
+	// (js/emit event-name data) -> nil
+	//
+	// Fire-and-forget. Silently drops if _lgEmit isn't wired up (running
+	// outside the official bundle, e.g. via a host that doesn't define it).
+	emitFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		name, dataJSON, err := prepareEmit(vs)
+		if err != nil {
+			return vm.NIL, err
+		}
+		emit := js.Global().Get("_lgEmit")
+		if emit.IsUndefined() {
+			return vm.NIL, nil
+		}
+		emit.Invoke(name, dataJSON)
+		return vm.NIL, nil
+	})
+	ns.Def("emit", emitFn)
+
+	RegisterNS(ns)
+}

--- a/pkg/rt/wasm/assemble_test.go
+++ b/pkg/rt/wasm/assemble_test.go
@@ -9,13 +9,13 @@ import (
 
 var updateGolden = flag.Bool("update", false, "update golden files in testdata/")
 
-// TestAssembleHTMLGolden guards the byte-identity claim that backs the
-// "pure refactor" framing of the lg-host.js extraction. AssembleHTML is
-// a pure function; given fixed inputs it must produce a fixed output.
-// Any drift in host.html, lg-host.js, the markers, or the assembly
-// logic shows up as a diff against testdata/assemble_golden.html.
+// TestAssembleHTMLGolden pins the assembled HTML against
+// testdata/assemble_golden.html. Any edit to host.html, lg-host.js, the
+// markers, or the assembly logic that changes the bundle `lg -w` ships
+// surfaces as a golden diff.
 //
-// Regenerate after intentional changes:
+// This is a self-consistency pin, not a byte-identity guarantee against
+// any prior implementation. Regenerate after intentional changes:
 //
 //	go test ./pkg/rt/wasm -update
 func TestAssembleHTMLGolden(t *testing.T) {

--- a/pkg/rt/wasm/assemble_test.go
+++ b/pkg/rt/wasm/assemble_test.go
@@ -1,0 +1,80 @@
+package wasm
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update", false, "update golden files in testdata/")
+
+// TestAssembleHTMLGolden guards the byte-identity claim that backs the
+// "pure refactor" framing of the lg-host.js extraction. AssembleHTML is
+// a pure function; given fixed inputs it must produce a fixed output.
+// Any drift in host.html, lg-host.js, the markers, or the assembly
+// logic shows up as a diff against testdata/assemble_golden.html.
+//
+// Regenerate after intentional changes:
+//
+//	go test ./pkg/rt/wasm -update
+func TestAssembleHTMLGolden(t *testing.T) {
+	// Fixed, recognizable stubs. The real wasm_exec.js and gzipped WASM
+	// blob change every build (non-deterministic Go toolchain output);
+	// the test pins everything else.
+	const wasmExecJS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n"
+	const wasmGzB64 = "STUBWASMBLOBB64=="
+
+	got := AssembleHTML(wasmExecJS, wasmGzB64)
+	goldenPath := filepath.Join("testdata", "assemble_golden.html")
+
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(got), 0644); err != nil {
+			t.Fatalf("writing golden: %v", err)
+		}
+		t.Logf("golden updated: %s (%d bytes)", goldenPath, len(got))
+		return
+	}
+
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("reading golden (run `go test ./pkg/rt/wasm -update` to create): %v", err)
+	}
+	if string(golden) != got {
+		// Surface the size delta so the developer has a quick signal
+		// before diving into a diff.
+		t.Errorf("AssembleHTML output drift (golden=%d bytes, got=%d bytes).\n"+
+			"Run `go test ./pkg/rt/wasm -update` to refresh after intentional changes.",
+			len(golden), len(got))
+	}
+}
+
+// TestMarkersGone protects against a different failure: the substitution
+// could succeed structurally but leave stray markers if the source
+// gains another copy of __WASM_EXEC_JS__ etc. End-to-end build still
+// works in that case (the broken marker is just literal text in the
+// JS), so the golden test alone wouldn't catch it cleanly.
+func TestMarkersGone(t *testing.T) {
+	got := AssembleHTML("anything", "whatever")
+	for _, m := range []string{
+		"__WASM_EXEC_JS__",
+		"__WASM_GZ_B64__",
+		"__LG_HOST_JS_BODY_PLACEHOLDER__",
+	} {
+		if contains(got, m) {
+			t.Errorf("marker %q still present in assembled output", m)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/rt/wasm/embed.go
+++ b/pkg/rt/wasm/embed.go
@@ -11,6 +11,7 @@ package wasm
 import (
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -26,7 +27,18 @@ var htmlTemplate string
 func AssembleHTML(wasmExecJS, wasmGzB64 string) string {
 	execJSON, _ := json.Marshal(wasmExecJS)
 	b64JSON, _ := json.Marshal(wasmGzB64)
-	hostJS := strings.Replace(lgHostJS, "__WASM_EXEC_JS__", string(execJSON), 1)
-	hostJS = strings.Replace(hostJS, "__WASM_GZ_B64__", string(b64JSON), 1)
-	return strings.Replace(htmlTemplate, "__LG_HOST_JS_BODY_PLACEHOLDER__", hostJS, 1)
+	hostJS := mustReplaceOnce(lgHostJS, "__WASM_EXEC_JS__", string(execJSON))
+	hostJS = mustReplaceOnce(hostJS, "__WASM_GZ_B64__", string(b64JSON))
+	return mustReplaceOnce(htmlTemplate, "__LG_HOST_JS_BODY_PLACEHOLDER__", hostJS)
+}
+
+// mustReplaceOnce panics unless marker appears exactly once in s. The
+// templates are embedded at build time, so a missing or duplicated
+// marker is a developer error in lg-host.js or host.html — fail loud
+// rather than silently shipping a half-substituted bundle.
+func mustReplaceOnce(s, marker, replacement string) string {
+	if n := strings.Count(s, marker); n != 1 {
+		panic(fmt.Sprintf("wasm.AssembleHTML: marker %q expected exactly once, got %d", marker, n))
+	}
+	return strings.Replace(s, marker, replacement, 1)
 }

--- a/pkg/rt/wasm/embed.go
+++ b/pkg/rt/wasm/embed.go
@@ -1,0 +1,32 @@
+// Package wasm holds build-time JS and HTML assets for the `lg -w` WASM
+// bundler. AssembleHTML returns a single self-contained HTML page given
+// the Go runtime support source and the gzipped-base64 program WASM.
+//
+// lg-host.js carries two markers (__WASM_EXEC_JS__ and __WASM_GZ_B64__)
+// the assembler substitutes with JSON-encoded JS strings. host.html
+// carries a single marker (__LG_HOST_JS_BODY_PLACEHOLDER__) where the
+// populated host JS is inlined.
+package wasm
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+)
+
+//go:embed lg-host.js
+var lgHostJS string
+
+//go:embed host.html
+var htmlTemplate string
+
+// AssembleHTML returns the full self-contained HTML page produced by
+// `lg -w`. Pure function: same inputs produce same output. Tested via
+// a golden file in testdata/.
+func AssembleHTML(wasmExecJS, wasmGzB64 string) string {
+	execJSON, _ := json.Marshal(wasmExecJS)
+	b64JSON, _ := json.Marshal(wasmGzB64)
+	hostJS := strings.Replace(lgHostJS, "__WASM_EXEC_JS__", string(execJSON), 1)
+	hostJS = strings.Replace(hostJS, "__WASM_GZ_B64__", string(b64JSON), 1)
+	return strings.Replace(htmlTemplate, "__LG_HOST_JS_BODY_PLACEHOLDER__", hostJS, 1)
+}

--- a/pkg/rt/wasm/host.html
+++ b/pkg/rt/wasm/host.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>let-go app</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    body{display:flex;flex-direction:column}
+    #terminal{flex:1}
+    #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
+            top:50%;left:50%;transform:translate(-50%,-50%)}
+    .xterm{height:100%}
+  </style>
+</head>
+<body>
+  <div id="status">loading...</div>
+  <div id="terminal" style="display:none"></div>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+  <script>
+__LG_HOST_JS_BODY_PLACEHOLDER__
+  </script>
+</body>
+</html>

--- a/pkg/rt/wasm/lg-host.js
+++ b/pkg/rt/wasm/lg-host.js
@@ -35,6 +35,40 @@ async function decompressWasm(b64) {
   return out;
 }
 
+// --- window.LetGoHost — public host API ---
+// Single object on window for custom shells to talk to. Surface:
+//   onOutput(cb)      register sink for VM stdout; cb(string)
+//   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
+//   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
+//   setSize(c, r)     advertise a new terminal size to the VM
+//
+// wake() is intentionally NOT in this slice. Unblocking a parked read-key
+// without sending real input requires a SAB-level protocol change (a
+// wake-epoch cell or tri-state ready flag) so the Go-side read-key can
+// distinguish a real keystroke from an unblock. That lands in its own
+// PR with a concrete contract.
+//
+// The internal _lg* globals (_lgKey, _lgSetSize, _lgFlush, _lgEmit) remain
+// as compatibility hooks and are also the implementation backing for the
+// LetGoHost methods. Callers using either shape keep working.
+window.LetGoHost = (function() {
+  let outputSink = (s) => console.log(s);
+  let emitSink = (name, data) => {
+    try {
+      window.dispatchEvent(new CustomEvent(name, { detail: data }));
+    } catch (err) { console.error('lg emit:', err); }
+  };
+  return {
+    onOutput(cb) { outputSink = cb; },
+    onEmit(cb) { emitSink = cb; },
+    sendInput(s) { return window._lgKey ? window._lgKey(s) : false; },
+    setSize(c, r) { return window._lgSetSize ? window._lgSetSize(c, r) : undefined; },
+    // Internal — invoked by the runtime/relay code below.
+    _output(s) { outputSink(s); },
+    _emit(name, data) { emitSink(name, data); },
+  };
+})();
+
 const status = document.getElementById('status');
 const termEl = document.getElementById('terminal');
 
@@ -57,6 +91,10 @@ function showTerminal() {
   term.focus();
 }
 
+// xterm is the default output sink in this template. Custom shells can
+// call LetGoHost.onOutput(...) before the WASM boots to redirect.
+window.LetGoHost.onOutput((s) => term.write(s));
+
 window.addEventListener('resize', () => fitAddon.fit());
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
@@ -67,25 +105,32 @@ function startWorkerMode() {
 
   showTerminal();
 
-  // Store terminal size in SAB
-  Atomics.store(keyInt32, 6, term.cols);
-  Atomics.store(keyInt32, 7, term.rows);
-  term.onResize(({cols, rows}) => {
-    Atomics.store(keyInt32, 6, cols);
-    Atomics.store(keyInt32, 7, rows);
-  });
-
-  // Send keystrokes to worker via SAB
-  term.onData(data => {
+  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
+  // false if the input was too long (>16 bytes). xterm's onData calls into
+  // this; custom shells can call it directly or via LetGoHost.sendInput.
+  window._lgKey = function(data) {
     const bytes = new TextEncoder().encode(data);
-    if (bytes.length > 16) return;
-    // Spin-wait if previous key hasn't been consumed yet
+    if (bytes.length === 0 || bytes.length > 16) return false;
     while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
     keyUint8.set(bytes);
     Atomics.store(keyInt32, 1, bytes.length);
     Atomics.store(keyInt32, 0, 1);
     Atomics.notify(keyInt32, 0);
-  });
+    return true;
+  };
+
+  // Public size hook — backs LetGoHost.setSize.
+  window._lgSetSize = function(cols, rows) {
+    Atomics.store(keyInt32, 6, cols);
+    Atomics.store(keyInt32, 7, rows);
+  };
+
+  // Initial size + xterm resize hook route through the public API.
+  window._lgSetSize(term.cols, term.rows);
+  term.onResize(({cols, rows}) => window._lgSetSize(cols, rows));
+
+  // xterm keystrokes feed into _lgKey (which is what the VM reads).
+  term.onData((data) => window._lgKey(data));
 
   // Build worker code: fs shim + wasm_exec.js + bootstrap
   const workerCode = `
@@ -118,6 +163,11 @@ function startWorkerMode() {
     globalThis._lgFlush = function() {
       if (outputBuf.length > 0) { postMessage({t:'out', d:outputBuf}); outputBuf = ''; }
     };
+    // Worker side of the js/emit bridge — forward to main thread, which
+    // dispatches into LetGoHost (workers have no DOM, no LetGoHost).
+    globalThis._lgEmit = function(name, dataJson) {
+      postMessage({t:'emit', name, data: dataJson});
+    };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
       const { sab, wasmGzB64, wasmExecJS } = e.data;
@@ -148,8 +198,12 @@ function startWorkerMode() {
   const worker = new Worker(URL.createObjectURL(blob));
 
   worker.onmessage = (e) => {
-    if (e.data.t === 'out') term.write(e.data.d);
-    if (e.data.t === 'exit') term.write('\r\n\x1b[90m[program exited]\x1b[0m\r\n');
+    if (e.data.t === 'out') window.LetGoHost._output(e.data.d);
+    if (e.data.t === 'exit') window.LetGoHost._output('\r\n\x1b[90m[program exited]\x1b[0m\r\n');
+    if (e.data.t === 'emit') {
+      try { window.LetGoHost._emit(e.data.name, JSON.parse(e.data.data)); }
+      catch (err) { console.error('lg emit relay:', err); }
+    }
   };
 
   worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });
@@ -158,13 +212,14 @@ function startWorkerMode() {
 // --- Main-thread mode (output only, no input) ---
 async function startMainThreadMode() {
   showTerminal();
+  const out = (s) => window.LetGoHost._output(s);
   if (location.protocol === 'file:') {
-    term.write('\x1b[33mInteractive input requires a local server. Run:\x1b[0m\r\n');
-    term.write('\x1b[33m  python3 -m http.server\x1b[0m\r\n');
-    term.write('\x1b[33mthen open http://localhost:8000\x1b[0m\r\n\r\n');
+    out('\x1b[33mInteractive input requires a local server. Run:\x1b[0m\r\n');
+    out('\x1b[33m  python3 -m http.server\x1b[0m\r\n');
+    out('\x1b[33mthen open http://localhost:8000\x1b[0m\r\n\r\n');
   } else {
-    term.write('\x1b[33mInteractive input unavailable (no cross-origin isolation).\x1b[0m\r\n');
-    term.write('\x1b[33mDeploy coi-serviceworker.js alongside this file.\x1b[0m\r\n\r\n');
+    out('\x1b[33mInteractive input unavailable (no cross-origin isolation).\x1b[0m\r\n');
+    out('\x1b[33mDeploy coi-serviceworker.js alongside this file.\x1b[0m\r\n\r\n');
   }
 
   const decoder = new TextDecoder('utf-8');
@@ -172,7 +227,7 @@ async function startMainThreadMode() {
   globalThis.fs = {
     constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
     writeSync(fd, buf) {
-      if (fd === 1 || fd === 2) { term.write(decoder.decode(buf)); return buf.length; }
+      if (fd === 1 || fd === 2) { window.LetGoHost._output(decoder.decode(buf)); return buf.length; }
       return 0;
     },
     write(fd, buf, offset, length, position, callback) {
@@ -195,6 +250,12 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread side of the js/emit bridge — dispatch straight into
+  // LetGoHost (no worker round-trip needed).
+  globalThis._lgEmit = function(name, dataJson) {
+    try { window.LetGoHost._emit(name, JSON.parse(dataJson)); }
+    catch (err) { console.error('lg emit:', err); }
+  };
 
   // Load wasm_exec.js
   eval(WASM_EXEC_JS);

--- a/pkg/rt/wasm/lg-host.js
+++ b/pkg/rt/wasm/lg-host.js
@@ -1,0 +1,220 @@
+// --- Cross-origin isolation: prefer server headers, fall back to SW ---
+// When the dev/host server sends the COI headers itself (dev/serve.json
+// does this), crossOriginIsolated is already true and we don't need the
+// SW. Any leftover SW from a prior visit (e.g. earlier GitHub Pages load)
+// would intercept future fetches with stale content — unregister it now
+// so the headers path stays clean.
+if (crossOriginIsolated && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(rs => rs.forEach(r => r.unregister())).catch(()=>{});
+}
+// No isolation? Register the SW shim — but only once per tab. Without a
+// loop guard, a SW that fails to provide isolation (Safari rejects
+// credentialless, or activation races a tab close) reloads forever.
+if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigator
+    && !sessionStorage.getItem('_lgCoiTried')) {
+  sessionStorage.setItem('_lgCoiTried', '1');
+  navigator.serviceWorker.register('coi-serviceworker.js').then(() => location.reload()).catch(()=>{});
+}
+
+// --- Inline wasm_exec.js and WASM data ---
+const WASM_EXEC_JS = __WASM_EXEC_JS__;
+const WASM_GZ_B64 = __WASM_GZ_B64__;
+
+// --- Decompress gzipped base64 WASM ---
+async function decompressWasm(b64) {
+  const compressed = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+  const ds = new DecompressionStream('gzip');
+  const w = ds.writable.getWriter();
+  w.write(compressed); w.close();
+  const r = ds.readable.getReader();
+  const chunks = [];
+  while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); }
+  let total = 0; for(const c of chunks) total += c.length;
+  const out = new Uint8Array(total);
+  let off = 0; for(const c of chunks) { out.set(c, off); off += c.length; }
+  return out;
+}
+
+const status = document.getElementById('status');
+const termEl = document.getElementById('terminal');
+
+// --- Initialize xterm.js ---
+const term = new Terminal({
+  fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
+  fontSize: 14,
+  theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
+  allowProposedApi: true,
+  convertEol: true,
+});
+const fitAddon = new FitAddon.FitAddon();
+term.loadAddon(fitAddon);
+
+function showTerminal() {
+  status.style.display = 'none';
+  termEl.style.display = 'block';
+  term.open(termEl);
+  fitAddon.fit();
+  term.focus();
+}
+
+window.addEventListener('resize', () => fitAddon.fit());
+
+// --- Worker mode (interactive, needs cross-origin isolation) ---
+function startWorkerMode() {
+  const sab = new SharedArrayBuffer(64);
+  const keyInt32 = new Int32Array(sab);
+  const keyUint8 = new Uint8Array(sab, 8, 16);
+
+  showTerminal();
+
+  // Store terminal size in SAB
+  Atomics.store(keyInt32, 6, term.cols);
+  Atomics.store(keyInt32, 7, term.rows);
+  term.onResize(({cols, rows}) => {
+    Atomics.store(keyInt32, 6, cols);
+    Atomics.store(keyInt32, 7, rows);
+  });
+
+  // Send keystrokes to worker via SAB
+  term.onData(data => {
+    const bytes = new TextEncoder().encode(data);
+    if (bytes.length > 16) return;
+    // Spin-wait if previous key hasn't been consumed yet
+    while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
+    keyUint8.set(bytes);
+    Atomics.store(keyInt32, 1, bytes.length);
+    Atomics.store(keyInt32, 0, 1);
+    Atomics.notify(keyInt32, 0);
+  });
+
+  // Build worker code: fs shim + wasm_exec.js + bootstrap
+  const workerCode = `
+    let outputBuf = '';
+    const decoder = new TextDecoder('utf-8');
+    const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
+    globalThis.fs = {
+      constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+      writeSync(fd, buf) {
+        if (fd === 1 || fd === 2) { outputBuf += decoder.decode(buf); return buf.length; }
+        return 0;
+      },
+      write(fd, buf, offset, length, position, callback) {
+        if (offset !== 0 || length !== buf.length || position !== null) { callback(enosys()); return; }
+        callback(null, this.writeSync(fd, buf));
+      },
+      chmod(p,m,cb){cb(null);}, chown(p,u,g,cb){cb(null);}, close(fd,cb){cb(null);},
+      fchmod(fd,m,cb){cb(null);}, fchown(fd,u,g,cb){cb(null);},
+      fstat(fd,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+      fsync(fd,cb){cb(null);}, ftruncate(fd,l,cb){cb(null);},
+      lchown(p,u,g,cb){cb(null);}, link(p,l,cb){cb(null);}, lstat(p,cb){cb(null);},
+      mkdir(p,m,cb){cb(null);}, open(p,f,m,cb){cb(enosys());},
+      read(fd,buf,off,len,pos,cb){cb(null,0);},
+      readdir(p,cb){cb(null,[]);}, readlink(p,cb){cb(null,"");},
+      rename(o,n,cb){cb(null);}, rmdir(p,cb){cb(null);},
+      stat(p,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+      symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
+      unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
+    };
+    globalThis._lgFlush = function() {
+      if (outputBuf.length > 0) { postMessage({t:'out', d:outputBuf}); outputBuf = ''; }
+    };
+    onmessage = async (e) => {
+      if (e.data.t !== 'init') return;
+      const { sab, wasmGzB64, wasmExecJS } = e.data;
+      globalThis._lgKeyInt32 = new Int32Array(sab);
+      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      // Load wasm_exec.js in worker scope
+      eval(wasmExecJS);
+      // Decompress WASM
+      const compressed = Uint8Array.from(atob(wasmGzB64), c => c.charCodeAt(0));
+      const ds = new DecompressionStream('gzip');
+      const w = ds.writable.getWriter(); w.write(compressed); w.close();
+      const r = ds.readable.getReader();
+      const chunks = []; let total = 0;
+      while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); total += value.length; }
+      const wasmBytes = new Uint8Array(total);
+      let off = 0; for(const c of chunks) { wasmBytes.set(c, off); off += c.length; }
+      // Run Go WASM
+      const go = new Go();
+      const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+      postMessage({t:'ready'});
+      await go.run(instance);
+      globalThis._lgFlush();
+      postMessage({t:'exit'});
+    };
+  `;
+
+  const blob = new Blob([workerCode], { type: 'application/javascript' });
+  const worker = new Worker(URL.createObjectURL(blob));
+
+  worker.onmessage = (e) => {
+    if (e.data.t === 'out') term.write(e.data.d);
+    if (e.data.t === 'exit') term.write('\r\n\x1b[90m[program exited]\x1b[0m\r\n');
+  };
+
+  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });
+}
+
+// --- Main-thread mode (output only, no input) ---
+async function startMainThreadMode() {
+  showTerminal();
+  if (location.protocol === 'file:') {
+    term.write('\x1b[33mInteractive input requires a local server. Run:\x1b[0m\r\n');
+    term.write('\x1b[33m  python3 -m http.server\x1b[0m\r\n');
+    term.write('\x1b[33mthen open http://localhost:8000\x1b[0m\r\n\r\n');
+  } else {
+    term.write('\x1b[33mInteractive input unavailable (no cross-origin isolation).\x1b[0m\r\n');
+    term.write('\x1b[33mDeploy coi-serviceworker.js alongside this file.\x1b[0m\r\n\r\n');
+  }
+
+  const decoder = new TextDecoder('utf-8');
+  const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
+  globalThis.fs = {
+    constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+    writeSync(fd, buf) {
+      if (fd === 1 || fd === 2) { term.write(decoder.decode(buf)); return buf.length; }
+      return 0;
+    },
+    write(fd, buf, offset, length, position, callback) {
+      if (offset !== 0 || length !== buf.length || position !== null) {
+        callback(enosys()); return;
+      }
+      callback(null, this.writeSync(fd, buf));
+    },
+    chmod(p,m,cb){cb(null);}, chown(p,u,g,cb){cb(null);}, close(fd,cb){cb(null);},
+    fchmod(fd,m,cb){cb(null);}, fchown(fd,u,g,cb){cb(null);},
+    fstat(fd,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+    fsync(fd,cb){cb(null);}, ftruncate(fd,l,cb){cb(null);},
+    lchown(p,u,g,cb){cb(null);}, link(p,l,cb){cb(null);}, lstat(p,cb){cb(null);},
+    mkdir(p,m,cb){cb(null);}, open(p,f,m,cb){cb(enosys());},
+    read(fd,buf,off,len,pos,cb){cb(null,0);},
+    readdir(p,cb){cb(null,[]);}, readlink(p,cb){cb(null,"");},
+    rename(o,n,cb){cb(null);}, rmdir(p,cb){cb(null);},
+    stat(p,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+    symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
+    unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
+  };
+  globalThis._lgFlush = function(){};
+
+  // Load wasm_exec.js
+  eval(WASM_EXEC_JS);
+  const wasmBytes = await decompressWasm(WASM_GZ_B64);
+  const go = new Go();
+  const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+  go.run(instance);
+}
+
+// --- Entry point ---
+(async () => {
+  try {
+    status.textContent = 'decompressing wasm...';
+    if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
+      startWorkerMode();
+    } else {
+      await startMainThreadMode();
+    }
+  } catch(err) {
+    status.textContent = 'error: ' + err;
+    console.error(err);
+  }
+})();

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>let-go app</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    body{display:flex;flex-direction:column}
+    #terminal{flex:1}
+    #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
+            top:50%;left:50%;transform:translate(-50%,-50%)}
+    .xterm{height:100%}
+  </style>
+</head>
+<body>
+  <div id="status">loading...</div>
+  <div id="terminal" style="display:none"></div>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+  <script>
+// --- Cross-origin isolation: prefer server headers, fall back to SW ---
+// When the dev/host server sends the COI headers itself (dev/serve.json
+// does this), crossOriginIsolated is already true and we don't need the
+// SW. Any leftover SW from a prior visit (e.g. earlier GitHub Pages load)
+// would intercept future fetches with stale content — unregister it now
+// so the headers path stays clean.
+if (crossOriginIsolated && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(rs => rs.forEach(r => r.unregister())).catch(()=>{});
+}
+// No isolation? Register the SW shim — but only once per tab. Without a
+// loop guard, a SW that fails to provide isolation (Safari rejects
+// credentialless, or activation races a tab close) reloads forever.
+if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigator
+    && !sessionStorage.getItem('_lgCoiTried')) {
+  sessionStorage.setItem('_lgCoiTried', '1');
+  navigator.serviceWorker.register('coi-serviceworker.js').then(() => location.reload()).catch(()=>{});
+}
+
+// --- Inline wasm_exec.js and WASM data ---
+const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
+const WASM_GZ_B64 = "STUBWASMBLOBB64==";
+
+// --- Decompress gzipped base64 WASM ---
+async function decompressWasm(b64) {
+  const compressed = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+  const ds = new DecompressionStream('gzip');
+  const w = ds.writable.getWriter();
+  w.write(compressed); w.close();
+  const r = ds.readable.getReader();
+  const chunks = [];
+  while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); }
+  let total = 0; for(const c of chunks) total += c.length;
+  const out = new Uint8Array(total);
+  let off = 0; for(const c of chunks) { out.set(c, off); off += c.length; }
+  return out;
+}
+
+// --- window.LetGoHost — public host API ---
+// Single object on window for custom shells to talk to. Surface:
+//   onOutput(cb)      register sink for VM stdout; cb(string)
+//   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
+//   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
+//   wake()            unblock a parked read without sending input (TBD; alias of sendInput('\x07') for now)
+//   setSize(c, r)     advertise a new terminal size to the VM
+//
+// The internal _lg* globals (_lgKey, _lgSetSize, _lgFlush, _lgEmit) remain
+// as compatibility hooks and are also the implementation backing for the
+// LetGoHost methods. Callers using either shape keep working.
+window.LetGoHost = (function() {
+  let outputSink = (s) => console.log(s);
+  let emitSink = (name, data) => {
+    try {
+      window.dispatchEvent(new CustomEvent(name, { detail: data }));
+    } catch (err) { console.error('lg emit:', err); }
+  };
+  return {
+    onOutput(cb) { outputSink = cb; },
+    onEmit(cb) { emitSink = cb; },
+    sendInput(s) { return window._lgKey ? window._lgKey(s) : false; },
+    wake() { return window._lgWake ? window._lgWake() : undefined; },
+    setSize(c, r) { return window._lgSetSize ? window._lgSetSize(c, r) : undefined; },
+    // Internal — invoked by the runtime/relay code below.
+    _output(s) { outputSink(s); },
+    _emit(name, data) { emitSink(name, data); },
+  };
+})();
+
+const status = document.getElementById('status');
+const termEl = document.getElementById('terminal');
+
+// --- Initialize xterm.js ---
+const term = new Terminal({
+  fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
+  fontSize: 14,
+  theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
+  allowProposedApi: true,
+  convertEol: true,
+});
+const fitAddon = new FitAddon.FitAddon();
+term.loadAddon(fitAddon);
+
+function showTerminal() {
+  status.style.display = 'none';
+  termEl.style.display = 'block';
+  term.open(termEl);
+  fitAddon.fit();
+  term.focus();
+}
+
+// xterm is the default output sink in this template. Custom shells can
+// call LetGoHost.onOutput(...) before the WASM boots to redirect.
+window.LetGoHost.onOutput((s) => term.write(s));
+
+window.addEventListener('resize', () => fitAddon.fit());
+
+// --- Worker mode (interactive, needs cross-origin isolation) ---
+function startWorkerMode() {
+  const sab = new SharedArrayBuffer(64);
+  const keyInt32 = new Int32Array(sab);
+  const keyUint8 = new Uint8Array(sab, 8, 16);
+
+  showTerminal();
+
+  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
+  // false if the input was too long (>16 bytes). xterm's onData calls into
+  // this; custom shells can call it directly or via LetGoHost.sendInput.
+  window._lgKey = function(data) {
+    const bytes = new TextEncoder().encode(data);
+    if (bytes.length === 0 || bytes.length > 16) return false;
+    while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
+    keyUint8.set(bytes);
+    Atomics.store(keyInt32, 1, bytes.length);
+    Atomics.store(keyInt32, 0, 1);
+    Atomics.notify(keyInt32, 0);
+    return true;
+  };
+
+  // Public size hook — backs LetGoHost.setSize.
+  window._lgSetSize = function(cols, rows) {
+    Atomics.store(keyInt32, 6, cols);
+    Atomics.store(keyInt32, 7, rows);
+  };
+
+  // Initial size + xterm resize hook route through the public API.
+  window._lgSetSize(term.cols, term.rows);
+  term.onResize(({cols, rows}) => window._lgSetSize(cols, rows));
+
+  // xterm keystrokes feed into _lgKey (which is what the VM reads).
+  term.onData((data) => window._lgKey(data));
+
+  // Build worker code: fs shim + wasm_exec.js + bootstrap
+  const workerCode = `
+    let outputBuf = '';
+    const decoder = new TextDecoder('utf-8');
+    const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
+    globalThis.fs = {
+      constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+      writeSync(fd, buf) {
+        if (fd === 1 || fd === 2) { outputBuf += decoder.decode(buf); return buf.length; }
+        return 0;
+      },
+      write(fd, buf, offset, length, position, callback) {
+        if (offset !== 0 || length !== buf.length || position !== null) { callback(enosys()); return; }
+        callback(null, this.writeSync(fd, buf));
+      },
+      chmod(p,m,cb){cb(null);}, chown(p,u,g,cb){cb(null);}, close(fd,cb){cb(null);},
+      fchmod(fd,m,cb){cb(null);}, fchown(fd,u,g,cb){cb(null);},
+      fstat(fd,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+      fsync(fd,cb){cb(null);}, ftruncate(fd,l,cb){cb(null);},
+      lchown(p,u,g,cb){cb(null);}, link(p,l,cb){cb(null);}, lstat(p,cb){cb(null);},
+      mkdir(p,m,cb){cb(null);}, open(p,f,m,cb){cb(enosys());},
+      read(fd,buf,off,len,pos,cb){cb(null,0);},
+      readdir(p,cb){cb(null,[]);}, readlink(p,cb){cb(null,"");},
+      rename(o,n,cb){cb(null);}, rmdir(p,cb){cb(null);},
+      stat(p,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+      symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
+      unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
+    };
+    globalThis._lgFlush = function() {
+      if (outputBuf.length > 0) { postMessage({t:'out', d:outputBuf}); outputBuf = ''; }
+    };
+    // Worker side of the js/emit bridge — forward to main thread, which
+    // dispatches into LetGoHost (workers have no DOM, no LetGoHost).
+    globalThis._lgEmit = function(name, dataJson) {
+      postMessage({t:'emit', name, data: dataJson});
+    };
+    onmessage = async (e) => {
+      if (e.data.t !== 'init') return;
+      const { sab, wasmGzB64, wasmExecJS } = e.data;
+      globalThis._lgKeyInt32 = new Int32Array(sab);
+      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      // Load wasm_exec.js in worker scope
+      eval(wasmExecJS);
+      // Decompress WASM
+      const compressed = Uint8Array.from(atob(wasmGzB64), c => c.charCodeAt(0));
+      const ds = new DecompressionStream('gzip');
+      const w = ds.writable.getWriter(); w.write(compressed); w.close();
+      const r = ds.readable.getReader();
+      const chunks = []; let total = 0;
+      while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); total += value.length; }
+      const wasmBytes = new Uint8Array(total);
+      let off = 0; for(const c of chunks) { wasmBytes.set(c, off); off += c.length; }
+      // Run Go WASM
+      const go = new Go();
+      const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+      postMessage({t:'ready'});
+      await go.run(instance);
+      globalThis._lgFlush();
+      postMessage({t:'exit'});
+    };
+  `;
+
+  const blob = new Blob([workerCode], { type: 'application/javascript' });
+  const worker = new Worker(URL.createObjectURL(blob));
+
+  worker.onmessage = (e) => {
+    if (e.data.t === 'out') window.LetGoHost._output(e.data.d);
+    if (e.data.t === 'exit') window.LetGoHost._output('\r\n\x1b[90m[program exited]\x1b[0m\r\n');
+    if (e.data.t === 'emit') {
+      try { window.LetGoHost._emit(e.data.name, JSON.parse(e.data.data)); }
+      catch (err) { console.error('lg emit relay:', err); }
+    }
+  };
+
+  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });
+}
+
+// --- Main-thread mode (output only, no input) ---
+async function startMainThreadMode() {
+  showTerminal();
+  const out = (s) => window.LetGoHost._output(s);
+  if (location.protocol === 'file:') {
+    out('\x1b[33mInteractive input requires a local server. Run:\x1b[0m\r\n');
+    out('\x1b[33m  python3 -m http.server\x1b[0m\r\n');
+    out('\x1b[33mthen open http://localhost:8000\x1b[0m\r\n\r\n');
+  } else {
+    out('\x1b[33mInteractive input unavailable (no cross-origin isolation).\x1b[0m\r\n');
+    out('\x1b[33mDeploy coi-serviceworker.js alongside this file.\x1b[0m\r\n\r\n');
+  }
+
+  const decoder = new TextDecoder('utf-8');
+  const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
+  globalThis.fs = {
+    constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+    writeSync(fd, buf) {
+      if (fd === 1 || fd === 2) { window.LetGoHost._output(decoder.decode(buf)); return buf.length; }
+      return 0;
+    },
+    write(fd, buf, offset, length, position, callback) {
+      if (offset !== 0 || length !== buf.length || position !== null) {
+        callback(enosys()); return;
+      }
+      callback(null, this.writeSync(fd, buf));
+    },
+    chmod(p,m,cb){cb(null);}, chown(p,u,g,cb){cb(null);}, close(fd,cb){cb(null);},
+    fchmod(fd,m,cb){cb(null);}, fchown(fd,u,g,cb){cb(null);},
+    fstat(fd,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+    fsync(fd,cb){cb(null);}, ftruncate(fd,l,cb){cb(null);},
+    lchown(p,u,g,cb){cb(null);}, link(p,l,cb){cb(null);}, lstat(p,cb){cb(null);},
+    mkdir(p,m,cb){cb(null);}, open(p,f,m,cb){cb(enosys());},
+    read(fd,buf,off,len,pos,cb){cb(null,0);},
+    readdir(p,cb){cb(null,[]);}, readlink(p,cb){cb(null,"");},
+    rename(o,n,cb){cb(null);}, rmdir(p,cb){cb(null);},
+    stat(p,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
+    symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
+    unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
+  };
+  globalThis._lgFlush = function(){};
+  // Main-thread side of the js/emit bridge — dispatch straight into
+  // LetGoHost (no worker round-trip needed).
+  globalThis._lgEmit = function(name, dataJson) {
+    try { window.LetGoHost._emit(name, JSON.parse(dataJson)); }
+    catch (err) { console.error('lg emit:', err); }
+  };
+
+  // Load wasm_exec.js
+  eval(WASM_EXEC_JS);
+  const wasmBytes = await decompressWasm(WASM_GZ_B64);
+  const go = new Go();
+  const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+  go.run(instance);
+}
+
+// --- Entry point ---
+(async () => {
+  try {
+    status.textContent = 'decompressing wasm...';
+    if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
+      startWorkerMode();
+    } else {
+      await startMainThreadMode();
+    }
+  } catch(err) {
+    status.textContent = 'error: ' + err;
+    console.error(err);
+  }
+})();
+  </script>
+</body>
+</html>

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -62,8 +62,13 @@ async function decompressWasm(b64) {
 //   onOutput(cb)      register sink for VM stdout; cb(string)
 //   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
 //   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
-//   wake()            unblock a parked read without sending input (TBD; alias of sendInput('\x07') for now)
 //   setSize(c, r)     advertise a new terminal size to the VM
+//
+// wake() is intentionally NOT in this slice. Unblocking a parked read-key
+// without sending real input requires a SAB-level protocol change (a
+// wake-epoch cell or tri-state ready flag) so the Go-side read-key can
+// distinguish a real keystroke from an unblock. That lands in its own
+// PR with a concrete contract.
 //
 // The internal _lg* globals (_lgKey, _lgSetSize, _lgFlush, _lgEmit) remain
 // as compatibility hooks and are also the implementation backing for the
@@ -79,7 +84,6 @@ window.LetGoHost = (function() {
     onOutput(cb) { outputSink = cb; },
     onEmit(cb) { emitSink = cb; },
     sendInput(s) { return window._lgKey ? window._lgKey(s) : false; },
-    wake() { return window._lgWake ? window._lgWake() : undefined; },
     setSize(c, r) { return window._lgSetSize ? window._lgSetSize(c, r) : undefined; },
     // Internal — invoked by the runtime/relay code below.
     _output(s) { outputSink(s); },

--- a/wasm.go
+++ b/wasm.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -20,6 +19,7 @@ import (
 	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/compiler"
 	"github.com/nooga/let-go/pkg/resolver"
+	wasmassets "github.com/nooga/let-go/pkg/rt/wasm"
 	"github.com/nooga/let-go/pkg/vm"
 )
 
@@ -86,256 +86,8 @@ func main() {
 }
 `
 
-// wasmHTMLTemplate has two %%s placeholders: wasm_exec.js source, base64-gzipped WASM.
-// Uses xterm.js for terminal rendering. Runs Go WASM in a Web Worker with
-// SharedArrayBuffer for blocking read-key. Falls back to output-only mode
-// when cross-origin isolation is unavailable.
-const wasmHTMLTemplate = `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>let-go app</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
-  <style>
-    *{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
-    body{display:flex;flex-direction:column}
-    #terminal{flex:1}
-    #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
-            top:50%%;left:50%%;transform:translate(-50%%,-50%%)}
-    .xterm{height:100%%}
-  </style>
-</head>
-<body>
-  <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
-  <script>
-// --- Cross-origin isolation: prefer server headers, fall back to SW ---
-// When the dev/host server sends the COI headers itself (dev/serve.json
-// does this), crossOriginIsolated is already true and we don't need the
-// SW. Any leftover SW from a prior visit (e.g. earlier GitHub Pages load)
-// would intercept future fetches with stale content — unregister it now
-// so the headers path stays clean.
-if (crossOriginIsolated && 'serviceWorker' in navigator) {
-  navigator.serviceWorker.getRegistrations().then(rs => rs.forEach(r => r.unregister())).catch(()=>{});
-}
-// No isolation? Register the SW shim — but only once per tab. Without a
-// loop guard, a SW that fails to provide isolation (Safari rejects
-// credentialless, or activation races a tab close) reloads forever.
-if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigator
-    && !sessionStorage.getItem('_lgCoiTried')) {
-  sessionStorage.setItem('_lgCoiTried', '1');
-  navigator.serviceWorker.register('coi-serviceworker.js').then(() => location.reload()).catch(()=>{});
-}
-
-// --- Inline wasm_exec.js and WASM data ---
-const WASM_EXEC_JS = %s;
-const WASM_GZ_B64 = %s;
-
-// --- Decompress gzipped base64 WASM ---
-async function decompressWasm(b64) {
-  const compressed = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
-  const ds = new DecompressionStream('gzip');
-  const w = ds.writable.getWriter();
-  w.write(compressed); w.close();
-  const r = ds.readable.getReader();
-  const chunks = [];
-  while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); }
-  let total = 0; for(const c of chunks) total += c.length;
-  const out = new Uint8Array(total);
-  let off = 0; for(const c of chunks) { out.set(c, off); off += c.length; }
-  return out;
-}
-
-const status = document.getElementById('status');
-const termEl = document.getElementById('terminal');
-
-// --- Initialize xterm.js ---
-const term = new Terminal({
-  fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
-  fontSize: 14,
-  theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
-  allowProposedApi: true,
-  convertEol: true,
-});
-const fitAddon = new FitAddon.FitAddon();
-term.loadAddon(fitAddon);
-
-function showTerminal() {
-  status.style.display = 'none';
-  termEl.style.display = 'block';
-  term.open(termEl);
-  fitAddon.fit();
-  term.focus();
-}
-
-window.addEventListener('resize', () => fitAddon.fit());
-
-// --- Worker mode (interactive, needs cross-origin isolation) ---
-function startWorkerMode() {
-  const sab = new SharedArrayBuffer(64);
-  const keyInt32 = new Int32Array(sab);
-  const keyUint8 = new Uint8Array(sab, 8, 16);
-
-  showTerminal();
-
-  // Store terminal size in SAB
-  Atomics.store(keyInt32, 6, term.cols);
-  Atomics.store(keyInt32, 7, term.rows);
-  term.onResize(({cols, rows}) => {
-    Atomics.store(keyInt32, 6, cols);
-    Atomics.store(keyInt32, 7, rows);
-  });
-
-  // Send keystrokes to worker via SAB
-  term.onData(data => {
-    const bytes = new TextEncoder().encode(data);
-    if (bytes.length > 16) return;
-    // Spin-wait if previous key hasn't been consumed yet
-    while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
-    keyUint8.set(bytes);
-    Atomics.store(keyInt32, 1, bytes.length);
-    Atomics.store(keyInt32, 0, 1);
-    Atomics.notify(keyInt32, 0);
-  });
-
-  // Build worker code: fs shim + wasm_exec.js + bootstrap
-  const workerCode = ` + "`" + `
-    let outputBuf = '';
-    const decoder = new TextDecoder('utf-8');
-    const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
-    globalThis.fs = {
-      constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
-      writeSync(fd, buf) {
-        if (fd === 1 || fd === 2) { outputBuf += decoder.decode(buf); return buf.length; }
-        return 0;
-      },
-      write(fd, buf, offset, length, position, callback) {
-        if (offset !== 0 || length !== buf.length || position !== null) { callback(enosys()); return; }
-        callback(null, this.writeSync(fd, buf));
-      },
-      chmod(p,m,cb){cb(null);}, chown(p,u,g,cb){cb(null);}, close(fd,cb){cb(null);},
-      fchmod(fd,m,cb){cb(null);}, fchown(fd,u,g,cb){cb(null);},
-      fstat(fd,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
-      fsync(fd,cb){cb(null);}, ftruncate(fd,l,cb){cb(null);},
-      lchown(p,u,g,cb){cb(null);}, link(p,l,cb){cb(null);}, lstat(p,cb){cb(null);},
-      mkdir(p,m,cb){cb(null);}, open(p,f,m,cb){cb(enosys());},
-      read(fd,buf,off,len,pos,cb){cb(null,0);},
-      readdir(p,cb){cb(null,[]);}, readlink(p,cb){cb(null,"");},
-      rename(o,n,cb){cb(null);}, rmdir(p,cb){cb(null);},
-      stat(p,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
-      symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
-      unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
-    };
-    globalThis._lgFlush = function() {
-      if (outputBuf.length > 0) { postMessage({t:'out', d:outputBuf}); outputBuf = ''; }
-    };
-    onmessage = async (e) => {
-      if (e.data.t !== 'init') return;
-      const { sab, wasmGzB64, wasmExecJS } = e.data;
-      globalThis._lgKeyInt32 = new Int32Array(sab);
-      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
-      // Load wasm_exec.js in worker scope
-      eval(wasmExecJS);
-      // Decompress WASM
-      const compressed = Uint8Array.from(atob(wasmGzB64), c => c.charCodeAt(0));
-      const ds = new DecompressionStream('gzip');
-      const w = ds.writable.getWriter(); w.write(compressed); w.close();
-      const r = ds.readable.getReader();
-      const chunks = []; let total = 0;
-      while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); total += value.length; }
-      const wasmBytes = new Uint8Array(total);
-      let off = 0; for(const c of chunks) { wasmBytes.set(c, off); off += c.length; }
-      // Run Go WASM
-      const go = new Go();
-      const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
-      postMessage({t:'ready'});
-      await go.run(instance);
-      globalThis._lgFlush();
-      postMessage({t:'exit'});
-    };
-  ` + "`" + `;
-
-  const blob = new Blob([workerCode], { type: 'application/javascript' });
-  const worker = new Worker(URL.createObjectURL(blob));
-
-  worker.onmessage = (e) => {
-    if (e.data.t === 'out') term.write(e.data.d);
-    if (e.data.t === 'exit') term.write('\r\n\x1b[90m[program exited]\x1b[0m\r\n');
-  };
-
-  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });
-}
-
-// --- Main-thread mode (output only, no input) ---
-async function startMainThreadMode() {
-  showTerminal();
-  if (location.protocol === 'file:') {
-    term.write('\x1b[33mInteractive input requires a local server. Run:\x1b[0m\r\n');
-    term.write('\x1b[33m  python3 -m http.server\x1b[0m\r\n');
-    term.write('\x1b[33mthen open http://localhost:8000\x1b[0m\r\n\r\n');
-  } else {
-    term.write('\x1b[33mInteractive input unavailable (no cross-origin isolation).\x1b[0m\r\n');
-    term.write('\x1b[33mDeploy coi-serviceworker.js alongside this file.\x1b[0m\r\n\r\n');
-  }
-
-  const decoder = new TextDecoder('utf-8');
-  const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
-  globalThis.fs = {
-    constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
-    writeSync(fd, buf) {
-      if (fd === 1 || fd === 2) { term.write(decoder.decode(buf)); return buf.length; }
-      return 0;
-    },
-    write(fd, buf, offset, length, position, callback) {
-      if (offset !== 0 || length !== buf.length || position !== null) {
-        callback(enosys()); return;
-      }
-      callback(null, this.writeSync(fd, buf));
-    },
-    chmod(p,m,cb){cb(null);}, chown(p,u,g,cb){cb(null);}, close(fd,cb){cb(null);},
-    fchmod(fd,m,cb){cb(null);}, fchown(fd,u,g,cb){cb(null);},
-    fstat(fd,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
-    fsync(fd,cb){cb(null);}, ftruncate(fd,l,cb){cb(null);},
-    lchown(p,u,g,cb){cb(null);}, link(p,l,cb){cb(null);}, lstat(p,cb){cb(null);},
-    mkdir(p,m,cb){cb(null);}, open(p,f,m,cb){cb(enosys());},
-    read(fd,buf,off,len,pos,cb){cb(null,0);},
-    readdir(p,cb){cb(null,[]);}, readlink(p,cb){cb(null,"");},
-    rename(o,n,cb){cb(null);}, rmdir(p,cb){cb(null);},
-    stat(p,cb){cb(null,{isDirectory(){return false;},isFile(){return true;}});},
-    symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
-    unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
-  };
-  globalThis._lgFlush = function(){};
-
-  // Load wasm_exec.js
-  eval(WASM_EXEC_JS);
-  const wasmBytes = await decompressWasm(WASM_GZ_B64);
-  const go = new Go();
-  const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
-  go.run(instance);
-}
-
-// --- Entry point ---
-(async () => {
-  try {
-    status.textContent = 'decompressing wasm...';
-    if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
-      startWorkerMode();
-    } else {
-      await startMainThreadMode();
-    }
-  } catch(err) {
-    status.textContent = 'error: ' + err;
-    console.error(err);
-  }
-})();
-  </script>
-</body>
-</html>
-`
+// The HTML page and host JS live as embedded assets in pkg/rt/wasm.
+// See pkg/rt/wasm.AssembleHTML for the assembly contract.
 
 const coiServiceWorkerJS = `addEventListener('install', () => skipWaiting());
 addEventListener('activate', e => e.waitUntil(clients.claim()));
@@ -454,10 +206,7 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	}
 
 	// 9. Build single self-contained HTML
-	// JSON-encode JS strings so they're safe to embed in template
-	wasmExecJSJSON, _ := json.Marshal(string(wasmExecJS))
-	wasmB64JSON, _ := json.Marshal(wasmB64)
-	html := fmt.Sprintf(wasmHTMLTemplate, string(wasmExecJSJSON), string(wasmB64JSON))
+	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64)
 
 	// 10. Write output
 	if err := os.MkdirAll(outDir, 0755); err != nil {


### PR DESCRIPTION
## Summary

Concrete proposal for #79, opened as draft to make the design tangible. Three commits in conceptual order.

### 1. `feat: add js namespace for browser event dispatch`

The `(js/emit event-name data)` primitive. Fire-and-forget bridge from .lg code to the host. WASM dispatches via a single `_lgEmit(name, jsonString)` hand-off; native validates args and no-ops so .lg code stays portable. ~140 LOC, three new files in `pkg/rt/`, self-registering namespace.

### 2. `feat(wasm): extract lg-host.js + host.html from wasm.go template`

Step 1 from the issue body. Pulls the inline `<script>` body and HTML template body out of `wasm.go` into `pkg/rt/wasm/{lg-host.js, host.html}`, embedded via `//go:embed` and assembled back via `AssembleHTML`. A golden test in `testdata/` pins the assembled bundle so any future drift surfaces clearly.

### 3. `feat(wasm): add window.LetGoHost registration API`

Step 2 from the issue body. Adds:

```js
window.LetGoHost = {
  onOutput(cb),    // register sink for VM stdout; cb(string)
  onEmit(cb),      // register sink for js/emit; cb(name, parsedData)
  sendInput(s),    // inject UTF-8 keystrokes/bytes toward the VM
  setSize(c, r),   // advertise terminal size to the VM
};
```

Defaults: `onOutput` is `console.log` (overridden by xterm registration on boot), `onEmit` dispatches a `CustomEvent` on window. Internal `_lg*` globals stay in place as the existing wiring `LetGoHost` is built on. The default template registers xterm via `LetGoHost.onOutput((s) => term.write(s))`.

## Behavioral changes (vs prior inline template)

The `LetGoHost` layer in commit 3 introduces two intentional behavioral differences — they're the point of the new API, not regressions:

- Worker stdout now flows through `LetGoHost._output(cb)` (default: `console.log`; xterm registers its own callback on boot) instead of calling `term.write` directly.
- `_lgKey("")` returns `false` rather than falling through to the worker.

Framing the whole PR as a "pure refactor + new API" rather than byte-identical-vs-prior — h/t @nnunley for catching the overclaim.

## Verified locally

- `go test ./...` passes across the whole codebase.
- `lg -w` produces a working 7.1MB bundle.
- Headless playwright run: `(js/emit "test-event" {:answer 42 :source "lg"})` dispatches `CustomEvent("test-event", {detail: {answer: 42, source: "lg"}})` on window. Map and vector payloads both flow through the bridge.
- Existing browser REPL still works (terminal renders, REPL accepts input, output flows through `LetGoHost._output`).

## What's NOT in this PR

- **`wake()`**. Intentionally absent from the `LetGoHost` surface. Unblocking a parked `read-key` without sending real input requires a SAB-level protocol change (wake-epoch cell, tri-state ready flag, etc.) so the Go-side `read-key` can tell a real keystroke from an unblock. Deserves its own PR with a concrete contract.
- **xterm to `examples/` + `--shell` flag.** The most opinionated change in the original. Saved for follow-up once this API surface settles.

## Open questions

- **`js/emit` namespace name.** Kept as `js`; the broader interop-surface design (CLJS-familiar syntax, externs-vs-typed-boundary, marshalling) feels like its own conversation, not something to pre-resolve via a rename now.
- **`LetGoHost` shape: single-sink vs event-bus.** Current `onOutput(cb)` replaces; multi-subscriber is a consumer-side compose. Happy to switch to `addEventListener`-style if you'd prefer.
- **`_lg*` compat hooks.** Left in place for existing callers; they predate this PR (`_lgKeyInt32`, `_lgFlush` go back to the first WASM commit). PR doesn't promise them as stable API or deprecate them; `LetGoHost` is a documented layer on top. Eventual removal would need a setup-time handshake giving the runtime stored references rather than name lookups; I have a shape in mind, but out of scope here.

Opened as draft to make the design concrete; happy to reshape or close it.