### PR TITLE
fix(vm): emit EDN-conformant string escapes from pr-str

### DIFF
--- a/pkg/vm/string.go
+++ b/pkg/vm/string.go
@@ -163,6 +163,40 @@ func (l String) ValueAtOr(key Value, dflt Value) Value {
 	return Char(r[numkey])
 }
 
+// String returns the EDN/Clojure-readable form: surrounded by double quotes
+// with EDN-conformant escapes. NOTE: Go's %q emits \xNN / \a / \v for control
+// chars, which the reader rejects ("unknown escape sequence \x") and which are
+// not valid EDN — so %q did not round-trip its own output (e.g. ANSI-colored
+// strings like "\x1b[32m..."). Escapes here match the reader's accepted set
+// (reader.go): \" \\ \t \r \n \b \f, and \uXXXX for everything else below
+// 0x20 plus DEL; printable Unicode passes through as raw UTF-8.
 func (l String) String() string {
-	return fmt.Sprintf("%q", string(l))
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range string(l) {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04X`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }

--- a/test/pr_str_edn_roundtrip_test.lg
+++ b/test/pr_str_edn_roundtrip_test.lg
@@ -1,0 +1,31 @@
+;; pr-str must emit EDN-conformant string escapes so its output round-trips
+;; through the reader. Regression guard: String.String() previously used Go's
+;; fmt %q, which emits \xNN / \a / \v for control chars — sequences the reader
+;; rejects ("unknown escape sequence \x") and which are not valid EDN. So
+;; pr-str could not round-trip its own output (notably ANSI-colored strings
+;; like "[32m..."). The fix emits \uXXXX for control chars instead.
+(ns test.pr-str-edn-roundtrip-test
+  (:require
+   [clojure.string :as str]
+   [test :refer :all]))
+
+(deftest pr-str-roundtrips-control-chars
+  (testing "every control char round-trips through pr-str -> read-string"
+    (let [s (apply str (map char [27 9 10 13 8 12 0 127]))]
+      (is (= s (read-string (pr-str s)))))))
+
+(deftest pr-str-roundtrips-ansi
+  (testing "ANSI-colored string round-trips (the %q regression case)"
+    (let [s (str (char 27) "[32mgreen" (char 27) "[0m")]
+      (is (= s (read-string (pr-str s)))))))
+
+(deftest pr-str-emits-edn-escapes-not-go-hex
+  (testing "control chars emit \\uXXXX, never Go's \\xNN"
+    (let [out (pr-str (str (char 27)))]
+      (is (not (str/includes? out "\\x")))
+      (is (str/includes? out "\\u001B")))))
+
+(deftest pr-str-leaves-printable-unchanged
+  (testing "printable ASCII and Unicode pass through unescaped"
+    (is (= "hello" (read-string (pr-str "hello"))))
+    (is (= "héllo→λ" (read-string (pr-str "héllo→λ"))))))


### PR DESCRIPTION
## Problem

`String.String()` used Go's `fmt %q`, which emits `\xNN` (and `\a`, `\v`) for control characters. The let-go reader rejects those (`unknown escape sequence \x`) and they aren't valid EDN — so **`pr-str` could not round-trip its own output**. The common trigger is ANSI-colored strings like `"\x1b[32m…"`:

```clojure
;; before
(read-string (pr-str (str (char 27))))   ; => reader error: unknown escape \x
```

## Fix

Emit the reader's accepted escape set — `\"` `\\` `\t` `\r` `\n` `\b` `\f`, and `\uXXXX` for any other char below `0x20` plus `DEL` (`0x7f`). Printable Unicode passes through as raw UTF-8.

```clojure
;; after
(pr-str (str (char 27) "[32m"))          ; => "\u001B[32m"
(read-string (pr-str (str (char 27))))    ; => "\u001b"   (round-trips)
```

## Test

`test/pr_str_edn_roundtrip_test.lg` — control chars (incl. NUL, DEL, ESC), ANSI strings, and printable Unicode all round-trip through `(read-string (pr-str x))`; output never contains `\x`.

## Verification
- pr-str round-trip test green; `pkg/vm` Go tests green; full `.lg` suite green (no regressions from the changed string rendering).