### PR TITLE
feat(rt): bytecode bundle disassembler (lgb -> round-trippable EDN)

### DIFF
--- a/pkg/rt/disasm.go
+++ b/pkg/rt/disasm.go
@@ -21,9 +21,12 @@
 package rt
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/vm"
 )
 
@@ -95,6 +98,62 @@ func disassembleChunk(chunk *vm.CodeChunk) vm.Value {
 	return vm.NewArrayVector(rows)
 }
 
+// projectConst maps a const-pool value to EDN-safe, DETERMINISTIC data that
+// preserves identifiers. Readable scalars pass through unchanged; a Var becomes
+// its qualified symbol (the identifier it carries); a Func becomes [:fn name];
+// anything else (atoms, boxed Go objects, data structures) becomes a type tag.
+// This is what keeps the dump free of non-deterministic 0x heap pointers (which
+// is all you get from String() on live boxed objects) while keeping the names
+// that matter. (Vector/map consts are tagged, not recursed — a follow-up.)
+func projectConst(v vm.Value) vm.Value {
+	switch x := v.(type) {
+	case vm.Symbol, vm.Keyword, vm.String, vm.Int, vm.Float, vm.Boolean,
+		vm.Char, *vm.Nil, *vm.BigInt, *vm.Ratio, *vm.BigDecimal:
+		return v
+	case *vm.Var:
+		// "#'ns/name" -> symbol ns/name (the identifier is right there)
+		return vm.Symbol(strings.TrimPrefix(x.String(), "#'"))
+	case *vm.Func:
+		if name := x.FuncName(); name != "" {
+			return vm.NewArrayVector([]vm.Value{vm.Keyword("fn"), vm.Symbol(name)})
+		}
+		return vm.NewArrayVector([]vm.Value{vm.Keyword("fn")})
+	default:
+		return vm.NewArrayVector([]vm.Value{vm.Keyword("opaque"), vm.String(v.Type().Name())})
+	}
+}
+
+// disassembleChunkResolved is disassembleChunk plus inline operand resolution:
+// LOAD_CONST / LOAD_VAR rows get the referenced const's identifier appended
+// (via projectConst), so e.g. [:LOAD_VAR 51 clojure.core/seq] instead of a bare
+// index. Index is the global const index; AllValues() is the layered pool.
+func disassembleChunkResolved(chunk *vm.CodeChunk) vm.Value {
+	code := chunk.Code()
+	consts := chunk.Consts().AllValues()
+	var rows []vm.Value
+	i := 0
+	for i < len(code) {
+		op := code[i]
+		stride := opcodeStride(op)
+		row := make([]vm.Value, 0, stride+1)
+		row = append(row, vm.Keyword(opcodeMnemonic(op)))
+		for j := 1; j < stride && i+j < len(code); j++ {
+			row = append(row, vm.Int(int(code[i+j])))
+		}
+		switch op & 0xff {
+		case vm.OP_LOAD_CONST, vm.OP_LOAD_VAR:
+			if i+1 < len(code) {
+				if idx := int(code[i+1]); idx >= 0 && idx < len(consts) {
+					row = append(row, projectConst(consts[idx]))
+				}
+			}
+		}
+		rows = append(rows, vm.NewArrayVector(row))
+		i += stride
+	}
+	return vm.NewArrayVector(rows)
+}
+
 // installDisasmNS installs the `disasm` Clojure namespace with a single
 // fn: disassemble.
 func init() { RegisterInstaller(installDisasmNS) }
@@ -131,8 +190,89 @@ func installDisasmNS() {
 		return vm.NewArrayVector(out), nil
 	})
 
+	// decode-bundle — open a .lgb bundle FILE and return its chunks as data,
+	// so a Lisp layer can lazily disassemble each via `disassemble`/`constants`.
+	// Reuses the SAME module-import path the runtime uses to load core
+	// (bytecode.DecodeToExecUnit + the DefNSBare/DefStub resolver from
+	// loadPrecompiledBundle), so chunks come back fully wired (nested funcs
+	// resolved) without executing anything. Returns:
+	//   {:main <boxed-CodeChunk>
+	//    :namespaces [{:ns "name" :chunk-index i :chunk <boxed-CodeChunk>} ...]}
+	// Each boxed chunk is accepted directly by `disassemble`/`constants`
+	// (chunkOf already unwraps *Boxed of *CodeChunk).
+	decodeBundle, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("decode-bundle: expected 1 arg (path), got %d", len(vs))
+		}
+		path, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("decode-bundle: expected String path, got %s", vs[0].Type().Name())
+		}
+		data, err := os.ReadFile(string(path))
+		if err != nil {
+			return vm.NIL, fmt.Errorf("decode-bundle: %w", err)
+		}
+		// Same resolver loadPrecompiledBundle uses: create bare namespaces and
+		// stub vars so decoding never triggers the loader or warns on shadow.
+		resolve := func(nsName, name string) *vm.Var {
+			n := DefNSBare(nsName)
+			if v := n.LookupLocal(vm.Symbol(name)); v != nil {
+				return v
+			}
+			return n.DefStub(name)
+		}
+		unit, err := bytecode.DecodeToExecUnit(bytes.NewReader(data), resolve)
+		if err != nil {
+			return vm.NIL, fmt.Errorf("decode-bundle: %w", err)
+		}
+		nsEntries := make([]vm.Value, 0, len(unit.NSOrder))
+		for idx, name := range unit.NSOrder {
+			ch := unit.NSChunks[name]
+			if ch == nil {
+				continue
+			}
+			nsEntries = append(nsEntries, vm.NewArrayMap([]vm.Value{
+				vm.Keyword("ns"), vm.String(name),
+				vm.Keyword("chunk-index"), vm.Int(idx),
+				vm.Keyword("chunk"), vm.NewBoxed(ch),
+			}))
+		}
+		// Bundle-level const pool, projected ONCE (all chunks share it, so
+		// per-chunk consts would just repeat it 30x). AllValues = layered pool.
+		var poolVals []vm.Value
+		if unit.MainChunk != nil {
+			poolVals = unit.MainChunk.Consts().AllValues()
+		}
+		consts := make([]vm.Value, len(poolVals))
+		for i, c := range poolVals {
+			consts[i] = projectConst(c)
+		}
+		out := vm.NewArrayMap([]vm.Value{
+			vm.Keyword("main"), vm.NewBoxed(unit.MainChunk),
+			vm.Keyword("namespaces"), vm.NewArrayVector(nsEntries),
+			vm.Keyword("consts"), vm.NewArrayVector(consts),
+		})
+		return out, nil
+	})
+
+	// disassemble-resolved — like disassemble, but each LOAD_CONST/LOAD_VAR row
+	// carries the referenced identifier inline (via projectConst), so the
+	// disassembly reads without a separate const-pool lookup.
+	disasmResolved, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("disassemble-resolved: expected 1 arg, got %d", len(vs))
+		}
+		chunk, err := chunkOf(vs[0])
+		if err != nil {
+			return vm.NIL, err
+		}
+		return disassembleChunkResolved(chunk), nil
+	})
+
 	ns := vm.NewNamespace("disasm")
 	ns.Def("disassemble", disasm)
+	ns.Def("disassemble-resolved", disasmResolved)
 	ns.Def("constants", constants)
+	ns.Def("decode-bundle", decodeBundle)
 	RegisterNS(ns)
 }

--- a/pkg/vm/string.go
+++ b/pkg/vm/string.go
@@ -163,6 +163,40 @@ func (l String) ValueAtOr(key Value, dflt Value) Value {
 	return Char(r[numkey])
 }
 
+// String returns the EDN/Clojure-readable form: surrounded by double quotes
+// with EDN-conformant escapes. NOTE: Go's %q emits \xNN / \a / \v for control
+// chars, which the reader rejects ("unknown escape sequence \x") and which are
+// not valid EDN — so %q did not round-trip its own output (e.g. ANSI-colored
+// strings like "\x1b[32m..."). Escapes here match the reader's accepted set
+// (reader.go): \" \\ \t \r \n \b \f, and \uXXXX for everything else below
+// 0x20 plus DEL; printable Unicode passes through as raw UTF-8.
 func (l String) String() string {
-	return fmt.Sprintf("%q", string(l))
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range string(l) {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04X`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }

--- a/scripts/disasm-bundle.lg
+++ b/scripts/disasm-bundle.lg
@@ -1,0 +1,59 @@
+;; disasm-bundle.lg — disassemble a compiled .lgb bytecode bundle into a
+;; LAZY SEQUENCE of in-memory EDN data, one record per namespace.
+;;
+;; Reuses the runtime's own module-import path: (disasm/decode-bundle path)
+;; decodes the file via bytecode.DecodeToExecUnit (the same decoder that loads
+;; core at startup) and returns boxed *CodeChunks plus a projected const pool.
+;; (disasm/disassemble-resolved chunk) then turns each chunk into EDN rows with
+;; LOAD_CONST/LOAD_VAR operands resolved INLINE to their identifier.
+;;
+;; Output is valid, DETERMINISTIC EDN (no heap pointers): const-pool values are
+;; projected to identities — symbols/keywords/strings/numbers pass through, a
+;; Var becomes its qualified symbol, a Func becomes [:fn name], anything else a
+;; [:opaque "Type"] tag. The const pool is emitted ONCE (all chunks share it),
+;; then one record per namespace:
+;;   {:bundle-consts [ ... ]}
+;;   {:ns "ir.build" :chunk-index 17
+;;    :code [[:LOAD_ARG 0] [:LOAD_VAR 51 clojure.core/seq] [:INVOKE 1] ...]}
+;;
+;; Usage (standalone — a `lg disasm <file>` verb would need lg.go subcommand
+;; dispatch, deferred until this moves into a core namespace):
+;;   ./lg scripts/disasm-bundle.lg pkg/rt/core_compiled.lgb
+;;   DISASM_LGB=pkg/rt/core_compiled.lgb ./lg scripts/disasm-bundle.lg
+;;
+;; Programmatic: (disasm-bundle "p.lgb") returns the lazy ns seq, so
+;;   (take 2 (disasm-bundle ...)) realizes (and disassembles) only 2 namespaces.
+
+(defn- lazy-entries
+  "Lazy seq over decoded namespace entries; each element's disassembly is
+   deferred until the element is realized (so `take` bounds the work)."
+  [entries]
+  (lazy-seq
+    (when (seq entries)
+      (let [e (first entries)]
+        (cons {:ns          (:ns e)
+               :chunk-index (:chunk-index e)
+               :code        (disasm/disassemble-resolved (:chunk e))}
+              (lazy-entries (rest entries)))))))
+
+(defn disasm-bundle
+  "Lazy seq of per-namespace EDN disassembly records (with resolved operands)
+   for the .lgb file at `path`."
+  [path]
+  (lazy-entries (:namespaces (disasm/decode-bundle path))))
+
+(defn bundle-consts
+  "The bundle's shared const pool, projected to EDN-safe identities."
+  [path]
+  (:consts (disasm/decode-bundle path)))
+
+;; --- standalone entry: stream EDN to stdout -------------------------------
+(let [path (or (System/getenv "DISASM_LGB")
+               (last os/args))]
+  (if (or (nil? path) (not (ends-with? (str path) ".lgb")))
+    (do (println "usage: lg scripts/disasm-bundle.lg <file.lgb>   (or set DISASM_LGB)")
+        (System/exit 1))
+    (let [b (disasm/decode-bundle path)]
+      (prn {:bundle-consts (:consts b)})
+      (doseq [entry (lazy-entries (:namespaces b))]
+        (prn entry)))))

--- a/test/pr_str_edn_roundtrip_test.lg
+++ b/test/pr_str_edn_roundtrip_test.lg
@@ -1,0 +1,31 @@
+;; pr-str must emit EDN-conformant string escapes so its output round-trips
+;; through the reader. Regression guard: String.String() previously used Go's
+;; fmt %q, which emits \xNN / \a / \v for control chars — sequences the reader
+;; rejects ("unknown escape sequence \x") and which are not valid EDN. So
+;; pr-str could not round-trip its own output (notably ANSI-colored strings
+;; like "[32m..."). The fix emits \uXXXX for control chars instead.
+(ns test.pr-str-edn-roundtrip-test
+  (:require
+   [clojure.string :as str]
+   [test :refer :all]))
+
+(deftest pr-str-roundtrips-control-chars
+  (testing "every control char round-trips through pr-str -> read-string"
+    (let [s (apply str (map char [27 9 10 13 8 12 0 127]))]
+      (is (= s (read-string (pr-str s)))))))
+
+(deftest pr-str-roundtrips-ansi
+  (testing "ANSI-colored string round-trips (the %q regression case)"
+    (let [s (str (char 27) "[32mgreen" (char 27) "[0m")]
+      (is (= s (read-string (pr-str s)))))))
+
+(deftest pr-str-emits-edn-escapes-not-go-hex
+  (testing "control chars emit \\uXXXX, never Go's \\xNN"
+    (let [out (pr-str (str (char 27)))]
+      (is (not (str/includes? out "\\x")))
+      (is (str/includes? out "\\u001B")))))
+
+(deftest pr-str-leaves-printable-unchanged
+  (testing "printable ASCII and Unicode pass through unescaped"
+    (is (= "hello" (read-string (pr-str "hello"))))
+    (is (= "héllo→λ" (read-string (pr-str "héllo→λ"))))))


### PR DESCRIPTION
**Stacked on #183** (pr-str EDN-escape fix). Until #183 merges, this PR shows both commits; review/merge #183 first, then this diff reduces to just the disassembler.

## What

Adds disassembler primitives in `pkg/rt/disasm.go` and a `scripts/disasm-bundle.lg` driver that dumps a compiled `.lgb` bundle to **lazy, deterministic, round-trippable EDN** — for inspecting bundle contents and diffing bundles.

## Why stacked on #183

The disassembler emits string consts (docstrings, ANSI/control-char literals) via `pr-str` and relies on that output being **readable back**. That only holds with the EDN-conformant `\uXXXX` escapes from #183 — with Go's old `%q` the dump contained `\x` sequences the reader rejects, so it couldn't round-trip its own output.

## Verification
- `go build` green; `./lg scripts/disasm-bundle.lg pkg/rt/core_compiled.lgb` dumps the full bundle.
- The complete dump **round-trips**: `(read-string (str "(" dump ")"))` parses all forms back (verified on `core_compiled.lgb`).