### PR TITLE
feat(vm): make Protocol and deftype/reify instances metadata-aware (IMeta)

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5193,6 +5193,11 @@ func installLangNS() {
 		}
 		m, ok := vs[0].(vm.IMeta)
 		if !ok {
+			// Non-IMeta values pass through unchanged. This is load-bearing:
+			// let-go compiles value-position type hints (e.g. `^long x`) into
+			// runtime with-meta calls, so erroring here would break every
+			// hinted scalar. Reference types (deftype/reify instances,
+			// protocols, collections) ARE IMeta and carry metadata for real.
 			return vs[0], nil
 		}
 		return m.WithMeta(vs[1]), nil

--- a/pkg/vm/deftype.go
+++ b/pkg/vm/deftype.go
@@ -43,6 +43,7 @@ func (t *DType) Box(bare any) (Value, error) {
 type DTypeInstance struct {
 	dtype  *DType
 	fields []Value
+	meta   Value // IMeta support (e.g. (with-meta (->Foo) m) / reify)
 }
 
 func NewDTypeInstance(dt *DType, fields []Value) *DTypeInstance {
@@ -61,7 +62,24 @@ func NewDTypeInstance(dt *DType, fields []Value) *DTypeInstance {
 }
 
 func (d *DTypeInstance) Type() ValueType { return d.dtype }
-func (d *DTypeInstance) Unbox() any      { return d }
+
+// Meta implements IMeta.
+func (d *DTypeInstance) Meta() Value {
+	if d.meta == nil {
+		return NIL
+	}
+	return d.meta
+}
+
+// WithMeta implements IMeta. Returns a copy carrying m; field storage is
+// shared with the original (metadata does not affect fields).
+func (d *DTypeInstance) WithMeta(m Value) Value {
+	cp := *d
+	cp.meta = m
+	return &cp
+}
+
+func (d *DTypeInstance) Unbox() any { return d }
 
 func (d *DTypeInstance) String() string {
 	b := &strings.Builder{}

--- a/pkg/vm/protocol.go
+++ b/pkg/vm/protocol.go
@@ -13,6 +13,7 @@ type Protocol struct {
 	methods []Symbol                     // method names
 	impls   map[ValueType]*PersistentMap // type → {method-name → fn}
 	nilImpl *PersistentMap               // implementation for nil
+	meta    Value                        // IMeta support
 }
 
 func NewProtocol(name string, methods []Symbol) *Protocol {
@@ -28,6 +29,22 @@ func (p *Protocol) Unbox() any        { return p }
 func (p *Protocol) String() string    { return fmt.Sprintf("<protocol %s>", p.name) }
 func (p *Protocol) Name() string      { return p.name }
 func (p *Protocol) Methods() []Symbol { return p.methods }
+
+// Meta implements IMeta.
+func (p *Protocol) Meta() Value {
+	if p.meta == nil {
+		return NIL
+	}
+	return p.meta
+}
+
+// WithMeta implements IMeta. Returns a copy carrying m; dispatch tables are
+// shared with the original (metadata does not affect protocol dispatch).
+func (p *Protocol) WithMeta(m Value) Value {
+	cp := *p
+	cp.meta = m
+	return &cp
+}
 
 // Extend adds implementations for a type.
 // implMap is a PersistentMap of {method-keyword → fn}.

--- a/pkg/vm/protocol_meta_test.go
+++ b/pkg/vm/protocol_meta_test.go
@@ -1,0 +1,22 @@
+package vm
+
+import "testing"
+
+func TestProtocolIsMetadataAware(t *testing.T) {
+	p := NewProtocol("P", []Symbol{Symbol("foo")})
+	var _ IMeta = p // Protocol must implement IMeta
+	if p.Meta() != NIL {
+		t.Fatalf("fresh protocol Meta() = %v, want NIL", p.Meta())
+	}
+	m := String("the-meta")
+	p2 := p.WithMeta(m).(*Protocol)
+	if p2.Meta() != Value(m) {
+		t.Fatalf("WithMeta did not attach meta: %v", p2.Meta())
+	}
+	if p.Meta() != NIL {
+		t.Fatalf("WithMeta mutated the original")
+	}
+	if p2.Name() != "P" || len(p2.Methods()) != 1 {
+		t.Fatalf("WithMeta lost protocol identity/dispatch data")
+	}
+}

--- a/test/protocol_with_meta_test.lg
+++ b/test/protocol_with_meta_test.lg
@@ -1,0 +1,19 @@
+(ns test.protocol-with-meta-test
+  (:require
+   [test :refer :all]))
+
+(defprotocol PMeta (pm-foo [x]))
+(deftype TM [a])
+
+(deftest with-meta-reference-types
+  (testing "with-meta attaches REAL metadata to protocols (now IMeta)"
+    (is (= {:doc "hi"} (meta (with-meta PMeta {:doc "hi"}))))
+    (is (nil? (meta PMeta))))
+  (testing "with-meta attaches REAL metadata to deftype/reify instances (now IMeta)"
+    (let [t (->TM 1) t2 (with-meta t {:k 1})]
+      (is (= {:k 1} (meta t2)))
+      (is (nil? (meta t)))              ; original unchanged
+      (is (= 1 (.a t2)))))              ; fields preserved
+  (testing "with-meta is a no-op on non-IMeta scalars (backs ^long type-hint compilation)"
+    (is (= 1 (with-meta 1 {:tag 'long})))
+    (is (= "x" (with-meta "x" {})))))


### PR DESCRIPTION
## What

`Protocol` and `DTypeInstance` now implement `IMeta` (`Meta`/`WithMeta`), so reference types created by `deftype`/`reify` and `defprotocol` carry **real** metadata through the normal `with-meta` path — instead of silently relying on `with-meta`'s non-`IMeta` passthrough.

```clojure
(meta (with-meta (->Foo) {:k 1}))   ;=> {:k 1}     ; deftype/reify instance
(meta (with-meta SomeProtocol {:doc "…"}))  ;=> {:doc "…"}
```

## Why

This tightens the actual gap behind protocol/reify-tagged compat code (e.g. malli's reified schemas): those values now carry metadata for real rather than no-op'ing through `with-meta`.

## `with-meta` semantics (unchanged here, now documented)

`with-meta` keeps its non-`IMeta` passthrough — and this PR adds a comment explaining **why it's load-bearing**: the compiler lowers value-position type hints (e.g. `^long x`) into runtime `with-meta` calls, so erroring on non-`IMeta` scalars would break every hinted scalar. Scalars (`Int`/`Float`/`Char`/`Keyword`/`Symbol` are value types) cannot carry metadata and are unaffected.

Making `with-meta` strict — and threading source type hints to where they belong (the compiler/IR) instead of onto runtime values — is a separate multi-layer feature (reader → compiler binding table → IR/typeinfer), scoped in the note on #182. This PR is just the `IMeta` correctness win and stands alone.

## Tests

- `pkg/vm/protocol_meta_test.go` — `Protocol` implements `IMeta`; `WithMeta` copies + preserves dispatch data.
- `test/protocol_with_meta_test.lg` — protocols and deftype/reify instances carry metadata (original unchanged, fields preserved); scalars pass through.
- Full suite green; malli example smoke verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
