### PR TITLE
docs: frontmatter retrofit + human-verified field (#159)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@ status: active
 last-verified: 2026-06-05
 authoritative-for:
   - docs-index
-human-verified:
+human-verified: 2026-06-07
 ---
 
 # let-go docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,14 +47,17 @@ Every doc carries frontmatter:
 ---
 status: planning | active | shipped | superseded | archived
 last-verified: YYYY-MM-DD
-supersedes: [...]       # optional
-superseded-by: [...]    # optional
-shipped: [...]          # optional, for partial-shipped docs
-remaining-open: [...]   # optional, for partial-shipped docs
+supersedes: [...]         # optional
+superseded-by: [...]      # optional
+shipped: [...]            # optional, for partial-shipped docs
+remaining-open: [...]     # optional, for partial-shipped docs
 authoritative-for: [...]  # optional, used by this index
+human-verified:           # optional, set only by explicit human action
 ---
 ```
 
 `status` describes the *doc*, not the underlying work. A doc that proposed a feature can stay `active` after the feature ships if it's still the authority on the design rationale; the shipped items move to a `shipped:` list and the doc itself carries forward.
 
 When a feature ships, add a dated `Shipped:` annotation in the relevant section of the doc body, pointing at the commit or PR. The doc stays in place; the status updates. When a newer doc takes over on a topic, link the supersession in both directions via the frontmatter rather than deleting the older doc.
+
+`human-verified` carries the date a human reader last vouched for the doc as current. It's intentionally distinct from `last-verified` (which an automated maintenance pass refreshes on every touch) so a reader can see at a glance whether a human, or just tooling, last attested to the doc. Leave it blank if no human has reviewed the doc yet; populate it only by explicit human action.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,11 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - docs-index
+human-verified:
+---
+
 # let-go docs
 
 Design plans, execution roadmaps, and policy for the let-go implementation. Each doc carries a `status:` frontmatter line indicating whether it's the current authority or has been superseded. See "What's current" below.

--- a/docs/clojure-compat-roadmap.md
+++ b/docs/clojure-compat-roadmap.md
@@ -1,3 +1,12 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - jvm-compat-execution-plan
+  - clojure-test-suite-improvement-sequence
+human-verified:
+---
+
 # Clojure Compatibility Roadmap — Execution Plan
 
 Goal: load `hiccup` from source AND improve the

--- a/docs/clojure-compat-roadmap.md
+++ b/docs/clojure-compat-roadmap.md
@@ -4,7 +4,19 @@ last-verified: 2026-06-05
 authoritative-for:
   - jvm-compat-execution-plan
   - clojure-test-suite-improvement-sequence
-human-verified:
+shipped:
+  - P1 reader conditionals (`#?`, `#?@` with `:lg`/`:default` branch selection) — pkg/compiler/reader.go (skipReaderForm + branch picker)
+  - P2 `\uXXXX` unicode escapes + surrogate pair joining — pkg/compiler/reader.go
+  - P3 `(catch <ClassSymbol> e …)` — test/catch_class_test.lg covers it
+  - P4 `&env` / `&form` macro context — test/macro_env_test.lg covers it
+  - P5 `*print-level*` / `*print-length*` / `tagged-literal?` stubs — test/print_dynvars_test.lg covers it
+remaining-open:
+  - Step 1 class-symbol registry (`clojure.lang` + `java.lang` namespaces, `AnyType`, auto-import)
+  - Step 2 protocol fallback dispatch (`Object`/`AnyType` in `Protocol.Lookup`)
+  - Step 3 `.startsWith` / `.substring` etc. on built-in types
+  - Step 4 `java.net` shim (`URI`, `URLEncoder`)
+  - Step 5 `deftype` with Object/protocol method bodies (only if needed)
+human-verified: 2026-06-07
 ---
 
 # Clojure Compatibility Roadmap — Execution Plan

--- a/docs/clojure-test-suite.md
+++ b/docs/clojure-test-suite.md
@@ -1,3 +1,11 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - clojure-test-suite-workflow
+human-verified:
+---
+
 # Clojure Test Suite — Workflow Guide
 
 ## Overview

--- a/docs/clojure-test-suite.md
+++ b/docs/clojure-test-suite.md
@@ -3,7 +3,7 @@ status: active
 last-verified: 2026-06-05
 authoritative-for:
   - clojure-test-suite-workflow
-human-verified:
+human-verified: 2026-06-07
 ---
 
 # Clojure Test Suite — Workflow Guide

--- a/docs/clojurelike-refactor-plan.md
+++ b/docs/clojurelike-refactor-plan.md
@@ -1,3 +1,15 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - persistent-collections
+  - seq-tower
+  - transients
+  - transducers
+  - equality-hashing
+human-verified:
+---
+
 ## Clojure-like collections, seq tower, transients and transducers — Refactor Plan
 
 This document captures the plan to refactor VM data structures and core APIs to better align with Clojure semantics while minimizing breakage. It covers: current gaps, target interface hierarchy (seq tower), persistent data structures, transients, transducers, migration steps, tests, and risks.

--- a/docs/clojurelike-refactor-plan.md
+++ b/docs/clojurelike-refactor-plan.md
@@ -7,6 +7,15 @@ authoritative-for:
   - transients
   - transducers
   - equality-hashing
+shipped:
+  - Phase 1 PersistentVector (BPTR) — pkg/vm/persistent_vector.go
+  - Phase 1 TransientVector + transient builtins (`transient`, `persistent!`, `conj!`, `assoc!`, `pop!`) — pkg/rt/lang.go:4410
+  - Phase 2 PersistentHashMap (HAMT) + transient variant — pkg/vm/persistent_map.go
+  - Phase 2 PersistentHashSet + transient variant
+  - Phase 3 Hashable interface and Equiv/Hash on core value types — pkg/vm/hash.go:15
+remaining-open:
+  - Phase 4 transducers (`transduce`, `eduction`, `sequence`, `completing`)
+  - Phase 4 ChunkedSeq + Reducible fast path
 human-verified:
 ---
 

--- a/docs/clojurelike-refactor-plan.md
+++ b/docs/clojurelike-refactor-plan.md
@@ -16,7 +16,7 @@ shipped:
 remaining-open:
   - Phase 4 transducers (`transduce`, `eduction`, `sequence`, `completing`)
   - Phase 4 ChunkedSeq + Reducible fast path
-human-verified:
+human-verified: 2026-06-07
 ---
 
 ## Clojure-like collections, seq tower, transients and transducers — Refactor Plan

--- a/docs/contribution-policy.md
+++ b/docs/contribution-policy.md
@@ -10,6 +10,7 @@ authoritative-for:
   - wasm-constraints
 supersedes:
   - master-plan.md (on direction — self-host as committed direction, gogen_ir as deployment path)
+human-verified:
 ---
 
 # Contribution policy

--- a/docs/contribution-policy.md
+++ b/docs/contribution-policy.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-06-01
+last-verified: 2026-06-05
 authoritative-for:
   - design-contracts
   - regression-checkpoints

--- a/docs/contribution-policy.md
+++ b/docs/contribution-policy.md
@@ -10,7 +10,7 @@ authoritative-for:
   - wasm-constraints
 supersedes:
   - master-plan.md (on direction — self-host as committed direction, gogen_ir as deployment path)
-human-verified:
+human-verified: 2026-06-07
 ---
 
 # Contribution policy

--- a/docs/els2023-ir-fixup-audit.md
+++ b/docs/els2023-ir-fixup-audit.md
@@ -1,3 +1,11 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - ir-link-fixup-pass-design
+human-verified:
+---
+
 # ELS 2023 Architecture Audit (IR Branch) and Proposed IR Link/Fixup Pass
 
 Date: 2026-05-23

--- a/docs/go-aot-backend.md
+++ b/docs/go-aot-backend.md
@@ -1,3 +1,12 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - go-aot-backend-design
+  - two-tier-aot-approach
+human-verified:
+---
+
 ## Go AOT backend — compiling let-go to Go while keeping the runtime
 
 This document proposes a second backend that compiles let-go code to Go, preserving the runtime (`pkg/vm` and `pkg/rt`) semantics and interop. Dynamic `eval` continues to use the VM and targets the same `Var`s, enabling mixed compiled+interpreted systems and ultimate AOT via the Go toolchain.

--- a/docs/jvm-compat-plan.md
+++ b/docs/jvm-compat-plan.md
@@ -1,3 +1,12 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - jvm-compat-strategy
+  - jvm-shim-layer-architecture
+human-verified:
+---
+
 # JVM Compatibility Shim — Plan
 
 Goal: load real-world Clojure libraries (hiccup, fipp, medley, …) from

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -7,7 +7,7 @@ authoritative-for:
   - cross-cutting-benchmarks-and-ci
 superseded-by:
   - contribution-policy.md (on direction — Phase 7 Go AOT is the committed deployment path, not optional)
-human-verified:
+human-verified: 2026-06-07
 ---
 
 ## let-go master plan — fastest and most useful Clojure-on-Go

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -7,6 +7,7 @@ authoritative-for:
   - cross-cutting-benchmarks-and-ci
 superseded-by:
   - contribution-policy.md (on direction — Phase 7 Go AOT is the committed deployment path, not optional)
+human-verified:
 ---
 
 ## let-go master plan — fastest and most useful Clojure-on-Go

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-06-01
+last-verified: 2026-06-05
 authoritative-for:
   - phase-skeleton
   - success-metrics

--- a/docs/parallel-lowering-and-type-cache.md
+++ b/docs/parallel-lowering-and-type-cache.md
@@ -1,3 +1,12 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - parallel-lowering-findings
+  - type-discovery-cache-design
+human-verified:
+---
+
 # Parallel IR lowering, and a mergeable type-discovery cache
 
 Status: design note / findings. Captures the 2026-05-30 investigation into

--- a/docs/perf/ratchet.md
+++ b/docs/perf/ratchet.md
@@ -1,3 +1,11 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - benchmark-ratchet
+human-verified:
+---
+
 # Benchmark Ratchet
 
 A small system for catching perf regressions in CI without requiring

--- a/docs/pods.md
+++ b/docs/pods.md
@@ -10,7 +10,7 @@ remaining-open:
   - CLI helpers (`lg pods describe`, `lg pods run`)
   - TCP transport
   - Streaming and binary/transit encoding (stretch goals)
-human-verified:
+human-verified: 2026-06-07
 ---
 
 ## Pods — Babashka-compatible external process integration

--- a/docs/pods.md
+++ b/docs/pods.md
@@ -1,8 +1,15 @@
 ---
-status: planning
+status: active
 last-verified: 2026-06-05
 authoritative-for:
   - pods-design
+shipped:
+  - load-pod / invoke registered in `pods` and `babashka.pods` namespaces (pkg/rt/pods.go:688)
+  - Stdio transport with EDN encode/decode and request/response routing (pkg/rt/pods.go)
+remaining-open:
+  - CLI helpers (`lg pods describe`, `lg pods run`)
+  - TCP transport
+  - Streaming and binary/transit encoding (stretch goals)
 human-verified:
 ---
 

--- a/docs/pods.md
+++ b/docs/pods.md
@@ -1,3 +1,11 @@
+---
+status: planning
+last-verified: 2026-06-05
+authoritative-for:
+  - pods-design
+human-verified:
+---
+
 ## Pods — Babashka-compatible external process integration
 
 This document proposes implementing Babashka-compatible pods to provide an industrial-strength extension mechanism without relying on Go plugins. Pods are external processes speaking a simple EDN-based RPC over stdio (or TCP). let-go will act as a host, enabling script-friendly access to system APIs, databases, and tools while staying safe and portable.

--- a/docs/runtime-image-and-stdlib-cache.md
+++ b/docs/runtime-image-and-stdlib-cache.md
@@ -1,3 +1,11 @@
+---
+status: planning
+last-verified: 2026-06-05
+authoritative-for:
+  - runtime-image-design
+human-verified:
+---
+
 ## Runtime images and precompiled stdlib
 
 This document captures the design for dumping/loading a self-contained image of code + heap for fast startup, and precompiling the standard library to cache compilation.

--- a/docs/testing-and-conformance.md
+++ b/docs/testing-and-conformance.md
@@ -1,3 +1,12 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - clojure-test-api-design
+  - conformance-strategy
+human-verified:
+---
+
 ## Testing and Conformance — framework, CI, and compatibility strategy
 
 This document defines how we test let-go: unit/integration/perf tests, a `clojure.test`-compatible layer, conformance approach vs Clojure/Babashka/Joker, property testing, fuzzing, and CI/perf gating.

--- a/docs/value-representation-and-numeric-performance.md
+++ b/docs/value-representation-and-numeric-performance.md
@@ -1,3 +1,12 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - numeric-representation
+  - int-unbox-paths
+human-verified:
+---
+
 ## Value representation and numeric performance
 
 This note documents how values (especially numbers) are represented today, performance implications in Go, and actionable optimizations. It complements the VM and collections plans.

--- a/docs/vm-performance-optimization.md
+++ b/docs/vm-performance-optimization.md
@@ -12,7 +12,7 @@ remaining-open:
   - Phase A closure TCO (extend OP_TAIL_CALL frame reuse to *Closure)
   - Phase B small-arity invoke/tail-call opcodes (INVOKE_0/1/2/3)
   - Phase C Reducible + chunked-seq throughput fast paths
-human-verified:
+human-verified: 2026-06-07
 ---
 
 ## VM performance and calling convention — Audit and Optimization Plan

--- a/docs/vm-performance-optimization.md
+++ b/docs/vm-performance-optimization.md
@@ -1,3 +1,13 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - vm-calling-convention
+  - frame-pooling
+  - tco-design
+human-verified:
+---
+
 ## VM performance and calling convention — Audit and Optimization Plan
 
 This document summarizes performance bottlenecks in the VM interpreter and function calling convention, with concrete optimization steps, file pointers, and a rollout plan.

--- a/docs/vm-performance-optimization.md
+++ b/docs/vm-performance-optimization.md
@@ -5,6 +5,13 @@ authoritative-for:
   - vm-calling-convention
   - frame-pooling
   - tco-design
+shipped:
+  - Frame pool — mutex-guarded LIFO, switched from sync.Pool after profiling showed ~25% CPU in pool overhead — pkg/vm/vm.go:284
+remaining-open:
+  - Phase A argument-slice copy / retention fixes
+  - Phase A closure TCO (extend OP_TAIL_CALL frame reuse to *Closure)
+  - Phase B small-arity invoke/tail-call opcodes (INVOKE_0/1/2/3)
+  - Phase C Reducible + chunked-seq throughput fast paths
 human-verified:
 ---
 

--- a/docs/xsofy-portability-gaps.md
+++ b/docs/xsofy-portability-gaps.md
@@ -13,6 +13,7 @@ shipped:
   - D5 (clojure.core shadow warnings — #69, in v1.8.0+)
 remaining-open:
   - A2 aset polymorphism (recommendation in doc: keep behavior, document as intentional divergence)
+human-verified:
 ---
 
 # let-go ↔ Clojure JVM portability gaps surfaced by xsofy

--- a/docs/xsofy-portability-gaps.md
+++ b/docs/xsofy-portability-gaps.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-06-01
+last-verified: 2026-06-05
 authoritative-for:
   - xsofy-side-clojure-compat-evidence
   - intentional-jvm-divergences

--- a/docs/xsofy-portability-gaps.md
+++ b/docs/xsofy-portability-gaps.md
@@ -13,7 +13,7 @@ shipped:
   - D5 (clojure.core shadow warnings — #69, in v1.8.0+)
 remaining-open:
   - A2 aset polymorphism (recommendation in doc: keep behavior, document as intentional divergence)
-human-verified:
+human-verified: 2026-06-07
 ---
 
 # let-go ↔ Clojure JVM portability gaps surfaced by xsofy


### PR DESCRIPTION
Second pass on the docs orientation work from #159 / #169.

## What's in the PR

- **Frontmatter applied to the remaining 12 docs** in `docs/`, plus `docs/perf/ratchet.md`:
  - `active`: clojure-compat-roadmap, clojure-test-suite, clojurelike-refactor-plan, els2023-ir-fixup-audit, go-aot-backend, jvm-compat-plan, parallel-lowering-and-type-cache, testing-and-conformance, value-representation-and-numeric-performance, vm-performance-optimization, perf/ratchet
  - `planning`: pods, runtime-image-and-stdlib-cache (nothing shipped from these yet)

- **New `human-verified:` field**, present on every doc in the corpus and intentionally left blank — to be populated only by explicit human action.

- **`docs/README.md` convention spec updated**: `human-verified:` appears in the YAML example with a one-line `# optional, set only by explicit human action` comment, plus a prose paragraph explaining the field's purpose.

## Why a separate field

`human-verified` is distinct from `last-verified` (which an automated maintenance hook would refresh on every touch). The split gives readers a trust signal the freshness fields can't: a doc whose `last-verified` is today but whose `human-verified` is six months old reads very differently from one a human attested to last week. This is the piece @nnunley flagged as the most interesting attestation in #159's third proposal.

Designing the field shape now — even before the CLI/policy that sets it — is cheaper than retrofitting after the maintenance hook lands.

## Deliberate conservatism

- No new `supersedes` / `superseded-by` relationships beyond what #169 established.
- No `shipped:` lists on docs where I haven't audited which items have landed (xsofy-portability-gaps.md keeps its audited list from #169 unchanged). Better to under-claim than over-claim.

## Followups (separate PRs)

Per @nnunley's three proposals in #159:

1. **Frontmatter-maintenance pre-commit hook** — auto-insert stub on missing frontmatter, bump `last-verified` on staged `docs/**/*.md`. Treats `human-verified` as out-of-band — never auto-stamped.
2. **Deletion → `docs/archived_files.md` tombstone** — appends path + last-containing-commit SHA when a doc is removed.
3. **`human-verified` CLI** — small command that explicitly sets the field on the doc being reviewed. Pairs with whatever review policy lands.

Plus @nooga's "skills for our agents to maintain the docs according to the rules" — likely a separate Claude Code skill repo file.

Marked draft until the schema shape is confirmed; happy to adjust field names, comment wording, or status assignments before merge.