### PR TITLE
docs: frontmatter maintenance pre-commit hook (#159)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,6 +71,33 @@ jobs:
       - name: make check-generated
         run: make check-generated
 
+  # Floor check on docs/**/*.md frontmatter for contributors who don't
+  # have the pre-commit hook installed. The hook (run locally) handles
+  # maintenance (last-verified bump); this CI step enforces only that the
+  # frontmatter exists and is well-formed on docs changed in the PR. PRs
+  # that sit across dates still pass — staleness is a reader signal, not
+  # a CI gate. See docs/frontmatter-hook.md.
+  docs-frontmatter:
+    name: docs-frontmatter
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check changed docs have well-formed frontmatter
+        run: |
+          git fetch --no-tags --depth=50 origin "${GITHUB_BASE_REF}"
+          changed=$(git diff --name-only --diff-filter=AM \
+            "origin/${GITHUB_BASE_REF}...HEAD" -- 'docs/**/*.md' || true)
+          if [ -z "$changed" ]; then
+            echo "No docs/**/*.md changed in this PR."
+            exit 0
+          fi
+          echo "Checking:"
+          echo "$changed"
+          echo "$changed" | xargs python3 scripts/docs_frontmatter_hook.py --check
+
   # Bootstrap-parity gate (deferred — runs as 'make parity-full' locally).
   # Until parity-full is wired as a CI job, `make check-generated` protects
   # the artifacts parity-full depends on.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,8 +88,11 @@ jobs:
       - name: Check changed docs have well-formed frontmatter
         run: |
           git fetch --no-tags --depth=50 origin "${GITHUB_BASE_REF}"
+          # `:(glob)` pathspec magic: without it, `**` matches a single
+          # segment, so root-level docs like docs/frontmatter-hook.md
+          # are skipped and only nested paths like docs/perf/foo.md match.
           changed=$(git diff --name-only --diff-filter=AM \
-            "origin/${GITHUB_BASE_REF}...HEAD" -- 'docs/**/*.md' || true)
+            "origin/${GITHUB_BASE_REF}...HEAD" -- ':(glob)docs/**/*.md' || true)
           if [ -z "$changed" ]; then
             echo "No docs/**/*.md changed in this PR."
             exit 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,19 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      # Frontmatter maintenance for docs/**/*.md: stub on missing,
+      # bump `last-verified:` on staged docs. Never touches
+      # `human-verified:` or any human-authored field. Stdlib-only
+      # Python — pre-commit itself already requires Python, so this
+      # adds no new dependency. See docs/frontmatter-hook.md.
+      - id: docs-frontmatter
+        name: docs frontmatter (stub + last-verified bump)
+        description: Maintain status/last-verified frontmatter on docs/**/*.md
+        entry: python3 scripts/docs_frontmatter_hook.py
+        language: system
+        files: ^docs/.*\.md$
+        stages: [pre-commit]
+
       - id: go-test
         name: go test ./... -skip TestClojureTestSuite
         description: Run Go test suite excluding the slow Clojure compat suite (mirrors CI test step)

--- a/docs/frontmatter-hook.md
+++ b/docs/frontmatter-hook.md
@@ -1,0 +1,102 @@
+---
+status: active
+last-verified: 2026-06-05
+authoritative-for:
+  - docs-frontmatter-convention
+  - frontmatter-maintenance-hook
+human-verified:
+---
+
+# Docs frontmatter — convention and maintenance hook
+
+Every doc in `docs/` carries a small YAML frontmatter block describing
+its status, freshness, and the topics it's authoritative on. See
+[`docs/README.md`](README.md) for the full schema.
+
+This file covers two things: **the conventions every contributor
+follows** when editing docs, and **the pre-commit hook** that keeps
+the mechanical fields honest.
+
+## Conventions
+
+The hook handles the mechanical fields automatically (see below).
+Everything else is contributor judgement:
+
+- **`status:`** — set when creating a new doc; one of `planning`,
+  `active`, `shipped`, `superseded`, `archived`. Update when the doc's
+  role changes. `status` describes the *doc*, not the underlying
+  work — a doc that proposed a now-shipped feature can stay `active`
+  if it's still the design-rationale authority.
+- **`authoritative-for:`** — the topics this doc is the current
+  authority on. The README index uses these to route readers.
+- **`supersedes:` / `superseded-by:`** — link displacement
+  relationships in both directions when a newer doc takes over on a
+  topic. Don't delete the older doc; let the supersession chain stand.
+- **`shipped:` / `remaining-open:`** — when a doc tracks a multi-item
+  plan, move items from `remaining-open:` (or the inline body) into
+  `shipped:` with a commit or PR reference once they land. Don't flip
+  `status:` unless the whole doc is now obsolete.
+- **If a code change outdates another doc** — update the doc in the
+  same PR rather than leaving the convention to rot.
+
+## The human/agent asymmetry
+
+One field behaves differently from everything else:
+
+**`human-verified:`** — the date a human reader last vouched for the
+doc as current. **Set only by explicit human action.** The
+maintenance hook will not touch it. Agent contributors (LLMs) must
+not autopilot-stamp it — even if a `YYYY-MM-DD`-shaped field looks
+like something to fill in, leave it blank unless a human has
+explicitly asked you to attest.
+
+This is the one rule that genuinely splits humans and agents. The
+goal is to keep `human-verified:` as a trustworthy signal: a doc
+whose `last-verified:` is today but whose `human-verified:` is six
+months old reads very differently from one a human vouched for last
+week. That signal collapses if any tooling can stamp it.
+
+## The pre-commit hook
+
+[`scripts/docs_frontmatter_hook.py`](../scripts/docs_frontmatter_hook.py),
+wired into [`.pre-commit-config.yaml`](../.pre-commit-config.yaml).
+Runs on every staged `docs/**/*.md`. Stdlib-only Python — pre-commit
+itself already requires Python, so no new dependency.
+
+What it does:
+
+1. **Missing frontmatter** → prepends a minimal stub:
+   ```yaml
+   ---
+   status: active
+   last-verified: <today>
+   human-verified:
+   ---
+   ```
+   Adjust `status:` and add `authoritative-for:` etc. before
+   re-staging.
+2. **Existing frontmatter** → bumps `last-verified:` to today if the
+   existing value is older or missing. Idempotent on docs already
+   stamped today.
+3. **Never touches** `status:` (when present), `authoritative-for:`,
+   `supersedes:`, `superseded-by:`, `shipped:`, `remaining-open:`, or
+   `human-verified:`.
+
+The hook modifies files in place. Pre-commit then reports "files
+were modified by this hook," at which point you review the changes
+and re-stage.
+
+When the hook does something, it prints a one-line note pointing back
+at this file — the channel an agent contributor can't miss.
+
+To bypass for in-progress work: `git commit --no-verify` (same
+escape hatch as the other hooks).
+
+## Out of scope (follow-ups)
+
+- **Tombstone-on-delete** — when a doc is removed, appending a
+  pointer to `docs/archived_files.md` with the SHA of the last
+  containing commit. Tracked separately.
+- **`docs-status` CLI / agent skill** — a report tool surfacing stale
+  docs, contradictions, missing `authoritative-for:` claims, and
+  similar judgement-level concerns. Tracked separately.

--- a/docs/frontmatter-hook.md
+++ b/docs/frontmatter-hook.md
@@ -63,7 +63,7 @@ wired into [`.pre-commit-config.yaml`](../.pre-commit-config.yaml).
 Runs on every staged `docs/**/*.md`. Stdlib-only Python — pre-commit
 itself already requires Python, so no new dependency.
 
-What it does:
+### Maintenance mode (default)
 
 1. **Missing frontmatter** → prepends a minimal stub:
    ```yaml
@@ -80,7 +80,9 @@ What it does:
    stamped today.
 3. **Never touches** `status:` (when present), `authoritative-for:`,
    `supersedes:`, `superseded-by:`, `shipped:`, `remaining-open:`, or
-   `human-verified:`.
+   `human-verified:`. Only top-level `last-verified:` (no leading
+   whitespace) is bumped — indented occurrences inside block scalars
+   or nested mappings under human-authored keys are left alone.
 
 The hook modifies files in place. Pre-commit then reports "files
 were modified by this hook," at which point you review the changes
@@ -91,6 +93,33 @@ at this file — the channel an agent contributor can't miss.
 
 To bypass for in-progress work: `git commit --no-verify` (same
 escape hatch as the other hooks).
+
+### Check mode (CI)
+
+```
+python3 scripts/docs_frontmatter_hook.py --check <files…>
+```
+
+Validates that each path has well-formed frontmatter with a
+top-level `status:` and `last-verified:`. Never mutates. Exits
+non-zero on any failure.
+
+The CI workflow runs this against the docs changed in each PR. The
+check is deliberately the *floor* — frontmatter present and
+parseable — not a freshness gate, so PRs that sit across dates still
+pass. Staleness is a signal for readers (via `last-verified:` and
+`human-verified:`), not a CI failure.
+
+### Edge cases
+
+- **Malformed frontmatter** (opening `---` with no closing delimiter):
+  treated as a hard error in both modes. The file is not modified;
+  the hook exits non-zero. Fix the delimiter and re-run.
+- **UTF-8 BOM** at the start of the file: stripped on read; written
+  back without one.
+- **Symlinks**: skipped. A staged `docs/*.md` symlink would otherwise
+  cause the hook to write through to whatever the symlink points at,
+  potentially outside `docs/` or outside the repo.
 
 ## Out of scope (follow-ups)
 

--- a/scripts/docs_frontmatter_hook.py
+++ b/scripts/docs_frontmatter_hook.py
@@ -2,25 +2,34 @@
 """
 Frontmatter maintenance for docs/**/*.md.
 
-Run from pre-commit. For each staged file passed on argv:
+Two modes:
 
-  - If the file has no YAML frontmatter, prepend a minimal stub:
-        status: active
-        last-verified: <today>
-        human-verified:
-  - If the file has frontmatter, bump `last-verified:` to today (only if
-    the existing value is older or missing). Idempotent on docs already
-    stamped today.
+  default: For each file in argv, stub the frontmatter if missing,
+           or bump `last-verified:` to today if older. Mutates files
+           in place. Used as a pre-commit hook.
 
-Never touches: `status:` (when present), `authoritative-for:`,
-`supersedes:`, `superseded-by:`, `shipped:`, `remaining-open:`, or
-`human-verified:`. Those fields are human-authored.
+  --check: Validate frontmatter is present and well-formed on each
+           file in argv. Never mutates. Exits non-zero on any
+           failure. Used in CI.
+
+The mode split is deliberate: CI enforces the *floor* (frontmatter
+present, parseable), pre-commit handles *maintenance* (last-verified
+bump). The two must not conflict — a doc authored a week ago is
+CI-clean even though the bump hasn't run.
+
+Both modes never touch: `status:` (when present),
+`authoritative-for:`, `supersedes:`, `superseded-by:`, `shipped:`,
+`remaining-open:`, or `human-verified:`. Those are human-authored.
+The bump matches only top-level `last-verified:` (no leading
+whitespace), so indented occurrences inside block scalars or nested
+mappings are left alone.
 
 Stdlib only — no external dependencies.
 """
 
 from __future__ import annotations
 
+import argparse
 import datetime
 import re
 import sys
@@ -28,17 +37,31 @@ from pathlib import Path
 
 TODAY = datetime.date.today().isoformat()
 DELIM = "---"
-LAST_VERIFIED_RE = re.compile(r"^(\s*)last-verified\s*:\s*(.*?)\s*$")
+LAST_VERIFIED_RE = re.compile(r"^last-verified\s*:\s*(.*?)\s*$")
+STATUS_RE = re.compile(r"^status\s*:\s*\S")
 
 
-def find_frontmatter_close(lines: list[str]) -> int | None:
-    """Return the index of the closing `---` line, or None if no frontmatter."""
+class MalformedFrontmatter(Exception):
+    """Opening `---` present but no closing delimiter (or other broken shape)."""
+
+
+def find_close(lines: list[str]) -> int | None:
+    """
+    Locate the closing `---` line of the frontmatter block.
+
+    Returns:
+      None       — file has no frontmatter at all.
+      int        — index of the closing delim line.
+
+    Raises:
+      MalformedFrontmatter — opening `---` but no closing delim.
+    """
     if not lines or lines[0] != DELIM:
         return None
     for i in range(1, len(lines)):
         if lines[i] == DELIM:
             return i
-    return None
+    raise MalformedFrontmatter("opening `---` present but no closing delimiter")
 
 
 def stub_block() -> str:
@@ -52,29 +75,30 @@ def stub_block() -> str:
 
 
 def bump(lines: list[str], close_idx: int) -> bool:
-    """Bump `last-verified:` inside the frontmatter block. Returns True if changed."""
+    """Bump top-level `last-verified:` inside the frontmatter. True if changed."""
     for i in range(1, close_idx):
         match = LAST_VERIFIED_RE.match(lines[i])
         if not match:
             continue
-        indent, existing = match.group(1), match.group(2).strip()
+        existing = match.group(1).strip()
         if existing and existing >= TODAY:
             return False
-        lines[i] = f"{indent}last-verified: {TODAY}"
+        lines[i] = f"last-verified: {TODAY}"
         return True
     lines.insert(close_idx, f"last-verified: {TODAY}")
     return True
 
 
-def process(path: Path) -> str | None:
-    """Process one file; return a short action string, or None if unchanged."""
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
+def read_text(path: Path) -> str:
+    # utf-8-sig strips a BOM if present; the file is written back without one.
+    return path.read_text(encoding="utf-8-sig")
 
+
+def maintain(path: Path) -> str | None:
+    """Stub or bump as needed. Returns an action description or None."""
+    text = read_text(path)
     lines = text.split("\n")
-    close_idx = find_frontmatter_close(lines)
+    close_idx = find_close(lines)
 
     if close_idx is None:
         path.write_text(stub_block() + text, encoding="utf-8")
@@ -87,25 +111,108 @@ def process(path: Path) -> str | None:
     return None
 
 
-def main(argv: list[str]) -> int:
+def check(path: Path) -> list[str]:
+    """Validate frontmatter is present and well-formed. Returns a list of issues."""
+    text = read_text(path)
+    lines = text.split("\n")
+    try:
+        close_idx = find_close(lines)
+    except MalformedFrontmatter as e:
+        return [str(e)]
+
+    if close_idx is None:
+        return ["no frontmatter (expected opening `---` block)"]
+
+    issues: list[str] = []
+    if not any(STATUS_RE.match(lines[i]) for i in range(1, close_idx)):
+        issues.append("missing top-level `status:`")
+    if not any(LAST_VERIFIED_RE.match(lines[i]) for i in range(1, close_idx)):
+        issues.append("missing top-level `last-verified:`")
+    return issues
+
+
+def eligible(path: Path) -> bool:
+    # Symlinks are skipped: a staged `docs/*.md` symlink would otherwise
+    # cause the hook to write through to whatever the symlink points at.
+    return (
+        not path.is_symlink()
+        and path.is_file()
+        and path.suffix.lower() == ".md"
+    )
+
+
+def run_maintain(paths: list[str]) -> int:
     actions: list[str] = []
-    for arg in argv:
+    errors: list[str] = []
+    for arg in paths:
         path = Path(arg)
-        if not path.is_file() or path.suffix.lower() != ".md":
+        if not eligible(path):
             continue
-        result = process(path)
+        try:
+            result = maintain(path)
+        except MalformedFrontmatter as e:
+            errors.append(f"{path}: {e}")
+            continue
+        except (OSError, UnicodeDecodeError) as e:
+            errors.append(f"{path}: {e}")
+            continue
         if result:
             actions.append(result)
 
+    for a in actions:
+        print(f"[docs-frontmatter] {a}")
     if actions:
-        for a in actions:
-            print(f"[docs-frontmatter] {a}")
         print(
-            "[docs-frontmatter] Note: human-verified is set only by explicit human "
-            "action; this hook and any automation must leave it blank. "
+            "[docs-frontmatter] Note: human-verified is set only by explicit "
+            "human action; this hook and any automation must leave it blank. "
             "See docs/frontmatter-hook.md."
         )
-    return 0
+    for err in errors:
+        print(f"[docs-frontmatter] error: {err}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+def run_check(paths: list[str]) -> int:
+    failures: list[tuple[Path, list[str]]] = []
+    for arg in paths:
+        path = Path(arg)
+        if not eligible(path):
+            continue
+        try:
+            issues = check(path)
+        except (OSError, UnicodeDecodeError) as e:
+            issues = [str(e)]
+        if issues:
+            failures.append((path, issues))
+
+    if not failures:
+        return 0
+
+    print("Frontmatter check failed:", file=sys.stderr)
+    for path, issues in failures:
+        for issue in issues:
+            print(f"  {path}: {issue}", file=sys.stderr)
+    print(
+        "\nSee docs/frontmatter-hook.md. To fix locally, run the pre-commit "
+        "hook (or `python3 scripts/docs_frontmatter_hook.py <file>`) and "
+        "re-commit.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate frontmatter without mutating. Exit non-zero on failure.",
+    )
+    parser.add_argument("paths", nargs="*")
+    args = parser.parse_args(argv)
+    if args.check:
+        return run_check(args.paths)
+    return run_maintain(args.paths)
 
 
 if __name__ == "__main__":

--- a/scripts/docs_frontmatter_hook.py
+++ b/scripts/docs_frontmatter_hook.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Frontmatter maintenance for docs/**/*.md.
+
+Run from pre-commit. For each staged file passed on argv:
+
+  - If the file has no YAML frontmatter, prepend a minimal stub:
+        status: active
+        last-verified: <today>
+        human-verified:
+  - If the file has frontmatter, bump `last-verified:` to today (only if
+    the existing value is older or missing). Idempotent on docs already
+    stamped today.
+
+Never touches: `status:` (when present), `authoritative-for:`,
+`supersedes:`, `superseded-by:`, `shipped:`, `remaining-open:`, or
+`human-verified:`. Those fields are human-authored.
+
+Stdlib only — no external dependencies.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import sys
+from pathlib import Path
+
+TODAY = datetime.date.today().isoformat()
+DELIM = "---"
+LAST_VERIFIED_RE = re.compile(r"^(\s*)last-verified\s*:\s*(.*?)\s*$")
+
+
+def find_frontmatter_close(lines: list[str]) -> int | None:
+    """Return the index of the closing `---` line, or None if no frontmatter."""
+    if not lines or lines[0] != DELIM:
+        return None
+    for i in range(1, len(lines)):
+        if lines[i] == DELIM:
+            return i
+    return None
+
+
+def stub_block() -> str:
+    return (
+        f"{DELIM}\n"
+        f"status: active\n"
+        f"last-verified: {TODAY}\n"
+        f"human-verified:\n"
+        f"{DELIM}\n\n"
+    )
+
+
+def bump(lines: list[str], close_idx: int) -> bool:
+    """Bump `last-verified:` inside the frontmatter block. Returns True if changed."""
+    for i in range(1, close_idx):
+        match = LAST_VERIFIED_RE.match(lines[i])
+        if not match:
+            continue
+        indent, existing = match.group(1), match.group(2).strip()
+        if existing and existing >= TODAY:
+            return False
+        lines[i] = f"{indent}last-verified: {TODAY}"
+        return True
+    lines.insert(close_idx, f"last-verified: {TODAY}")
+    return True
+
+
+def process(path: Path) -> str | None:
+    """Process one file; return a short action string, or None if unchanged."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    lines = text.split("\n")
+    close_idx = find_frontmatter_close(lines)
+
+    if close_idx is None:
+        path.write_text(stub_block() + text, encoding="utf-8")
+        return f"stubbed: {path} (status: active, last-verified: {TODAY})"
+
+    if bump(lines, close_idx):
+        path.write_text("\n".join(lines), encoding="utf-8")
+        return f"bumped last-verified: {path}"
+
+    return None
+
+
+def main(argv: list[str]) -> int:
+    actions: list[str] = []
+    for arg in argv:
+        path = Path(arg)
+        if not path.is_file() or path.suffix.lower() != ".md":
+            continue
+        result = process(path)
+        if result:
+            actions.append(result)
+
+    if actions:
+        for a in actions:
+            print(f"[docs-frontmatter] {a}")
+        print(
+            "[docs-frontmatter] Note: human-verified is set only by explicit human "
+            "action; this hook and any automation must leave it blank. "
+            "See docs/frontmatter-hook.md."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Companion to #196 — mechanically enforce the frontmatter convention so it doesn't rot.

**Not visible in the diff:**
- **No PyYAML dependency by design.** Pre-commit already requires Python; the hook is stdlib-only line manipulation against the YAML's constrained shape. Avoided pulling a third-party dep for ~70 lines of logic.
- **`human-verified:` must never be auto-stamped.** The hook never reads or writes that field — the single-line stdout reminder pointing at `docs/frontmatter-hook.md` is the channel agent contributors can't miss.
- **Silent on no-op** so the hook doesn't become wallpaper on every commit.

## Demo

Four staged fixtures — no frontmatter, stale date, already today, frontmatter without `last-verified`:

```
$ python3 scripts/docs_frontmatter_hook.py new-doc.md old-date.md already-today.md partial-fm.md
[docs-frontmatter] stubbed: new-doc.md (status: active, last-verified: 2026-06-05)
[docs-frontmatter] bumped last-verified: old-date.md
[docs-frontmatter] bumped last-verified: partial-fm.md
[docs-frontmatter] Note: human-verified is set only by explicit human action; this hook and any automation must leave it blank. See docs/frontmatter-hook.md.
```

The `old-date.md` fixture deliberately carried `human-verified: 2026-01-15` alongside its stale `last-verified:`. After the hook ran, `last-verified` bumped to `2026-06-05` and `human-verified` was untouched — the asymmetry the design protects.

## Followups (separate PRs)

- Tombstone-on-delete (deletion → `docs/archived_files.md` with last-containing-SHA).
- `docs-status` CLI / agent skill (judgement-level reporting on stale or contradictory docs).