### PR TITLE
chore: remove accidentally committed variadic scratch files

### DIFF
--- a/debug_variadic.lg
+++ b/debug_variadic.lg
@@ -1,2 +1,0 @@
-(defn test-variadic [x & rest]
-  (cons x rest))

--- a/test_variadic.lg
+++ b/test_variadic.lg
@@ -1,2 +1,0 @@
-(defn test-variadic [x & rest]
-  (cons x rest))


### PR DESCRIPTION
## Summary

`test_variadic.lg` and `debug_variadic.lg` are identical 2-line scratch files in the repo root:

```clojure
(defn test-variadic [x & rest]
  (cons x rest))
```

They landed via #85 (lginterop work) — looks like a stray `git add` of a REPL scratch buffer rather than anything intentional. `rg test_variadic debug_variadic` against `Makefile`, `scripts/`, `cmd/`, `pkg/`, and the rest of the tree finds zero references.

The legit root-level Go e2e tests (`resources_e2e_test.go`, `scope_e2e_test.go`, `source_paths_e2e_test.go`) are `package main` and stay where they belong — only these two `.lg` scratch files are going.

## Test plan

- [x] `git rm` both files; commit is `chore`-typed, no code changes
- [ ] CI: build + existing test suites should be unaffected (no references to remove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)