### PR TITLE
feat(rt): route print/pr/prn/println through *out* and error sites through *err*

### DIFF
--- a/pkg/nrepl/server.go
+++ b/pkg/nrepl/server.go
@@ -236,26 +236,27 @@ func (n *NreplServer) handleEval(conn net.Conn, msg map[string]any) {
 	sessID := msgStr(msg, "session")
 	code := msgStr(msg, "code")
 
-	// Capture stdout
+	// Capture eval output via binding-based capture: rebind *out* to a
+	// per-call bytes.Buffer for the eval's scope, restore via defer.
+	// Replaces the prior os.Stdout = pw swap, which was broken after the
+	// print refactor (println now writes via the IOHandle's saved *os.File
+	// instead of os.Stdout, so the swap stopped capturing).
+	//
+	// Concurrency caveat: vm.Var's binding stack is process-global, not
+	// per-goroutine. Concurrent nREPL evals can still interleave their
+	// captures, and the captures still race with with-out-str calls
+	// happening elsewhere in the process. No worse than the prior swap
+	// (which had the same hazard), but no better either. Proper isolation
+	// would need goroutine-local bindings or serialization at this layer.
 	var outBuf bytes.Buffer
-	origStdout := os.Stdout
-	pr, pw, _ := os.Pipe()
-	os.Stdout = pw
-
-	// Read pipe in background
-	outDone := make(chan struct{})
-	go func() {
-		io.Copy(&outBuf, pr)
-		close(outDone)
-	}()
+	outVar := rt.LookupCoreVar("*out*")
+	if outVar != nil {
+		outVar.PushBinding(vm.NewBoxed(rt.NewWriterHandle("nrepl-eval", &outBuf)))
+		defer outVar.PopBinding()
+	}
 
 	// Eval
 	_, val, err := n.ctx.CompileMultiple(strings.NewReader(code))
-
-	// Restore stdout and flush
-	pw.Close()
-	os.Stdout = origStdout
-	<-outDone
 
 	// Send stdout if any
 	if outBuf.Len() > 0 {

--- a/pkg/rt/http.go
+++ b/pkg/rt/http.go
@@ -71,7 +71,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
 		resp.WriteHeader(500)
 		_, err := resp.Write(fmt.Appendf(nil, "%s", err))
 		if err != nil {
-			fmt.Println("HTTP Error while writing error 500", err)
+			_ = WriteToErr(fmt.Sprintln("HTTP Error while writing error 500", err))
 		}
 		return
 	}
@@ -106,7 +106,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
 		resp.WriteHeader(500)
 		_, err := resp.Write(fmt.Appendf(nil, "%s", err))
 		if err != nil {
-			fmt.Println("HTTP Error while writing error 500", err)
+			_ = WriteToErr(fmt.Sprintln("HTTP Error while writing error 500", err))
 		}
 		return
 	}
@@ -116,7 +116,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
 		resp.WriteHeader(500)
 		_, err := resp.Write([]byte("handler returned malformed response"))
 		if err != nil {
-			fmt.Println("HTTP Error while writing error 500", err)
+			_ = WriteToErr(fmt.Sprintln("HTTP Error while writing error 500", err))
 		}
 		return
 	}
@@ -146,14 +146,14 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
 	resp.WriteHeader(int(status.(vm.Int)))
 	respBody, bodyErr := coerceResponseBody(body)
 	if bodyErr != nil {
-		fmt.Println("HTTP Error coercing body:", bodyErr)
+		_ = WriteToErr(fmt.Sprintln("HTTP Error coercing body:", bodyErr))
 		return
 	}
 	if respBody != nil {
 		_, err = resp.Write(respBody)
 	}
 	if err != nil {
-		fmt.Println("HTTP Error while writing error 500", err)
+		_ = WriteToErr(fmt.Sprintln("HTTP Error while writing error 500", err))
 	}
 }
 

--- a/pkg/rt/ions.go
+++ b/pkg/rt/ions.go
@@ -181,7 +181,11 @@ func coerceReaderBuiltin(v vm.Value) (*LGReader, error) {
 			return newLGReader(buf, nil), nil
 		}
 		if h, ok := b.Unbox().(*IOHandle); ok {
-			return newLGReader(h.Reader(), nil), nil
+			r := h.Reader()
+			if r == nil {
+				return nil, fmt.Errorf("cannot coerce IOHandle %q to reader: handle is not readable", h.name)
+			}
+			return newLGReader(r, nil), nil
 		}
 		// Any boxed io.Reader
 		if r, ok := b.Unbox().(io.Reader); ok {
@@ -234,7 +238,11 @@ func coerceWriterBuiltin(v vm.Value) (*LGWriter, error) {
 			return newLGWriter(buf, nil), nil
 		}
 		if h, ok := b.Unbox().(*IOHandle); ok {
-			return newLGWriter(h.File, nil), nil
+			w := h.Writer()
+			if w == nil {
+				return nil, fmt.Errorf("cannot coerce IOHandle %q to writer: handle is not writable", h.name)
+			}
+			return newLGWriter(w, nil), nil
 		}
 		if w, ok := b.Unbox().(io.Writer); ok {
 			var closer io.Closer

--- a/pkg/rt/iort.go
+++ b/pkg/rt/iort.go
@@ -8,34 +8,103 @@ package rt
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/nooga/let-go/pkg/vm"
 )
 
-// IOHandle wraps an *os.File with optional buffered reader for line-based reads.
+// IOHandle is the runtime's I/O abstraction. It wraps an io.Writer and/or
+// io.Reader so the same type backs file handles, stdin/stdout/stderr,
+// bytes.Buffer-style captures, and embedder-supplied sinks. File-backed
+// handles also retain the *os.File so callers that need Fd()/Sync() still
+// have it.
 type IOHandle struct {
-	File   *os.File
-	reader *bufio.Reader
+	name   string
+	file   *os.File // set only when this handle wraps a file
+	writer io.Writer
+	reader io.Reader
+	bufrd  *bufio.Reader
 }
 
+// NewIOHandle wraps an *os.File. Preserves all existing call sites and
+// keeps file-specific operations (Fd, Sync) available via File().
 func NewIOHandle(f *os.File) *IOHandle {
-	return &IOHandle{File: f}
+	return &IOHandle{name: f.Name(), file: f, writer: f, reader: f}
+}
+
+// NewWriterHandle wraps an arbitrary io.Writer. No reads.
+func NewWriterHandle(name string, w io.Writer) *IOHandle {
+	return &IOHandle{name: name, writer: w}
+}
+
+// NewReaderHandle wraps an arbitrary io.Reader. No writes.
+func NewReaderHandle(name string, r io.Reader) *IOHandle {
+	return &IOHandle{name: name, reader: r}
+}
+
+// File returns the underlying *os.File or nil when the handle wraps an
+// arbitrary writer/reader. Callers that need Fd()/Sync() (e.g. term/raw
+// mode) must handle nil.
+func (h *IOHandle) File() *os.File { return h.file }
+
+// Writer / Reader are the interface-shaped accessors the print/error
+// refactor consults.
+func (h *IOHandle) Writer() io.Writer    { return h.writer }
+func (h *IOHandle) ReaderRaw() io.Reader { return h.reader }
+
+// Write is the convenience write-string path used by the print fns and
+// (write! handle x). Returns an error if the handle isn't writable.
+func (h *IOHandle) Write(s string) (int, error) {
+	if h.writer == nil {
+		return 0, fmt.Errorf("IOHandle %q is not writable", h.name)
+	}
+	return io.WriteString(h.writer, s)
 }
 
 func (h *IOHandle) String() string {
-	return fmt.Sprintf("#<IOHandle %s>", h.File.Name())
+	return fmt.Sprintf("#<IOHandle %s>", h.name)
 }
 
+// Reader returns a buffered reader over the underlying io.Reader, lazily
+// constructed on first use. Returns nil for write-only handles.
 func (h *IOHandle) Reader() *bufio.Reader {
 	if h.reader == nil {
-		h.reader = bufio.NewReader(h.File)
+		return nil
 	}
-	return h.reader
+	if h.bufrd == nil {
+		h.bufrd = bufio.NewReader(h.reader)
+	}
+	return h.bufrd
 }
 
+// Close closes the underlying file if file-backed, or any wrapped writer/
+// reader that implements io.Closer. No-op for non-closable handles like
+// bytes.Buffer or os.Stdout.
 func (h *IOHandle) Close() error {
-	return h.File.Close()
+	if h.file != nil {
+		return h.file.Close()
+	}
+	if c, ok := h.writer.(io.Closer); ok {
+		return c.Close()
+	}
+	if c, ok := h.reader.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// Sync flushes/syncs the handle. For file-backed handles, calls File.Sync.
+// For writers that implement a Flush() error method (e.g. bufio.Writer),
+// calls that. Otherwise no-op (buffers are eager).
+func (h *IOHandle) Sync() error {
+	if h.file != nil {
+		return h.file.Sync()
+	}
+	if f, ok := h.writer.(interface{ Flush() error }); ok {
+		return f.Flush()
+	}
+	return nil
 }
 
 // getIOHandle extracts an *IOHandle from a Boxed value or wraps a raw *os.File.
@@ -44,11 +113,11 @@ func getIOHandle(v vm.Value) (*IOHandle, error) {
 	if !ok {
 		return nil, fmt.Errorf("expected IOHandle, got %s", v.Type().Name())
 	}
-	if h, ok := b.Unbox().(*IOHandle); ok {
-		return h, nil
-	}
-	if f, ok := b.Unbox().(*os.File); ok {
-		return NewIOHandle(f), nil
+	switch u := b.Unbox().(type) {
+	case *IOHandle:
+		return u, nil
+	case *os.File:
+		return NewIOHandle(u), nil
 	}
 	return nil, fmt.Errorf("expected IOHandle, got %T", b.Unbox())
 }
@@ -120,7 +189,11 @@ func installIOBuiltins(ns *vm.Namespace) {
 		if err != nil {
 			return vm.NIL, err
 		}
-		line, err := h.Reader().ReadString('\n')
+		r := h.Reader()
+		if r == nil {
+			return vm.NIL, fmt.Errorf("read-line: handle %q is not readable", h.name)
+		}
+		line, err := r.ReadString('\n')
 		if err != nil {
 			if len(line) > 0 {
 				// Return what we have even on EOF
@@ -153,7 +226,7 @@ func installIOBuiltins(ns *vm.Namespace) {
 		} else {
 			s = vs[1].String()
 		}
-		_, err = h.File.WriteString(s)
+		_, err = h.Write(s)
 		return vm.NIL, err
 	})
 
@@ -166,7 +239,7 @@ func installIOBuiltins(ns *vm.Namespace) {
 		if err != nil {
 			return vm.NIL, err
 		}
-		return vm.NIL, h.File.Sync()
+		return vm.NIL, h.Sync()
 	})
 
 	// read-bytes — (read-bytes handle n) → String or nil at EOF
@@ -182,8 +255,11 @@ func installIOBuiltins(ns *vm.Namespace) {
 		if !ok {
 			return vm.NIL, fmt.Errorf("read-bytes expected Int count")
 		}
+		if h.reader == nil {
+			return vm.NIL, fmt.Errorf("read-bytes: handle is not readable")
+		}
 		buf := make([]byte, int(n))
-		nread, err := h.File.Read(buf)
+		nread, err := h.reader.Read(buf)
 		if nread == 0 {
 			return vm.NIL, nil // EOF
 		}

--- a/pkg/rt/iort.go
+++ b/pkg/rt/iort.go
@@ -327,3 +327,56 @@ func installIOBuiltins(ns *vm.Namespace) {
 	ns.Def("*out*", stdoutHandle)
 	ns.Def("*err*", stderrHandle)
 }
+
+// resolveIOHandleVar looks up a var (e.g. "*out*") in the core namespace
+// and unwraps its current binding to an *IOHandle. Returns nil if the var
+// isn't installed yet (e.g. during early init) or the current binding
+// doesn't unwrap to a handle / *os.File. Callers must fall back to a sane
+// default in that case.
+//
+// Resolution path: ns.LookupLocal -> Var.Deref (lock-free atomic load,
+// respects (binding [...] ...) per pkg/vm/var.go:95-103) -> Boxed.Unbox.
+func resolveIOHandleVar(varName string) *IOHandle {
+	ns := lookupNSCached(NameCoreNS)
+	if ns == nil {
+		return nil
+	}
+	v := ns.LookupLocal(vm.Symbol(varName))
+	if v == nil {
+		return nil
+	}
+	b, ok := v.Deref().(*vm.Boxed)
+	if !ok {
+		return nil
+	}
+	switch u := b.Unbox().(type) {
+	case *IOHandle:
+		return u
+	case *os.File:
+		return NewIOHandle(u)
+	}
+	return nil
+}
+
+// WriteToOut writes s through the current dynamic binding of *out*. Falls
+// back to os.Stdout if *out* isn't installed yet or doesn't resolve to a
+// handle (early-boot conditions only).
+func WriteToOut(s string) error {
+	if h := resolveIOHandleVar("*out*"); h != nil {
+		_, err := h.Write(s)
+		return err
+	}
+	_, err := io.WriteString(os.Stdout, s)
+	return err
+}
+
+// WriteToErr writes s through the current dynamic binding of *err*. Falls
+// back to os.Stderr.
+func WriteToErr(s string) error {
+	if h := resolveIOHandleVar("*err*"); h != nil {
+		_, err := h.Write(s)
+		return err
+	}
+	_, err := io.WriteString(os.Stderr, s)
+	return err
+}

--- a/pkg/rt/iort.go
+++ b/pkg/rt/iort.go
@@ -380,3 +380,14 @@ func WriteToErr(s string) error {
 	_, err := io.WriteString(os.Stderr, s)
 	return err
 }
+
+// LookupCoreVar returns the *Var for a name in the core namespace, or nil
+// if not installed. Exported for packages (e.g. nrepl) that need to
+// PushBinding/PopBinding on the core I/O vars to implement scoped capture.
+func LookupCoreVar(varName string) *vm.Var {
+	ns := lookupNSCached(NameCoreNS)
+	if ns == nil {
+		return nil
+	}
+	return ns.LookupLocal(vm.Symbol(varName))
+}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3468,7 +3468,10 @@ func installLangNS() {
 		vm.CurrentScope().Go(func(ctx context.Context) {
 			v, err := at.Invoke(nil)
 			if err != nil {
-				fmt.Println(err)
+				// Async (go ...) error — route to *err*. Previously
+				// fmt.Println, which targets stdout despite being error
+				// output: double-wrong.
+				_ = WriteToErr(fmt.Sprintln(err))
 			}
 			// The result send is cancellable via the registry. (Channel
 			// ops <!/>! INSIDE the block are still synchronous and not yet

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -6,6 +6,7 @@
 package rt
 
 import (
+	"bytes"
 	"context"
 	crand "crypto/rand"
 	_ "embed"
@@ -7452,7 +7453,19 @@ func installLangNS() {
 	})
 	ns.Def("pop!", popBang)
 
-	// with-out-str — capture stdout as string (macro helper)
+	// with-out-str* — capture *out* output as string. Binding-based capture
+	// (no process-global os.Stdout swap). Rebinds *out* to a bytes.Buffer-
+	// backed IOHandle for the thunk's scope; restores via defer so a
+	// panicking thunk doesn't leak the binding.
+	//
+	// Concurrency caveat: vm.Var holds a single process-global binding
+	// stack guarded by bindingsMu (pkg/vm/var.go:38). Concurrent
+	// with-out-str calls on the same *out* DO NOT isolate captures from
+	// each other — their push/pop interleavings can cause one goroutine's
+	// println to land in another's buffer. This is no worse than the
+	// previous os.Stdout swap (which had the same global-state race),
+	// but it's also not better. Real isolation would require either
+	// goroutine-local binding stacks in vm.Var or external serialization.
 	withOutStrf, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("with-out-str* expects 1 arg (a thunk)")
@@ -7461,23 +7474,19 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("with-out-str* expects a function")
 		}
-		// Capture stdout
-		old := os.Stdout
-		r, w, err := os.Pipe()
-		if err != nil {
-			return vm.NIL, err
+		outVar := lookupNSCached(NameCoreNS).LookupLocal(vm.Symbol("*out*"))
+		if outVar == nil {
+			return vm.NIL, fmt.Errorf("with-out-str*: *out* not installed")
 		}
-		os.Stdout = w
+		buf := &bytes.Buffer{}
+		handle := vm.NewBoxed(NewWriterHandle("with-out-str*", buf))
+		outVar.PushBinding(handle)
+		defer outVar.PopBinding()
 		_, callErr := fn.Invoke(nil)
-		w.Close()
-		os.Stdout = old
-		buf := make([]byte, 64*1024)
-		n, _ := r.Read(buf)
-		r.Close()
 		if callErr != nil {
 			return vm.NIL, callErr
 		}
-		return vm.String(buf[:n]), nil
+		return vm.String(buf.String()), nil
 	})
 	ns.Def("with-out-str*", withOutStrf)
 

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -4828,14 +4828,13 @@ func installLangNS() {
 		return prThroughToString(vs, true)
 	})
 
-	// prn: print readably + newline to stdout
+	// prn: print readably + newline through *out*
 	prn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		s, err := prThroughToString(vs, true)
 		if err != nil {
 			return vm.NIL, err
 		}
-		fmt.Fprintln(os.Stdout, string(s.(vm.String)))
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(string(s.(vm.String)) + "\n")
 	})
 
 	// prn-str: print readably + newline to string
@@ -5454,34 +5453,31 @@ func installLangNS() {
 		return vm.MakeInt(c), nil
 	})
 
-	// print — print human-readably to stdout, no newline
+	// print — print human-readably through *out*, no newline
 	printf, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		s, err := prThroughToString(vs, false)
 		if err != nil {
 			return vm.NIL, err
 		}
-		fmt.Fprint(os.Stdout, string(s.(vm.String)))
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(string(s.(vm.String)))
 	})
 
-	// pr — print readably to stdout, no newline
+	// pr — print readably through *out*, no newline
 	prf, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		s, err := prThroughToString(vs, true)
 		if err != nil {
 			return vm.NIL, err
 		}
-		fmt.Fprint(os.Stdout, string(s.(vm.String)))
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(string(s.(vm.String)))
 	})
 
-	// println — print human-readably to stdout with newline
+	// println — print human-readably through *out* with newline
 	printlnf, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		s, err := prThroughToString(vs, false)
 		if err != nil {
 			return vm.NIL, err
 		}
-		fmt.Fprintln(os.Stdout, string(s.(vm.String)))
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(string(s.(vm.String)) + "\n")
 	})
 
 	// --- Bitwise ops ---

--- a/pkg/rt/pods.go
+++ b/pkg/rt/pods.go
@@ -141,12 +141,15 @@ func (p *Pod) startRouter() {
 				return
 			}
 
-			// Handle out/err on any message
+			// Handle out/err on any message — route through the runtime's
+			// dynamic *out*/*err*, not raw stdio. Pod stdout/stderr is
+			// pod content; it should follow whatever capture/redirect the
+			// caller has set up via (binding ...) or pkg/api options.
 			if out, ok := msg["out"].(string); ok {
-				fmt.Print(out)
+				_ = WriteToOut(out)
 			}
 			if errStr, ok := msg["err"].(string); ok {
-				fmt.Fprint(os.Stderr, errStr)
+				_ = WriteToErr(errStr)
 			}
 
 			// Route by id

--- a/pkg/rt/pods.go
+++ b/pkg/rt/pods.go
@@ -414,8 +414,8 @@ func createProxyNamespaces(p *Pod) error {
 				// Client-side code: evaluate in the pod's namespace
 				if err := evalPodCode(pv.code, ns); err != nil {
 					// Non-fatal: log and continue (the var may still be usable)
-					fmt.Fprintf(os.Stderr, "pod %s: client code eval error for %s/%s: %v\n",
-						p.id, pns.name, pv.name, err)
+					_ = WriteToErr(fmt.Sprintf("pod %s: client code eval error for %s/%s: %v\n",
+						p.id, pns.name, pv.name, err))
 				}
 				continue
 			}
@@ -515,7 +515,15 @@ func startPod(binary string) (*Pod, error) {
 	}
 
 	go func() {
-		io.Copy(os.Stderr, stderr) //nolint:errcheck
+		// Stream the child pod's stderr to *err*. Resolve once at start;
+		// if *err* later rebinds, this goroutine keeps writing to the
+		// originally-resolved sink (acceptable for a child process's
+		// stderr that lives for its lifetime).
+		if h := resolveIOHandleVar("*err*"); h != nil && h.Writer() != nil {
+			io.Copy(h.Writer(), stderr) //nolint:errcheck
+		} else {
+			io.Copy(os.Stderr, stderr) //nolint:errcheck
+		}
 	}()
 
 	p := &Pod{
@@ -709,7 +717,7 @@ type invokable interface {
 func callFn(fn vm.Value, args []vm.Value) {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "pod callback panic: %v\n", r)
+			_ = WriteToErr(fmt.Sprintf("pod callback panic: %v\n", r))
 		}
 	}()
 	if f, ok := fn.(invokable); ok {

--- a/pkg/rt/pods.go
+++ b/pkg/rt/pods.go
@@ -141,10 +141,13 @@ func (p *Pod) startRouter() {
 				return
 			}
 
-			// Handle out/err on any message — route through the runtime's
-			// dynamic *out*/*err*, not raw stdio. Pod stdout/stderr is
-			// pod content; it should follow whatever capture/redirect the
-			// caller has set up via (binding ...) or pkg/api options.
+			// Handle out/err on any message — route pod stdout/stderr through
+			// the runtime's dynamic *out*/*err* rather than raw stdio. In
+			// practice this resolves to the *root* *out*/*err*: startRouter is
+			// a long-lived goroutine that typically outlives a caller's
+			// (binding [*out* ...] ...) scope, so the binding is usually popped
+			// before pod messages arrive. The win here is that errors now reach
+			// *err* (→ stderr) instead of being hard-wired to stdout.
 			if out, ok := msg["out"].(string); ok {
 				_ = WriteToOut(out)
 			}

--- a/pkg/rt/syscall_linux.go
+++ b/pkg/rt/syscall_linux.go
@@ -760,7 +760,7 @@ func installSyscallNS() {
 		if err != nil {
 			return nil, false, err
 		}
-		return h.File, false, nil
+		return h.File(), false, nil
 	}
 
 	// syscall/spawn-async — (syscall/spawn-async path argv env cloneflags stdin stdout stderr [opts])

--- a/pkg/rt/syscall_linux.go
+++ b/pkg/rt/syscall_linux.go
@@ -760,7 +760,11 @@ func installSyscallNS() {
 		if err != nil {
 			return nil, false, err
 		}
-		return h.File(), false, nil
+		f := h.File()
+		if f == nil {
+			return nil, false, fmt.Errorf("IOHandle is not file-backed; spawn stdio requires a real file descriptor")
+		}
+		return f, false, nil
 	}
 
 	// syscall/spawn-async — (syscall/spawn-async path argv env cloneflags stdin stdout stderr [opts])

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -78,7 +78,11 @@ func fdFromHandle(v vm.Value) (int, error) {
 		return -1, fmt.Errorf("expected IOHandle")
 	}
 	if h, ok := b.Unbox().(*IOHandle); ok {
-		return int(h.File.Fd()), nil
+		f := h.File()
+		if f == nil {
+			return -1, fmt.Errorf("IOHandle is not file-backed; raw-mode terminal ops require a real file descriptor")
+		}
+		return int(f.Fd()), nil
 	}
 	if f, ok := b.Unbox().(*os.File); ok {
 		return int(f.Fd()), nil

--- a/pkg/rt/unix_linux.go
+++ b/pkg/rt/unix_linux.go
@@ -112,7 +112,7 @@ func installUnixNS() {
 			return int(fv), nil
 		case *vm.Boxed:
 			if h, ok := fv.Unbox().(*IOHandle); ok {
-				return int(h.File.Fd()), nil
+				return int(h.File().Fd()), nil
 			}
 			if f, ok := fv.Unbox().(*os.File); ok {
 				return int(f.Fd()), nil

--- a/pkg/rt/unix_linux.go
+++ b/pkg/rt/unix_linux.go
@@ -112,7 +112,11 @@ func installUnixNS() {
 			return int(fv), nil
 		case *vm.Boxed:
 			if h, ok := fv.Unbox().(*IOHandle); ok {
-				return int(h.File().Fd()), nil
+				f := h.File()
+				if f == nil {
+					return 0, fmt.Errorf("IOHandle is not file-backed; fd ops require a real file descriptor")
+				}
+				return int(f.Fd()), nil
 			}
 			if f, ok := fv.Unbox().(*os.File); ok {
 				return int(f.Fd()), nil

--- a/test/io_binding_test.lg
+++ b/test/io_binding_test.lg
@@ -1,0 +1,90 @@
+;; Dynamic *out* / *err* binding tests — the cases that gave the
+;; runtime I/O proposal its production-bug grounding. Before the print
+;; refactor, every (binding [*out* x] (println ...)) write silently went
+;; to stdout regardless of what x was. These tests pin the fixed
+;; behavior so the regression can't sneak back.
+(ns test.io-binding-test
+  (:require [test :refer :all]))
+
+;; ----------------------------------------------------------------
+;; Core claim: println/print/pr/prn consult the CURRENT binding
+;; of *out*, not the runtime's stdout.
+;; ----------------------------------------------------------------
+
+(deftest println-consults-out-binding
+  (testing "println output goes through *out*'s current binding"
+    (is (= "hello\n"
+           (with-out-str (println "hello"))))))
+
+(deftest print-consults-out-binding
+  (testing "print (no newline) goes through *out*'s current binding"
+    (is (= "hello"
+           (with-out-str (print "hello"))))))
+
+(deftest pr-consults-out-binding
+  (testing "pr (readable, no newline) goes through *out*'s current binding"
+    (is (= "\"hello\""
+           (with-out-str (pr "hello"))))))
+
+(deftest prn-consults-out-binding
+  (testing "prn (readable + newline) goes through *out*'s current binding"
+    (is (= "\"hello\"\n"
+           (with-out-str (prn "hello"))))))
+
+;; ----------------------------------------------------------------
+;; The lgcr die pattern: (binding [*out* *err*] (println ...))
+;; Before fix: println wrote to stdout regardless. After fix: it
+;; respects *err*. We can't easily assert against the process
+;; stderr from inside a deftest, but we CAN observe that the
+;; outer with-out-str (binding *out* to a buffer) doesn't capture
+;; output emitted under (binding [*out* something-else] ...) —
+;; which is the same Clojure-correct semantic.
+;; ----------------------------------------------------------------
+
+(deftest binding-out-respects-rebind
+  (testing "(binding [*out* x] (println ...)) writes to x, not the outer binding"
+    ;; Outer captures *out*; inner rebinds to a fresh handle; the
+    ;; outer buffer must be empty because println wrote to the
+    ;; inner binding, not the outer one.
+    (let [outer (with-out-str
+                  (binding [*out* *err*]
+                    ;; Output goes to *err*, not the outer with-out-str
+                    ;; buffer. We don't check *err* here (process-level
+                    ;; assertion is awkward in deftest); the load-bearing
+                    ;; observation is that the OUTER buffer is empty.
+                    (println "to-err")))]
+      (is (= "" outer)))))
+
+;; ----------------------------------------------------------------
+;; Arbitrary handle as binding target (the lgcr stream-file pattern).
+;; ----------------------------------------------------------------
+
+(deftest binding-out-to-arbitrary-handle
+  (testing "(binding [*out* file-handle] (print ...)) writes to the file"
+    (let [path "/tmp/letgo-io-binding-test.txt"
+          f (open path :write)]
+      (binding [*out* f]
+        (print "via-binding"))
+      (close! f)
+      (is (= "via-binding" (slurp path))))))
+
+;; ----------------------------------------------------------------
+;; with-out-str composability (regression check for the rewrite).
+;; ----------------------------------------------------------------
+
+(deftest with-out-str-nests
+  (testing "with-out-str nested in with-out-str captures correctly"
+    (let [inner (with-out-str
+                  (println "outer-1")
+                  (let [captured (with-out-str
+                                   (println "inner"))]
+                    (println "captured was:" (count captured))))]
+      ;; Outer captured: outer-1, then "captured was: 6" (the count of "inner\n")
+      (is (= "outer-1\ncaptured was: 6\n" inner)))))
+
+(deftest with-out-str-default-stdout-unchanged
+  (testing "outside any with-out-str/binding, println goes to runtime stdout"
+    ;; We can't directly assert against the process stdout from
+    ;; inside a test, but we can ensure (a) it doesn't throw and
+    ;; (b) the return value is nil (matches Clojure).
+    (is (nil? (println "this goes to process stdout — visible in test output")))))


### PR DESCRIPTION
## Summary

let-go already has the right abstraction for I/O: `*in*`/`*out*`/`*err*` are dynamic vars holding IOHandles (`pkg/rt/iort.go`), and `(write! *err* "x")` and `(binding [*out* h] (write! *out* ...))` both work today. What's missing is that the four top-level print fns (`print`/`pr`/`prn`/`println`) and the runtime's error-output sites **don't consult those vars** — they write straight to `os.Stdout`/`os.Stderr`. So `(binding [*out* *err*] (println "x"))` silently writes to stdout, where Clojure writes to stderr.

This PR finishes the abstraction: the print fns resolve the current dynamic binding of `*out*` at each call, error sites resolve `*err*`, and the two internal output-capture mechanisms that depended on swapping `os.Stdout` are rewritten to use the binding stack instead.

Default behavior is unchanged — `*out*`'s root binding is still the IOHandle wrapping `os.Stdout`, so bare `(println ...)` is identical to today.

## Context — where this fits

This is the runtime-semantics layer under the browser-interop direction in #79. #174 (LetGoHost: `onOutput`/`onEmit`/…) landed the **JS-side** host surface; this PR is the **Go-side** plumbing that makes it clean — once `print`/`pr`/`prn`/`println` honor `*out*`, the runtime stops reaching for `os.Stdout` directly, and `pkg/api.WithStdout` (a follow-up PR) becomes the exact dual of `LetGoHost.onOutput`, eventually retiring the `fs.writeSync` shim. Scope here is deliberately just the runtime semantics; the embedder API and the WASM host writer are separate, sequenced follow-ups.

## Why this matters (it's a real compat bug, not just ergonomics)

`(binding [*out* *err*] ...)` is the idiomatic Clojure way to send output to stderr, and downstream let-go code already relies on it. Surveyed instances that are silently broken today:

- `nooga/lgcr` ships three copies of `(defn die [& m] (binding [*out* *err*] (println ...)) (os/exit 1))` (cli.lg, imgstore.lg, container.lg) — every error message has been going to **stdout**.
- `lgcr`'s `stream-file` does `(binding [*out* sink] (print chunk))` to redirect a stream — the redirect is a no-op today, and it's on the container log-streaming path (`stdout.log`/`stderr.log`).
- *(Both lgcr cases are filed and repro'd at nooga/lgcr#1.)*
- `examples/ys-on-let-go/ys-runtime.lg`'s `warn` has the same `die`-shaped bug.

After this PR, each starts behaving as written once the consumer bumps its let-go pin to a release that includes it. That pin bump is the one required step — there are no code changes on the consumer side beyond it.

## The 6 commits (reviewable independently)

1. **`refactor(rt): IOHandle wraps io.Writer/io.Reader`** — IOHandle was `*os.File`-locked; now it wraps an `io.Writer`/`io.Reader` pair, keeping the `*os.File` for handles that need `Fd()`/`Sync()` (raw-mode term, fsync). One-way handles are nil-guarded so a write-only handle passed to a reader (or vice-versa) returns a clear error instead of panicking.
2. **`feat(rt): print/pr/prn/println consult dynamic *out*`** — the 5 stdout sites (4 print fns + the pod stdout router) go through a small `WriteToOut` helper that resolves `*out*` via the core ns + `Var.Deref` (lock-free).
3. **`feat(rt): error sites consult dynamic *err* (10 sites)`** — error output in `pkg/rt/*` goes through `*err*`. Six of these were *double-wrong*: naked `fmt.Println` targeting **stdout** for semantically-error output (async-fn errors, HTTP error logs).
4. **`feat(rt): with-out-str* uses binding-based capture`** — see "the interlock" below.
5. **`feat(nrepl): eval-capture uses binding-based *out* rebind`** — the same rewrite for nREPL's per-eval capture; exports `rt.LookupCoreVar` for it.
6. **`test(io): pin the *out* binding semantics`** — 8 `.lg` tests covering each print fn, the `die` pattern, the arbitrary-handle pattern, nesting, and the default-unchanged case.

## Breaking changes

Two, both worth a reviewer's attention:

1. **`IOHandle.File` (exported field) → `IOHandle.File()` (method).** The struct now wraps an `io.Writer`/`io.Reader` pair and keeps the `*os.File` privately, so the field became an accessor. Any Go embedder reading `handle.File` must switch to `handle.File()`. All in-repo callers are updated; this only affects external code holding the old field.
2. **`print`/`pr`/`prn`/`println` no longer follow a runtime reassignment of `os.Stdout`.** They resolve `*out*`, whose default root binding wraps the `os.Stdout` present at runtime init. Go code that does `os.Stdout = w` at runtime to capture output — the pattern this PR removes from `with-out-str`/nREPL — won't be picked up; rebind `*out*` instead. The WASM path is unaffected: the default handle still wraps fd 1, so writes still reach the `wasm_exec.js` fd hook (browser-verified, see Testing).

## Critical: the print and `with-out-str` changes are coupled

**The print refactor and `with-out-str` are non-separable.** `with-out-str*` (and the structurally identical nREPL eval-capture) captured output by swapping the process-global `os.Stdout`. Once `println` stops writing to `os.Stdout` and goes through the IOHandle instead, that swap captures nothing — `(with-out-str (println "x"))` would return `""` and leak to the real stdout. So commits 4 and 5 rewrite both to capture by pushing a `bytes.Buffer`-backed binding on `*out*` for the body's scope. That's why they're in the same PR as the print change; they can't ship separately.

Two side effects of that rewrite: it removes a latent **64 KB truncation** in the old pipe-read path (it read the capture pipe into a fixed `64*1024` buffer), and a panic in the body no longer leaks process-global state (the binding is popped via `defer`).

## Concurrency

The binding-based capture isn't an isolation guarantee. `vm.Var` holds a single process-global binding stack (not goroutine-local, as on the Clojure JVM), so concurrent `with-out-str` calls — or a `with-out-str` racing an nREPL eval — can interleave push/pop and capture each other's output. In practice the surface is a multi-client nREPL server, or output produced from `(go …)` blocks during a capture. It removes the package-global side effect of the old `os.Stdout` swap and otherwise matches its safety: the global-state hazard is identical, not new. Real isolation would need goroutine-local binding stacks in `vm.Var` or serialization at the capture layer — out of scope here. The docstrings say this explicitly.

## Deliberately out of scope

- **3 `pkg/vm/*` error sites** stay on `os.Stderr` (panic recover, core-shadow warning, GLS drain timeout): `pkg/vm` can't import `pkg/rt` without a cyclic dep, and they're last-resort diagnostics.
- **44 `term/*` ANSI control sites** — separable Phase 1.5; open question whether `(term/clear)` inside a `*out*` rebind should follow it.
- **`pkg/api` embedder options** (`WithStdout`/`WithStderr`) — the follow-up PR, so the instance-isolation question gets its own review.

## Testing

`go test ./...` green across all packages. The 8 new `.lg` tests are in `test/io_binding_test.lg`, named in the descriptive-phrase `deftest` style already used across `test/` (e.g. `assoc-preserves-metadata`, `async-go-returns-channel`).

Beyond the unit suite:
- **WASM, in a real browser:** built the hosted REPL and confirmed `(println …)` still reaches fd 1 → the `wasm_exec.js` console hook, `(with-out-str …)` captures correctly, captured output does not leak, and `(binding [*out* *err*] …)` routes to fd 2. All pass.
- **Cross-platform build:** `GOOS=js GOARCH=wasm go build ./pkg/...` and the Plan9 `pkg/rt` build are both clean.
- **Throughput:** a 1M-`println` loop shows no reliable regression vs base — the added per-call `*out*` resolution is within measurement noise.
