### PR TITLE
feat(api): WithStdout/WithStderr embedder options for *out*/*err*

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"io"
 	"reflect"
 
 	"github.com/nooga/let-go/pkg/compiler"
@@ -9,13 +10,86 @@ import (
 	"github.com/nooga/let-go/pkg/vm"
 )
 
+// Option configures a LetGo runtime instance at construction. Options
+// are applied in order; later options override earlier ones for the
+// same configuration key.
+type Option func(*config)
+
+// config collects the resolved option values. Pure data, no behavior.
+type config struct {
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// WithStdout configures the runtime to route output written via *out*
+// (i.e. (println ...), (print ...), (pr ...), (prn ...), and any user
+// code that consults *out*) through w for this runtime instance.
+//
+// Implementation: each Run call pushes an IOHandle wrapping w as a
+// dynamic binding on *out*, then pops it on return. Per-Run scope
+// means two LetGo instances with different WithStdout values DO NOT
+// interfere with each other's sequential output capture, and a
+// LetGo constructed without WithStdout sees the unaltered os.Stdout
+// default regardless of what other instances have done.
+//
+// Concurrency caveat: vm.Var's binding stack is process-global. If
+// two goroutines call Run on different LetGo instances concurrently,
+// their bindings push onto the same *out* stack — push/pop
+// interleavings can scramble captures. For deterministic isolation,
+// serialize Run calls or run different instances in different
+// processes.
+//
+// Default: os.Stdout (no binding pushed; runtime root unchanged).
+func WithStdout(w io.Writer) Option {
+	return func(c *config) { c.stdout = w }
+}
+
+// WithStderr configures the runtime to route output written via *err*
+// (HTTP server error logs, pod stderr, panic reports, etc.) through w
+// for this runtime instance. Same per-Run binding semantics as
+// WithStdout; same concurrency caveat.
+//
+// Default: os.Stderr.
+func WithStderr(w io.Writer) Option {
+	return func(c *config) { c.stderr = w }
+}
+
+// (Other options deliberately NOT exposed:
+//
+//   - WithStdin: stdin substitution is tied to the wake() / SAB protocol
+//     deferred from nooga/let-go#174 and the readline-driven REPL path.
+//     *in*'s root binding remains os.Stdin; embedders that need stdin
+//     substitution today can rebind *in* manually before calling Run.
+//
+//   - WithEmit: a callback for (js/emit ...) would require either
+//     a *emit-fn* var in the core ns that js/emit consults, or a
+//     refactor of pkg/rt/js_wasm.go's _lgEmit lookup path. Neither is
+//     done. Until the wiring is real, a public option that silently
+//     does nothing would be misleading.)
+
 type LetGo struct {
 	cp     *vm.Consts
 	c      *compiler.Context
 	loader *resolver.NSResolver
+
+	// stdoutHandle/stderrHandle are pre-constructed Boxed IOHandles, or
+	// nil when no option was supplied. Run pushes them as dynamic
+	// bindings on *out*/*err* and pops on return.
+	stdoutHandle vm.Value
+	stderrHandle vm.Value
 }
 
-func NewLetGo(ns string) (*LetGo, error) {
+// NewLetGo constructs a runtime. With no options, behavior is exactly
+// as it was pre-option: *out* and *err* keep their global default root
+// bindings (os.Stdout / os.Stderr). Each I/O option installed gets
+// pushed as a dynamic binding around each Run call, so different
+// LetGo instances don't share or overwrite each other's I/O routing.
+func NewLetGo(ns string, opts ...Option) (*LetGo, error) {
+	cfg := &config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
 	cp := vm.NewConsts()
 	nso := rt.NS(ns)
 	c := compiler.NewCompiler(cp, nso)
@@ -27,6 +101,14 @@ func NewLetGo(ns string) (*LetGo, error) {
 		loader: loader,
 	}
 	rt.SetNSLoader(ret.loader)
+
+	if cfg.stdout != nil {
+		ret.stdoutHandle = vm.NewBoxed(rt.NewWriterHandle("api.WithStdout", cfg.stdout))
+	}
+	if cfg.stderr != nil {
+		ret.stderrHandle = vm.NewBoxed(rt.NewWriterHandle("api.WithStderr", cfg.stderr))
+	}
+
 	return ret, nil
 }
 
@@ -44,7 +126,29 @@ func (l *LetGo) Def(name string, value any) error {
 	return nil
 }
 
+// Run compiles and evaluates expr. If this LetGo was constructed with
+// WithStdout / WithStderr, the corresponding IOHandle is pushed as a
+// dynamic binding on *out* / *err* for the eval's scope and popped on
+// return (including on error / panic).
+//
+// Two LetGo instances calling Run sequentially each get their own
+// configured streams: A's Run pushes A's handle, evaluates, pops; then
+// B's Run pushes B's handle. The root binding of *out*/*err* is
+// never mutated.
 func (l *LetGo) Run(expr string) (vm.Value, error) {
+	if l.stdoutHandle != nil {
+		if v := rt.LookupCoreVar("*out*"); v != nil {
+			v.PushBinding(l.stdoutHandle)
+			defer v.PopBinding()
+		}
+	}
+	if l.stderrHandle != nil {
+		if v := rt.LookupCoreVar("*err*"); v != nil {
+			v.PushBinding(l.stderrHandle)
+			defer v.PopBinding()
+		}
+	}
+
 	c, err := l.c.Compile(expr)
 	if err != nil {
 		return vm.NIL, err

--- a/pkg/api/options_test.go
+++ b/pkg/api/options_test.go
@@ -1,0 +1,134 @@
+package api_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWithStdout proves the basic embedder-capture story: a buffer
+// passed via api.WithStdout receives (println ...) output as if it
+// were the runtime's stdout.
+func TestWithStdout(t *testing.T) {
+	var buf bytes.Buffer
+	lg, err := api.NewLetGo("withstdout-test", api.WithStdout(&buf))
+	assert.NoError(t, err)
+
+	_, err = lg.Run(`(println "hello-from-api")`)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello-from-api\n", buf.String())
+}
+
+// TestWithStderr proves the same story for *err* — including the
+// previously-broken (binding [*out* *err*] (println ...)) pattern.
+func TestWithStderr(t *testing.T) {
+	var out, err bytes.Buffer
+	lg, errInit := api.NewLetGo("withstderr-test",
+		api.WithStdout(&out),
+		api.WithStderr(&err))
+	assert.NoError(t, errInit)
+
+	// Direct write to *err* via the IOHandle.
+	_, errRun := lg.Run(`(write! *err* "direct-to-err")`)
+	assert.NoError(t, errRun)
+	assert.Equal(t, "", out.String())
+	assert.Equal(t, "direct-to-err", err.String())
+
+	// Reset, then test the binding-redirected println case.
+	out.Reset()
+	err.Reset()
+	_, errRun = lg.Run(`(binding [*out* *err*] (println "redirected"))`)
+	assert.NoError(t, errRun)
+	assert.Equal(t, "", out.String())
+	assert.Equal(t, "redirected\n", err.String())
+}
+
+// TestPrintFnsConsultOut covers all four print fns (print/pr/prn/println)
+// and confirms the runtime correctly routes each through *out*.
+func TestPrintFnsConsultOut(t *testing.T) {
+	var buf bytes.Buffer
+	lg, err := api.NewLetGo("printfns-test", api.WithStdout(&buf))
+	assert.NoError(t, err)
+
+	// Run only processes one form per call, so wrap in a do.
+	_, err = lg.Run(`(do (print "a") (pr "b") (println "c") (prn "d"))`)
+	assert.NoError(t, err)
+	// print: a (no newline)
+	// pr:    "b" (readable, no newline)
+	// println: c (with newline)
+	// prn: "d" (readable, with newline)
+	assert.Equal(t, `a"b"c
+"d"
+`, buf.String())
+}
+
+// TestWithOutStrUnaffected proves the with-out-str rewrite preserves
+// its semantic: nested captures don't leak past the inner binding.
+func TestWithOutStrUnaffected(t *testing.T) {
+	var buf bytes.Buffer
+	lg, err := api.NewLetGo("withoutstr-test", api.WithStdout(&buf))
+	assert.NoError(t, err)
+
+	val, err := lg.Run(`(with-out-str (println "captured"))`)
+	assert.NoError(t, err)
+	// The with-out-str result IS the captured value.
+	assert.Equal(t, `"captured\n"`, val.String())
+	// And nothing leaked to the outer *out*.
+	assert.Equal(t, "", buf.String())
+}
+
+// TestTwoRuntimesIsolation is the regression test for the bug codex
+// caught: WithStdout used to mutate the process-global root binding of
+// core/*out*, so creating a second LetGo would silently redirect the
+// first one's output. The fix moves the binding push to Run scope, so
+// each Run only sees its own configured stream.
+func TestTwoRuntimesIsolation(t *testing.T) {
+	var bufA, bufB bytes.Buffer
+	lgA, err := api.NewLetGo("iso-a", api.WithStdout(&bufA))
+	assert.NoError(t, err)
+	lgB, err := api.NewLetGo("iso-b", api.WithStdout(&bufB))
+	assert.NoError(t, err)
+
+	_, err = lgA.Run(`(println "from-A")`)
+	assert.NoError(t, err)
+	_, err = lgB.Run(`(println "from-B")`)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "from-A\n", bufA.String())
+	assert.Equal(t, "from-B\n", bufB.String())
+
+	// Interleaved: run A again. Should still hit bufA.
+	_, err = lgA.Run(`(println "from-A-again")`)
+	assert.NoError(t, err)
+	assert.Equal(t, "from-A\nfrom-A-again\n", bufA.String())
+	assert.Equal(t, "from-B\n", bufB.String())
+}
+
+// TestNoOptionRuntimeUnaffectedByConfiguredOne — a LetGo constructed
+// without WithStdout must NOT inherit the writer of a previously-
+// constructed configured LetGo. Pre-fix, this would have failed
+// because WithStdout mutated the global root.
+//
+// We can't easily assert against the process os.Stdout from a test,
+// but we CAN assert that the configured runtime's buffer doesn't
+// receive output from the unconfigured one's Run.
+func TestNoOptionRuntimeUnaffectedByConfiguredOne(t *testing.T) {
+	var bufConfigured bytes.Buffer
+	lgConfigured, err := api.NewLetGo("dflt-cfg", api.WithStdout(&bufConfigured))
+	assert.NoError(t, err)
+	lgDefault, err := api.NewLetGo("dflt-no-cfg")
+	assert.NoError(t, err)
+
+	// Configured runtime writes into its buffer.
+	_, err = lgConfigured.Run(`(println "configured")`)
+	assert.NoError(t, err)
+	assert.Equal(t, "configured\n", bufConfigured.String())
+
+	// Default runtime's output goes to os.Stdout (not asserted) — the
+	// load-bearing claim is that it does NOT land in bufConfigured.
+	_, err = lgDefault.Run(`(println "default")`)
+	assert.NoError(t, err)
+	assert.Equal(t, "configured\n", bufConfigured.String())
+}


### PR DESCRIPTION
## Summary

Adds two `pkg/api` constructor options that let a Go embedder redirect a runtime's output without touching globals:

```go
api.New(api.WithStdout(w), api.WithStderr(w2))
```

Each option pushes a dynamic binding on `*out*`/`*err*` **for the scope of `Run`** and pops it on return (per-`Run` scope, leaving the root vars untouched), so two runtimes configured with different writers stay independent. This is the Go-side dual of the JS `LetGoHost.onOutput` that #174 already shipped; once it's in, the `fs.writeSync` shim can eventually retire.

`WithStdin`/`WithEmit` are deliberately **not** exposed here (input is tied to the SAB/`wake()` conversation #174 deferred; a public no-op `WithEmit` is worse than none).

## Follows #206 (merged)

Builds on #206 (`d6d0128`, now merged), which routes print/error through `*out*`/`*err*`; this consumes that `*out*` resolution. Single commit on `main` — `pkg/api/{api,options_test}.go`, +239/-1.

## The open question — instance isolation

`vm.Var`'s binding stack is process-global, not goroutine-local (unlike Clojure-on-JVM). So per-`Run` scoping holds for the common embed-and-run case, but two runtimes whose `Run`s overlap *on different goroutines* can interleave each other's bindings. The tests pin the sequential-isolation guarantee (`TestTwoRuntimesIsolation`, `TestNoOptionRuntimeUnaffectedByConfiguredOne`); true concurrent isolation would need goroutine-local binding stacks in `vm`, which is a bigger change I kept out of scope. Flagging it because it's the part most worth a maintainer's eye.

## Tests

6 Go tests in `pkg/api/options_test.go`: `TestWithStdout`, `TestWithStderr`, `TestPrintFnsConsultOut`, `TestWithOutStrUnaffected`, `TestTwoRuntimesIsolation`, `TestNoOptionRuntimeUnaffectedByConfiguredOne`. `go test ./...` green.

---

Totally open to prototyping other approaches if you had something in mind.
