### PR TITLE
build: cap Go heap (GOMEMLIMIT) for bootstrap/lowering targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,17 @@ REPORT-SCRIPT := scripts/clojure_compat_report.sh
 GOMEMLIMIT ?= 2GiB
 GO-TEST-TIMEOUT ?= 60s
 
+# Export the heap cap to EVERY recipe's environment, not just `make test`.
+# The bootstrap/lowering targets (generate, lowered, parity) shell out to
+# `go run -tags bootstrap` / `go test`, which compile the whole .lg stdlib
+# from source and balloon the heap; uncapped, parallel invocations OOM a
+# 16GB machine. `export` makes GOMEMLIMIT visible to those go subprocesses
+# too. Sub-make/scripts inherit it unless they override.
+export GOMEMLIMIT
+
 # Standard flags + env for `go test`. Use as: $(GO-TEST-ENV) go test $(GO-TEST-FLAGS) ./...
+# GO-TEST-ENV is retained for explicitness at test call sites; the value is
+# already exported above, so it is now belt-and-suspenders.
 GO-TEST-ENV := GOMEMLIMIT=$(GOMEMLIMIT)
 GO-TEST-FLAGS := -timeout $(GO-TEST-TIMEOUT)
 

--- a/scripts/gogen-parity.sh
+++ b/scripts/gogen-parity.sh
@@ -27,6 +27,12 @@
 
 set -euo pipefail
 
+# Bound the Go heap for the bootstrap `go run`/`go test` invocations below.
+# These compile the whole .lg stdlib from source and balloon the heap;
+# uncapped they OOM a 16GB machine. Soft cap — runtime GCs to stay under.
+# Honors an outer GOMEMLIMIT (e.g. from the Makefile export) if already set.
+export GOMEMLIMIT="${GOMEMLIMIT:-2GiB}"
+
 MODE="${1:-default}"
 case "$MODE" in
     --quick)      RUN_JANK=1; RUN_LOWERGO=0; RUN_IRCOMPILE=0 ;;


### PR DESCRIPTION
## Summary

The 2GiB `GOMEMLIMIT` soft cap was only applied to the `make test` recipe (via `GO-TEST-ENV`). The memory-heavy targets — `make generate`, `make lowered`, and `scripts/gogen-parity.sh` — shell out to `go run -tags bootstrap ./cmd/lgbgen` / `go test`, which compile the whole `.lg` stdlib from source and balloon the heap. Uncapped and run in parallel (e.g. the parity script's bootstrap + gogen builds), these can OOM a 16GB machine.

## Changes

- **Makefile**: `export GOMEMLIMIT` so every recipe's `go` subprocess inherits the cap, not just `test`. `GO-TEST-ENV` is kept for explicitness at the test call site (now belt-and-suspenders).
- **scripts/gogen-parity.sh**: default `GOMEMLIMIT=2GiB` (honors an outer value if already set) for its direct bootstrap `go run`/`go test` invocations.

Soft cap — the runtime GCs more aggressively as it approaches the limit rather than growing unbounded. Override with `make … GOMEMLIMIT=4GiB`.

## Why now

Surfaced while reproducing the `-tags bootstrap` CI failures locally: repeated `make generate` / `make lowered` / parity runs drove the machine into the OOM killer because none of those paths inherited the cap that `make test` already had.