### PR TITLE
feat(rt): str/replace + replace-first accept a function replacement

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -1022,6 +1022,68 @@ func isNilValue(v vm.Value) bool {
 	return v == nil || v == vm.NIL
 }
 
+// strReplaceCallback adapts a let-go replacement fn to the Go callback used by
+// (*vm.Regex).ReplaceAllFunc. Per clojure.string/replace semantics, the fn is
+// called with the whole match (a String) when the pattern has no capture
+// groups, or a vector [whole g1 g2 ...] when it does (nil for groups that did
+// not participate). The fn must return a String.
+func strReplaceCallback(fn vm.Fn) func(groups []string, present []bool) (string, error) {
+	return func(groups []string, present []bool) (string, error) {
+		var arg vm.Value
+		if len(groups) <= 1 {
+			arg = vm.String(groups[0])
+		} else {
+			elems := make([]vm.Value, len(groups))
+			for i := range groups {
+				if present[i] {
+					elems[i] = vm.String(groups[i])
+				} else {
+					elems[i] = vm.NIL
+				}
+			}
+			arg = vm.NewArrayVector(elems)
+		}
+		res, err := fn.Invoke([]vm.Value{arg})
+		if err != nil {
+			return "", err
+		}
+		rs, ok := res.(vm.String)
+		if !ok {
+			return "", fmt.Errorf("str-replace replacement function must return a String")
+		}
+		return string(rs), nil
+	}
+}
+
+// literalReplaceFn implements (str/replace s "lit" fn): a literal match with a
+// function replacement, called with the matched substring for each occurrence.
+func literalReplaceFn(lit, s string, fn vm.Fn, first bool) (vm.Value, error) {
+	if lit == "" {
+		return vm.String(s), nil
+	}
+	cb := strReplaceCallback(fn)
+	var b strings.Builder
+	for {
+		idx := strings.Index(s, lit)
+		if idx < 0 {
+			b.WriteString(s)
+			break
+		}
+		b.WriteString(s[:idx])
+		rep, err := cb([]string{lit}, []bool{true})
+		if err != nil {
+			return vm.NIL, err
+		}
+		b.WriteString(rep)
+		s = s[idx+len(lit):]
+		if first {
+			b.WriteString(s)
+			break
+		}
+	}
+	return vm.String(b.String()), nil
+}
+
 func isNaNValue(v vm.Value) bool {
 	if f, ok := v.(vm.Float); ok {
 		return math.IsNaN(float64(f))
@@ -3771,6 +3833,21 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("str-replace expected String")
 		}
+		// Function replacement (clojure.string/replace semantics).
+		if fn, isFn := vs[2].(vm.Fn); isFn {
+			switch m := vs[1].(type) {
+			case *vm.Regex:
+				out, err := m.ReplaceAllFunc(string(s), strReplaceCallback(fn))
+				if err != nil {
+					return vm.NIL, err
+				}
+				return vm.String(out), nil
+			case vm.String:
+				return literalReplaceFn(string(m), string(s), fn, false)
+			default:
+				return vm.NIL, fmt.Errorf("str-replace expected String or Regex")
+			}
+		}
 		r, ok := vs[2].(vm.String)
 		if !ok {
 			return vm.NIL, fmt.Errorf("str-replace expected String")
@@ -3792,6 +3869,21 @@ func installLangNS() {
 		s, ok := vs[0].(vm.String)
 		if !ok {
 			return vm.NIL, fmt.Errorf("str-replace-first expected String")
+		}
+		// Function replacement (clojure.string/replace-first semantics).
+		if fn, isFn := vs[2].(vm.Fn); isFn {
+			switch m := vs[1].(type) {
+			case *vm.Regex:
+				out, err := m.ReplaceFirstFunc(string(s), strReplaceCallback(fn))
+				if err != nil {
+					return vm.NIL, err
+				}
+				return vm.String(out), nil
+			case vm.String:
+				return literalReplaceFn(string(m), string(s), fn, true)
+			default:
+				return vm.NIL, fmt.Errorf("str-replace-first expected String or Regex")
+			}
 		}
 		r, ok := vs[2].(vm.String)
 		if !ok {

--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 )
 
 type theRegexType struct {
@@ -61,6 +62,54 @@ func (l *Regex) ReplaceFirst(s string, replacement string) string {
 	}
 	out := l.re.ExpandString([]byte(s[:loc[0]]), replacement, s, loc)
 	return string(out) + s[loc[1]:]
+}
+
+// ReplaceAllFunc replaces every non-overlapping match using f, matching
+// clojure.string/replace with a function replacement. For each match, f
+// receives the submatch groups: groups[0] is the whole match, groups[i] the
+// i-th capture group; present[i] is false for a group that did not
+// participate (so the caller can pass nil, as Clojure's re-groups does).
+func (l *Regex) ReplaceAllFunc(s string, f func(groups []string, present []bool) (string, error)) (string, error) {
+	return l.replaceFunc(s, f, false)
+}
+
+// ReplaceFirstFunc is ReplaceAllFunc limited to the first match, matching
+// clojure.string/replace-first with a function replacement.
+func (l *Regex) ReplaceFirstFunc(s string, f func(groups []string, present []bool) (string, error)) (string, error) {
+	return l.replaceFunc(s, f, true)
+}
+
+func (l *Regex) replaceFunc(s string, f func(groups []string, present []bool) (string, error), first bool) (string, error) {
+	n := -1
+	if first {
+		n = 1
+	}
+	matches := l.re.FindAllStringSubmatchIndex(s, n)
+	if matches == nil {
+		return s, nil
+	}
+	var b strings.Builder
+	last := 0
+	for _, m := range matches {
+		b.WriteString(s[last:m[0]])
+		ng := len(m) / 2
+		groups := make([]string, ng)
+		present := make([]bool, ng)
+		for i := 0; i < ng; i++ {
+			if m[2*i] >= 0 {
+				groups[i] = s[m[2*i]:m[2*i+1]]
+				present[i] = true
+			}
+		}
+		rep, err := f(groups, present)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(rep)
+		last = m[1]
+	}
+	b.WriteString(s[last:])
+	return b.String(), nil
 }
 
 func (l *Regex) FindStringSubmatch(s string) []string {

--- a/test/string_replace_fn_test.lg
+++ b/test/string_replace_fn_test.lg
@@ -1,0 +1,45 @@
+;; clojure.string/replace + replace-first with a FUNCTION replacement.
+;; The fn is called per match with the whole match (a String) when the
+;; pattern has no capture groups, or a vector [whole g1 g2 ...] when it does;
+;; it must return a String.
+(ns test.string-replace-fn-test
+  (:require
+   [string :as str]
+   [test :refer :all]))
+
+(deftest replace-regex-fn-no-groups
+  (testing "fn receives the whole match string when there are no groups"
+    (is (= "a<1>b<2>"
+           (str/replace "a1b2" #"\d" (fn [m] (str "<" m ">")))))))
+
+(deftest replace-regex-fn-with-groups
+  (testing "fn receives a vector [whole g1 g2 ...] when the pattern has groups"
+    (is (= "a[1]b[2]"
+           (str/replace "a1b2" #"(\d)" (fn [[_ g1]] (str "[" g1 "]")))))
+    (is (= "John|Smith"
+           (str/replace "John Smith" #"(\w+) (\w+)"
+                        (fn [[_ a b]] (str a "|" b)))))))
+
+(deftest replace-regex-fn-multigroup-yamlstar-shape
+  (testing "destructuring [[_ n1 n2]] over two groups, as yamlstar scalar folding does"
+    (is (= "xXy"
+           (str/replace "x\ny" #"(\n)(\n*)"
+                        (fn [[_ _n1 n2]] (if (pos? (count n2)) n2 "X")))))))
+
+(deftest replace-first-regex-fn
+  (testing "replace-first calls the fn only for the first match"
+    (is (= "aXb2"
+           (str/replace-first "a1b2" #"\d" (fn [_] "X"))))))
+
+(deftest replace-literal-fn
+  (testing "a literal-string match with a fn replacement"
+    (is (= "a/b/c"
+           (str/replace "a.b.c" "." (fn [_] "/"))))
+    (is (= "a/b.c"
+           (str/replace-first "a.b.c" "." (fn [_] "/"))))))
+
+(deftest replace-string-and-regex-string-still-work
+  (testing "string and regex replacements with a String replacement are unchanged"
+    (is (= "hell0 w0rld" (str/replace "hello world" "o" "0")))
+    (is (= "a#b#c#" (str/replace "a1b2c3" #"[0-9]" "#")))
+    (is (= "Smith John" (str/replace "John Smith" #"(\w+) (\w+)" "$2 $1")))))


### PR DESCRIPTION
## What

`clojure.string/replace` and `replace-first` now accept a **function** as the replacement, matching Clojure semantics. Previously the replacement had to be a `String` (`str-replace expected String`).

Per match, the fn is called with:
- the **whole match** (a `String`) when the pattern has no capture groups, or
- a **vector** `[whole g1 g2 ...]` when it does (`nil` for groups that didn't participate, as `re-groups` does).

The fn must return a `String`. Works for both regex and literal-string matches, for `replace` and `replace-first`.

```clojure
(str/replace "a1b2" #"(\d)" (fn [[_ d]] (str "[" d "]"))) ;=> "a[1]b[2]"
(str/replace "a1b2" #"\d"   (fn [m] (str "<" m ">")))      ;=> "a<1>b<2>"
```

## Why

Standard Clojure feature that was missing; surfaced while running a real Clojure codebase (yamlstar's YAML parser) on let-go, whose scalar-folding uses `(str/replace text #"(\n)(\n*)" (fn [[_ n1 n2]] ...))`.

## How

- `pkg/vm/regex.go`: `ReplaceAllFunc` / `ReplaceFirstFunc` iterate matches via `FindAllStringSubmatchIndex` and call back with the submatch groups.
- `pkg/rt/lang.go`: `str-replace` / `str-replace-first` dispatch to the fn path when the replacement is a `vm.Fn`; `strReplaceCallback` builds the Clojure-shaped arg (string vs. vector) and requires a `String` return; `literalReplaceFn` handles literal-match + fn.

## Tests

`test/string_replace_fn_test.lg` covers no-group/with-group/multi-group regex, `replace-first`, literal+fn, and confirms the existing String/`$N` replacement paths are unchanged. `go test ./pkg/vm/ ./pkg/rt/ ./test/` green.