### PR TITLE
Publish Homebrew formula to shared tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
           GORELEASER_PAT: ${{ secrets.GORELEASER_PAT }}
 
-      - name: Merge Homebrew cask PR
+      - name: Merge Homebrew formula PR
         env:
           GH_TOKEN: ${{ secrets.GORELEASER_PAT }}
-        run: gh pr merge "goreleaser-cask-${GITHUB_REF_NAME#v}" --repo nooga/let-go --squash --admin --delete-branch
+        run: gh pr merge "let-go-${GITHUB_REF_NAME#v}" --repo nooga/homebrew-tap --squash --admin --delete-branch

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,7 +44,15 @@ builds:
       - arm
 
 archives:
-  - formats: ["tar.gz"]
+  - id: unix
+    ids:
+      - unix
+    formats: ["tar.gz"]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: plan9
+    ids:
+      - plan9
+    formats: ["tar.gz"]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
@@ -58,25 +66,22 @@ changelog:
       - '^test:'
       - '^chore:'
 
-homebrew_casks:
+brews:
   - name: let-go
     ids:
-      - default
-    binaries:
-      - lg
-    directory: Casks
+      - unix
+    goarm: 7
+    directory: Formula
+    install: |
+      bin.install "lg"
     repository:
       owner: nooga
-      name: let-go
+      name: homebrew-tap
       token: "{{ .Env.GORELEASER_PAT }}"
-      branch: "goreleaser-cask-{{ .Version }}"
+      branch: "let-go-{{ .Version }}"
       pull_request:
         enabled: true
         base:
           branch: main
     homepage: https://github.com/nooga/let-go
     description: Clojure dialect implemented as a bytecode VM in Go
-    hooks:
-      post:
-        install: |
-          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/lg"] if OS.mac?

--- a/README.md
+++ b/README.md
@@ -223,8 +223,7 @@ build of let-go.
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew tap nooga/let-go https://github.com/nooga/let-go
-brew install let-go
+brew install nooga/tap/let-go
 ```
 
 ### Download


### PR DESCRIPTION
## Summary
- publish the let-go Homebrew formula to nooga/homebrew-tap
- merge the generated formula PR in the shared tap repo
- update install docs to use nooga/tap

## Checks
- ruby YAML parse for .goreleaser.yml and release workflow
- git diff --check