### PR TITLE
chore(pre-commit): add checkmake hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,8 @@ repos:
         types: [go]
         pass_filenames: false
         stages: [pre-push]
+  - repo: https://github.com/checkmake/checkmake.git
+    rev: v0.2.2
+    hooks:
+      - id: checkmake
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary
- add the upstream `checkmake` hook to `.pre-commit-config.yaml`
- run Makefile validation during `pre-commit`
- keep the change isolated from the larger `land-genmanifest` branch


