### PR TITLE
feat(rt): route term/* ANSI output through *out*

### DIFF
--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -536,10 +536,16 @@ func installTermNS() {
 	})
 	ns.Def("main-screen", mainScreen)
 
-	// flush — flush stdout
-	flushFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		os.Stdout.Sync()
-		return vm.NIL, nil
+	// flush — sync the active *out* binding so flush hits the same sink the
+	// term/* bytes did. File-backed handles fsync; buffered embedder writers
+	// flush; otherwise no-op. Falls back to os.Stdout only at early boot
+	// (before *out* is installed). Pre-#223 this synced os.Stdout directly,
+	// which diverged once the term/* ops started honoring *out*.
+	flushFn := vm.NewCtxNativeFn("flush", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		if h := resolveIOHandleVar(ec, "*out*"); h != nil {
+			return vm.NIL, h.Sync()
+		}
+		return vm.NIL, os.Stdout.Sync()
 	})
 	ns.Def("flush", flushFn)
 

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -361,7 +361,7 @@ func installTermNS() {
 	ns.Def("open-pty", openPty)
 
 	// move-cursor — (move-cursor col row) — 1-based ANSI positioning
-	moveCursor, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	moveCursor := vm.NewCtxNativeFn("move-cursor", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 2 {
 			return vm.NIL, fmt.Errorf("move-cursor expects 2 args (col row)")
 		}
@@ -370,48 +370,44 @@ func installTermNS() {
 		if !ok1 || !ok2 {
 			return vm.NIL, fmt.Errorf("move-cursor expects integers")
 		}
-		fmt.Printf("\033[%d;%dH", int(row), int(col))
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, fmt.Sprintf("\033[%d;%dH", int(row), int(col)))
 	})
 	ns.Def("move-cursor", moveCursor)
 
 	// clear — clear screen
-	clearFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[2J")
-		return vm.NIL, nil
+	clearFn := vm.NewCtxNativeFn("clear", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[2J")
 	})
 	ns.Def("clear", clearFn)
 
 	// clear-line — clear current line
-	clearLine, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[2K")
-		return vm.NIL, nil
+	clearLine := vm.NewCtxNativeFn("clear-line", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[2K")
 	})
 	ns.Def("clear-line", clearLine)
 
 	// hide-cursor — hide terminal cursor
-	hideCursor, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?25l")
-		return vm.NIL, nil
+	hideCursor := vm.NewCtxNativeFn("hide-cursor", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?25l")
 	})
 	ns.Def("hide-cursor", hideCursor)
 
 	// show-cursor — show terminal cursor
-	showCursor, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?25h")
-		return vm.NIL, nil
+	showCursor := vm.NewCtxNativeFn("show-cursor", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?25h")
 	})
 	ns.Def("show-cursor", showCursor)
 
 	// set-fg — (set-fg r g b) or (set-fg color-code)
-	setFg, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	setFg := vm.NewCtxNativeFn("set-fg", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var seq string
 		switch len(vs) {
 		case 1:
 			c, ok := vs[0].(vm.Int)
 			if !ok {
 				return vm.NIL, fmt.Errorf("set-fg expects integer color code")
 			}
-			fmt.Printf("\033[38;5;%dm", int(c))
+			seq = fmt.Sprintf("\033[38;5;%dm", int(c))
 		case 3:
 			r, ok1 := vs[0].(vm.Int)
 			g, ok2 := vs[1].(vm.Int)
@@ -419,23 +415,24 @@ func installTermNS() {
 			if !ok1 || !ok2 || !ok3 {
 				return vm.NIL, fmt.Errorf("set-fg expects 3 integers (r g b)")
 			}
-			fmt.Printf("\033[38;2;%d;%d;%dm", int(r), int(g), int(b))
+			seq = fmt.Sprintf("\033[38;2;%d;%d;%dm", int(r), int(g), int(b))
 		default:
 			return vm.NIL, fmt.Errorf("set-fg expects 1 or 3 args")
 		}
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, seq)
 	})
 	ns.Def("set-fg", setFg)
 
 	// set-bg — (set-bg r g b) or (set-bg color-code)
-	setBg, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	setBg := vm.NewCtxNativeFn("set-bg", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var seq string
 		switch len(vs) {
 		case 1:
 			c, ok := vs[0].(vm.Int)
 			if !ok {
 				return vm.NIL, fmt.Errorf("set-bg expects integer color code")
 			}
-			fmt.Printf("\033[48;5;%dm", int(c))
+			seq = fmt.Sprintf("\033[48;5;%dm", int(c))
 		case 3:
 			r, ok1 := vs[0].(vm.Int)
 			g, ok2 := vs[1].(vm.Int)
@@ -443,44 +440,40 @@ func installTermNS() {
 			if !ok1 || !ok2 || !ok3 {
 				return vm.NIL, fmt.Errorf("set-bg expects 3 integers (r g b)")
 			}
-			fmt.Printf("\033[48;2;%d;%d;%dm", int(r), int(g), int(b))
+			seq = fmt.Sprintf("\033[48;2;%d;%d;%dm", int(r), int(g), int(b))
 		default:
 			return vm.NIL, fmt.Errorf("set-bg expects 1 or 3 args")
 		}
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, seq)
 	})
 	ns.Def("set-bg", setBg)
 
 	// reset-style — reset all ANSI attributes
-	resetStyle, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[0m")
-		return vm.NIL, nil
+	resetStyle := vm.NewCtxNativeFn("reset-style", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[0m")
 	})
 	ns.Def("reset-style", resetStyle)
 
 	// bold — enable bold
-	bold, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[1m")
-		return vm.NIL, nil
+	bold := vm.NewCtxNativeFn("bold", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[1m")
 	})
 	ns.Def("bold", bold)
 
 	// underline — enable underline
-	underline, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[4m")
-		return vm.NIL, nil
+	underline := vm.NewCtxNativeFn("underline", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[4m")
 	})
 	ns.Def("underline", underline)
 
 	// inverse — enable inverse/reverse video
-	inverse, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[7m")
-		return vm.NIL, nil
+	inverse := vm.NewCtxNativeFn("inverse", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[7m")
 	})
 	ns.Def("inverse", inverse)
 
 	// write — (write str) — write string at current cursor position, no newline
-	writeFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	writeFn := vm.NewCtxNativeFn("write", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("write expects 1 arg")
 		}
@@ -490,13 +483,12 @@ func installTermNS() {
 		} else {
 			s = vs[0].String()
 		}
-		fmt.Print(s)
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, s)
 	})
 	ns.Def("write", writeFn)
 
 	// write-at — (write-at col row str) — write string at position
-	writeAt, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	writeAt := vm.NewCtxNativeFn("write-at", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 3 {
 			return vm.NIL, fmt.Errorf("write-at expects 3 args (col row str)")
 		}
@@ -511,8 +503,7 @@ func installTermNS() {
 		} else {
 			s = vs[2].String()
 		}
-		fmt.Printf("\033[%d;%dH%s", int(row), int(col), s)
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, fmt.Sprintf("\033[%d;%dH%s", int(row), int(col), s))
 	})
 	ns.Def("write-at", writeAt)
 
@@ -534,16 +525,14 @@ func installTermNS() {
 	ns.Def("char-width", charWidth)
 
 	// alternate-screen — switch to alternate screen buffer
-	altScreen, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?1049h")
-		return vm.NIL, nil
+	altScreen := vm.NewCtxNativeFn("alternate-screen", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1049h")
 	})
 	ns.Def("alternate-screen", altScreen)
 
 	// main-screen — switch back to main screen buffer
-	mainScreen, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?1049l")
-		return vm.NIL, nil
+	mainScreen := vm.NewCtxNativeFn("main-screen", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1049l")
 	})
 	ns.Def("main-screen", mainScreen)
 

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -186,9 +186,12 @@ func installTermNS() {
 	})
 	ns.Def("char-width", charWidth)
 
-	flushFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		os.Stdout.Sync()
-		return vm.NIL, nil
+	// flush — sync the active *out* binding (see term.go for rationale).
+	flushFn := vm.NewCtxNativeFn("flush", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		if h := resolveIOHandleVar(ec, "*out*"); h != nil {
+			return vm.NIL, h.Sync()
+		}
+		return vm.NIL, os.Stdout.Sync()
 	})
 	ns.Def("flush", flushFn)
 

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -16,8 +16,9 @@ import (
 )
 
 // Plan 9 has no termios/ioctl. raw-mode/size/pty are stubbed; the ANSI output
-// functions still run via fmt.Print (rio won't render escapes, but they're
-// harmless). If you need real terminal control on plan9, wire in /dev/cons here.
+// functions route through *out* (WriteToOut) like native (rio won't render
+// escapes, but they're harmless). If you need real terminal control on plan9,
+// wire in /dev/cons here.
 
 func init() { RegisterInstaller(installTermNS) }
 
@@ -59,7 +60,7 @@ func installTermNS() {
 	})
 	ns.Def("open-pty", openPty)
 
-	moveCursor, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	moveCursor := vm.NewCtxNativeFn("move-cursor", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 2 {
 			return vm.NIL, fmt.Errorf("move-cursor expects 2 args (col row)")
 		}
@@ -68,37 +69,35 @@ func installTermNS() {
 		if !ok1 || !ok2 {
 			return vm.NIL, fmt.Errorf("move-cursor expects integers")
 		}
-		fmt.Printf("\033[%d;%dH", int(row), int(col))
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, fmt.Sprintf("\033[%d;%dH", int(row), int(col)))
 	})
 	ns.Def("move-cursor", moveCursor)
 
-	ansi := func(seq string) vm.Value {
-		fn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-			fmt.Print(seq)
-			return vm.NIL, nil
+	ansi := func(name, seq string) vm.Value {
+		return vm.NewCtxNativeFn(name, func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+			return vm.NIL, WriteToOut(ec, seq)
 		})
-		return fn
 	}
-	ns.Def("clear", ansi("\033[2J"))
-	ns.Def("clear-line", ansi("\033[2K"))
-	ns.Def("hide-cursor", ansi("\033[?25l"))
-	ns.Def("show-cursor", ansi("\033[?25h"))
-	ns.Def("reset-style", ansi("\033[0m"))
-	ns.Def("bold", ansi("\033[1m"))
-	ns.Def("underline", ansi("\033[4m"))
-	ns.Def("inverse", ansi("\033[7m"))
-	ns.Def("alternate-screen", ansi("\033[?1049h"))
-	ns.Def("main-screen", ansi("\033[?1049l"))
+	ns.Def("clear", ansi("clear", "\033[2J"))
+	ns.Def("clear-line", ansi("clear-line", "\033[2K"))
+	ns.Def("hide-cursor", ansi("hide-cursor", "\033[?25l"))
+	ns.Def("show-cursor", ansi("show-cursor", "\033[?25h"))
+	ns.Def("reset-style", ansi("reset-style", "\033[0m"))
+	ns.Def("bold", ansi("bold", "\033[1m"))
+	ns.Def("underline", ansi("underline", "\033[4m"))
+	ns.Def("inverse", ansi("inverse", "\033[7m"))
+	ns.Def("alternate-screen", ansi("alternate-screen", "\033[?1049h"))
+	ns.Def("main-screen", ansi("main-screen", "\033[?1049l"))
 
-	setFg, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	setFg := vm.NewCtxNativeFn("set-fg", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var seq string
 		switch len(vs) {
 		case 1:
 			c, ok := vs[0].(vm.Int)
 			if !ok {
 				return vm.NIL, fmt.Errorf("set-fg expects integer color code")
 			}
-			fmt.Printf("\033[38;5;%dm", int(c))
+			seq = fmt.Sprintf("\033[38;5;%dm", int(c))
 		case 3:
 			r, ok1 := vs[0].(vm.Int)
 			g, ok2 := vs[1].(vm.Int)
@@ -106,22 +105,23 @@ func installTermNS() {
 			if !ok1 || !ok2 || !ok3 {
 				return vm.NIL, fmt.Errorf("set-fg expects 3 integers (r g b)")
 			}
-			fmt.Printf("\033[38;2;%d;%d;%dm", int(r), int(g), int(b))
+			seq = fmt.Sprintf("\033[38;2;%d;%d;%dm", int(r), int(g), int(b))
 		default:
 			return vm.NIL, fmt.Errorf("set-fg expects 1 or 3 args")
 		}
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, seq)
 	})
 	ns.Def("set-fg", setFg)
 
-	setBg, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	setBg := vm.NewCtxNativeFn("set-bg", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var seq string
 		switch len(vs) {
 		case 1:
 			c, ok := vs[0].(vm.Int)
 			if !ok {
 				return vm.NIL, fmt.Errorf("set-bg expects integer color code")
 			}
-			fmt.Printf("\033[48;5;%dm", int(c))
+			seq = fmt.Sprintf("\033[48;5;%dm", int(c))
 		case 3:
 			r, ok1 := vs[0].(vm.Int)
 			g, ok2 := vs[1].(vm.Int)
@@ -129,15 +129,15 @@ func installTermNS() {
 			if !ok1 || !ok2 || !ok3 {
 				return vm.NIL, fmt.Errorf("set-bg expects 3 integers (r g b)")
 			}
-			fmt.Printf("\033[48;2;%d;%d;%dm", int(r), int(g), int(b))
+			seq = fmt.Sprintf("\033[48;2;%d;%d;%dm", int(r), int(g), int(b))
 		default:
 			return vm.NIL, fmt.Errorf("set-bg expects 1 or 3 args")
 		}
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, seq)
 	})
 	ns.Def("set-bg", setBg)
 
-	writeFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	writeFn := vm.NewCtxNativeFn("write", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("write expects 1 arg")
 		}
@@ -147,12 +147,11 @@ func installTermNS() {
 		} else {
 			s = vs[0].String()
 		}
-		fmt.Print(s)
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, s)
 	})
 	ns.Def("write", writeFn)
 
-	writeAt, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	writeAt := vm.NewCtxNativeFn("write-at", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 3 {
 			return vm.NIL, fmt.Errorf("write-at expects 3 args (col row str)")
 		}
@@ -167,8 +166,7 @@ func installTermNS() {
 		} else {
 			s = vs[2].String()
 		}
-		fmt.Printf("\033[%d;%dH%s", int(row), int(col), s)
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, fmt.Sprintf("\033[%d;%dH%s", int(row), int(col), s))
 	})
 	ns.Def("write-at", writeAt)
 

--- a/pkg/rt/term_wasm.go
+++ b/pkg/rt/term_wasm.go
@@ -130,10 +130,12 @@ func installTermNS() {
 	})
 	ns.Def("size", sizeFn)
 
-	// --- Output functions — identical to native, just emit ANSI via fmt.Print ---
-	// xterm.js handles all ANSI escape sequences natively.
+	// --- Output functions — identical to native; route ANSI through *out* ---
+	// (WriteToOut) so (binding [*out* …]) is honored. xterm.js handles ANSI
+	// natively. *out*'s root is os.Stdout, so the served bundle's output still
+	// flows through the existing fs.writeSync path until the host-writer lands.
 
-	moveCursor, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	moveCursor := vm.NewCtxNativeFn("move-cursor", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 2 {
 			return vm.NIL, fmt.Errorf("move-cursor expects 2 args (col row)")
 		}
@@ -142,43 +144,39 @@ func installTermNS() {
 		if !ok1 || !ok2 {
 			return vm.NIL, fmt.Errorf("move-cursor expects integers")
 		}
-		fmt.Printf("\033[%d;%dH", int(row), int(col))
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, fmt.Sprintf("\033[%d;%dH", int(row), int(col)))
 	})
 	ns.Def("move-cursor", moveCursor)
 
-	clearFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[2J")
-		return vm.NIL, nil
+	clearFn := vm.NewCtxNativeFn("clear", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[2J")
 	})
 	ns.Def("clear", clearFn)
 
-	clearLine, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[2K")
-		return vm.NIL, nil
+	clearLine := vm.NewCtxNativeFn("clear-line", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[2K")
 	})
 	ns.Def("clear-line", clearLine)
 
-	hideCursor, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?25l")
-		return vm.NIL, nil
+	hideCursor := vm.NewCtxNativeFn("hide-cursor", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?25l")
 	})
 	ns.Def("hide-cursor", hideCursor)
 
-	showCursor, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?25h")
-		return vm.NIL, nil
+	showCursor := vm.NewCtxNativeFn("show-cursor", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?25h")
 	})
 	ns.Def("show-cursor", showCursor)
 
-	setFg, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	setFg := vm.NewCtxNativeFn("set-fg", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var seq string
 		switch len(vs) {
 		case 1:
 			c, ok := vs[0].(vm.Int)
 			if !ok {
 				return vm.NIL, fmt.Errorf("set-fg expects integer color code")
 			}
-			fmt.Printf("\033[38;5;%dm", int(c))
+			seq = fmt.Sprintf("\033[38;5;%dm", int(c))
 		case 3:
 			r, ok1 := vs[0].(vm.Int)
 			g, ok2 := vs[1].(vm.Int)
@@ -186,22 +184,23 @@ func installTermNS() {
 			if !ok1 || !ok2 || !ok3 {
 				return vm.NIL, fmt.Errorf("set-fg expects 3 integers (r g b)")
 			}
-			fmt.Printf("\033[38;2;%d;%d;%dm", int(r), int(g), int(b))
+			seq = fmt.Sprintf("\033[38;2;%d;%d;%dm", int(r), int(g), int(b))
 		default:
 			return vm.NIL, fmt.Errorf("set-fg expects 1 or 3 args")
 		}
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, seq)
 	})
 	ns.Def("set-fg", setFg)
 
-	setBg, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	setBg := vm.NewCtxNativeFn("set-bg", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var seq string
 		switch len(vs) {
 		case 1:
 			c, ok := vs[0].(vm.Int)
 			if !ok {
 				return vm.NIL, fmt.Errorf("set-bg expects integer color code")
 			}
-			fmt.Printf("\033[48;5;%dm", int(c))
+			seq = fmt.Sprintf("\033[48;5;%dm", int(c))
 		case 3:
 			r, ok1 := vs[0].(vm.Int)
 			g, ok2 := vs[1].(vm.Int)
@@ -209,39 +208,35 @@ func installTermNS() {
 			if !ok1 || !ok2 || !ok3 {
 				return vm.NIL, fmt.Errorf("set-bg expects 3 integers (r g b)")
 			}
-			fmt.Printf("\033[48;2;%d;%d;%dm", int(r), int(g), int(b))
+			seq = fmt.Sprintf("\033[48;2;%d;%d;%dm", int(r), int(g), int(b))
 		default:
 			return vm.NIL, fmt.Errorf("set-bg expects 1 or 3 args")
 		}
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, seq)
 	})
 	ns.Def("set-bg", setBg)
 
-	resetStyle, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[0m")
-		return vm.NIL, nil
+	resetStyle := vm.NewCtxNativeFn("reset-style", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[0m")
 	})
 	ns.Def("reset-style", resetStyle)
 
-	bold, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[1m")
-		return vm.NIL, nil
+	bold := vm.NewCtxNativeFn("bold", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[1m")
 	})
 	ns.Def("bold", bold)
 
-	underline, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[4m")
-		return vm.NIL, nil
+	underline := vm.NewCtxNativeFn("underline", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[4m")
 	})
 	ns.Def("underline", underline)
 
-	inverse, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[7m")
-		return vm.NIL, nil
+	inverse := vm.NewCtxNativeFn("inverse", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[7m")
 	})
 	ns.Def("inverse", inverse)
 
-	writeFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	writeFn := vm.NewCtxNativeFn("write", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("write expects 1 arg")
 		}
@@ -251,12 +246,11 @@ func installTermNS() {
 		} else {
 			s = vs[0].String()
 		}
-		fmt.Print(s)
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, s)
 	})
 	ns.Def("write", writeFn)
 
-	writeAt, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	writeAt := vm.NewCtxNativeFn("write-at", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 3 {
 			return vm.NIL, fmt.Errorf("write-at expects 3 args (col row str)")
 		}
@@ -271,8 +265,7 @@ func installTermNS() {
 		} else {
 			s = vs[2].String()
 		}
-		fmt.Printf("\033[%d;%dH%s", int(row), int(col), s)
-		return vm.NIL, nil
+		return vm.NIL, WriteToOut(ec, fmt.Sprintf("\033[%d;%dH%s", int(row), int(col), s))
 	})
 	ns.Def("write-at", writeAt)
 
@@ -292,15 +285,13 @@ func installTermNS() {
 	})
 	ns.Def("char-width", charWidth)
 
-	altScreen, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?1049h")
-		return vm.NIL, nil
+	altScreen := vm.NewCtxNativeFn("alternate-screen", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1049h")
 	})
 	ns.Def("alternate-screen", altScreen)
 
-	mainScreen, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		fmt.Print("\033[?1049l")
-		return vm.NIL, nil
+	mainScreen := vm.NewCtxNativeFn("main-screen", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1049l")
 	})
 	ns.Def("main-screen", mainScreen)
 

--- a/pkg/rt/term_wasm.go
+++ b/pkg/rt/term_wasm.go
@@ -295,8 +295,17 @@ func installTermNS() {
 	})
 	ns.Def("main-screen", mainScreen)
 
-	// flush — flush buffered output to xterm.js via postMessage
-	flushFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	// flush — sync the active *out* binding, then drive the JS-side transport
+	// flush so the default screen path still reaches xterm.js. A rebound
+	// (buffered/embedder) *out* is flushed by Sync(); _lgFlush then no-ops on
+	// the empty screen buffer. The default-root *out* wraps os.Stdout, whose
+	// Sync() is a no-op in wasm, so _lgFlush stays the real screen flush.
+	flushFn := vm.NewCtxNativeFn("flush", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		if h := resolveIOHandleVar(ec, "*out*"); h != nil {
+			if err := h.Sync(); err != nil {
+				return vm.NIL, err
+			}
+		}
 		flush := js.Global().Get("_lgFlush")
 		if !flush.IsUndefined() {
 			flush.Invoke()

--- a/test/term_out_binding_test.lg
+++ b/test/term_out_binding_test.lg
@@ -1,0 +1,65 @@
+;; term/* ANSI output now consults the CURRENT binding of *out*, the
+;; same way println/print/pr/prn do (test.io-binding-test). Before this
+;; change every term/* op wrote ANSI straight to os.Stdout via fmt.Print,
+;; so (binding [*out* x] (term/clear)) silently ignored x. These tests pin
+;; the fixed behavior — and, by capturing escapes through with-out-str,
+;; double as proof that ANSI rides in-band on *out* (one stream, not two).
+(ns test.term-out-binding-test
+  (:require [test :refer :all]))
+
+;; ----------------------------------------------------------------
+;; ANSI control sequences route through *out*'s current binding.
+;; \u001b is ESC. move-cursor/write-at take (col row ...) and emit
+;; ESC[row;col... (row before col, per the ANSI CUP convention).
+;; ----------------------------------------------------------------
+
+(deftest clear-consults-out-binding
+  (testing "term/clear emits ESC[2J through *out*"
+    (is (= "\u001b[2J"
+           (with-out-str (term/clear))))))
+
+(deftest move-cursor-consults-out-binding
+  (testing "term/move-cursor col=3 row=5 emits ESC[5;3H through *out*"
+    (is (= "\u001b[5;3H"
+           (with-out-str (term/move-cursor 3 5))))))
+
+(deftest write-consults-out-binding
+  (testing "term/write emits its string through *out*"
+    (is (= "X"
+           (with-out-str (term/write "X"))))))
+
+(deftest set-fg-consults-out-binding
+  (testing "term/set-fg r g b emits the truecolor SGR through *out*"
+    (is (= "\u001b[38;2;1;2;3m"
+           (with-out-str (term/set-fg 1 2 3))))))
+
+(deftest write-at-consults-out-binding
+  (testing "term/write-at col=2 row=4 emits ESC[4;2H + string through *out*"
+    (is (= "\u001b[4;2Hhi"
+           (with-out-str (term/write-at 2 4 "hi"))))))
+
+;; ----------------------------------------------------------------
+;; The architectural claim: ANSI control and text share ONE stream.
+;; A render-shaped sequence captures as a single interleaved string.
+;; ----------------------------------------------------------------
+
+(deftest ansi-and-text-interleave-on-one-stream
+  (testing "cursor move + glyph + style reset capture as one in-band string"
+    (is (= "\u001b[1;1HX\u001b[0m"
+           (with-out-str
+             (term/move-cursor 1 1)
+             (term/write "X")
+             (term/reset-style))))))
+
+;; ----------------------------------------------------------------
+;; The load-bearing new behavior: term/* honors a *out* rebind. Before
+;; this change the outer with-out-str would have captured the ESC[2J
+;; even though the inner binding pointed *out* elsewhere.
+;; ----------------------------------------------------------------
+
+(deftest term-respects-out-rebind
+  (testing "(binding [*out* *err*] (term/clear)) does NOT hit the outer *out*"
+    (let [outer (with-out-str
+                  (binding [*out* *err*]
+                    (term/clear)))]
+      (is (= "" outer)))))

--- a/test/term_out_binding_test.lg
+++ b/test/term_out_binding_test.lg
@@ -58,8 +58,35 @@
 ;; ----------------------------------------------------------------
 
 (deftest term-respects-out-rebind
-  (testing "(binding [*out* *err*] (term/clear)) does NOT hit the outer *out*"
-    (let [outer (with-out-str
-                  (binding [*out* *err*]
+  (testing "(binding [*out* file] (term/clear)) routes to the rebound handle, not the outer *out*"
+    ;; Rebind to a temp file rather than *err*: *err* is a real terminal, so
+    ;; the ESC[2J would clear/pollute the terminal or CI log during the run.
+    ;; The file lets us assert both halves — the outer *out* captured nothing,
+    ;; and the rebound handle received the escape.
+    (let [path "/tmp/letgo-term-out-rebind-test.txt"
+          f (open path :write)
+          outer (with-out-str
+                  (binding [*out* f]
                     (term/clear)))]
-      (is (= "" outer)))))
+      (close! f)
+      (is (= "" outer))
+      (is (= "\u001b[2J" (slurp path))))))
+
+;; ----------------------------------------------------------------
+;; term/flush syncs the ACTIVE *out* binding, not the process stdout —
+;; so a redirected render flushes the same sink that received the bytes.
+;; A file handle is unbuffered, so this pins that flush resolves *out*
+;; and targets it without error; it can't catch a byte-level missed
+;; flush. The buffered-writer case (where the flush is load-bearing) is
+;; an embedder concern, and the wasm xterm flush runs every render frame.
+;; ----------------------------------------------------------------
+
+(deftest flush-targets-out-binding
+  (testing "(binding [*out* file] (term/write ...) (term/flush)) lands in the rebound handle"
+    (let [path "/tmp/letgo-term-flush-test.txt"
+          f (open path :write)]
+      (binding [*out* f]
+        (term/write "frame")
+        (term/flush))
+      (close! f)
+      (is (= "frame" (slurp path))))))


### PR DESCRIPTION
## Summary

#206 made `print`/`pr`/`prn`/`println` consult the current dynamic binding of `*out*`. The `term/*` ANSI ops never got the same treatment: `move-cursor`, `clear`, `set-fg`, `write`, and the rest wrote their escape sequences straight to `os.Stdout` via `fmt.Print`. So `(binding [*out* x] (term/clear))` silently ignored `x`, the same compat bug #206 fixed for the print fns, still live for the terminal-control ops.

This routes all 15 ANSI output ops through the existing `WriteToOut` helper, so they honor `*out*` the way `println` does. This is the "Phase 1.5" the I/O proposal called out.

## Context: where this fits

This is a small, separable follow-up in the #79 browser-interop line, after the two merged PRs:

- **#206** (PR1) — print fns honor `*out*`, error sites honor `*err*`.
- **#207** (PR2) — `pkg/api.WithStdout`/`WithStderr` embedder options.
- **this PR** — the `term/*` ANSI ops, the remaining set that still bypassed `*out*`.
- **PR3** (next) — the WASM host writer that lets a browser shell receive output directly, retiring `fs.writeSync`.

It depends only on what's already merged. It does not touch `pkg/vm`, so it's independent of the in-flight deref work (#220).

## Why this matters

`(binding [*out* h] ...)` is how you redirect output in let-go, and it already works for the print fns and `write!`. For `term/*` it was a no-op: the escape sequence went to `os.Stdout` regardless of the binding. That blocks the obvious uses: capturing a TUI frame to a string, rendering into a buffer, or sending control and text to the same redirected sink a browser shell provides.

It also means ANSI and text now ride the same stream. `(with-out-str (term/move-cursor 1 1) (term/write "X") (term/reset-style))` captures `"\033[1;1HX\033[0m"` as one in-band string: control and text interleaved, exactly as on a real TTY, instead of the control half leaking past the capture.

## What changed

All 15 ANSI output ops across the three build targets — `term.go` (native), `term_wasm.go`, `term_plan9.go` — become context-aware builtins. Each is now a `vm.NewCtxNativeFn` that receives the `ExecContext` and threads it into `WriteToOut(ec, …)`, which resolves `*out*`'s current binding through the explicit context #210 introduced. This is the same shape `println`/`print`/`pr` use post-#210.

The ops covered: `move-cursor`, `clear`, `clear-line`, `hide-cursor`, `show-cursor`, `set-fg`, `set-bg`, `reset-style`, `bold`, `underline`, `inverse`, `write`, `write-at`, `alternate-screen`, `main-screen`.

The PTY/termios ops — `raw-mode!`, `restore-mode!`, `read-key`, `key-pending?`, `size`, `set-size`, `tty?`, `open-pty` — stay plain native fns on real file descriptors. They're fd/ioctl operations, not byte output, and have no business on `*out*`. `flush` and `char-width` likewise stay as-is (`flush` syncs the real fd; `char-width` computes, emits nothing).

## Transparency / compatibility

Byte-identical default output on every target. `*out*`'s root binding is the IOHandle wrapping `os.Stdout`, so a bare `(term/clear)` writes the same bytes to the same place it always did: native terminal, WASM via the existing `fs.writeSync` path until the host writer lands, plan9. The only new behavior is that `term/*` now honors a `*out*` rebind.

## Tests

`test/term_out_binding_test.lg` (7 deftests) pins the fixed behavior by capturing escapes through `with-out-str`: each op routes through the current `*out*` binding; control and text capture as one stream; and `(binding [*out* *err*] (term/clear))` hits `*err*`, not the outer `*out*`.

## Pre-merge checks

- `go test ./test` (full `.lg` suite) and `go test ./pkg/...`, both green.
- Cross-target builds: `GOOS=linux`, `GOOS=js/wasm` (`./pkg/rt`), `GOOS=plan9` (`./pkg/rt`), all build.
- `gofmt` clean; `go vet ./pkg/rt` clean.
- Browser smoke: a WASM bundle built with this branch boots headless (`crossOriginIsolated`, no console errors or exceptions) and renders its `term/*`-drawn title screen, confirming the wasm `term/*` output still reaches xterm.js through `*out*` (the path `go test` doesn't cover).
