### PR TITLE
perf(vm): cut redundant value hashing on the lowering hot path

### DIFF
--- a/pkg/vm/boxed.go
+++ b/pkg/vm/boxed.go
@@ -24,12 +24,14 @@ func (t *aBoxedType) Box(value any) (Value, error) {
 	if !reflect.TypeOf(value).ConvertibleTo(t.typ) {
 		return NIL, NewTypeError(value, "can't be boxed as", t)
 	}
-	return &Boxed{value, t}, nil
+	return &Boxed{value: value, typ: t}, nil
 }
 
 type Boxed struct {
-	value any
-	typ   *aBoxedType
+	value  any
+	typ    *aBoxedType
+	hash   uint32
+	hashed bool
 }
 
 // Type implements Value
@@ -40,6 +42,22 @@ func (n *Boxed) Unbox() any { return n.value }
 
 func (n *Boxed) String() string {
 	return fmt.Sprintf("<%s %v>", n.typ.Name(), n.value)
+}
+
+// Hash implements Hashable. Without it, hashValue falls back to
+// computeHash -> hashBytes(String()), which formats the boxed value via
+// fmt.Sprintf("%v") on EVERY hash — catastrophic when boxed values (e.g.
+// SourceInfo) are embedded in IR vectors that get hashed repeatedly during
+// lowering (= comparisons, CSE, map/set keys). *Boxed is an immutable pointer,
+// so we compute the String-based hash once and cache it. The value is
+// identical to the old computeHash fallback, so map/set semantics are
+// unchanged — only the repeated Sprintf is eliminated.
+func (n *Boxed) Hash() uint32 {
+	if !n.hashed {
+		n.hash = hashString(n.String())
+		n.hashed = true
+	}
+	return n.hash
 }
 
 func (n *Boxed) InvokeMethod(methodName Symbol, args []Value) (Value, error) {

--- a/pkg/vm/hash.go
+++ b/pkg/vm/hash.go
@@ -5,8 +5,6 @@
 
 package vm
 
-import "unicode/utf16"
-
 const (
 	fnvOffset32 = uint32(2166136261)
 	fnvPrime32  = uint32(16777619)
@@ -56,49 +54,28 @@ func hashString(s string) uint32 {
 	return h
 }
 
+// hashUnencodedChars computes a Murmur3-derived 32-bit hash over the string's
+// UTF-8 bytes, two bytes per mix word. It deliberately does NOT decode to runes
+// or re-encode to UTF-16: the previous code did that purely for Java/Clojure
+// hash parity, but this hash is used only for internal map/set bucketing
+// (consistency, not specific values), and no normalization or case-folding is
+// involved — so the raw byte sequence suffices. For ASCII input (every keyword
+// and identifier — the hot path during lowering) the result is identical to the
+// old UTF-16-code-unit hash; for non-ASCII the value differs but stays
+// consistent (equal strings hash equal). Single pass, no allocation, no
+// interface dispatch.
 func hashUnencodedChars(s string) uint32 {
-	ascii := true
-	for i := 0; i < len(s); i++ {
-		if s[i] >= 0x80 {
-			ascii = false
-			break
-		}
-	}
-	if ascii {
-		return hashUTF16CodeUnits(uint16FromBytes(s))
-	}
-	return hashUTF16CodeUnits(uint16Slice(utf16.Encode([]rune(s))))
-}
-
-type uint16FromBytes string
-
-func (s uint16FromBytes) Len() int            { return len(s) }
-func (s uint16FromBytes) At(i int) uint32     { return uint32(s[i]) }
-func (s uint16FromBytes) LengthBytes() uint32 { return uint32(2 * len(s)) }
-
-type uint16Slice []uint16
-
-func (s uint16Slice) Len() int            { return len(s) }
-func (s uint16Slice) At(i int) uint32     { return uint32(s[i]) }
-func (s uint16Slice) LengthBytes() uint32 { return uint32(2 * len(s)) }
-
-type utf16CodeUnits interface {
-	Len() int
-	At(int) uint32
-	LengthBytes() uint32
-}
-
-func hashUTF16CodeUnits(s utf16CodeUnits) uint32 {
 	var h uint32
+	n := len(s)
 	i := 1
-	for ; i < s.Len(); i += 2 {
-		k := s.At(i-1) | s.At(i)<<16
+	for ; i < n; i += 2 {
+		k := uint32(s[i-1]) | uint32(s[i])<<16
 		h = mixH1(h, mixK1(k))
 	}
-	if i == s.Len() {
-		h ^= mixK1(s.At(i - 1))
+	if i == n {
+		h ^= mixK1(uint32(s[i-1]))
 	}
-	return mixFinishLen(h, s.LengthBytes())
+	return mixFinishLen(h, uint32(2*n))
 }
 
 func mixK1(k uint32) uint32 {
@@ -177,11 +154,23 @@ func valueEquiv(a, b Value) bool {
 	if IsNumber(a) && IsNumber(b) {
 		return NumEq(a, b)
 	}
-	// Fast negative: if both are Hashable and hashes differ, not equal
-	ha, aOk := a.(Hashable)
-	hb, bOk := b.(Hashable)
-	if aOk && bOk {
-		if ha.Hash() != hb.Hash() {
+	// Fast negative via hash — ONLY when neither operand is a collection.
+	// Collections (anything Sequable: vectors/lists/maps/sets) have O(size)
+	// Hash(), exactly as costly as the structural Equals it would avoid — and
+	// Equals short-circuits on length and then the first differing element,
+	// whereas the hash is always a full pass with no short-circuit. valueEquiv
+	// is also reached during map/set lookup only AFTER the hash trie matched, so
+	// the operands' hashes usually agree, making the check pure overhead (it
+	// dominated PersistentVector.Hash in lowering profiles). Boxed (not
+	// Sequable, and has no Equals) keeps the check — its cached hash is its only
+	// fast discriminator. Correctness is unaffected: this is only a negative
+	// shortcut; equal values still hash equal and fall through to Equals.
+	_, aSeqable := a.(Sequable)
+	_, bSeqable := b.(Sequable)
+	if !aSeqable && !bSeqable {
+		ha, aOk := a.(Hashable)
+		hb, bOk := b.(Hashable)
+		if aOk && bOk && ha.Hash() != hb.Hash() {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

Profiling self-AOT lowering (`lgbgen --target=go`) showed it was dominated by **hashing**. Three fixes on the value-hash hot path:

### 1. Cache `Boxed.Hash()`
`*Boxed` implemented no `Hash()`, so `hashValue` fell back to `computeHash` → `hashBytes(String())`, formatting the wrapped value via `fmt.Sprintf("<%s %v>")` on **every** hash. Boxed values (e.g. `SourceInfo`) embedded in IR vectors were re-stringified on every `=`, map/set key, and CSE hash. `*Boxed` is immutable; cache the hash (same value as the old fallback).

### 2. Hash strings by UTF-8 bytes
`hashUnencodedChars` decoded to runes and re-encoded to UTF-16 code units (Java/Clojure hash parity), boxing into an interface (a `convTstring` alloc) + virtual `At()`/`Len()` in the Murmur3 loop. The hash is only for internal bucketing — no normalization/case-folding — so hash the UTF-8 bytes directly in one pass. **ASCII (every keyword/identifier) is byte-identical**; non-ASCII changes but stays consistent.

### 3. Skip the hash fast-negative in `valueEquiv` for collections
`valueEquiv` (map/set key comparison) computed both operands' hashes as a "fast negative" — but for `Sequable` types `Hash()` is **O(size)**, exactly as costly as the structural `Equals` it precedes, which short-circuits on length then the first differing element. And `valueEquiv` is reached only **after** the hash trie already matched, so the operands' hashes usually agree (pure overhead). Skipping it for `Sequable` operands eliminated the dominant remaining cost — `PersistentVector`/`ArrayVector` re-hashing during map `assoc`. `Boxed` (not `Sequable`, no `Equals`) keeps the check. It's only a negative shortcut, so correctness is unaffected.

## Impact (CPU profile composition, lowering)

| | before | after |
|---|---|---|
| `hashValue` cum | 49.7% | **~1%** |
| `fmt.Sprintf` | 31% | eliminated |
| `PersistentVector.Hash` | dominant | off the profile |

## Verification

- Lowered Go output **byte-identical** (0 files differ) — no codegen change
- `go test ./pkg/...` green
- **jank clojure-test-suite: 5631 assertions pass, 0 fail** under both VM variants (bytecode + gogen_ir), parity-identical
