### PR TITLE
feat(resolver): LG_FORCE_SOURCE_NS for incremental .lg dev loop

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -190,11 +190,33 @@ func (r *NSResolver) Load(name string) *vm.Namespace {
 	return nil
 }
 
+// forceSourceNS reports whether namespace `name` is listed in the
+// LG_FORCE_SOURCE_NS env var (comma-separated). Such namespaces skip the
+// precompiled bundle chunk and load from the //go:embed raw .lg source, which
+// `go build`/`go test` recompiles whenever the .lg file changes — giving a
+// fast edit→test loop for a single namespace WITHOUT `make generate`. Dev/test
+// only; empty/unset means normal (bundle-first) behavior for every namespace.
+func forceSourceNS(name string) bool {
+	env := os.Getenv("LG_FORCE_SOURCE_NS")
+	if env == "" {
+		return false
+	}
+	for _, s := range stdstrings.Split(env, ",") {
+		if stdstrings.TrimSpace(s) == name {
+			return true
+		}
+	}
+	return false
+}
+
 // loadEmbedded loads bundled namespaces from embedded sources
 func (r *NSResolver) loadEmbedded(name string) *vm.Namespace {
-	// Try precompiled bytecode first
-	if chunk := compiler.PrecompiledNSChunk(name); chunk != nil {
-		return r.execPrecompiled(name, chunk)
+	// Try precompiled bytecode first — unless this ns is pinned to source
+	// loading via LG_FORCE_SOURCE_NS (dev loop; see forceSourceNS).
+	if !forceSourceNS(name) {
+		if chunk := compiler.PrecompiledNSChunk(name); chunk != nil {
+			return r.execPrecompiled(name, chunk)
+		}
 	}
 
 	if name == "term" {

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -39,3 +39,24 @@ func TestPathsFromInputs_ExplicitEmptyMeansNoPaths(t *testing.T) {
 		t.Fatalf("PathsFromInputs() = %#v, want empty (no paths)", got)
 	}
 }
+
+func TestForceSourceNS(t *testing.T) {
+	cases := []struct {
+		env  string
+		name string
+		want bool
+	}{
+		{"", "ir.passes.typeinfer", false},                   // unset: never force
+		{"ir.passes.typeinfer", "ir.passes.typeinfer", true}, // single match
+		{"ir.passes.typeinfer", "ir.build", false},           // single non-match
+		{"core, ir.build ,string", "ir.build", true},         // trimmed middle entry
+		{"core,ir.build", "string", false},                   // not listed
+		{"core,ir.build", "", false},                         // empty name never matches a listed ns
+	}
+	for _, c := range cases {
+		t.Setenv("LG_FORCE_SOURCE_NS", c.env)
+		if got := forceSourceNS(c.name); got != c.want {
+			t.Errorf("forceSourceNS(%q) with LG_FORCE_SOURCE_NS=%q = %v, want %v", c.name, c.env, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `forceSourceNS`: namespaces listed in the `LG_FORCE_SOURCE_NS` env var (comma-separated) skip the precompiled bundle chunk in `loadEmbedded` and load from the `//go:embed` raw `.lg` source instead.

## Why

Editing a core `.lg` namespace normally requires a full `make generate` (regenerate the `.lgb` bundle + lowered Go tree) before the change is visible, because `loadEmbedded` tries `PrecompiledNSChunk` first. That's a slow inner loop when iterating on a single namespace (e.g. `ir.passes.typeinfer`).

With `LG_FORCE_SOURCE_NS=ir.passes.typeinfer`, `go build`/`go test` recompiles the embedded source on every `.lg` edit (an incremental Go build of `pkg/rt`'s embed — seconds), giving a fast edit→test loop without `make generate`.

## Scope / safety

- **Dev/test only.** Empty/unset `LG_FORCE_SOURCE_NS` is the existing bundle-first behavior for every namespace — the no-flag path is unchanged.
- Pure Go, no generated-artifact changes.
- Unit-tested (`TestForceSourceNS`: unset, match, non-match, whitespace-trimmed list, empty-name).

Caveat for users: a `^:private` var of a source-loaded ns isn't resolvable cross-ns; public entry points and same-ns access work normally.