### PR TITLE
fix(vm): Indexed collection protocol — correct nth dispatch + chunked-seq/conj semantics

### DIFF
--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -13,11 +13,17 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"runtime/pprof"
 	"sort"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/compiler"
@@ -290,26 +296,70 @@ func sortStrings(s []string) {
 func main() {
 	// Parse mode: --target=go <out-dir>, --target=both [bundle-path], or
 	// default bytecode mode. `both` emits the .lgb bundle AND the gogen_ir
-	// Go tree from a single core compile (see the dispatch below).
+	// Go tree from a single core compile (see the dispatch below). Optional
+	// -cpuprofile writes a Go CPU profile for the lgbgen process itself.
 	targetGo := false
 	targetBoth := false
 	outPath := "pkg/rt/core_compiled.lgb"
 	goOutDir := "pkg/rt/core_go_lowered"
+	var target string
+	var cpuProfilePath string
 
-	args := os.Args[1:]
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&target, "target", "", "generation target: go, both, or empty for bundle-only")
+	fs.StringVar(&cpuProfilePath, "cpuprofile", "", "write Go CPU profile for the lgbgen process")
+	fs.Parse(os.Args[1:])
+
+	switch target {
+	case "":
+	case "go":
+		targetGo = true
+	case "both":
+		targetBoth = true
+	default:
+		fmt.Fprintf(os.Stderr, "unknown --target=%q (expected go or both)\n", target)
+		os.Exit(2)
+	}
+
+	args := fs.Args()
 	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "--target=go":
-			targetGo = true
-			if i+1 < len(args) {
-				goOutDir = args[i+1]
-				i++
-			}
-		case "--target=both":
-			targetBoth = true
-		default:
+		if targetGo && i == 0 {
+			goOutDir = args[i]
+		} else {
 			outPath = args[i]
 		}
+	}
+	if cpuProfilePath != "" {
+		f, err := os.Create(cpuProfilePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "create cpuprofile %s: %v\n", cpuProfilePath, err)
+			os.Exit(1)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			f.Close()
+			fmt.Fprintf(os.Stderr, "start cpuprofile %s: %v\n", cpuProfilePath, err)
+			os.Exit(1)
+		}
+		var stopProfileOnce sync.Once
+		stopProfile := func() {
+			stopProfileOnce.Do(func() {
+				pprof.StopCPUProfile()
+				if err := f.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "close cpuprofile %s: %v\n", cpuProfilePath, err)
+				}
+			})
+		}
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+		go func() {
+			sig := <-sigCh
+			fmt.Fprintf(os.Stderr, "received %s, flushing cpu profile\n", sig)
+			stopProfile()
+			time.Sleep(250 * time.Millisecond)
+			os.Exit(130)
+		}()
+		defer stopProfile()
 	}
 
 	// rt.init() has already run — native builtins are registered in CoreNS.

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -1188,6 +1188,43 @@ func forceSeq(s vm.Seq) vm.Seq {
 	return s
 }
 
+func appendSeqValues(dst []vm.Value, s vm.Seq) []vm.Value {
+	for s != nil {
+		if cs, ok := vm.AsChunkedSeq(s); ok {
+			c := cs.ChunkedFirst()
+			n := c.ChunkCount()
+			for i := 0; i < n; i++ {
+				dst = append(dst, c.Nth(i))
+			}
+			s = cs.ChunkedNext()
+			continue
+		}
+		dst = append(dst, s.First())
+		s = s.Next()
+	}
+	return dst
+}
+
+func nthInSeq(s vm.Seq, n int) (vm.Value, bool) {
+	for i := 0; s != nil; i++ {
+		if cs, ok := vm.AsChunkedSeq(s); ok {
+			c := cs.ChunkedFirst()
+			nc := c.ChunkCount()
+			if n < i+nc {
+				return c.Nth(n - i), true
+			}
+			i += nc - 1
+			s = cs.ChunkedNext()
+			continue
+		}
+		if i == n {
+			return s.First(), true
+		}
+		s = s.Next()
+	}
+	return vm.NIL, false
+}
+
 func mapLazy1(f vm.Fn, s vm.Seq) vm.Seq {
 	if s == nil {
 		return nil
@@ -2881,15 +2918,19 @@ func installLangNS() {
 			}
 			return vm.NIL, nil
 		}
-		// Fast path: Lookup types (ArrayVector, PersistentVector, String)
-		if l, ok := vs[0].(vm.Lookup); ok {
-			if hasDefault {
-				return l.ValueAtOr(vm.Int(n), notFound), nil
-			}
-			if c, ok := vs[0].(vm.Counted); ok && (n < 0 || n >= c.RawCount()) {
+		// Fast path: positional collections (vm.Indexed) — those addressed by a
+		// 0-based integer index. Maps and sets are key-addressable rather than
+		// positional and fall through to the seq walk below, as do lazy seqs.
+		// This path is the only correct route for positional-but-not-seqable
+		// types (transient vectors, chunks): the seq walk would return nil.
+		if ix, ok := vs[0].(vm.Indexed); ok {
+			if n < 0 || n >= ix.RawCount() {
+				if hasDefault {
+					return notFound, nil
+				}
 				return vm.NIL, fmt.Errorf("nth index out of bounds")
 			}
-			return l.ValueAt(vm.Int(n)), nil
+			return ix.Nth(n), nil
 		}
 		// Seq path: linear walk
 		if n < 0 {
@@ -2902,11 +2943,8 @@ func installLangNS() {
 		if err != nil {
 			return notFound, nil
 		}
-		for i := 0; s != nil; i++ {
-			if i == n {
-				return s.First(), nil
-			}
-			s = s.Next()
+		if v, ok := nthInSeq(forceSeq(s), n); ok {
+			return v, nil
 		}
 		if !hasDefault {
 			return vm.NIL, fmt.Errorf("nth index out of bounds")
@@ -3095,8 +3133,33 @@ func installLangNS() {
 		if err != nil {
 			return vm.NIL, fmt.Errorf("some expected Seq")
 		}
+		// seqOf returns LazySeq directly; resolve here so an unresolved-empty
+		// LazySeq becomes nil instead of invoking the predicate once with nil.
+		if ls, ok := seq.(*vm.LazySeq); ok {
+			seq = ls.Resolve()
+		}
+		fargs := []vm.Value{nil}
 		for seq != nil {
-			v, err := ec.Invoke(f, []vm.Value{seq.First()})
+			// Chunked fast path: walk whole chunks via Nth to avoid per-element
+			// seq.Next()/First() churn on chunked sources such as vectors/ranges.
+			if cs, ok := vm.AsChunkedSeq(seq); ok {
+				c := cs.ChunkedFirst()
+				n := c.ChunkCount()
+				for i := 0; i < n; i++ {
+					fargs[0] = c.Nth(i)
+					v, err := ec.Invoke(f, fargs)
+					if err != nil {
+						return vm.NIL, err
+					}
+					if vm.IsTruthy(v) {
+						return v, nil
+					}
+				}
+				seq = cs.ChunkedNext()
+				continue
+			}
+			fargs[0] = seq.First()
+			v, err := ec.Invoke(f, fargs)
 			if err != nil {
 				return vm.NIL, err
 			}
@@ -3146,14 +3209,11 @@ func installLangNS() {
 		if err != nil {
 			return vm.NIL, fmt.Errorf("apply expected Seq")
 		}
+		seq = forceSeq(seq)
 		if seq == nil {
 			return ec.Invoke(f, nil)
 		}
-		var args []vm.Value
-		for seq != nil {
-			args = append(args, seq.First())
-			seq = seq.Next()
-		}
+		args := appendSeqValues(nil, seq)
 		return ec.Invoke(f, args)
 	})
 
@@ -3345,10 +3405,7 @@ func installLangNS() {
 			if err != nil {
 				return vm.NIL, fmt.Errorf("concat expected Seq")
 			}
-			for vseq != nil {
-				ret = append(ret, vseq.First())
-				vseq = vseq.Next()
-			}
+			ret = appendSeqValues(ret, forceSeq(vseq))
 		}
 		r, err := vm.ListType.Box(ret)
 		if err != nil {

--- a/pkg/vm/persistent_vector.go
+++ b/pkg/vm/persistent_vector.go
@@ -206,6 +206,9 @@ func (s *PersistentVectorSeq) Cons(val Value) Seq {
 	return NewCons(val, s)
 }
 
+// Nth implements Indexed: positional access by integer index.
+func (s *PersistentVectorSeq) Nth(i int) Value { return s.ValueAt(Int(i)) }
+
 // ValueAt implements Lookup for PersistentVectorSeq so that `get` works on seq views.
 func (s *PersistentVectorSeq) ValueAt(key Value) Value {
 	return s.ValueAtOr(key, NIL)
@@ -392,6 +395,9 @@ func newPath(level uint, tail []Value) *vnode {
 	ret.array = append(ret.array, newPath(level-shift, tail))
 	return ret
 }
+
+// Nth implements Indexed: positional access by integer index.
+func (v PersistentVector) Nth(i int) Value { return v.ValueAt(Int(i)) }
 
 // ValueAt implements Associative
 func (v PersistentVector) ValueAt(key Value) Value {
@@ -634,15 +640,12 @@ func (s *PersistentVectorSeq) Empty() Collection {
 
 // Conj implements Collection
 func (s *PersistentVectorSeq) Conj(val Value) Collection {
-	// Use EmptyList and build the collection
-	result := EmptyList.Cons(val).(Collection)
-
-	// Add all remaining elements from the sequence
+	values := make([]Value, s.vec.count-s.i+1)
+	values[0] = val
 	for i := s.i; i < s.vec.count; i++ {
-		result = result.Conj(s.vec.ValueAt(Int(i)))
+		values[i-s.i+1] = s.vec.ValueAt(Int(i))
 	}
-
-	return result
+	return NewList(values).(*List)
 }
 
 type theSequenceType struct{}

--- a/pkg/vm/range.go
+++ b/pkg/vm/range.go
@@ -123,6 +123,9 @@ func (l *Range) String() string {
 	return out + ")"
 }
 
+// Nth implements Indexed: positional access by integer index.
+func (l *Range) Nth(i int) Value { return l.ValueAt(Int(i)) }
+
 func (l *Range) ValueAt(key Value) Value {
 	return l.ValueAtOr(key, NIL)
 }

--- a/pkg/vm/string.go
+++ b/pkg/vm/string.go
@@ -147,6 +147,9 @@ func (l String) Seq() Seq {
 	return ret
 }
 
+// Nth implements Indexed: positional access by integer index.
+func (l String) Nth(i int) Value { return l.ValueAt(Int(i)) }
+
 func (l String) ValueAt(key Value) Value {
 	return l.ValueAtOr(key, NIL)
 }

--- a/pkg/vm/transient.go
+++ b/pkg/vm/transient.go
@@ -260,6 +260,11 @@ func (t *TransientVector) Persistent() (Value, error) {
 	return NewPersistentVector(t.array), nil
 }
 
+// Nth implements Indexed: positional access by integer index. TransientVector
+// is positional but not seqable, so `nth` must reach it through this rather
+// than seq traversal.
+func (t *TransientVector) Nth(i int) Value { return t.ValueAt(Int(i)) }
+
 func (t *TransientVector) ValueAt(key Value) Value {
 	idx, ok := key.(Int)
 	if !ok || int(idx) < 0 || int(idx) >= len(t.array) {

--- a/pkg/vm/typed_array.go
+++ b/pkg/vm/typed_array.go
@@ -237,6 +237,9 @@ func (a *TypedArray) Seq() Seq {
 
 // --- Lookup interface (for nth/get fast path) ---
 
+// Nth implements Indexed: positional access by integer index.
+func (a *TypedArray) Nth(i int) Value { return a.ValueAt(Int(i)) }
+
 func (a *TypedArray) ValueAt(key Value) Value {
 	return a.ValueAtOr(key, NIL)
 }
@@ -315,6 +318,9 @@ func (s *TypedArraySeq) Empty() Collection { return EmptyList }
 func (s *TypedArraySeq) Conj(val Value) Collection {
 	return s.Cons(val).(*List)
 }
+
+// Nth implements Indexed: positional access by integer index.
+func (s *TypedArraySeq) Nth(i int) Value { return s.ValueAt(Int(i)) }
 
 func (s *TypedArraySeq) ValueAt(key Value) Value {
 	return s.ValueAtOr(key, NIL)

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -76,6 +76,21 @@ type Lookup interface {
 	ValueAtOr(Value, Value) Value
 }
 
+// Indexed marks positional collections — those whose elements are addressed by
+// a 0-based integer index, as opposed to maps/sets (key-addressable) and lazy
+// seqs (sequential-only). `nth` dispatches on this to use an O(1)-ish indexed
+// access without seq traversal. Implementations must satisfy: Nth(i) is valid
+// for 0 <= i < RawCount(); callers bounds-check via RawCount() before calling.
+//
+// Crucially this excludes maps/sets (which are Lookup+Counted but NOT positional)
+// and transient/chunk types that aren't seqable — so adding a new positional
+// type is a matter of implementing this interface, not editing a type switch.
+type Indexed interface {
+	Value
+	Nth(i int) Value
+	RawCount() int
+}
+
 type Keyed interface {
 	Value
 	Contains(Value) Boolean

--- a/pkg/vm/vector.go
+++ b/pkg/vm/vector.go
@@ -225,13 +225,18 @@ func (s *ArrayVectorSeq) Empty() Collection {
 }
 
 func (s *ArrayVectorSeq) Conj(val Value) Collection {
-	// Conj on a seq creates a new seq with val at front
-	return s.Cons(val).(*List)
+	values := make([]Value, len(s.vec)-s.i+1)
+	values[0] = val
+	copy(values[1:], s.vec[s.i:])
+	return NewList(values).(*List)
 }
 
 func (s *ArrayVectorSeq) Seq() Seq {
 	return s
 }
+
+// Nth implements Indexed: positional access by integer index.
+func (s *ArrayVectorSeq) Nth(i int) Value { return s.ValueAt(Int(i)) }
 
 // ValueAt implements Lookup for ArrayVectorSeq so that `get` works on seq views.
 func (s *ArrayVectorSeq) ValueAt(key Value) Value {
@@ -273,6 +278,8 @@ func NewArrayVector(v []Value) Value {
 	copy(vk, v)
 	return ArrayVector(vk)
 }
+
+func (l ArrayVector) Nth(i int) Value { return l.ValueAt(Int(i)) }
 
 func (l ArrayVector) ValueAt(key Value) Value {
 	return l.ValueAtOr(key, NIL)

--- a/pkg/vm/vector_test.go
+++ b/pkg/vm/vector_test.go
@@ -296,11 +296,9 @@ func TestPersistentVectorSeq(t *testing.T) {
 		// Test Conj
 		result := seq.(Collection).Conj(Int(42)).(Collection)
 
-		// Verify result (should be prepended to the end of the collection)
+		// conj onto a seq prepends: (42 1 2 3).
 		resultSeq := result.(Sequable).Seq()
-		// Looking at the test results, it seems that Conj is resulting in [3, 2, 1, 42]
-		// rather than [42, 1, 2, 3] as we initially expected
-		expectedValues := []Value{Int(3), Int(2), Int(1), Int(42)}
+		expectedValues := []Value{Int(42), Int(1), Int(2), Int(3)}
 
 		for i, expected := range expectedValues {
 			if got := resultSeq.First(); got != expected {

--- a/test/builtins_test.lg
+++ b/test/builtins_test.lg
@@ -1,6 +1,7 @@
 ;; Tests for builtins that don't have dedicated tests
 (ns test.builtins-test
-  (:require [test :refer :all]))
+  (:require
+   [test :refer :all]))
 
 (deftest subs-test
   (testing "subs substring"
@@ -128,6 +129,13 @@
 
   (testing "nth on lazy seq"
     (is (= 5 (nth (iterate inc 0) 5))))
+
+  (testing "nth on unresolved-empty lazy seq"
+    (is (= :default (nth (mapcat (fn [x] [x]) []) 0 :default)))
+    (is (= :caught (try (nth (mapcat (fn [x] [x]) []) 0) (catch e :caught)))))
+
+  (testing "nth on seqable non-indexed collection"
+    (is (= [:b 2] (nth (array-map :a 1 :b 2 :c 3) 1))))
 
   (testing "nth on string"
     (is (= \e (nth "hello" 1)))))

--- a/test/coll_test.lg
+++ b/test/coll_test.lg
@@ -1,20 +1,19 @@
 ;; Clojure collection semantics tests
 (ns test.coll-test
-  (:require [test :refer :all]))
+  (:require
+   [test :refer :all]))
 
 (deftest vector-ops
   (testing "vector creation"
     (is (= [] (vector)))
     (is (= [1 2 3] (vector 1 2 3)))
     (is (= [1 2 3] (vec '(1 2 3)))))
-  
   (testing "vector access"
     (is (= 2 (get [1 2 3] 1)))
     (is (= 2 ([1 2 3] 1)))  ; vector as function
     (is (= :caught (try ([1 2 3] 10) (catch e :caught))))
     (is (nil? (get [1 2 3] 10)))
     (is (= :default (get [1 2 3] 10 :default))))
-  
   (testing "vector modification"
     (is (= [1 2 3 4] (conj [1 2 3] 4)))
     (is (= [1 :x 3] (assoc [1 2 3] 1 :x)))
@@ -31,7 +30,6 @@
   (testing "map literals and array-map preserve insertion order"
     (is (= '([:a 1] [:b 2] [:c 3]) (seq {:a 1 :b 2 :c 3})))
     (is (= '([:a 1] [:b 2] [:c 3]) (seq (array-map :a 1 :b 2 :c 3)))))
-  
   (testing "map access"
     (is (= 1 (get {:a 1 :b 2} :a)))
     (is (= 1 ({:a 1 :b 2} :a)))  ; map as function
@@ -42,7 +40,6 @@
     (is (= :caught (try (val [:a 1]) (catch e :caught))))
     (is (nil? (get {:a 1} :b)))
     (is (= :default (get {:a 1} :b :default))))
-  
   (testing "map modification"
     (is (= {:a 1 :b 2} (conj {:a 1} [:b 2])))
     (is (= :caught (try (conj {:a 1} '(:b 2)) (catch e :caught))))
@@ -80,11 +77,9 @@
     (is (= 1 (get-in {:a {:b {:c 1}}} [:a :b :c])))
     (is (nil? (get-in {:a 1} [:a :b])))
     (is (= :default (get-in {:a 1} [:a :b] :default))))
-  
   (testing "assoc-in"
     (is (= {:a {:b 1}} (assoc-in {} [:a :b] 1)))
     (is (= {:a {:b 2}} (assoc-in {:a {:b 1}} [:a :b] 2))))
-  
   (testing "update-in"
     (is (= {:a {:b 2}} (update-in {:a {:b 1}} [:a :b] inc)))))
 
@@ -93,22 +88,23 @@
     (is (= #{} (hash-set)))
     (is (= #{1 2 3} (hash-set 1 2 3)))
     (is (= #{1 2 3} (set [1 2 2 3 3 3]))))
-  
   (testing "set operations"
     (is (= #{1 2 3} (conj #{1 2} 3)))
     (is (= #{1 3} (disj #{1 2 3} 2)))
     (is (contains? #{1 2 3} 2))
     (is (not (contains? #{1 2 3} 4))))
-  
   (testing "set as function"
     (is (= 2 (#{1 2 3} 2)))
     (is (nil? (#{1 2 3} 4)))))
+
+(deftest conj-seq-view-test
+  (testing "conj on a vector seq view prepends without reversing the tail"
+    (is (= '(0 1 2 3) (conj (seq [1 2 3]) 0)))))
 
 (deftest set-algebra
   (testing "difference"
     (is (= #{1 2} (difference #{1 2 3} #{3 4})))
     (is (= #{1} (difference #{1 2 3} #{2} #{3}))))
-  
   (testing "intersection"
     (is (= #{2 3} (intersection #{1 2 3} #{2 3 4})))))
 
@@ -121,7 +117,6 @@
     (is (= 0 (count #{})))
     (is (= 3 (count [1 2 3])))
     (is (= 3 (count "abc"))))
-  
   (testing "empty?"
     (is (empty? nil))
     (is (empty? []))

--- a/test/fn_test.lg
+++ b/test/fn_test.lg
@@ -1,6 +1,7 @@
 ;; Clojure function and higher-order function tests
 (ns test.fn-test
-  (:require [test :refer :all]))
+  (:require
+   [test :refer :all]))
 
 (deftest fn-basics
   (testing "anonymous functions"
@@ -8,16 +9,14 @@
     (is (= 3 (#(+ %1 %2) 1 2)))
     (is (= 6 (#(+ %1 %2 %3) 1 2 3)))
     (is (= :caught (try ((fn [x] x) 1 2) (catch e :caught)))))
-  
   (testing "multi-arity"
-    (let [f (fn 
+    (let [f (fn
               ([x] x)
               ([x y] (+ x y))
               ([x y z] (+ x y z)))]
       (is (= 1 (f 1)))
       (is (= 3 (f 1 2)))
       (is (= 6 (f 1 2 3)))))
-  
   (testing "variadic"
     (let [f (fn [x & rest] (cons x rest))]
       (is (= '(1) (f 1)))
@@ -28,7 +27,10 @@
     (is (= 6 (apply + [1 2 3])))
     (is (= 10 (apply + 1 2 [3 4])))
     (is (= [] (apply vector [])))
-    (is (= [1 2 3] (apply vector [1 2 3])))))
+    (is (= [1 2 3] (apply vector [1 2 3]))))
+  (testing "apply ignores unresolved-empty lazy arg seq"
+    (is (= [] (apply vector (mapcat (fn [x] [x]) []))))
+    (is (= 10 (apply + 10 (mapcat (fn [x] [x]) []))))))
 
 (deftest partial-test
   (testing "partial application"
@@ -58,7 +60,6 @@
   (testing "identity"
     (is (= 5 (identity 5)))
     (is (= [1 2] (identity [1 2]))))
-  
   (testing "complement"
     (is ((complement even?) 3))
     (is (not ((complement even?) 2)))))
@@ -66,12 +67,26 @@
 (deftest some-every
   (testing "some"
     (is (some even? [1 2 3]))  ; returns first truthy result (true from even?)
-    (is (not (some even? [1 3 5]))))
-  
+    (is (not (some even? [1 3 5])))
+    (is (= 40 (some #{40} (range 100))))
+    (is (nil? (some #{200} (range 100))))
+    (let [seen (atom 0)]
+      (is (= 40
+             (some (fn [x]
+                     (swap! seen inc)
+                     (when (= x 40) x))
+                   (range 100))))
+      (is (= 41 @seen)))
+    ;; Regression: some must not invoke the predicate on an unresolved-empty
+    ;; LazySeq. seqOf returns LazySeq directly, so some must resolve empties
+    ;; before its iteration loop.
+    (let [seen (atom 0)]
+      (is (nil? (some (fn [x] (swap! seen inc) x)
+                      (mapcat (fn [x] [x]) []))))
+      (is (= 0 @seen))))
   (testing "every?"
     (is (every? even? [2 4 6]))
     (is (not (every? even? [2 3 4]))))
-  
   (testing "not-every? and not-any?"
     (is (not-every? even? [1 2 3]))
     (is (not-any? even? [1 3 5]))))

--- a/test/seq_test.lg
+++ b/test/seq_test.lg
@@ -1,6 +1,7 @@
 ;; Clojure sequence semantics tests
 (ns test.seq-test
-  (:require [test :refer :all]))
+  (:require
+   [test :refer :all]))
 
 (deftest seq-basics
   (testing "seq returns nil for empty collections"
@@ -10,7 +11,6 @@
     (is (nil? (seq #{})))
     (is (nil? (seq "")))
     (is (nil? (seq nil))))
-  
   (testing "seq returns seq for non-empty"
     (is (seq [1]))
     (is (seq '(1)))
@@ -22,13 +22,11 @@
     (is (= 1 (first '(1 2 3))))
     (is (nil? (first [])))
     (is (nil? (first nil))))
-  
   (testing "rest vs next"
     (is (= '(2 3) (rest [1 2 3])))
     ;; rest returns empty seq, next returns nil
     (is (nil? (next [1])))
     (is (nil? (next []))))
-  
   (testing "second"
     (is (= 2 (second [1 2 3])))
     (is (nil? (second [1])))
@@ -39,7 +37,6 @@
     (is (= '(0 1 2) (cons 0 [1 2])))
     (is (= '(0 1 2) (cons 0 '(1 2))))
     (is (= '(0) (cons 0 nil))))
-  
   (testing "conj adds appropriately"
     (is (= [1 2 3] (conj [1 2] 3)))      ; vectors add at end
     (is (= '(3 1 2) (conj '(1 2) 3)))    ; lists add at front
@@ -50,12 +47,10 @@
     (is (= '(2 4 6) (map #(* 2 %) [1 2 3])))
     (is (= '() (map inc [])))
     (is (= '(5 7 9) (map + [1 2 3] [4 5 6]))))
-  
   (testing "filter"
     (is (= '(2 4) (filter even? [1 2 3 4 5])))
     (is (nil? (seq (filter even? [1 3 5]))))
     (is (= '(1 2 3) (filter identity [1 nil 2 false 3]))))
-  
   (testing "reduce"
     (is (= 10 (reduce + [1 2 3 4])))
     (is (= 10 (reduce + 0 [1 2 3 4])))
@@ -74,7 +69,6 @@
     (is (= '(1 2) (take 5 [1 2])))  ; take more than available
     (is (nil? (seq (take 0 [1 2 3]))))    ; returns empty lazy seq
     (is (nil? (seq (take 3 nil)))))
-  
   (testing "drop"
     (is (= '(4 5) (drop 3 [1 2 3 4 5])))
     (is (nil? (drop 10 [1 2])))))
@@ -82,7 +76,10 @@
 (deftest concat-test
   (testing "concat"
     (is (= '(1 2 3 4) (concat [1 2] [3 4])))
-    (is (= '(1 2 3 4 5 6) (concat [1 2] [3 4] [5 6])))))
+    (is (= '(1 2 3 4 5 6) (concat [1 2] [3 4] [5 6]))))
+  (testing "concat ignores unresolved-empty lazy inputs"
+    (is (= '(1 2) (concat [1 2] (mapcat (fn [x] [x]) []))))
+    (is (= '(1 2) (concat (mapcat (fn [x] [x]) []) [1 2])))))
 
 (deftest partition-test
   (testing "partition"
@@ -104,7 +101,6 @@
     (is (= '(1 :x 2 :x 3) (interpose :x [1 2 3])))
     (is (= '(1) (interpose :x [1])))
     (is (nil? (seq (interpose :x [])))))
-  
   (testing "interleave"
     (is (= '(1 :a 2 :b) (interleave [1 2] [:a :b])))
     (is (= '(1 :a) (interleave [1 2 3] [:a])))))  ; stops at shortest
@@ -116,4 +112,3 @@
 (deftest group-by-test
   (testing "group-by"
     (is (= {true [2 4] false [1 3 5]} (group-by even? [1 2 3 4 5])))))
-

--- a/test/transducer_test.lg
+++ b/test/transducer_test.lg
@@ -1,5 +1,6 @@
 (ns test.transducer-test
-  (:require [test :refer :all]))
+  (:require
+   [test :refer :all]))
 
 ;; --- reduced ---
 
@@ -14,8 +15,16 @@
 (deftest reduce-with-reduced
   (testing "reduce stops on reduced"
     (is (= 6 (reduce (fn [acc x]
-                        (if (= x 4) (reduced acc) (+ acc x)))
-                      0 [1 2 3 4 5])))))
+                       (if (= x 4) (reduced acc) (+ acc x)))
+               0 [1 2 3 4 5])))
+    (let [seen (atom 0)]
+      (is (= 780
+             (reduce (fn [acc x]
+                       (swap! seen inc)
+                       (if (= x 40) (reduced acc) (+ acc x)))
+                     0
+                     (range 100))))
+      (is (= 41 @seen)))))
 
 ;; --- map transducer ---
 


### PR DESCRIPTION
Introduces `vm.Indexed` (`Value` + `Nth(i) Value` + `RawCount() int`), mirroring Clojure's `clojure.lang.Indexed`, implemented by every positional collection: `ArrayVector`(+`Seq`), `PersistentVector`(+`Seq`), `TransientVector`, `Range`, `TypedArray`(+`Seq`), `String` (`ArrayChunk` already qualified).

`nth` now dispatches on `Indexed` for O(1)-ish positional access, and — crucially — correctly reaches **positional-but-not-seqable** types (transient vectors, chunks) that the prior concrete type-switch silently dropped. That omission collapsed the gogen self-AOT lowered tree to *empty* whenever core read transient bitsets via `nth`, which is what motivated this fix.

Also:
- Tightens chunked-seq walking.
- Fixes `conj` onto a seq to **prepend**: `(conj (seq [1 2 3]) 42)` ⇒ `(42 1 2 3)`.
- Updates the test corpus (`builtins`/`coll`/`fn`/`seq`/`transducer`) to the Clojure-correct behavior; verified against Clojure + jank.

`go build ./...`, `pkg/vm`, and `pkg/rt` (TestRunner/lg corpus) all green.

---
**Stack (bottom → top):**
1. #227 — lgbgen CPU profiling
2. **this PR** — Indexed collection protocol
3. #222 — lower try/catch/finally to native Go (depends on this fix to regenerate a non-empty tree)

Stacked on #227; review/merge bottom-up. This PR's diff will include #227 until that merges.