### PR TITLE
fix(nrepl): report OS-assigned port under -p 0

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -888,7 +888,7 @@ func main() {
 			if err != nil {
 				fmt.Println("failed to run nREPL server on port", nreplPort, err)
 			}
-			fmt.Printf("nREPL server running at tcp://127.0.0.1:%d\n", nreplPort)
+			fmt.Printf("nREPL server running at tcp://127.0.0.1:%d\n", nreplServer.Port())
 		}
 		repl(context)
 	}

--- a/pkg/nrepl/server.go
+++ b/pkg/nrepl/server.go
@@ -84,6 +84,11 @@ func (n *NreplServer) Start(port int) error {
 		return err
 	}
 	n.listener = l
+	// Resolve the port the OS actually bound. With -p 0 the kernel picks a
+	// free ephemeral port; the supplied `port` is still 0 and would be a lie
+	// in the banner and .nrepl-port (which CIDER and other clients scrape to
+	// discover the server).
+	port = l.Addr().(*net.TCPAddr).Port
 	n.port = port
 	n.stop = make(chan struct{})
 
@@ -112,6 +117,12 @@ func (n *NreplServer) Start(port int) error {
 		}
 	})
 	return nil
+}
+
+// Port returns the port the server is bound to. After Start with -p 0 this is
+// the OS-assigned ephemeral port, not the 0 that was requested.
+func (n *NreplServer) Port() int {
+	return n.port
 }
 
 // Stop shuts down the server and cleans up.

--- a/pkg/nrepl/server_test.go
+++ b/pkg/nrepl/server_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package nrepl
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// With -p 0 the OS picks a free ephemeral port. The server must report the
+// bound port (not the requested 0) via Port(), the banner, and .nrepl-port,
+// otherwise no client can discover where it's listening.
+func TestStartResolvesEphemeralPort(t *testing.T) {
+	t.Chdir(t.TempDir()) // Start writes .nrepl-port in cwd
+
+	n := NewNreplServer(nil)
+	if err := n.Start(0); err != nil {
+		t.Fatalf("Start(0): %v", err)
+	}
+	defer n.Stop()
+
+	bound := n.listener.Addr().(*net.TCPAddr).Port
+	if bound == 0 {
+		t.Fatal("listener bound to port 0")
+	}
+	if n.Port() != bound {
+		t.Errorf("Port() = %d, want bound port %d", n.Port(), bound)
+	}
+
+	data, err := os.ReadFile(".nrepl-port")
+	if err != nil {
+		t.Fatalf("read .nrepl-port: %v", err)
+	}
+	if got := string(data); got != strconv.Itoa(bound) {
+		t.Errorf(".nrepl-port = %q, want %q", got, strconv.Itoa(bound))
+	}
+}
+
+// A fixed port must still round-trip unchanged.
+func TestStartFixedPort(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	// Grab a free port, release it, then ask the server for it explicitly.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	want := probe.Addr().(*net.TCPAddr).Port
+	probe.Close()
+
+	n := NewNreplServer(nil)
+	if err := n.Start(want); err != nil {
+		t.Fatalf("Start(%d): %v", want, err)
+	}
+	defer n.Stop()
+
+	if n.Port() != want {
+		t.Errorf("Port() = %d, want %d", n.Port(), want)
+	}
+}


### PR DESCRIPTION
Closes #50.

## Why

`-p 0` is the standard "let the OS pick a free port" idiom, and the right default for test harnesses and CI that can't assume a given port is free. But under `-p 0` let-go was unconnectable: `net.Listen` binds a random ephemeral port while `.nrepl-port`, the startup banner, and the "running at" line all still reported `0`. The discovery channels that CIDER and other clients scrape (`.nrepl-port`, the `nrepl://` URL) pointed at a port nothing was listening on.

## What

`Start` now reads the bound port off the listener (`l.Addr().(*net.TCPAddr).Port`) right after `net.Listen` and uses it for `n.port`, the file, and the banner. A new `NreplServer.Port()` accessor lets `lg.go`'s "running at" banner report the real port too.

## Notes

- The issue named the `server.go` banner and `.nrepl-port`. There's a second banner in `lg.go` ("nREPL server running at ...") printing the raw flag value, which would also have lied — fixed via the accessor.
- Fixed ports are untouched: for `-p N`, the listener reports `N`, so the resolution is a no-op there. New test covers both the `-p 0` and fixed cases.
- `pkg/nrepl` had no tests; this adds the first.

## Test

`go test ./pkg/nrepl/` — both cases pass. gofmt/vet clean. linux and plan9 cross-builds clean (the windows/js-wasm `go build ./...` failures are pre-existing, in `term.go` and the readline dep, unrelated to this change).
