### PR TITLE
feat(wasm): route *out*/*err* through a Go HostWriter, retire the fs.writeSync output shim

### DIFF
--- a/pkg/rt/hostwriter_js_wasm.go
+++ b/pkg/rt/hostwriter_js_wasm.go
@@ -1,0 +1,41 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ *
+ * HostWriter routes runtime output to the WASM bundle's JS host directly, via
+ * a global _lgOutput(string) callback, instead of writing to os.Stdout/Stderr
+ * and relying on the bundle's JS-side fs.writeSync shim to intercept fd 1/2.
+ * Installed as the root binding of the *out* / *err* vars (see
+ * NewWriterHandle), it makes (println ...) and the error sites reach
+ * LetGoHost.onOutput as the Go-side dual of api.WithStdout.
+ *
+ * Same hidden contract shape as js/emit's _lgEmit: a global function
+ *   _lgOutput(s string)
+ * defined per mode by the bundle bootstrap (worker version postMessages to the
+ * main thread; main-thread version calls LetGoHost._output directly). Resolved
+ * per Write, so boot order doesn't matter; if the bundle hasn't wired it
+ * (running outside the official host), the write is dropped rather than
+ * erroring — fire-and-forget, like emit.
+ */
+
+package rt
+
+import "syscall/js"
+
+// HostWriter is an io.Writer that forwards bytes to the JS _lgOutput global.
+type HostWriter struct{}
+
+// NewHostWriter returns a HostWriter. Pass it to NewWriterHandle to build an
+// IOHandle suitable for the *out* / *err* vars.
+func NewHostWriter() *HostWriter { return &HostWriter{} }
+
+func (w *HostWriter) Write(p []byte) (int, error) {
+	out := js.Global().Get("_lgOutput")
+	if out.IsUndefined() {
+		return len(p), nil
+	}
+	out.Invoke(string(p))
+	return len(p), nil
+}

--- a/pkg/rt/wasm/lg-host.js
+++ b/pkg/rt/wasm/lg-host.js
@@ -134,13 +134,15 @@ function startWorkerMode() {
 
   // Build worker code: fs shim + wasm_exec.js + bootstrap
   const workerCode = `
-    let outputBuf = '';
     const decoder = new TextDecoder('utf-8');
     const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
     globalThis.fs = {
       constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+      // App output now flows through _lgOutput (the Go-side HostWriter), not
+      // fd 1/2 interception. This only catches Go-runtime direct writes
+      // (e.g. panics) — surface those on the worker console.
       writeSync(fd, buf) {
-        if (fd === 1 || fd === 2) { outputBuf += decoder.decode(buf); return buf.length; }
+        if (fd === 1 || fd === 2) { console.log(decoder.decode(buf)); return buf.length; }
         return 0;
       },
       write(fd, buf, offset, length, position, callback) {
@@ -160,9 +162,12 @@ function startWorkerMode() {
       symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
       unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
     };
-    globalThis._lgFlush = function() {
-      if (outputBuf.length > 0) { postMessage({t:'out', d:outputBuf}); outputBuf = ''; }
+    // Worker side of the output bridge — the Go HostWriter calls _lgOutput;
+    // relay each chunk to the main thread, which feeds LetGoHost._output.
+    globalThis._lgOutput = function(s) {
+      postMessage({t:'out', d:s});
     };
+    globalThis._lgFlush = function() {};
     // Worker side of the js/emit bridge — forward to main thread, which
     // dispatches into LetGoHost (workers have no DOM, no LetGoHost).
     globalThis._lgEmit = function(name, dataJson) {
@@ -226,8 +231,11 @@ async function startMainThreadMode() {
   const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
   globalThis.fs = {
     constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+    // App output now flows through _lgOutput (the Go-side HostWriter), not
+    // fd 1/2 interception. This only catches Go-runtime direct writes
+    // (e.g. panics) — surface those on the console.
     writeSync(fd, buf) {
-      if (fd === 1 || fd === 2) { window.LetGoHost._output(decoder.decode(buf)); return buf.length; }
+      if (fd === 1 || fd === 2) { console.log(decoder.decode(buf)); return buf.length; }
       return 0;
     },
     write(fd, buf, offset, length, position, callback) {
@@ -250,6 +258,11 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread side of the output bridge — the Go HostWriter calls
+  // _lgOutput; feed it straight into LetGoHost (no worker round-trip).
+  globalThis._lgOutput = function(s) {
+    window.LetGoHost._output(s);
+  };
   // Main-thread side of the js/emit bridge — dispatch straight into
   // LetGoHost (no worker round-trip needed).
   globalThis._lgEmit = function(name, dataJson) {

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -156,13 +156,15 @@ function startWorkerMode() {
 
   // Build worker code: fs shim + wasm_exec.js + bootstrap
   const workerCode = `
-    let outputBuf = '';
     const decoder = new TextDecoder('utf-8');
     const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
     globalThis.fs = {
       constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+      // App output now flows through _lgOutput (the Go-side HostWriter), not
+      // fd 1/2 interception. This only catches Go-runtime direct writes
+      // (e.g. panics) — surface those on the worker console.
       writeSync(fd, buf) {
-        if (fd === 1 || fd === 2) { outputBuf += decoder.decode(buf); return buf.length; }
+        if (fd === 1 || fd === 2) { console.log(decoder.decode(buf)); return buf.length; }
         return 0;
       },
       write(fd, buf, offset, length, position, callback) {
@@ -182,9 +184,12 @@ function startWorkerMode() {
       symlink(p,l,cb){cb(null);}, truncate(p,l,cb){cb(null);},
       unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
     };
-    globalThis._lgFlush = function() {
-      if (outputBuf.length > 0) { postMessage({t:'out', d:outputBuf}); outputBuf = ''; }
+    // Worker side of the output bridge — the Go HostWriter calls _lgOutput;
+    // relay each chunk to the main thread, which feeds LetGoHost._output.
+    globalThis._lgOutput = function(s) {
+      postMessage({t:'out', d:s});
     };
+    globalThis._lgFlush = function() {};
     // Worker side of the js/emit bridge — forward to main thread, which
     // dispatches into LetGoHost (workers have no DOM, no LetGoHost).
     globalThis._lgEmit = function(name, dataJson) {
@@ -248,8 +253,11 @@ async function startMainThreadMode() {
   const enosys = () => { const e = new Error("not implemented"); e.code = "ENOSYS"; return e; };
   globalThis.fs = {
     constants: { O_WRONLY:-1, O_RDWR:-1, O_CREAT:-1, O_TRUNC:-1, O_APPEND:-1, O_EXCL:-1, O_DIRECTORY:-1 },
+    // App output now flows through _lgOutput (the Go-side HostWriter), not
+    // fd 1/2 interception. This only catches Go-runtime direct writes
+    // (e.g. panics) — surface those on the console.
     writeSync(fd, buf) {
-      if (fd === 1 || fd === 2) { window.LetGoHost._output(decoder.decode(buf)); return buf.length; }
+      if (fd === 1 || fd === 2) { console.log(decoder.decode(buf)); return buf.length; }
       return 0;
     },
     write(fd, buf, offset, length, position, callback) {
@@ -272,6 +280,11 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread side of the output bridge — the Go HostWriter calls
+  // _lgOutput; feed it straight into LetGoHost (no worker round-trip).
+  globalThis._lgOutput = function(s) {
+    window.LetGoHost._output(s);
+  };
   // Main-thread side of the js/emit bridge — dispatch straight into
   // LetGoHost (no worker round-trip needed).
   globalThis._lgEmit = function(name, dataJson) {

--- a/wasm.go
+++ b/wasm.go
@@ -48,6 +48,19 @@ func main() {
 	nsResolver := resolver.NewNSResolver(ctx, []string{"."})
 	rt.SetNSLoader(nsResolver)
 
+	// Route *out*/*err* to the JS host via _lgOutput (HostWriter), instead of
+	// os.Stdout/Stderr + the bundle's fs.writeSync fd interception. SetRoot,
+	// not a per-Run binding, because this generated main drives bytecode
+	// directly rather than through pkg/api. Guarded: if the core I/O vars
+	// aren't installed yet, output falls back to os.Stdout.
+	hostWriter := rt.NewHostWriter()
+	if v := rt.LookupCoreVar("*out*"); v != nil {
+		v.SetRoot(vm.NewBoxed(rt.NewWriterHandle("host-stdout", hostWriter)))
+	}
+	if v := rt.LookupCoreVar("*err*"); v != nil {
+		v.SetRoot(vm.NewBoxed(rt.NewWriterHandle("host-stderr", hostWriter)))
+	}
+
 	resolve := func(nsName, name string) *vm.Var {
 		n := rt.DefNSBare(nsName)
 		v := n.LookupLocal(vm.Symbol(name))


### PR DESCRIPTION

## Summary

#206 made the print fns consult `*out*`; #207 added `pkg/api.WithStdout`/`WithStderr` as the embedder dual; #223 routed the `term/*` ANSI ops through `*out*` too. The one place still reaching around `*out*` was the WASM bundle itself: app output left the runtime as a write to fd 1/2 and was caught by a JS-side `fs.writeSync` shim that forwarded it to `LetGoHost.onOutput`. That worked, but it's an interception, not a binding; the runtime never knew where its output went, and the shim had to pattern-match file descriptors.

This binds `*out*`/`*err*` to a Go `HostWriter` that calls the bundle's JS host directly. `(println …)`, `(binding [*out* *err*] …)`, `with-out-str`, and every `term/*` op now reach `LetGoHost.onOutput` through the same `*out*` path the native and embedder builds use. `fs.writeSync` is demoted to what it should always have been: a sink for Go-runtime/panic noise on fd 1/2, routed to `console.log`.

## Context — where this fits

This is the WASM leaf of the arc #79 sketched. PR1/PR2 made the Go runtime honor `*out*` and gave embedders `WithStdout`; this makes the **browser** the same kind of embedder. After this there's one output contract (write to `*out*`) bound three ways: native → `os.Stdout`, `pkg/api` embedder → `WithStdout`, WASM → `HostWriter`. The fd-interception special case is gone.

It also unblocks the next host-bound seams. A `console.log` / startup-banner demo, a future graphics/audio/controller bridge: each slots in as a *peer* capability that binds a runtime var to a JS callback, the way this binds `*out*`. `HostWriter` is the first instance of that shape on the output side; the JS-side `_lgEmit` bridge is its sibling on the event side.

## What changed (one commit, three files)

`pkg/rt/hostwriter_js_wasm.go` (new, `//go:build js && wasm`) — `HostWriter` is an `io.Writer` whose `Write` invokes a global `_lgOutput(string)`. It resolves the callback per write, so boot order doesn't matter, and drops the write (no error) if the host hasn't wired `_lgOutput`. Fire-and-forget, the same contract shape as the existing `_lgEmit` bridge.

`wasm.go` — the generated bundle `main` installs `HostWriter` as the **root** binding of `*out*` and `*err*` via `rt.NewWriterHandle` + `Var.SetRoot`. It uses `SetRoot` rather than the literal `api.WithStdout` option because this generated main drives bytecode directly and bypasses `pkg/api`, so it reaches for PR2's `NewWriterHandle` primitive instead. Guarded: if the core I/O vars aren't installed, output falls back to `os.Stdout`.

`pkg/rt/wasm/lg-host.js` — adds the JS half of the bridge in both modes. Worker mode: `_lgOutput` postMessages `{t:'out', d:s}` to the main thread, which feeds `LetGoHost._output`. Main-thread mode: `_lgOutput` calls `LetGoHost._output` directly. `fs.writeSync` for fd 1/2 now goes to `console.log` (Go-runtime/panic noise only) instead of carrying app output. The dead `_lgFlush` output buffer is removed.

## Deliberately out of scope

- **HostReader (SAB input)** — the input dual of this writer, deferred to its own PR; it has the SharedArrayBuffer/ring concerns that don't belong here.
- **A structured HostEmitter** — `_lgEmit` already exists as a JS bridge; promoting it to a typed Go-side surface is separate.
- **`flush`** stays per-platform. It's non-uniform (wasm does `Sync()` + a JS flush hook; native/plan9 just `Sync()` the active handle), so it isn't part of the `*out*`-binding story.

## Downstream

- **The website playground (`wasm/main.go` + `wasm/index.html`) is untouched.** It's a separate harness (stock `wasm_exec.js` and an `Eval` bridge that returns the result value, no `lg-host.js`, no `HostWriter`), so `println` side effects there keep going to the browser console as before. This PR only changes the `lg -w` bundle path.
- **One behavior change in the bundle:** the handful of `pkg/vm` last-resort diagnostics (panic-recover, core-shadow warning, GLS-drain) write straight to `os.Stderr`; they can't import `pkg/rt`, so they bypass `*err*`. They used to reach `onOutput` via the fd 1/2 shim; now they land on `console.log`. That keeps a panic from scribbling over the app's screen, but it's a move worth noting.
- The wasm `AssembleHTML` golden is regenerated to match the new `lg-host.js`; `generated.sums` is unaffected (`lg-host.js` is a static embedded asset, not a regen-tracked artifact).

## Testing

`go vet` clean on both the host build and `GOOS=js GOARCH=wasm`; the generated WASM bundle builds. Native A/B/C output cases (default `*out*`, rebind, capture) are covered by the suite #206 added.

Beyond that, **live in a real browser (worker mode):** built the xsofy bundle on this branch and loaded it headless with a hook wrapping `LetGoHost._output` before boot. The game's entire screen render (1,899 truecolor ANSI chunks) arrived through the full chain: `term/*` → `*out*` → `HostWriter.Write` → `_lgOutput` → worker `postMessage` → main-thread `LetGoHost._output` → terminal. The title screen painted correctly, zero console errors. Because #223 routes `term/*` through `*out*`, this path is exercised on every frame, not just by an explicit `println`, so the merged arc gets end-to-end browser coverage here, not only at the unit layer.
