### PR TITLE
ci(perf-timeline): add workflow_dispatch for historical backfill

### DIFF
--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -6,6 +6,15 @@ on:
     paths-ignore:
       - 'docs/perf/index.html'
       - 'docs/perf/timeline/**'
+  # Manual backfill: dispatch once per historical commit to fill the timeline
+  # gap. Snapshot identity is derived from the checked-out HEAD (name, sha,
+  # commit time), so the rest of the job is already commit-agnostic.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit SHA/ref to snapshot (backfill)'
+        required: true
+        default: 'main'
 
 permissions:
   contents: write
@@ -13,6 +22,11 @@ permissions:
 concurrency:
   group: perf-timeline-main
   cancel-in-progress: false
+  # Retain every queued run (FIFO, up to 100) instead of the default
+  # queue: single, which keeps only the latest pending run. The backfill
+  # dispatches one run per historical commit; under queue: single all but
+  # the last would supersede each other and be canceled.
+  queue: max
 
 jobs:
   profile:
@@ -22,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.ref || github.sha }}
           submodules: recursive
           fetch-depth: 0
 
@@ -94,5 +109,8 @@ jobs:
             echo "No perf changes to commit."
             exit 0
           fi
-          git -C "$wt" commit -m "perf: record timeline snapshot for ${{ github.sha }}"
+          # Name the snapshot's own commit, not the dispatch ref (under
+          # workflow_dispatch github.sha is the branch tip, not the backfilled
+          # commit). snapshot_name embeds the correct short sha + commit time.
+          git -C "$wt" commit -m "perf: record timeline snapshot ${snapshot_name}"
           git -C "$wt" push "$remote" HEAD:perf-data


### PR DESCRIPTION
## What

Add a `workflow_dispatch` trigger to the perf-timeline workflow so it can
snapshot an arbitrary commit, then dispatch it once per historical commit
to backfill the timeline.

## Why

The "Are we fast yet?" timeline only records a snapshot on push to `main`,
so it has just the seed points: no trend line, and branch work produces
nothing to look at. Filling the v1.8.0→main gap meant either a one-off
local sweep (different hardware, manual perf-data push) or this — dispatch
the existing job per commit, on the same `ubuntu-latest` hardware as every
other point, auto-published to `perf-data`.

## How

The job was already commit-agnostic: snapshot name, sha, and commit time
all derive from `HEAD`. The only thing tied to the push event was which
commit `checkout` grabbed.

- `checkout` takes `ref: ${{ github.event.inputs.ref || github.sha }}`
  (`fetch-depth: 0` was already set, so arbitrary shas resolve).
- The `push` trigger and every downstream step are unchanged, so per-merge
  behavior is identical.
- The perf-data commit message no longer uses `github.sha`, which under
  dispatch is the branch tip rather than the backfilled commit; it names
  the snapshot's own commit via `snapshot_name`.

`make lowered` regenerates the gitignored IR tree per run, so no generated
code is committed.

## Backfill

After this merges, the sweep is a sampled dispatch loop:

    for sha in $(git rev-list --reverse v1.8.0..main | awk 'NR % 10 == 1'); do
      gh workflow run perf-timeline.yml -f ref="$sha"
    done

Runs queue on the `perf-timeline-main` concurrency group and drain onto
`perf-data` one at a time. Start coarse, fill in around interesting steps
later.
