### PR TITLE
fix(term): tolerate ENOTTY from flush Sync on a file-backed TTY

### DIFF
--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -8,6 +8,7 @@
 package rt
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -542,10 +543,26 @@ func installTermNS() {
 	// (before *out* is installed). Pre-#223 this synced os.Stdout directly,
 	// which diverged once the term/* ops started honoring *out*.
 	flushFn := vm.NewCtxNativeFn("flush", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var (
+			err        error
+			fileBacked bool
+		)
 		if h := resolveIOHandleVar(ec, "*out*"); h != nil {
-			return vm.NIL, h.Sync()
+			err = h.Sync()
+			fileBacked = h.File() != nil
+		} else {
+			err = os.Stdout.Sync()
+			fileBacked = true
 		}
-		return vm.NIL, os.Stdout.Sync()
+		// fsync on a terminal returns ENOTTY (macOS/BSD); flushing a TTY is a
+		// no-op, so swallow it. Only for a file-backed *out* — an embedder
+		// writer's Sync goes through Flush() and must surface its own errors.
+		// A regular file's fsync never returns ENOTTY, so real I/O errors
+		// (EIO, ENOSPC, …) still propagate.
+		if fileBacked && errors.Is(err, syscall.ENOTTY) {
+			err = nil
+		}
+		return vm.NIL, err
 	})
 	ns.Def("flush", flushFn)
 


### PR DESCRIPTION
## Summary

`term/flush` returns the error from `Sync()` on the active `*out*` handle (or `os.Stdout` at early boot). On macOS/BSD, `Sync()` on a terminal returns `ENOTTY` — `fsync` isn't a valid operation on a character device. That error propagates as fatal, so any native let-go program that calls `(term/flush)` with `*out*` bound to a TTY crashes:

```
error: sync /dev/stdout: inappropriate ioctl for device
  --> main.lg:35:3
     35 |   (term/flush)
```

Linux doesn't return `ENOTTY` for `Sync` on a TTY, so CI on Linux never hit this — it only shows up running a TUI natively on macOS.

## Provenance

This is a regression from #223. The original `flush` (`fe4ff71`) called `os.Stdout.Sync()`, discarded the error, and returned `nil`. #223 rewrote it to a context-aware builtin that calls `IOHandle.Sync()` and returns the error — correct for surfacing real flush failures, but it also started surfacing the benign `ENOTTY` that the old code swallowed. Linux CI didn't catch the behavior change because Linux fsync-on-a-TTY doesn't return `ENOTTY`.

## Fix

Swallow `ENOTTY` only when `*out*` is file-backed (`IOHandle.File() != nil`). A terminal's `fsync` is a no-op, and a regular file's `fsync` never returns `ENOTTY`, so real I/O errors (`EIO`, `ENOSPC`, …) still propagate. Embedder-supplied writers route their `Sync` through `Flush()` and surface their own errors unchanged.

```go
var fileBacked bool
if h := resolveIOHandleVar(ec, "*out*"); h != nil {
    err = h.Sync()
    fileBacked = h.File() != nil
} else {
    err = os.Stdout.Sync()
    fileBacked = true
}
if fileBacked && errors.Is(err, syscall.ENOTTY) {
    err = nil
}
```

## Repro

Any native TUI that flushes on macOS — e.g. a program ending in `(term/flush)` during terminal teardown — run from a real terminal (so `*out*` is a TTY). Before: crashes with the error above. After: flushes cleanly.

## Testing

`gofmt` clean; `pkg/rt` builds under host, `GOOS=linux`, `GOOS=js`, and `GOOS=plan9` (`term.go` is `!js && !plan9`, so the change only affects the native build). Verified by hand on macOS: a TUI that previously crashed on the teardown flush now exits cleanly.

This is awkward to cover with a unit test — it needs a real TTY for `Sync` to return `ENOTTY`, which doesn't reproduce under `go test`'s piped stdout. Happy to add a build-tagged manual check if you'd prefer one.
