### PR TITLE
ci(perf-timeline): resolve dispatch ref in a script step (support short SHAs)

### DIFF
--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -36,9 +36,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref || github.sha }}
           submodules: recursive
           fetch-depth: 0
+
+      - name: Check out target ref
+        run: |
+          ref="${{ github.event.inputs.ref || github.sha }}"
+          # actions/checkout only treats a *full* 40-char SHA as a commit; a
+          # short SHA is read as a branch/tag name and fails ("a branch or tag
+          # with the name '<sha>' could not be found"). Resolve here instead —
+          # fetch-depth:0 already pulled every branch and tag, so any committish
+          # (short SHA, full SHA, branch, tag) resolves locally.
+          git checkout --force "$ref"
+          git submodule update --init --recursive
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -40,14 +40,15 @@ jobs:
           fetch-depth: 0
 
       - name: Check out target ref
+        env:
+          TARGET_REF: ${{ github.event.inputs.ref || github.sha }}
         run: |
-          ref="${{ github.event.inputs.ref || github.sha }}"
           # actions/checkout only treats a *full* 40-char SHA as a commit; a
           # short SHA is read as a branch/tag name and fails ("a branch or tag
           # with the name '<sha>' could not be found"). Resolve here instead —
           # fetch-depth:0 already pulled every branch and tag, so any committish
           # (short SHA, full SHA, branch, tag) resolves locally.
-          git checkout --force "$ref"
+          git checkout --force "$TARGET_REF"
           git submodule update --init --recursive
 
       - name: Set up Go


### PR DESCRIPTION
## What

Resolve the dispatch `ref` in a script step so the timeline job accepts any committish — short SHA, full SHA, branch, or tag — not just full 40-char SHAs.

## Why

`actions/checkout@v4` only treats a **full 40-char SHA** as a commit. A short SHA passed to the `ref` input is interpreted as a branch/tag name and fails:

```
##[error]A branch or tag with the name 'd4eb364' could not be found
```

The documented backfill loop (`git rev-list …`) is unaffected, since it emits full SHAs. But hand-dispatching from the Actions UI with a short SHA — the natural thing to do — fails at checkout. Hit while validating the #236 backfill on a fork.

## How

Drop the `ref` input; check out at `fetch-depth: 0` (which already fetches every branch and tag), then `git checkout "$ref"` in a script step. Git resolves any committish locally against the full clone. Submodules are re-synced to the resolved commit, and snapshot identity still derives from `HEAD` (now the resolved target).

Follow-up to #236.
