### PR TITLE
build: keep the readline REPL out of GOOS=js builds

### DIFF
--- a/lg_repl.go
+++ b/lg_repl.go
@@ -1,4 +1,4 @@
-//go:build !plan9
+//go:build !plan9 && !js
 
 /*
  * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>

--- a/lg_repl_stub.go
+++ b/lg_repl_stub.go
@@ -1,4 +1,4 @@
-//go:build plan9
+//go:build plan9 || js
 
 /*
  * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>
@@ -18,10 +18,11 @@ import (
 	"github.com/nooga/let-go/pkg/vm"
 )
 
-// repl is a minimal line-by-line REPL for plan9. The alimpfard/line readline
-// library depends on termios/ioctl (not available on plan9), so this build
-// reads from stdin via bufio.Scanner — no completion, no syntax highlighting,
-// no in-line editing. Use rio's edit-line history instead.
+// repl is a minimal line-by-line REPL for platforms without readline. The
+// chzyer/readline library depends on termios/ioctl, unavailable on plan9 and
+// js/wasm, so these builds read from stdin via bufio.Scanner — no completion,
+// no syntax highlighting, no in-line editing. (On js the root binary isn't the
+// REPL entry at all; this just keeps GOOS=js go build ./... compiling.)
 func repl(ctx *compiler.Context) {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)


### PR DESCRIPTION
`GOOS=js GOARCH=wasm go build ./...` fails to compile: the root `main` package builds the REPL, which imports `github.com/chzyer/readline` — a termios/ioctl library with no js/wasm support. `lg_repl.go` was tagged `!plan9` only, so it compiled under `GOOS=js` and dragged readline in.

This has never built for `GOOS=js` — the gap predates the `chzyer/readline` migration (#90); `alimpfard/line` before it was equally termios-bound. It went unnoticed because the shipped `lg -w` bundle builds a generated `main` (the `wasm/` tree), not the root package, and CI builds only the bundle (`pages.yml`), never `go build ./...`.

Fix: route js to the readline-free stub REPL the same way plan9 already does.

- `lg_repl.go`: `!plan9` → `!plan9 && !js`
- `lg_repl_plan9.go` → `lg_repl_stub.go`, tag `plan9` → `plan9 || js` (the `bufio.Scanner` REPL needs no termios, so it serves both)

`go build ./...` now passes for `GOOS=js`; native is unchanged.

Closes #242.
