### PR TITLE
feat(rt,api): typed KeySource seam — route term/read-key + key-pending? through a host capability

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,6 +20,7 @@ type config struct {
 	stdout io.Writer
 	stderr io.Writer
 	emit   func(name, dataJSON string)
+	keys   rt.KeySource
 }
 
 // WithStdout configures the runtime to route output written via *out*
@@ -70,10 +71,27 @@ func WithEmit(fn func(name, dataJSON string)) Option {
 	return func(c *config) { c.emit = fn }
 }
 
+// WithKeySource routes term/read-key and key-pending? through ks for this
+// instance, the input dual of WithStdout. An embedder or test supplies the
+// keystrokes the guest reads — driving a TUI without a real terminal, or
+// feeding a deterministic script. ks is an rt.KeySource (ReadKey +
+// KeyPending); see pkg/rt/keysource.go.
+//
+// Implementation: each Run pushes ks as a dynamic binding on *keys*, popped
+// on return. Same per-Run isolation and process-global-binding-stack
+// concurrency caveat as WithStdout.
+//
+// Default: the platform key source (stdin+SIGWINCH on native, the SAB in
+// WASM). Wake — unblocking a parked read-key without a real key — is not part
+// of this seam yet; see the note in pkg/rt/wasm/lg-host.js.
+func WithKeySource(ks rt.KeySource) Option {
+	return func(c *config) { c.keys = ks }
+}
+
 // (Other options deliberately NOT exposed:
 //
-//   - WithStdin: stdin substitution is tied to the wake() / SAB protocol
-//     deferred from nooga/let-go#174 and the readline-driven REPL path.
+//   - WithStdin: line-stream stdin substitution is the *in* io.Reader dual
+//     of WithStdout, separate from WithKeySource's interactive key input.
 //     *in*'s root binding remains os.Stdin; embedders that need stdin
 //     substitution today can rebind *in* manually before calling Run.)
 
@@ -88,6 +106,7 @@ type LetGo struct {
 	stdoutHandle vm.Value
 	stderrHandle vm.Value
 	emitHandle   vm.Value
+	keysHandle   vm.Value
 }
 
 // NewLetGo constructs a runtime. With no options, behavior is exactly
@@ -121,6 +140,9 @@ func NewLetGo(ns string, opts ...Option) (*LetGo, error) {
 	}
 	if cfg.emit != nil {
 		ret.emitHandle = vm.NewBoxed(rt.FuncEmitter(cfg.emit))
+	}
+	if cfg.keys != nil {
+		ret.keysHandle = vm.NewBoxed(cfg.keys)
 	}
 
 	return ret, nil
@@ -165,6 +187,12 @@ func (l *LetGo) Run(expr string) (vm.Value, error) {
 	if l.emitHandle != nil {
 		if v := rt.LookupCoreVar("*emit*"); v != nil {
 			v.PushBinding(l.emitHandle)
+			defer v.PopBinding()
+		}
+	}
+	if l.keysHandle != nil {
+		if v := rt.LookupCoreVar("*keys*"); v != nil {
+			v.PushBinding(l.keysHandle)
 			defer v.PopBinding()
 		}
 	}

--- a/pkg/api/keysource_test.go
+++ b/pkg/api/keysource_test.go
@@ -1,0 +1,77 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/api"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// scriptedKeys is a deterministic rt.KeySource for tests: it hands out a
+// fixed sequence of keys, then reports end-of-input.
+type scriptedKeys struct {
+	keys []string
+	i    int
+}
+
+func (s *scriptedKeys) ReadKey() (string, error) {
+	if s.i >= len(s.keys) {
+		return "", nil // EOF → read-key nil
+	}
+	k := s.keys[s.i]
+	s.i++
+	return k, nil
+}
+
+func (s *scriptedKeys) KeyPending() bool { return s.i < len(s.keys) }
+
+// TestWithKeySource proves the input dual of TestWithStdout: keys supplied
+// via api.WithKeySource flow out of (term/read-key) in order, and exhaustion
+// surfaces as the nil contract — no real terminal involved.
+func TestWithKeySource(t *testing.T) {
+	ks := &scriptedKeys{keys: []string{"a", "\x1b[A", "b"}}
+	lg, err := api.NewLetGo("withkeys-test", api.WithKeySource(ks))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"a", "\x1b[A", "b"} {
+		v, err := lg.Run(`(term/read-key)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s, ok := v.(vm.String)
+		if !ok || string(s) != want {
+			t.Fatalf("read-key = %#v, want %q", v, want)
+		}
+	}
+
+	// Exhausted → nil.
+	v, err := lg.Run(`(term/read-key)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != vm.NIL {
+		t.Errorf("read-key after exhaustion = %#v, want nil", v)
+	}
+}
+
+// TestWithKeySourcePending proves key-pending? routes through the same bound
+// source: true while keys remain, false once drained.
+func TestWithKeySourcePending(t *testing.T) {
+	ks := &scriptedKeys{keys: []string{"x"}}
+	lg, err := api.NewLetGo("withkeys-pending-test", api.WithKeySource(ks))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, err := lg.Run(`(term/key-pending?)`); err != nil || v != vm.TRUE {
+		t.Fatalf("key-pending? with a queued key = %#v (err %v), want true", v, err)
+	}
+	if _, err := lg.Run(`(term/read-key)`); err != nil {
+		t.Fatal(err)
+	}
+	if v, err := lg.Run(`(term/key-pending?)`); err != nil || v != vm.FALSE {
+		t.Fatalf("key-pending? after draining = %#v (err %v), want false", v, err)
+	}
+}

--- a/pkg/rt/iort.go
+++ b/pkg/rt/iort.go
@@ -333,6 +333,12 @@ func installIOBuiltins(ns *vm.Namespace) {
 	// api.WithEmit. Lives in core (not the js ns) so it binds the same way
 	// *out* does. See emitter.go.
 	ns.Def("*emit*", vm.NewBoxed(nopEmitter{}))
+
+	// *keys* — host key-source for term/read-key and key-pending?. Defaults
+	// to a no-op (no input); each platform's term install replaces the root
+	// with a real source (stdin+SIGWINCH on native, the SAB in WASM), and
+	// api.WithKeySource rebinds it per Run. See keysource.go.
+	ns.Def("*keys*", vm.NewBoxed(nopKeySource{}))
 }
 
 // resolveIOHandleVar looks up a var (e.g. "*out*") in the core namespace

--- a/pkg/rt/keysource.go
+++ b/pkg/rt/keysource.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ *
+ * KeySource is the host seam for blocking key input — the source behind
+ * term/read-key and term/key-pending?. It is the input peer of the *out*
+ * HostWriter and the *emit* HostEmitter: term ops consult a host-bound
+ * capability at the *keys* var instead of reaching for os.Stdin / the
+ * SharedArrayBuffer globals directly.
+ *
+ * Bound at the *keys* root per platform — a stdin+SIGWINCH source on native
+ * (term.go), a SharedArrayBuffer source in the WASM bundle
+ * (keysource_js_wasm.go) — and overridable per-Run by api.WithKeySource so
+ * an embedder or test can feed synthetic keys.
+ *
+ * Scope: ReadKey + KeyPending only. Terminal geometry (size / set-size) stays
+ * a separate term op, and wake — unblocking a parked ReadKey without a real
+ * key — is deferred (see the note in pkg/rt/wasm/lg-host.js); it needs a
+ * SAB-level protocol this seam leaves room for but doesn't introduce.
+ */
+
+package rt
+
+import "github.com/nooga/let-go/pkg/vm"
+
+// KeySource is a source of keypresses for term/read-key and key-pending?.
+type KeySource interface {
+	// ReadKey blocks until a key is available, returning the key's bytes as
+	// a string. Returns "" for end-of-input (the read-key nil contract).
+	ReadKey() (string, error)
+	// KeyPending reports whether a key is buffered and ready, without
+	// consuming it — the non-blocking peer of ReadKey.
+	KeyPending() bool
+}
+
+// nopKeySource is the placeholder root: no input, nothing pending. Each
+// platform's term install replaces it with a real source; it only governs
+// stub platforms (plan9) and the pre-install window.
+type nopKeySource struct{}
+
+func (nopKeySource) ReadKey() (string, error) { return "", nil }
+func (nopKeySource) KeyPending() bool         { return false }
+
+// resolveKeySourceVar unwraps the current dynamic binding of varName (e.g.
+// "*keys*") to a KeySource, mirroring resolveIOHandleVar / resolveEmitterVar.
+// Returns nil if the var isn't installed or doesn't unwrap to a KeySource.
+func resolveKeySourceVar(ec *vm.ExecContext, varName string) KeySource {
+	ns := lookupNSCached(NameCoreNS)
+	if ns == nil {
+		return nil
+	}
+	v := ns.LookupLocal(vm.Symbol(varName))
+	if v == nil {
+		return nil
+	}
+	b, ok := ec.Deref(v).(*vm.Boxed)
+	if !ok {
+		return nil
+	}
+	if ks, ok := b.Unbox().(KeySource); ok {
+		return ks
+	}
+	return nil
+}
+
+// boundKeySource returns the KeySource currently bound at *keys*, falling
+// back to nopKeySource so the term ops always have something to call.
+func boundKeySource(ec *vm.ExecContext) KeySource {
+	if ks := resolveKeySourceVar(ec, "*keys*"); ks != nil {
+		return ks
+	}
+	return nopKeySource{}
+}

--- a/pkg/rt/keysource_js_wasm.go
+++ b/pkg/rt/keysource_js_wasm.go
@@ -1,0 +1,69 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ *
+ * HostKeySource is the WASM key source: term/read-key and key-pending? read
+ * keystrokes from the bundle's SharedArrayBuffer instead of poking the
+ * _lgKeyInt32 / Atomics globals inline. The dual of HostWriter / HostEmitter
+ * — installed at the *keys* root by term_wasm.go's install, resolving the JS
+ * globals per call so SAB setup order doesn't matter.
+ *
+ * SAB layout (Int32Array): [0] key-ready flag, [1] byte count; Uint8Array at
+ * offset 8, length 16, holds the key bytes. See pkg/rt/wasm/lg-host.js.
+ */
+
+package rt
+
+import (
+	"fmt"
+	"syscall/js"
+)
+
+// HostKeySource reads keys from the bundle's SharedArrayBuffer.
+type HostKeySource struct{}
+
+// NewHostKeySource returns a HostKeySource for the *keys* root binding.
+func NewHostKeySource() *HostKeySource { return &HostKeySource{} }
+
+func (HostKeySource) ReadKey() (string, error) {
+	atomics := js.Global().Get("Atomics")
+	keyInt32 := js.Global().Get("_lgKeyInt32")
+	keyUint8 := js.Global().Get("_lgKeyUint8")
+	if keyInt32.IsUndefined() || keyUint8.IsUndefined() {
+		return "", fmt.Errorf("read-key: terminal input not available (no SharedArrayBuffer)")
+	}
+
+	// Flush output before parking on the key wait.
+	js.Global().Call("_lgFlush")
+
+	// Block until a key is ready.
+	atomics.Call("wait", keyInt32, 0, 0)
+
+	keyLen := jsLoadInt(atomics, keyInt32, 1)
+	if keyLen <= 0 || keyLen > 16 {
+		atomics.Call("store", keyInt32, 0, 0)
+		return "", nil
+	}
+
+	keyBytes := make([]byte, keyLen)
+	for i := 0; i < keyLen; i++ {
+		keyBytes[i] = byte(keyUint8.Index(i).Int())
+	}
+	atomics.Call("store", keyInt32, 0, 0)
+	return string(keyBytes), nil
+}
+
+func (HostKeySource) KeyPending() bool {
+	keyInt32 := js.Global().Get("_lgKeyInt32")
+	atomics := js.Global().Get("Atomics")
+	if keyInt32.IsUndefined() || atomics.IsUndefined() {
+		return false
+	}
+	v := atomics.Call("load", keyInt32, 0)
+	if v.IsUndefined() || v.IsNull() {
+		return false
+	}
+	return v.Int() != 0
+}

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -93,10 +93,121 @@ func fdFromHandle(v vm.Value) (int, error) {
 
 var termOldState *term.State
 
+// nativeKeySource is the native *keys* binding: term/read-key and key-pending?
+// read from stdin, with the SIGWINCH wake-byte self-pipe (setupWinch) breaking
+// a blocked read on resize. The body is the pre-seam read-key/key-pending?
+// logic, unchanged — it just lives behind the KeySource interface now so the
+// term ops, embedders (api.WithKeySource), and tests share one source.
+type nativeKeySource struct{}
+
+func (nativeKeySource) ReadKey() (string, error) {
+	setupWinch() // idempotent; armed on first read-key
+
+	if winchPipeR == nil {
+		// Pipe setup failed; plain blocking read (preserves prior behavior).
+		buf := make([]byte, 16)
+		n, err := os.Stdin.Read(buf)
+		if err != nil || n == 0 {
+			return "", nil
+		}
+		return string(buf[:n]), nil
+	}
+
+	stdinFd := int(os.Stdin.Fd())
+	winchFd := int(winchPipeR.Fd())
+	fds := []unix.PollFd{
+		{Fd: int32(stdinFd), Events: unix.POLLIN},
+		{Fd: int32(winchFd), Events: unix.POLLIN},
+	}
+
+	// Retry on EINTR — golang.org/x/sys/unix.Poll doesn't auto-retry.
+	// SIGWINCH (which we install) and Go runtime preemption (SIGURG) can
+	// both interrupt the blocking poll(2). Pre-PR os.Stdin.Read got
+	// transparent EINTR retry via Go's ignoringEINTR; preserve that here.
+	for {
+		_, err := unix.Poll(fds, -1)
+		if err == unix.EINTR {
+			continue
+		}
+		if err != nil {
+			return "", nil
+		}
+		break
+	}
+
+	// Drain the wake pipe unconditionally if it fired — keeps it quiescent
+	// for the next cycle even when stdin also has data.
+	if fds[1].Revents&unix.POLLIN != 0 {
+		drain := make([]byte, 16)
+		_, _ = winchPipeR.Read(drain)
+	}
+
+	// Disconnect / error on stdin (POLLHUP / POLLERR / POLLNVAL). These are
+	// always reported in Revents regardless of requested Events. Some kernels
+	// set POLLIN alongside (Linux on pipe EOF: POLLIN|POLLHUP → falls into the
+	// POLLIN branch below, Read returns n==0); some don't (Linux on closed pty
+	// master: POLLHUP only). Without explicit handling, the latter would fall
+	// through to the BEL return below, the caller would re-enter read-key,
+	// Poll would re-fire immediately, and the loop would spin at 100% CPU
+	// emitting BEL forever — EOF never surfaced. Routing through os.Stdin.Read
+	// here too surfaces n==0 as the nil contract callers had pre-PR.
+	if fds[0].Revents&(unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 {
+		buf := make([]byte, 16)
+		n, err := os.Stdin.Read(buf)
+		if err != nil || n == 0 {
+			return "", nil
+		}
+		return string(buf[:n]), nil
+	}
+
+	// Prefer real input — user keys shouldn't queue behind a resize wake.
+	if fds[0].Revents&unix.POLLIN != 0 {
+		buf := make([]byte, 16)
+		n, err := os.Stdin.Read(buf)
+		if err != nil || n == 0 {
+			return "", nil
+		}
+		return string(buf[:n]), nil
+	}
+
+	// Only the wake fired — return BEL so the loop's term/size diff runs.
+	return "\x07", nil
+}
+
+func (nativeKeySource) KeyPending() bool {
+	// Arm the winch handler if it hasn't been already — a caller that hits
+	// key-pending? before any read-key would otherwise miss SIGWINCH wakes.
+	setupWinch()
+
+	var n int32
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(os.Stdin.Fd()),
+		uintptr(fionread),
+		uintptr(unsafe.Pointer(&n)))
+	if errno == 0 && n > 0 {
+		return true
+	}
+	if winchPipeR != nil {
+		var pn int32
+		_, _, perrno := syscall.Syscall(syscall.SYS_IOCTL,
+			uintptr(winchPipeR.Fd()),
+			uintptr(fionread),
+			uintptr(unsafe.Pointer(&pn)))
+		if perrno == 0 && pn > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func init() { RegisterInstaller(installTermNS) }
 
 // nolint
 func installTermNS() {
+	// Bind the native key source (stdin + SIGWINCH wake-pipe) at the *keys*
+	// root, the input dual of the os.Stdout *out* default in iort.go.
+	CoreNS.Lookup("*keys*").(*vm.Var).SetRoot(vm.NewBoxed(nativeKeySource{}))
+
 	ns := vm.NewNamespace("term")
 	ns.Refer(CoreNS, "", true)
 
@@ -161,87 +272,21 @@ func installTermNS() {
 	})
 	ns.Def("restore-mode!", restoreMode)
 
-	// read-key — read a single keypress, returns a string
+	// read-key — read a single keypress through the *keys* source.
 	// Returns single chars, or escape sequences like "\x1b[A" for arrow keys.
-	// Also returns BEL ("\x07") when the terminal is resized (SIGWINCH) so
-	// the game loop's term/size check can fire without waiting for input;
-	// see setupWinch above for the design.
-	readKey, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		setupWinch() // idempotent; armed on first read-key
-
-		if winchPipeR == nil {
-			// Pipe setup failed; plain blocking read (preserves prior behavior).
-			buf := make([]byte, 16)
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return vm.NIL, nil
-			}
-			return vm.String(buf[:n]), nil
+	// nativeKeySource also returns BEL ("\x07") on resize (SIGWINCH) so the
+	// game loop's term/size check can fire without waiting for input; see
+	// setupWinch above. Ctx-aware so api.WithKeySource / (binding [*keys* …])
+	// is honored; "" is the end-of-input nil contract.
+	readKey := vm.NewCtxNativeFn("read-key", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		s, err := boundKeySource(ec).ReadKey()
+		if err != nil {
+			return vm.NIL, err
 		}
-
-		stdinFd := int(os.Stdin.Fd())
-		winchFd := int(winchPipeR.Fd())
-		fds := []unix.PollFd{
-			{Fd: int32(stdinFd), Events: unix.POLLIN},
-			{Fd: int32(winchFd), Events: unix.POLLIN},
+		if s == "" {
+			return vm.NIL, nil
 		}
-
-		// Retry on EINTR — golang.org/x/sys/unix.Poll doesn't auto-retry.
-		// SIGWINCH (which we install) and Go runtime preemption (SIGURG)
-		// can both interrupt the blocking poll(2). Pre-PR os.Stdin.Read
-		// got transparent EINTR retry via Go's ignoringEINTR; preserve
-		// that contract here.
-		for {
-			_, err := unix.Poll(fds, -1)
-			if err == unix.EINTR {
-				continue
-			}
-			if err != nil {
-				return vm.NIL, nil
-			}
-			break
-		}
-
-		// Drain the wake pipe unconditionally if it fired — keeps it
-		// quiescent for the next cycle even when stdin also has data.
-		if fds[1].Revents&unix.POLLIN != 0 {
-			drain := make([]byte, 16)
-			_, _ = winchPipeR.Read(drain)
-		}
-
-		// Disconnect / error on stdin (POLLHUP / POLLERR / POLLNVAL).
-		// These are always reported in Revents regardless of requested
-		// Events. Some kernels set POLLIN alongside (Linux on pipe EOF:
-		// POLLIN|POLLHUP → falls into the POLLIN branch below, Read
-		// returns n==0); some don't (Linux on closed pty master:
-		// POLLHUP only). Without explicit handling, the latter would
-		// fall through to the BEL return below, the caller would re-
-		// enter read-key, Poll would re-fire immediately, and the loop
-		// would spin at 100% CPU emitting BEL forever — EOF never
-		// surfaced. Routing through os.Stdin.Read here too surfaces
-		// n==0 as vm.NIL, the same end-of-input contract callers had
-		// pre-PR.
-		if fds[0].Revents&(unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 {
-			buf := make([]byte, 16)
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return vm.NIL, nil
-			}
-			return vm.String(buf[:n]), nil
-		}
-
-		// Prefer real input — user keys shouldn't queue behind a resize wake.
-		if fds[0].Revents&unix.POLLIN != 0 {
-			buf := make([]byte, 16)
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return vm.NIL, nil
-			}
-			return vm.String(buf[:n]), nil
-		}
-
-		// Only the wake fired — return BEL so the loop's term/size diff runs.
-		return vm.String("\x07"), nil
+		return vm.String(s), nil
 	})
 	ns.Def("read-key", readKey)
 
@@ -256,29 +301,9 @@ func installTermNS() {
 	// (when (key-pending?) (read-key)) idiom honest for animation /
 	// poll loops that want to break out on input OR on resize.
 	// Returns false if both checks come up empty or error out.
-	keyPendingFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		// Arm the winch handler if it hasn't been already — a caller
-		// that hits key-pending? before any read-key would otherwise
-		// miss SIGWINCH wakes entirely.
-		setupWinch()
-
-		var n int32
-		_, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-			uintptr(os.Stdin.Fd()),
-			uintptr(fionread),
-			uintptr(unsafe.Pointer(&n)))
-		if errno == 0 && n > 0 {
+	keyPendingFn := vm.NewCtxNativeFn("key-pending?", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		if boundKeySource(ec).KeyPending() {
 			return vm.TRUE, nil
-		}
-		if winchPipeR != nil {
-			var pn int32
-			_, _, perrno := syscall.Syscall(syscall.SYS_IOCTL,
-				uintptr(winchPipeR.Fd()),
-				uintptr(fionread),
-				uintptr(unsafe.Pointer(&pn)))
-			if perrno == 0 && pn > 0 {
-				return vm.TRUE, nil
-			}
 		}
 		return vm.FALSE, nil
 	})

--- a/pkg/rt/term_wasm.go
+++ b/pkg/rt/term_wasm.go
@@ -40,6 +40,10 @@ func installTermNS() {
 	// Set *in-wasm* so user code can detect WASM environment
 	CoreNS.Lookup("*in-wasm*").(*vm.Var).SetRoot(vm.TRUE)
 
+	// Bind the WASM key source (SharedArrayBuffer) at the *keys* root — the
+	// input dual of the HostWriter *out* install in wasmMainTmpl.
+	CoreNS.Lookup("*keys*").(*vm.Var).SetRoot(vm.NewBoxed(NewHostKeySource()))
+
 	ns := vm.NewNamespace("term")
 	ns.Refer(CoreNS, "", true)
 
@@ -55,56 +59,25 @@ func installTermNS() {
 	})
 	ns.Def("restore-mode!", restoreMode)
 
-	// read-key — blocks via Atomics.wait on SharedArrayBuffer
-	readKey, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		atomics := js.Global().Get("Atomics")
-		keyInt32 := js.Global().Get("_lgKeyInt32")
-		keyUint8 := js.Global().Get("_lgKeyUint8")
-
-		if keyInt32.IsUndefined() || keyUint8.IsUndefined() {
-			return vm.NIL, fmt.Errorf("read-key: terminal input not available (no SharedArrayBuffer)")
+	// read-key — reads through the *keys* source (HostKeySource → SAB by
+	// default). Ctx-aware so api.WithKeySource / (binding [*keys* …]) is
+	// honored. "" is the end-of-input nil contract.
+	readKey := vm.NewCtxNativeFn("read-key", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		s, err := boundKeySource(ec).ReadKey()
+		if err != nil {
+			return vm.NIL, err
 		}
-
-		// Flush output before blocking
-		js.Global().Call("_lgFlush")
-
-		// Block until a key is ready
-		atomics.Call("wait", keyInt32, 0, 0)
-
-		// Read key length and bytes
-		keyLen := jsLoadInt(atomics, keyInt32, 1)
-		if keyLen <= 0 || keyLen > 16 {
-			atomics.Call("store", keyInt32, 0, 0)
+		if s == "" {
 			return vm.NIL, nil
 		}
-
-		keyBytes := make([]byte, keyLen)
-		for i := 0; i < keyLen; i++ {
-			keyBytes[i] = byte(keyUint8.Index(i).Int())
-		}
-
-		// Reset flag for next key
-		atomics.Call("store", keyInt32, 0, 0)
-
-		return vm.String(keyBytes), nil
+		return vm.String(s), nil
 	})
 	ns.Def("read-key", readKey)
 
-	// key-pending? — true if the key-ready flag at SAB[0] is set, i.e.
-	// the JS side has written a key that read-key has not yet consumed.
-	// Lets animation / poll loops break out on user input without
-	// entering read-key (which would Atomics.wait if no key is queued).
-	keyPendingFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		keyInt32 := js.Global().Get("_lgKeyInt32")
-		atomics := js.Global().Get("Atomics")
-		if keyInt32.IsUndefined() || atomics.IsUndefined() {
-			return vm.FALSE, nil
-		}
-		v := atomics.Call("load", keyInt32, 0)
-		if v.IsUndefined() || v.IsNull() {
-			return vm.FALSE, nil
-		}
-		if v.Int() != 0 {
+	// key-pending? — non-blocking peek at the *keys* source. Lets animation
+	// / poll loops break out on input without parking in read-key.
+	keyPendingFn := vm.NewCtxNativeFn("key-pending?", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		if boundKeySource(ec).KeyPending() {
 			return vm.TRUE, nil
 		}
 		return vm.FALSE, nil


### PR DESCRIPTION

Promotes blocking key input to a host-bound capability, the input peer of the `*out*` HostWriter (#231) and `*emit*` HostEmitter (#241). `term/read-key` and `key-pending?` consult a `KeySource` at the `*keys*` var instead of reaching for `os.Stdin` / the SharedArrayBuffer globals inline — the same decoupling move output and emit made. This is the input item of the §6 sequence in the host-decoupling design doc (#233).

### What

- **`pkg/rt/keysource.go`** — `KeySource` interface (`ReadKey() (string, error)` + `KeyPending() bool`), a default `nopKeySource`, and `resolveKeySourceVar` / `boundKeySource` (duals of `resolveIOHandleVar` / the emit resolver).
- **`*keys*` core var** (`iort.go`), root-bound per platform: a stdin+SIGWINCH `nativeKeySource` on native, a SharedArrayBuffer `HostKeySource` in the WASM bundle (`keysource_js_wasm.go`).
- **`term/read-key` + `key-pending?`** are now ctx-aware natives dispatching through the bound source, so `api.WithKeySource` and `(binding [*keys* …] …)` are honored.
- **`api.WithKeySource(ks)`** — per-Run binding on `*keys*`, the input dual of `WithStdout`. An embedder or test feeds the keys the guest reads, with no real terminal.

The native `read-key` / `key-pending?` logic moves verbatim behind the interface — the SIGWINCH wake-pipe, the `unix.Poll` loop, the EINTR retry, and the POLLHUP/EOF handling are unchanged, just relocated into `nativeKeySource`.

### Scope

`ReadKey` + `KeyPending` only. Terminal geometry (`size` / `set-size`) stays a separate `term` op — native `size` takes a handle arg and queries real winsize, which doesn't belong in a key source.

**Wake stays deferred.** Unblocking a parked `read-key` without a real key is the one open design question (a `wake()` method vs the native `BEL`-on-resize sentinel vs a SAB wake-epoch cell). It's already called out as out of scope in `lg-host.js`; this seam leaves room for it but doesn't introduce the SAB-level protocol. Holding it back keeps the input seam a clean mirror of the writer; happy to take it up next as its own change.

No `.lg` or `lg-host.js` change, so `core_compiled.lgb` and the assemble golden are untouched.

### Testing

`pkg/api/keysource_test.go` binds a scripted `KeySource` via `WithKeySource` and proves keys flow out of `(term/read-key)` in order, exhaustion surfaces as nil, and `(term/key-pending?)` tracks the queue — all without a TTY. Native `go build ./...` and `GOOS=js GOARCH=wasm go build ./pkg/rt/` are clean, as is `go vet`.

### Diffstat

```
 pkg/api/api.go              |  32 ++++-
 pkg/api/keysource_test.go   |  77 ++++++++++
 pkg/rt/iort.go              |   6 +
 pkg/rt/keysource.go         |  73 +++++++++
 pkg/rt/keysource_js_wasm.go |  69 +++++++++
 pkg/rt/term.go              | 225 ++++++++++++++++++-------------
 pkg/rt/term_wasm.go         |  61 +++-----
 7 files changed, 397 insertions(+), 146 deletions(-)
```

### Relationship to #241

Independent — both branch off `main` and neither needs the other. They do touch the same two files in different spots (`iort.go` adds `*keys*` vs `*emit*`; `api.go` adds an option), so whichever merges second will want a trivial rebase there.
