### PR TITLE
feat(wasm): client-owned shell — split lg-host.js, add -w-shell none

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -587,6 +587,7 @@ var compileOutput string
 var bundleOutput string
 var bundleBase string
 var wasmOutput string
+var wasmShell string
 var sourcePaths string
 var resourcePaths string
 
@@ -602,6 +603,7 @@ func init() {
 	flag.StringVar(&bundleOutput, "b", "", "bundle .lg file into a standalone executable (specify output path)")
 	flag.StringVar(&bundleBase, "bundle-base", "", "path to target-platform lg binary for cross-OS bundling (defaults to current executable)")
 	flag.StringVar(&wasmOutput, "w", "", "build .lg file into a WASM web app (specify output directory)")
+	flag.StringVar(&wasmShell, "w-shell", "xterm", "shell for -w: 'xterm' (default) or 'none' (emit core only; client supplies its own shell via window.LetGoHost)")
 	flag.StringVar(&sourcePaths, "source-paths", "",
 		"namespace search paths separated by the OS path-list separator "+
 			"(':' on Unix, ';' on Windows). When given, fully defines the search "+
@@ -833,7 +835,11 @@ func main() {
 			fmt.Fprintln(os.Stderr, "error: -w requires exactly one input file")
 			os.Exit(1)
 		}
-		if err := buildWasm(context, nsResolver, files[0], wasmOutput); err != nil {
+		if wasmShell != "xterm" && wasmShell != "none" {
+			fmt.Fprintf(os.Stderr, "error: -w-shell must be 'xterm' or 'none', got %q\n", wasmShell)
+			os.Exit(1)
+		}
+		if err := buildWasm(context, nsResolver, files[0], wasmOutput, wasmShell == "xterm"); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}

--- a/pkg/rt/wasm/assemble_test.go
+++ b/pkg/rt/wasm/assemble_test.go
@@ -25,30 +25,39 @@ func TestAssembleHTMLGolden(t *testing.T) {
 	const wasmExecJS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n"
 	const wasmGzB64 = "STUBWASMBLOBB64=="
 
-	got := AssembleHTML(wasmExecJS, wasmGzB64)
-	goldenPath := filepath.Join("testdata", "assemble_golden.html")
+	// Pin both bundle shapes: the default xterm shell and the shell-less
+	// core-only build (-w-shell none).
+	for _, tc := range []struct {
+		name   string
+		shell  bool
+		golden string
+	}{
+		{"default xterm shell", true, "assemble_golden.html"},
+		{"shell-less core", false, "assemble_golden_shellless.html"},
+	} {
+		got := AssembleHTML(wasmExecJS, wasmGzB64, tc.shell)
+		goldenPath := filepath.Join("testdata", tc.golden)
 
-	if *updateGolden {
-		if err := os.MkdirAll("testdata", 0755); err != nil {
-			t.Fatalf("mkdir testdata: %v", err)
+		if *updateGolden {
+			if err := os.MkdirAll("testdata", 0755); err != nil {
+				t.Fatalf("mkdir testdata: %v", err)
+			}
+			if err := os.WriteFile(goldenPath, []byte(got), 0644); err != nil {
+				t.Fatalf("writing golden: %v", err)
+			}
+			t.Logf("golden updated: %s (%d bytes)", goldenPath, len(got))
+			continue
 		}
-		if err := os.WriteFile(goldenPath, []byte(got), 0644); err != nil {
-			t.Fatalf("writing golden: %v", err)
-		}
-		t.Logf("golden updated: %s (%d bytes)", goldenPath, len(got))
-		return
-	}
 
-	golden, err := os.ReadFile(goldenPath)
-	if err != nil {
-		t.Fatalf("reading golden (run `go test ./pkg/rt/wasm -update` to create): %v", err)
-	}
-	if string(golden) != got {
-		// Surface the size delta so the developer has a quick signal
-		// before diving into a diff.
-		t.Errorf("AssembleHTML output drift (golden=%d bytes, got=%d bytes).\n"+
-			"Run `go test ./pkg/rt/wasm -update` to refresh after intentional changes.",
-			len(golden), len(got))
+		golden, err := os.ReadFile(goldenPath)
+		if err != nil {
+			t.Fatalf("%s: reading golden (run `go test ./pkg/rt/wasm -update` to create): %v", tc.name, err)
+		}
+		if string(golden) != got {
+			t.Errorf("%s: AssembleHTML output drift (golden=%d bytes, got=%d bytes).\n"+
+				"Run `go test ./pkg/rt/wasm -update` to refresh after intentional changes.",
+				tc.name, len(golden), len(got))
+		}
 	}
 }
 
@@ -58,14 +67,18 @@ func TestAssembleHTMLGolden(t *testing.T) {
 // works in that case (the broken marker is just literal text in the
 // JS), so the golden test alone wouldn't catch it cleanly.
 func TestMarkersGone(t *testing.T) {
-	got := AssembleHTML("anything", "whatever")
-	for _, m := range []string{
-		"__WASM_EXEC_JS__",
-		"__WASM_GZ_B64__",
-		"__LG_HOST_JS_BODY_PLACEHOLDER__",
-	} {
-		if contains(got, m) {
-			t.Errorf("marker %q still present in assembled output", m)
+	for _, shell := range []bool{true, false} {
+		got := AssembleHTML("anything", "whatever", shell)
+		for _, m := range []string{
+			"__WASM_EXEC_JS__",
+			"__WASM_GZ_B64__",
+			"__LG_HOST_JS_BODY_PLACEHOLDER__",
+			"__LG_XTERM_CSS__",
+			"__LG_XTERM_JS__",
+		} {
+			if contains(got, m) {
+				t.Errorf("shell=%v: marker %q still present in assembled output", shell, m)
+			}
 		}
 	}
 }

--- a/pkg/rt/wasm/embed.go
+++ b/pkg/rt/wasm/embed.go
@@ -2,10 +2,17 @@
 // bundler. AssembleHTML returns a single self-contained HTML page given
 // the Go runtime support source and the gzipped-base64 program WASM.
 //
-// lg-host.js carries two markers (__WASM_EXEC_JS__ and __WASM_GZ_B64__)
-// the assembler substitutes with JSON-encoded JS strings. host.html
-// carries a single marker (__LG_HOST_JS_BODY_PLACEHOLDER__) where the
-// populated host JS is inlined.
+// The host JS is split into two assets:
+//   - lg-host-core.js: the host-agnostic glue (COI, wasm decode, the
+//     window.LetGoHost surface, the worker/main-thread boot). Always emitted.
+//   - lg-shell-xterm.js: the default xterm.js shell, which binds to the
+//     runtime only through LetGoHost. Emitted unless shell == false, i.e.
+//     `lg -w -w-shell none`, where the client supplies its own shell.
+//
+// lg-host-core.js carries two markers (__WASM_EXEC_JS__ and __WASM_GZ_B64__)
+// the assembler substitutes with JSON-encoded JS strings. host.html carries
+// __LG_XTERM_CSS__ / __LG_XTERM_JS__ (the xterm CDN tags, dropped in shell-less
+// builds) and __LG_HOST_JS_BODY_PLACEHOLDER__ where the host JS is inlined.
 package wasm
 
 import (
@@ -15,26 +22,50 @@ import (
 	"strings"
 )
 
-//go:embed lg-host.js
-var lgHostJS string
+//go:embed lg-host-core.js
+var lgHostCoreJS string
+
+//go:embed lg-shell-xterm.js
+var lgShellXtermJS string
 
 //go:embed host.html
 var htmlTemplate string
 
+const (
+	xtermCSS = `  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">`
+	xtermJS  = `  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>`
+)
+
 // AssembleHTML returns the full self-contained HTML page produced by
-// `lg -w`. Pure function: same inputs produce same output. Tested via
-// a golden file in testdata/.
-func AssembleHTML(wasmExecJS, wasmGzB64 string) string {
+// `lg -w`. With shell == true the default xterm shell and its CDN tags are
+// included; with shell == false only the host-agnostic core ships and the
+// client binds its own shell to window.LetGoHost. Pure function: same inputs
+// produce same output. Tested via golden files in testdata/.
+func AssembleHTML(wasmExecJS, wasmGzB64 string, shell bool) string {
 	execJSON, _ := json.Marshal(wasmExecJS)
 	b64JSON, _ := json.Marshal(wasmGzB64)
-	hostJS := mustReplaceOnce(lgHostJS, "__WASM_EXEC_JS__", string(execJSON))
+
+	hostJS := mustReplaceOnce(lgHostCoreJS, "__WASM_EXEC_JS__", string(execJSON))
 	hostJS = mustReplaceOnce(hostJS, "__WASM_GZ_B64__", string(b64JSON))
-	return mustReplaceOnce(htmlTemplate, "__LG_HOST_JS_BODY_PLACEHOLDER__", hostJS)
+
+	css, js := "", ""
+	if shell {
+		// Core first, then the shell — the shell's onReady binding needs
+		// LetGoHost to exist, and the entry point at the end of core fires
+		// after both <script> bodies have evaluated.
+		hostJS = hostJS + "\n" + lgShellXtermJS
+		css, js = xtermCSS, xtermJS
+	}
+
+	out := mustReplaceOnce(htmlTemplate, "__LG_XTERM_CSS__", css)
+	out = mustReplaceOnce(out, "__LG_XTERM_JS__", js)
+	return mustReplaceOnce(out, "__LG_HOST_JS_BODY_PLACEHOLDER__", hostJS)
 }
 
 // mustReplaceOnce panics unless marker appears exactly once in s. The
 // templates are embedded at build time, so a missing or duplicated
-// marker is a developer error in lg-host.js or host.html — fail loud
+// marker is a developer error in the JS or HTML assets — fail loud
 // rather than silently shipping a half-substituted bundle.
 func mustReplaceOnce(s, marker, replacement string) string {
 	if n := strings.Count(s, marker); n != 1 {

--- a/pkg/rt/wasm/host.html
+++ b/pkg/rt/wasm/host.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>let-go app</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+__LG_XTERM_CSS__
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
@@ -17,8 +17,7 @@
 <body>
   <div id="status">loading...</div>
   <div id="terminal" style="display:none"></div>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+__LG_XTERM_JS__
   <script>
 __LG_HOST_JS_BODY_PLACEHOLDER__
   </script>

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -1,25 +1,3 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>let-go app</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
-  <style>
-    *{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
-    body{display:flex;flex-direction:column}
-    #terminal{flex:1}
-    #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
-            top:50%;left:50%;transform:translate(-50%,-50%)}
-    .xterm{height:100%}
-  </style>
-</head>
-<body>
-  <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
-  <script>
 // --- Cross-origin isolation: prefer server headers, fall back to SW ---
 // When the dev/host server sends the COI headers itself (dev/serve.json
 // does this), crossOriginIsolated is already true and we don't need the
@@ -39,8 +17,8 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 }
 
 // --- Inline wasm_exec.js and WASM data ---
-const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
-const WASM_GZ_B64 = "STUBWASMBLOBB64==";
+const WASM_EXEC_JS = __WASM_EXEC_JS__;
+const WASM_GZ_B64 = __WASM_GZ_B64__;
 
 // --- Decompress gzipped base64 WASM ---
 async function decompressWasm(b64) {
@@ -313,51 +291,3 @@ async function startMainThreadMode() {
     console.error(err);
   }
 })();
-
-// --- Default xterm.js shell ---
-// The shell `lg -w` ships unless built with -w-shell none. It owns the
-// presentation layer (the Terminal, its font/theme, the DOM) and binds to
-// the runtime purely through window.LetGoHost — the same surface a client's
-// own shell uses. Nothing in lg-host-core.js references xterm; everything
-// terminal-specific lives here.
-(function() {
-  const status = document.getElementById('status');
-  const termEl = document.getElementById('terminal');
-
-  const term = new Terminal({
-    fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
-    fontSize: 14,
-    theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
-    allowProposedApi: true,
-    convertEol: true,
-  });
-  const fitAddon = new FitAddon.FitAddon();
-  term.loadAddon(fitAddon);
-
-  function showTerminal() {
-    if (status) status.style.display = 'none';
-    termEl.style.display = 'block';
-    term.open(termEl);
-    fitAddon.fit();
-    term.focus();
-  }
-
-  window.addEventListener('resize', () => fitAddon.fit());
-
-  // Bind once the core glue is wired. onOutput routes VM stdout to xterm;
-  // in worker mode the keystroke/size path is live, so advertise the
-  // initial size and forward xterm input + resizes through LetGoHost.
-  window.LetGoHost.onReady((mode) => {
-    showTerminal();
-    window.LetGoHost.onOutput((s) => term.write(s));
-    if (mode === 'worker') {
-      window.LetGoHost.setSize(term.cols, term.rows);
-      term.onResize(({cols, rows}) => window.LetGoHost.setSize(cols, rows));
-      term.onData((data) => window.LetGoHost.sendInput(data));
-    }
-  });
-})();
-
-  </script>
-</body>
-</html>

--- a/pkg/rt/wasm/lg-shell-xterm.js
+++ b/pkg/rt/wasm/lg-shell-xterm.js
@@ -1,0 +1,43 @@
+// --- Default xterm.js shell ---
+// The shell `lg -w` ships unless built with -w-shell none. It owns the
+// presentation layer (the Terminal, its font/theme, the DOM) and binds to
+// the runtime purely through window.LetGoHost — the same surface a client's
+// own shell uses. Nothing in lg-host-core.js references xterm; everything
+// terminal-specific lives here.
+(function() {
+  const status = document.getElementById('status');
+  const termEl = document.getElementById('terminal');
+
+  const term = new Terminal({
+    fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
+    fontSize: 14,
+    theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
+    allowProposedApi: true,
+    convertEol: true,
+  });
+  const fitAddon = new FitAddon.FitAddon();
+  term.loadAddon(fitAddon);
+
+  function showTerminal() {
+    if (status) status.style.display = 'none';
+    termEl.style.display = 'block';
+    term.open(termEl);
+    fitAddon.fit();
+    term.focus();
+  }
+
+  window.addEventListener('resize', () => fitAddon.fit());
+
+  // Bind once the core glue is wired. onOutput routes VM stdout to xterm;
+  // in worker mode the keystroke/size path is live, so advertise the
+  // initial size and forward xterm input + resizes through LetGoHost.
+  window.LetGoHost.onReady((mode) => {
+    showTerminal();
+    window.LetGoHost.onOutput((s) => term.write(s));
+    if (mode === 'worker') {
+      window.LetGoHost.setSize(term.cols, term.rows);
+      term.onResize(({cols, rows}) => window.LetGoHost.setSize(cols, rows));
+      term.onData((data) => window.LetGoHost.sendInput(data));
+    }
+  });
+})();

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -1,3 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>let-go app</title>
+
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    body{display:flex;flex-direction:column}
+    #terminal{flex:1}
+    #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
+            top:50%;left:50%;transform:translate(-50%,-50%)}
+    .xterm{height:100%}
+  </style>
+</head>
+<body>
+  <div id="status">loading...</div>
+  <div id="terminal" style="display:none"></div>
+
+  <script>
 // --- Cross-origin isolation: prefer server headers, fall back to SW ---
 // When the dev/host server sends the COI headers itself (dev/serve.json
 // does this), crossOriginIsolated is already true and we don't need the
@@ -17,8 +38,8 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 }
 
 // --- Inline wasm_exec.js and WASM data ---
-const WASM_EXEC_JS = __WASM_EXEC_JS__;
-const WASM_GZ_B64 = __WASM_GZ_B64__;
+const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
+const WASM_GZ_B64 = "STUBWASMBLOBB64==";
 
 // --- Decompress gzipped base64 WASM ---
 async function decompressWasm(b64) {
@@ -36,7 +57,12 @@ async function decompressWasm(b64) {
 }
 
 // --- window.LetGoHost — public host API ---
-// Single object on window for custom shells to talk to. Surface:
+// Single object on window. This is the whole contract between the runtime
+// glue (this file) and a shell — the default xterm shell that ships with
+// `lg -w`, or a client's own under `-w-shell none`. Surface:
+//   onReady(cb)       cb(mode) once glue is wired and the boot mode
+//                     ('worker' | 'main') is known, before the VM runs.
+//                     A shell opens its UI and binds output/input here.
 //   onOutput(cb)      register sink for VM stdout; cb(string)
 //   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
 //   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
@@ -52,50 +78,46 @@ async function decompressWasm(b64) {
 // as compatibility hooks and are also the implementation backing for the
 // LetGoHost methods. Callers using either shape keep working.
 window.LetGoHost = (function() {
-  let outputSink = (s) => console.log(s);
+  // Output emitted before a shell registers onOutput is buffered and
+  // replayed on the first onOutput, not dropped to console. The boot path
+  // runs synchronously to its first await, so in main-thread mode the
+  // "interactive input unavailable" notice is written before the default
+  // shell (concatenated after core) registers its sink; without the buffer
+  // that text would leak to console instead of the terminal. Buffering also
+  // covers a client shell that binds onOutput late (e.g. after an async CDN
+  // load) under -w-shell none.
+  let outputSink = null;
+  const outputBuffer = [];
   let emitSink = (name, data) => {
     try {
       window.dispatchEvent(new CustomEvent(name, { detail: data }));
     } catch (err) { console.error('lg emit:', err); }
   };
+  let readyCb = null;
+  let readyMode = null; // set if _ready fires before onReady registers
   return {
-    onOutput(cb) { outputSink = cb; },
+    onReady(cb) {
+      readyCb = cb;
+      if (readyMode !== null) cb(readyMode); // late registration still fires
+    },
+    onOutput(cb) {
+      outputSink = cb;
+      if (outputBuffer.length) { for (const s of outputBuffer.splice(0)) cb(s); }
+    },
     onEmit(cb) { emitSink = cb; },
     sendInput(s) { return window._lgKey ? window._lgKey(s) : false; },
     setSize(c, r) { return window._lgSetSize ? window._lgSetSize(c, r) : undefined; },
     // Internal — invoked by the runtime/relay code below.
-    _output(s) { outputSink(s); },
+    _output(s) { if (outputSink) outputSink(s); else outputBuffer.push(s); },
     _emit(name, data) { emitSink(name, data); },
+    _ready(mode) { readyMode = mode; if (readyCb) readyCb(mode); },
   };
 })();
 
+// Boot status text. May be absent when a client ships its own HTML without
+// a #status element, so every use is guarded.
 const status = document.getElementById('status');
-const termEl = document.getElementById('terminal');
-
-// --- Initialize xterm.js ---
-const term = new Terminal({
-  fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
-  fontSize: 14,
-  theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
-  allowProposedApi: true,
-  convertEol: true,
-});
-const fitAddon = new FitAddon.FitAddon();
-term.loadAddon(fitAddon);
-
-function showTerminal() {
-  status.style.display = 'none';
-  termEl.style.display = 'block';
-  term.open(termEl);
-  fitAddon.fit();
-  term.focus();
-}
-
-// xterm is the default output sink in this template. Custom shells can
-// call LetGoHost.onOutput(...) before the WASM boots to redirect.
-window.LetGoHost.onOutput((s) => term.write(s));
-
-window.addEventListener('resize', () => fitAddon.fit());
+function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
 function startWorkerMode() {
@@ -103,11 +125,9 @@ function startWorkerMode() {
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
 
-  showTerminal();
-
   // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if the input was too long (>16 bytes). xterm's onData calls into
-  // this; custom shells can call it directly or via LetGoHost.sendInput.
+  // false if the input was too long (>16 bytes). A shell's keystrokes feed
+  // through here via LetGoHost.sendInput.
   window._lgKey = function(data) {
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
@@ -125,12 +145,9 @@ function startWorkerMode() {
     Atomics.store(keyInt32, 7, rows);
   };
 
-  // Initial size + xterm resize hook route through the public API.
-  window._lgSetSize(term.cols, term.rows);
-  term.onResize(({cols, rows}) => window._lgSetSize(cols, rows));
-
-  // xterm keystrokes feed into _lgKey (which is what the VM reads).
-  term.onData((data) => window._lgKey(data));
+  // Glue is wired (_lgKey / _lgSetSize installed). The shell opens its UI,
+  // binds output via onOutput, and pushes input/size via sendInput/setSize.
+  window.LetGoHost._ready('worker');
 
   // Build worker code: fs shim + wasm_exec.js + bootstrap
   const workerCode = `
@@ -216,7 +233,10 @@ function startWorkerMode() {
 
 // --- Main-thread mode (output only, no input) ---
 async function startMainThreadMode() {
-  showTerminal();
+  // Glue is wired (no SAB input in this mode). The shell opens its UI and
+  // binds output via onOutput before the unavailable-input notice below.
+  window.LetGoHost._ready('main');
+
   const out = (s) => window.LetGoHost._output(s);
   if (location.protocol === 'file:') {
     out('\x1b[33mInteractive input requires a local server. Run:\x1b[0m\r\n');
@@ -281,14 +301,18 @@ async function startMainThreadMode() {
 // --- Entry point ---
 (async () => {
   try {
-    status.textContent = 'decompressing wasm...';
+    setStatus('decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
       startWorkerMode();
     } else {
       await startMainThreadMode();
     }
   } catch(err) {
-    status.textContent = 'error: ' + err;
+    setStatus('error: ' + err);
     console.error(err);
   }
 })();
+
+  </script>
+</body>
+</html>

--- a/wasm.go
+++ b/wasm.go
@@ -127,7 +127,7 @@ addEventListener('fetch', e => {
 });
 `
 
-func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string) error {
+func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool) error {
 	// 1. Compile .lg → .lgb in memory
 	ctx.SetSource(src)
 	f, err := os.Open(src)
@@ -218,8 +218,10 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		return err
 	}
 
-	// 9. Build single self-contained HTML
-	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64)
+	// 9. Build single self-contained HTML. shell=false emits the core glue
+	// only (no xterm shell / CDN tags); the client binds its own shell to
+	// window.LetGoHost.
+	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64, shell)
 
 	// 10. Write output
 	if err := os.MkdirAll(outDir, 0755); err != nil {


### PR DESCRIPTION
Make "the client owns the shell" a supported `lg -w` path. Today `lg -w` emits one `index.html` with let-go's xterm shell baked in; a client can only post-patch that artifact. This splits the host JS so a client can supply its own shell and bind the published `window.LetGoHost` surface, with the default xterm shell kept as the convenience. This is the endgame the decoupling doc (#233 §6) names: the generator wiring the seams, not the client patching the output.

Companion: [nooga/xsofy#78](https://github.com/nooga/xsofy/pull/78) — the real client that proves the contract. Conceptually stacks on the I/O seams (#241 emit, #244 input) but is independent code.

### The split

The host JS becomes two assets around one contract:

- **`lg-host-core.js`** — host-agnostic glue: COI bootstrap, wasm decode, the `window.LetGoHost` surface, the worker/main-thread boot. Never names xterm. Fires `LetGoHost.onReady(mode)` once the glue is wired (`mode` is `'worker'` | `'main'`), before the VM runs.
- **`lg-shell-xterm.js`** — the default xterm shell, binding output/input/size purely through `LetGoHost` in its `onReady` handler. The only asset that touches xterm.

`onReady` is the one new surface. A shell — the default, or a client's — opens its UI and binds in that callback, instead of the boot path hardcoding `term.*` calls mid-flight. Output emitted before a shell binds is buffered and replayed on the first `onOutput`, so a shell that binds late (async CDN load under `-w-shell none`) loses nothing.

### The flag

- **`-w-shell xterm`** (default) — today's bundle, byte-for-byte behavior; the default golden is regenerated because the JS is reorganized through `onReady`, but the shipped behavior is unchanged.
- **`-w-shell none`** — emits core only, no xterm shell, no CDN tags. The client provides its own `index.html` shell and binds `LetGoHost`. `coi-serviceworker.js` still ships (COI is glue, not shell).

`embed.go`'s `AssembleHTML` gains a `shell bool`; `wasm.go` threads the flag; `lg.go` validates it. A second golden pins the shell-less output, and `TestMarkersGone` covers both modes.

### Validated end-to-end

xsofy (a TUI game on let-go), built with `-w-shell none` and wearing its own shell bound only through `LetGoHost.onReady`, runs **interactively on a real iPhone** (worker mode, input live) over a header-capable HTTPS serve. The client owns presentation outright: its own embedded fonts, an audio hook, graphics rendered alongside the terminal, whatever it needs — none of it something let-go has to know about. What used to mean patching the generated shell is now just the client's own code against `LetGoHost`.

### Scope and honest edges

- **Shell ownership is presentation ownership.** A client owns the terminal, font, theme, DOM. Two adjacent concerns are *not* covered by the `LetGoHost` contract and stay where they are: passing env/config into the worker VM (xsofy reads `os/getenv` in the worker) and the COI bounded-retry for header-less hosts (GitHub Pages). Those touch the worker boot and COI lifecycle, not the shell — candidates for follow-up seams (a `setEnv`/config surface, a COI option), noted but out of scope here.
- **Wake** stays deferred (the input-seam follow-up, #244), unrelated to this.

### Delivery shapes

`-w-shell none` decouples *who owns the shell*. A second, related axis is *how the glue and the compiled wasm reach the client*. Four shapes, in increasing order of decoupling:

- **A — inline, single file (what this PR ships).** One self-contained `index.html`: the host glue plus the gzipped-base64 wasm payload baked in, default xterm dropped. The client attaches its shell by appending. Zero-config, works on any dumb static host, validated on-device. Cost: the payload parses as a JS string with no streaming compile, and it can't be cached separately — so every load re-ships and re-decodes it. (The base64's ~33% inflation washes out under gzip/brotli, so it's not a transfer cost — see the perf follow-up below.)
- **B — glue+payload as one emitted `.js`.** The client authors `index.html` from scratch and `<script src>`s it — truly owns the page, no version skew (glue and payload ship together). The payload is still embedded, so A's size and streaming costs remain.
- **C — client supplies the glue, let-go emits only the payload.** Most independent, but the client's vendored glue can drift from the payload's boot/`LetGoHost` contract — a skew risk, and it needs a stable, published glue API that doesn't exist yet.
- **D — let-go emits glue/loader and a separate `main.wasm`; the client hosts the payload wherever.** The glue stays versioned with let-go (no skew, unlike C); the wasm becomes a real artifact — separately servable, cacheable, `instantiateStreaming`-able, HTTP-compressible (no base64). Costs one new surface: a configurable payload URL (default `./main.wasm`, client-overridable). Caveat: a cross-origin payload must satisfy COEP (`Cross-Origin-Resource-Policy` or CORS), since the page is cross-origin-isolated for SharedArrayBuffer.

**Leaning: ship A as the default, treat D as the production target.** A is the right default — self-contained and zero-config is what most `-w` users want, and it's what's validated here. I benchmarked the two (perf follow-up comment below): on a server that streams (HTTP/1.1 chunked + `application/wasm`), D is faster both cold (+14–29%) and on warm/repeat load (+80–90%, roughly network-flat), with transfer size a wash. So D isn't a speed tradeoff — it's the better-performing shape for a client that owns its page and serves from real infrastructure; A's remaining edge is purely zero-config simplicity. B and C are waypoints worth skipping: B is D without pulling the payload out, and C is D with a skew risk. (A separate surfacing question — a `-w` template-path flag versus the glue-only mode this builds — is orthogonal; glue-only is the smaller change and what's here.)

---

Opening as a **draft** to demonstrate the shell-extraction path end-to-end alongside the companion client. Marked draft because it sits behind the I/O seams (#241, #244) in the #233 sequencing; the delivery-shape choice above (A now, D later) is the main thing I'd want a read on before merge.
