### PR TITLE
feat(wasm): -w-wasm external — ship the payload as a separate streaming main.wasm

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -294,6 +294,7 @@ var bundleOutput string
 var bundleBase string
 var wasmOutput string
 var wasmShell string
+var wasmPayload string
 var sourcePaths string
 var resourcePaths string
 
@@ -310,6 +311,7 @@ func init() {
 	flag.StringVar(&bundleBase, "bundle-base", "", "path to target-platform lg binary for cross-OS bundling (defaults to current executable)")
 	flag.StringVar(&wasmOutput, "w", "", "build .lg file into a WASM web app (specify output directory)")
 	flag.StringVar(&wasmShell, "w-shell", "xterm", "shell for -w: 'xterm' (default) or 'none' (emit core only; client supplies its own shell via window.LetGoHost)")
+	flag.StringVar(&wasmPayload, "w-wasm", "inline", "wasm delivery for -w: 'inline' (default; gzip-base64 baked into index.html) or 'external' (emit a separate main.wasm the loader fetches + streams)")
 	flag.StringVar(&sourcePaths, "source-paths", "",
 		"namespace search paths separated by the OS path-list separator "+
 			"(':' on Unix, ';' on Windows). When given, fully defines the search "+
@@ -545,7 +547,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: -w-shell must be 'xterm' or 'none', got %q\n", wasmShell)
 			os.Exit(1)
 		}
-		if err := buildWasm(context, nsResolver, files[0], wasmOutput, wasmShell == "xterm"); err != nil {
+		if wasmPayload != "inline" && wasmPayload != "external" {
+			fmt.Fprintf(os.Stderr, "error: -w-wasm must be 'inline' or 'external', got %q\n", wasmPayload)
+			os.Exit(1)
+		}
+		if err := buildWasm(context, nsResolver, files[0], wasmOutput, wasmShell == "xterm", wasmPayload == "external"); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}

--- a/pkg/rt/wasm/assemble_test.go
+++ b/pkg/rt/wasm/assemble_test.go
@@ -25,17 +25,20 @@ func TestAssembleHTMLGolden(t *testing.T) {
 	const wasmExecJS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n"
 	const wasmGzB64 = "STUBWASMBLOBB64=="
 
-	// Pin both bundle shapes: the default xterm shell and the shell-less
-	// core-only build (-w-shell none).
+	// Pin every bundle shape across both axes: shell (xterm | none) and
+	// payload delivery (inline | external).
 	for _, tc := range []struct {
-		name   string
-		shell  bool
-		golden string
+		name     string
+		shell    bool
+		external bool
+		golden   string
 	}{
-		{"default xterm shell", true, "assemble_golden.html"},
-		{"shell-less core", false, "assemble_golden_shellless.html"},
+		{"xterm shell, inline wasm", true, false, "assemble_golden.html"},
+		{"shell-less core, inline wasm", false, false, "assemble_golden_shellless.html"},
+		{"xterm shell, external wasm", true, true, "assemble_golden_external.html"},
+		{"shell-less core, external wasm", false, true, "assemble_golden_shellless_external.html"},
 	} {
-		got := AssembleHTML(wasmExecJS, wasmGzB64, tc.shell)
+		got := AssembleHTML(wasmExecJS, wasmGzB64, tc.shell, tc.external)
 		goldenPath := filepath.Join("testdata", tc.golden)
 
 		if *updateGolden {
@@ -68,16 +71,19 @@ func TestAssembleHTMLGolden(t *testing.T) {
 // JS), so the golden test alone wouldn't catch it cleanly.
 func TestMarkersGone(t *testing.T) {
 	for _, shell := range []bool{true, false} {
-		got := AssembleHTML("anything", "whatever", shell)
-		for _, m := range []string{
-			"__WASM_EXEC_JS__",
-			"__WASM_GZ_B64__",
-			"__LG_HOST_JS_BODY_PLACEHOLDER__",
-			"__LG_XTERM_CSS__",
-			"__LG_XTERM_JS__",
-		} {
-			if contains(got, m) {
-				t.Errorf("shell=%v: marker %q still present in assembled output", shell, m)
+		for _, external := range []bool{true, false} {
+			got := AssembleHTML("anything", "whatever", shell, external)
+			for _, m := range []string{
+				"__WASM_EXEC_JS__",
+				"__WASM_MODE__",
+				"__WASM_GZ_B64__",
+				"__LG_HOST_JS_BODY_PLACEHOLDER__",
+				"__LG_XTERM_CSS__",
+				"__LG_XTERM_JS__",
+			} {
+				if contains(got, m) {
+					t.Errorf("shell=%v external=%v: marker %q still present in assembled output", shell, external, m)
+				}
 			}
 		}
 	}

--- a/pkg/rt/wasm/embed.go
+++ b/pkg/rt/wasm/embed.go
@@ -40,13 +40,26 @@ const (
 // AssembleHTML returns the full self-contained HTML page produced by
 // `lg -w`. With shell == true the default xterm shell and its CDN tags are
 // included; with shell == false only the host-agnostic core ships and the
-// client binds its own shell to window.LetGoHost. Pure function: same inputs
-// produce same output. Tested via golden files in testdata/.
-func AssembleHTML(wasmExecJS, wasmGzB64 string, shell bool) string {
+// client binds its own shell to window.LetGoHost. With externalWasm == true
+// the payload is delivered as a separate main.wasm the loader fetches and
+// streams (wasmGzB64 is ignored); otherwise it is gzip-base64 inlined into the
+// page. Pure function: same inputs produce same output. Tested via golden
+// files in testdata/.
+func AssembleHTML(wasmExecJS, wasmGzB64 string, shell, externalWasm bool) string {
 	execJSON, _ := json.Marshal(wasmExecJS)
+
+	// WASM_MODE selects the loader path; in external mode the inline payload
+	// is emptied (the wasm ships as a separate main.wasm), keeping index small.
+	mode := "inline"
+	if externalWasm {
+		mode = "external"
+		wasmGzB64 = ""
+	}
+	modeJSON, _ := json.Marshal(mode)
 	b64JSON, _ := json.Marshal(wasmGzB64)
 
 	hostJS := mustReplaceOnce(lgHostCoreJS, "__WASM_EXEC_JS__", string(execJSON))
+	hostJS = mustReplaceOnce(hostJS, "__WASM_MODE__", string(modeJSON))
 	hostJS = mustReplaceOnce(hostJS, "__WASM_GZ_B64__", string(b64JSON))
 
 	css, js := "", ""

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -16,11 +16,19 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
   navigator.serviceWorker.register('coi-serviceworker.js').then(() => location.reload()).catch(()=>{});
 }
 
-// --- Inline wasm_exec.js and WASM data ---
+// --- wasm_exec.js + WASM payload ---
+// WASM_MODE is 'inline' (gzip-base64 baked into this page, decoded in JS) or
+// 'external' (a separate main.wasm fetched + stream-compiled). Both load paths
+// ship below; the build picks one via -w-wasm.
 const WASM_EXEC_JS = __WASM_EXEC_JS__;
-const WASM_GZ_B64 = __WASM_GZ_B64__;
+const WASM_MODE = __WASM_MODE__;
+const WASM_GZ_B64 = __WASM_GZ_B64__; // inline payload; "" in external mode
+// External mode resolves the payload to an absolute URL so the Blob-URL worker
+// (whose relative base is the blob, not the page) can fetch it. A client can
+// override this to point at its own CDN.
+const WASM_URL = WASM_MODE === 'external' ? new URL('main.wasm', location.href).href : null;
 
-// --- Decompress gzipped base64 WASM ---
+// --- Decompress gzipped base64 WASM (inline mode) ---
 async function decompressWasm(b64) {
   const compressed = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
   const ds = new DecompressionStream('gzip');
@@ -99,7 +107,7 @@ const status = document.getElementById('status');
 function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
-function startWorkerMode() {
+async function startWorkerMode() {
   const sab = new SharedArrayBuffer(64);
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
@@ -171,29 +179,49 @@ function startWorkerMode() {
     };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
-      const { sab, wasmGzB64, wasmExecJS } = e.data;
+      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
       globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
       // Load wasm_exec.js in worker scope
       eval(wasmExecJS);
-      // Decompress WASM
-      const compressed = Uint8Array.from(atob(wasmGzB64), c => c.charCodeAt(0));
-      const ds = new DecompressionStream('gzip');
-      const w = ds.writable.getWriter(); w.write(compressed); w.close();
-      const r = ds.readable.getReader();
-      const chunks = []; let total = 0;
-      while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); total += value.length; }
-      const wasmBytes = new Uint8Array(total);
-      let off = 0; for(const c of chunks) { wasmBytes.set(c, off); off += c.length; }
-      // Run Go WASM
       const go = new Go();
-      const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+      let instance;
+      if (mode === 'external') {
+        // External: the main thread compiled the payload via compileStreaming
+        // and posted the WebAssembly.Module (structured-cloneable). The worker
+        // only instantiates — no fetch, no recompile — so download+compile
+        // overlapped worker spin-up. instantiate(Module, imports) resolves to
+        // the Instance directly (the {instance,module} shape is BufferSource-only).
+        instance = await WebAssembly.instantiate(wasmModule, go.importObject);
+      } else {
+        // Inline: decode the gzip-base64 payload posted from the main thread.
+        const compressed = Uint8Array.from(atob(wasmGzB64), c => c.charCodeAt(0));
+        const ds = new DecompressionStream('gzip');
+        const w = ds.writable.getWriter(); w.write(compressed); w.close();
+        const r = ds.readable.getReader();
+        const chunks = []; let total = 0;
+        while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); total += value.length; }
+        const wasmBytes = new Uint8Array(total);
+        let off = 0; for(const c of chunks) { wasmBytes.set(c, off); off += c.length; }
+        ({ instance } = await WebAssembly.instantiate(wasmBytes, go.importObject));
+      }
       postMessage({t:'ready'});
       await go.run(instance);
       globalThis._lgFlush();
       postMessage({t:'exit'});
     };
   `;
+
+  // External mode: kick off download + streaming compile on the main thread
+  // *now*, so it overlaps worker creation. instantiateStreaming is MIME-strict,
+  // so fall back to compile(arrayBuffer) if the host doesn't serve application/wasm.
+  const modPromise = WASM_MODE === 'external' ? (async () => {
+    try {
+      return await WebAssembly.compileStreaming(fetch(WASM_URL));
+    } catch (streamErr) {
+      return await WebAssembly.compile(await (await fetch(WASM_URL)).arrayBuffer());
+    }
+  })() : null;
 
   const blob = new Blob([workerCode], { type: 'application/javascript' });
   const worker = new Worker(URL.createObjectURL(blob));
@@ -207,7 +235,13 @@ function startWorkerMode() {
     }
   };
 
-  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });
+  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };
+  if (WASM_MODE === 'external') {
+    initMsg.wasmModule = await modPromise; // compiled on the main thread
+  } else {
+    initMsg.wasmGzB64 = WASM_GZ_B64;       // worker decodes the inline payload
+  }
+  worker.postMessage(initMsg);
 }
 
 // --- Main-thread mode (output only, no input) ---
@@ -271,16 +305,28 @@ async function startMainThreadMode() {
 
   // Load wasm_exec.js
   eval(WASM_EXEC_JS);
-  const wasmBytes = await decompressWasm(WASM_GZ_B64);
   const go = new Go();
-  const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+  let instance;
+  if (WASM_MODE === 'external') {
+    // Fetch the separate payload (streaming, with arrayBuffer fallback).
+    try {
+      ({ instance } = await WebAssembly.instantiateStreaming(fetch(WASM_URL), go.importObject));
+    } catch (streamErr) {
+      const buf = await (await fetch(WASM_URL)).arrayBuffer();
+      ({ instance } = await WebAssembly.instantiate(buf, go.importObject));
+    }
+  } else {
+    // Decode the inline gzip-base64 payload.
+    const wasmBytes = await decompressWasm(WASM_GZ_B64);
+    ({ instance } = await WebAssembly.instantiate(wasmBytes, go.importObject));
+  }
   go.run(instance);
 }
 
 // --- Entry point ---
 (async () => {
   try {
-    setStatus('decompressing wasm...');
+    setStatus(WASM_MODE === 'external' ? 'fetching wasm...' : 'decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
       startWorkerMode();
     } else {

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -112,10 +112,19 @@ async function startWorkerMode() {
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
 
+  // Input is unsafe until the worker has been told to start (init posted):
+  // before that there is no consumer to drain the SAB slot, so the producer
+  // busy-wait below would spin the main thread — worst case for the whole
+  // multi-second external fetch+compile. Drop pre-start keys rather than block.
+  // (The narrow post-start window before the VM first reads a key is the
+  // pre-existing busy-wait; retiring that belongs to the input seam, #244.)
+  let workerReady = false;
+
   // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if the input was too long (>16 bytes). A shell's keystrokes feed
-  // through here via LetGoHost.sendInput.
+  // false if dropped (worker not started yet, or input too long >16 bytes).
+  // A shell's keystrokes feed through here via LetGoHost.sendInput.
   window._lgKey = function(data) {
+    if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
     while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
@@ -242,6 +251,9 @@ async function startWorkerMode() {
     initMsg.wasmGzB64 = WASM_GZ_B64;       // worker decodes the inline payload
   }
   worker.postMessage(initMsg);
+  // A consumer now exists — accept input. Keys typed during the (possibly
+  // multi-second, external-mode) load above were dropped, not queued.
+  workerReady = true;
 }
 
 // --- Main-thread mode (output only, no input) ---
@@ -328,7 +340,10 @@ async function startMainThreadMode() {
   try {
     setStatus(WASM_MODE === 'external' ? 'fetching wasm...' : 'decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
-      startWorkerMode();
+      // await so external-mode fetch/compile rejections (after the first await
+      // in startWorkerMode) surface through the catch below, not as an
+      // unhandled rejection that strands the page at "fetching wasm...".
+      await startWorkerMode();
     } else {
       await startMainThreadMode();
     }

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -134,10 +134,19 @@ async function startWorkerMode() {
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
 
+  // Input is unsafe until the worker has been told to start (init posted):
+  // before that there is no consumer to drain the SAB slot, so the producer
+  // busy-wait below would spin the main thread — worst case for the whole
+  // multi-second external fetch+compile. Drop pre-start keys rather than block.
+  // (The narrow post-start window before the VM first reads a key is the
+  // pre-existing busy-wait; retiring that belongs to the input seam, #244.)
+  let workerReady = false;
+
   // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if the input was too long (>16 bytes). A shell's keystrokes feed
-  // through here via LetGoHost.sendInput.
+  // false if dropped (worker not started yet, or input too long >16 bytes).
+  // A shell's keystrokes feed through here via LetGoHost.sendInput.
   window._lgKey = function(data) {
+    if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
     while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
@@ -264,6 +273,9 @@ async function startWorkerMode() {
     initMsg.wasmGzB64 = WASM_GZ_B64;       // worker decodes the inline payload
   }
   worker.postMessage(initMsg);
+  // A consumer now exists — accept input. Keys typed during the (possibly
+  // multi-second, external-mode) load above were dropped, not queued.
+  workerReady = true;
 }
 
 // --- Main-thread mode (output only, no input) ---
@@ -350,7 +362,10 @@ async function startMainThreadMode() {
   try {
     setStatus(WASM_MODE === 'external' ? 'fetching wasm...' : 'decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
-      startWorkerMode();
+      // await so external-mode fetch/compile rejections (after the first await
+      // in startWorkerMode) surface through the catch below, not as an
+      // unhandled rejection that strands the page at "fetching wasm...".
+      await startWorkerMode();
     } else {
       await startMainThreadMode();
     }

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -43,8 +43,8 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 // 'external' (a separate main.wasm fetched + stream-compiled). Both load paths
 // ship below; the build picks one via -w-wasm.
 const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
-const WASM_MODE = "inline";
-const WASM_GZ_B64 = "STUBWASMBLOBB64=="; // inline payload; "" in external mode
+const WASM_MODE = "external";
+const WASM_GZ_B64 = ""; // inline payload; "" in external mode
 // External mode resolves the payload to an absolute URL so the Blob-URL worker
 // (whose relative base is the blob, not the page) can fetch it. A client can
 // override this to point at its own CDN.

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -134,10 +134,19 @@ async function startWorkerMode() {
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
 
+  // Input is unsafe until the worker has been told to start (init posted):
+  // before that there is no consumer to drain the SAB slot, so the producer
+  // busy-wait below would spin the main thread — worst case for the whole
+  // multi-second external fetch+compile. Drop pre-start keys rather than block.
+  // (The narrow post-start window before the VM first reads a key is the
+  // pre-existing busy-wait; retiring that belongs to the input seam, #244.)
+  let workerReady = false;
+
   // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if the input was too long (>16 bytes). A shell's keystrokes feed
-  // through here via LetGoHost.sendInput.
+  // false if dropped (worker not started yet, or input too long >16 bytes).
+  // A shell's keystrokes feed through here via LetGoHost.sendInput.
   window._lgKey = function(data) {
+    if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
     while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
@@ -264,6 +273,9 @@ async function startWorkerMode() {
     initMsg.wasmGzB64 = WASM_GZ_B64;       // worker decodes the inline payload
   }
   worker.postMessage(initMsg);
+  // A consumer now exists — accept input. Keys typed during the (possibly
+  // multi-second, external-mode) load above were dropped, not queued.
+  workerReady = true;
 }
 
 // --- Main-thread mode (output only, no input) ---
@@ -350,7 +362,10 @@ async function startMainThreadMode() {
   try {
     setStatus(WASM_MODE === 'external' ? 'fetching wasm...' : 'decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
-      startWorkerMode();
+      // await so external-mode fetch/compile rejections (after the first await
+      // in startWorkerMode) surface through the catch below, not as an
+      // unhandled rejection that strands the page at "fetching wasm...".
+      await startWorkerMode();
     } else {
       await startMainThreadMode();
     }

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -37,11 +37,19 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
   navigator.serviceWorker.register('coi-serviceworker.js').then(() => location.reload()).catch(()=>{});
 }
 
-// --- Inline wasm_exec.js and WASM data ---
+// --- wasm_exec.js + WASM payload ---
+// WASM_MODE is 'inline' (gzip-base64 baked into this page, decoded in JS) or
+// 'external' (a separate main.wasm fetched + stream-compiled). Both load paths
+// ship below; the build picks one via -w-wasm.
 const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
-const WASM_GZ_B64 = "STUBWASMBLOBB64==";
+const WASM_MODE = "inline";
+const WASM_GZ_B64 = "STUBWASMBLOBB64=="; // inline payload; "" in external mode
+// External mode resolves the payload to an absolute URL so the Blob-URL worker
+// (whose relative base is the blob, not the page) can fetch it. A client can
+// override this to point at its own CDN.
+const WASM_URL = WASM_MODE === 'external' ? new URL('main.wasm', location.href).href : null;
 
-// --- Decompress gzipped base64 WASM ---
+// --- Decompress gzipped base64 WASM (inline mode) ---
 async function decompressWasm(b64) {
   const compressed = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
   const ds = new DecompressionStream('gzip');
@@ -120,7 +128,7 @@ const status = document.getElementById('status');
 function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
-function startWorkerMode() {
+async function startWorkerMode() {
   const sab = new SharedArrayBuffer(64);
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
@@ -192,29 +200,49 @@ function startWorkerMode() {
     };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
-      const { sab, wasmGzB64, wasmExecJS } = e.data;
+      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
       globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
       // Load wasm_exec.js in worker scope
       eval(wasmExecJS);
-      // Decompress WASM
-      const compressed = Uint8Array.from(atob(wasmGzB64), c => c.charCodeAt(0));
-      const ds = new DecompressionStream('gzip');
-      const w = ds.writable.getWriter(); w.write(compressed); w.close();
-      const r = ds.readable.getReader();
-      const chunks = []; let total = 0;
-      while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); total += value.length; }
-      const wasmBytes = new Uint8Array(total);
-      let off = 0; for(const c of chunks) { wasmBytes.set(c, off); off += c.length; }
-      // Run Go WASM
       const go = new Go();
-      const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+      let instance;
+      if (mode === 'external') {
+        // External: the main thread compiled the payload via compileStreaming
+        // and posted the WebAssembly.Module (structured-cloneable). The worker
+        // only instantiates — no fetch, no recompile — so download+compile
+        // overlapped worker spin-up. instantiate(Module, imports) resolves to
+        // the Instance directly (the {instance,module} shape is BufferSource-only).
+        instance = await WebAssembly.instantiate(wasmModule, go.importObject);
+      } else {
+        // Inline: decode the gzip-base64 payload posted from the main thread.
+        const compressed = Uint8Array.from(atob(wasmGzB64), c => c.charCodeAt(0));
+        const ds = new DecompressionStream('gzip');
+        const w = ds.writable.getWriter(); w.write(compressed); w.close();
+        const r = ds.readable.getReader();
+        const chunks = []; let total = 0;
+        while (true) { const {done,value} = await r.read(); if(done) break; chunks.push(value); total += value.length; }
+        const wasmBytes = new Uint8Array(total);
+        let off = 0; for(const c of chunks) { wasmBytes.set(c, off); off += c.length; }
+        ({ instance } = await WebAssembly.instantiate(wasmBytes, go.importObject));
+      }
       postMessage({t:'ready'});
       await go.run(instance);
       globalThis._lgFlush();
       postMessage({t:'exit'});
     };
   `;
+
+  // External mode: kick off download + streaming compile on the main thread
+  // *now*, so it overlaps worker creation. instantiateStreaming is MIME-strict,
+  // so fall back to compile(arrayBuffer) if the host doesn't serve application/wasm.
+  const modPromise = WASM_MODE === 'external' ? (async () => {
+    try {
+      return await WebAssembly.compileStreaming(fetch(WASM_URL));
+    } catch (streamErr) {
+      return await WebAssembly.compile(await (await fetch(WASM_URL)).arrayBuffer());
+    }
+  })() : null;
 
   const blob = new Blob([workerCode], { type: 'application/javascript' });
   const worker = new Worker(URL.createObjectURL(blob));
@@ -228,7 +256,13 @@ function startWorkerMode() {
     }
   };
 
-  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });
+  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };
+  if (WASM_MODE === 'external') {
+    initMsg.wasmModule = await modPromise; // compiled on the main thread
+  } else {
+    initMsg.wasmGzB64 = WASM_GZ_B64;       // worker decodes the inline payload
+  }
+  worker.postMessage(initMsg);
 }
 
 // --- Main-thread mode (output only, no input) ---
@@ -292,16 +326,28 @@ async function startMainThreadMode() {
 
   // Load wasm_exec.js
   eval(WASM_EXEC_JS);
-  const wasmBytes = await decompressWasm(WASM_GZ_B64);
   const go = new Go();
-  const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+  let instance;
+  if (WASM_MODE === 'external') {
+    // Fetch the separate payload (streaming, with arrayBuffer fallback).
+    try {
+      ({ instance } = await WebAssembly.instantiateStreaming(fetch(WASM_URL), go.importObject));
+    } catch (streamErr) {
+      const buf = await (await fetch(WASM_URL)).arrayBuffer();
+      ({ instance } = await WebAssembly.instantiate(buf, go.importObject));
+    }
+  } else {
+    // Decode the inline gzip-base64 payload.
+    const wasmBytes = await decompressWasm(WASM_GZ_B64);
+    ({ instance } = await WebAssembly.instantiate(wasmBytes, go.importObject));
+  }
   go.run(instance);
 }
 
 // --- Entry point ---
 (async () => {
   try {
-    setStatus('decompressing wasm...');
+    setStatus(WASM_MODE === 'external' ? 'fetching wasm...' : 'decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
       startWorkerMode();
     } else {

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -133,10 +133,19 @@ async function startWorkerMode() {
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
 
+  // Input is unsafe until the worker has been told to start (init posted):
+  // before that there is no consumer to drain the SAB slot, so the producer
+  // busy-wait below would spin the main thread — worst case for the whole
+  // multi-second external fetch+compile. Drop pre-start keys rather than block.
+  // (The narrow post-start window before the VM first reads a key is the
+  // pre-existing busy-wait; retiring that belongs to the input seam, #244.)
+  let workerReady = false;
+
   // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if the input was too long (>16 bytes). A shell's keystrokes feed
-  // through here via LetGoHost.sendInput.
+  // false if dropped (worker not started yet, or input too long >16 bytes).
+  // A shell's keystrokes feed through here via LetGoHost.sendInput.
   window._lgKey = function(data) {
+    if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
     while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
@@ -263,6 +272,9 @@ async function startWorkerMode() {
     initMsg.wasmGzB64 = WASM_GZ_B64;       // worker decodes the inline payload
   }
   worker.postMessage(initMsg);
+  // A consumer now exists — accept input. Keys typed during the (possibly
+  // multi-second, external-mode) load above were dropped, not queued.
+  workerReady = true;
 }
 
 // --- Main-thread mode (output only, no input) ---
@@ -349,7 +361,10 @@ async function startMainThreadMode() {
   try {
     setStatus(WASM_MODE === 'external' ? 'fetching wasm...' : 'decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
-      startWorkerMode();
+      // await so external-mode fetch/compile rejections (after the first await
+      // in startWorkerMode) surface through the catch below, not as an
+      // unhandled rejection that strands the page at "fetching wasm...".
+      await startWorkerMode();
     } else {
       await startMainThreadMode();
     }

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -133,10 +133,19 @@ async function startWorkerMode() {
   const keyInt32 = new Int32Array(sab);
   const keyUint8 = new Uint8Array(sab, 8, 16);
 
+  // Input is unsafe until the worker has been told to start (init posted):
+  // before that there is no consumer to drain the SAB slot, so the producer
+  // busy-wait below would spin the main thread — worst case for the whole
+  // multi-second external fetch+compile. Drop pre-start keys rather than block.
+  // (The narrow post-start window before the VM first reads a key is the
+  // pre-existing busy-wait; retiring that belongs to the input seam, #244.)
+  let workerReady = false;
+
   // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if the input was too long (>16 bytes). A shell's keystrokes feed
-  // through here via LetGoHost.sendInput.
+  // false if dropped (worker not started yet, or input too long >16 bytes).
+  // A shell's keystrokes feed through here via LetGoHost.sendInput.
   window._lgKey = function(data) {
+    if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
     while (Atomics.load(keyInt32, 0) !== 0) { /* busy wait */ }
@@ -263,6 +272,9 @@ async function startWorkerMode() {
     initMsg.wasmGzB64 = WASM_GZ_B64;       // worker decodes the inline payload
   }
   worker.postMessage(initMsg);
+  // A consumer now exists — accept input. Keys typed during the (possibly
+  // multi-second, external-mode) load above were dropped, not queued.
+  workerReady = true;
 }
 
 // --- Main-thread mode (output only, no input) ---
@@ -349,7 +361,10 @@ async function startMainThreadMode() {
   try {
     setStatus(WASM_MODE === 'external' ? 'fetching wasm...' : 'decompressing wasm...');
     if (typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated) {
-      startWorkerMode();
+      // await so external-mode fetch/compile rejections (after the first await
+      // in startWorkerMode) surface through the catch below, not as an
+      // unhandled rejection that strands the page at "fetching wasm...".
+      await startWorkerMode();
     } else {
       await startMainThreadMode();
     }

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>let-go app</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
@@ -17,8 +17,7 @@
 <body>
   <div id="status">loading...</div>
   <div id="terminal" style="display:none"></div>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+
   <script>
 // --- Cross-origin isolation: prefer server headers, fall back to SW ---
 // When the dev/host server sends the COI headers itself (dev/serve.json
@@ -43,8 +42,8 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 // 'external' (a separate main.wasm fetched + stream-compiled). Both load paths
 // ship below; the build picks one via -w-wasm.
 const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
-const WASM_MODE = "inline";
-const WASM_GZ_B64 = "STUBWASMBLOBB64=="; // inline payload; "" in external mode
+const WASM_MODE = "external";
+const WASM_GZ_B64 = ""; // inline payload; "" in external mode
 // External mode resolves the payload to an absolute URL so the Blob-URL worker
 // (whose relative base is the blob, not the page) can fetch it. A client can
 // override this to point at its own CDN.
@@ -358,50 +357,6 @@ async function startMainThreadMode() {
     setStatus('error: ' + err);
     console.error(err);
   }
-})();
-
-// --- Default xterm.js shell ---
-// The shell `lg -w` ships unless built with -w-shell none. It owns the
-// presentation layer (the Terminal, its font/theme, the DOM) and binds to
-// the runtime purely through window.LetGoHost — the same surface a client's
-// own shell uses. Nothing in lg-host-core.js references xterm; everything
-// terminal-specific lives here.
-(function() {
-  const status = document.getElementById('status');
-  const termEl = document.getElementById('terminal');
-
-  const term = new Terminal({
-    fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
-    fontSize: 14,
-    theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
-    allowProposedApi: true,
-    convertEol: true,
-  });
-  const fitAddon = new FitAddon.FitAddon();
-  term.loadAddon(fitAddon);
-
-  function showTerminal() {
-    if (status) status.style.display = 'none';
-    termEl.style.display = 'block';
-    term.open(termEl);
-    fitAddon.fit();
-    term.focus();
-  }
-
-  window.addEventListener('resize', () => fitAddon.fit());
-
-  // Bind once the core glue is wired. onOutput routes VM stdout to xterm;
-  // in worker mode the keystroke/size path is live, so advertise the
-  // initial size and forward xterm input + resizes through LetGoHost.
-  window.LetGoHost.onReady((mode) => {
-    showTerminal();
-    window.LetGoHost.onOutput((s) => term.write(s));
-    if (mode === 'worker') {
-      window.LetGoHost.setSize(term.cols, term.rows);
-      term.onResize(({cols, rows}) => window.LetGoHost.setSize(cols, rows));
-      term.onData((data) => window.LetGoHost.sendInput(data));
-    }
-  });
 })();
 
   </script>

--- a/wasm.go
+++ b/wasm.go
@@ -134,7 +134,7 @@ addEventListener('fetch', e => {
 });
 `
 
-func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool) error {
+func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool, externalWasm bool) error {
 	// 1. Compile .lg → .lgb in memory
 	ctx.SetSource(src)
 	f, err := os.Open(src)
@@ -207,17 +207,21 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		return fmt.Errorf("go build wasm: %w", err)
 	}
 
-	// 7. Read and compress WASM binary
-	fmt.Println("compressing...")
+	// 7. Read the WASM binary. Inline mode gzip+base64s it into the page;
+	// external mode ships it as a separate file the loader fetches + streams.
 	wasmData, err := os.ReadFile(wasmPath)
 	if err != nil {
 		return err
 	}
-	var gzBuf bytes.Buffer
-	gz, _ := gzip.NewWriterLevel(&gzBuf, gzip.BestCompression)
-	gz.Write(wasmData)
-	gz.Close()
-	wasmB64 := base64.StdEncoding.EncodeToString(gzBuf.Bytes())
+	var wasmB64 string
+	if !externalWasm {
+		fmt.Println("compressing...")
+		var gzBuf bytes.Buffer
+		gz, _ := gzip.NewWriterLevel(&gzBuf, gzip.BestCompression)
+		gz.Write(wasmData)
+		gz.Close()
+		wasmB64 = base64.StdEncoding.EncodeToString(gzBuf.Bytes())
+	}
 
 	// 8. Read wasm_exec.js
 	wasmExecJS, err := readWasmExecJS()
@@ -225,10 +229,10 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		return err
 	}
 
-	// 9. Build single self-contained HTML. shell=false emits the core glue
-	// only (no xterm shell / CDN tags); the client binds its own shell to
-	// window.LetGoHost.
-	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64, shell)
+	// 9. Build the HTML. shell=false emits the core glue only (no xterm shell
+	// / CDN tags). externalWasm=true emits the streaming loader and an empty
+	// inline payload (the wasm ships as main.wasm, written below).
+	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64, shell, externalWasm)
 
 	// 10. Write output
 	if err := os.MkdirAll(outDir, 0755); err != nil {
@@ -237,6 +241,14 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	outPath := filepath.Join(outDir, "index.html")
 	if err := os.WriteFile(outPath, []byte(html), 0644); err != nil {
 		return err
+	}
+
+	// External mode: emit the raw wasm as a separately-servable asset. The
+	// loader fetches it (instantiateStreaming) instead of decoding an inline blob.
+	if externalWasm {
+		if err := os.WriteFile(filepath.Join(outDir, "main.wasm"), wasmData, 0644); err != nil {
+			return err
+		}
 	}
 
 	// 11. Write coi-serviceworker.js for cross-origin isolation on hosted servers


### PR DESCRIPTION
> Stacks on #245 (builds on its `lg-host-core` core/shell split). Opened against `main`, so until #245 merges the diff below includes #245's changes too — the payload-delivery work is the top commit (`feat(wasm): -w-wasm external …`); it rebases to a clean diff once #245 lands.

Make wasm delivery a choice, orthogonal to the shell. #245 splits *who owns the shell*; this adds the second axis from its "Delivery shapes" note — *how the compiled wasm reaches the client*:

- **`-w-wasm inline`** (default) — today's behavior: the gzip-base64 payload is baked into `index.html` and decoded in JS. Byte-for-behavior unchanged.
- **`-w-wasm external`** — emit a separate `main.wasm`; the loader fetches and stream-compiles it (`WebAssembly.compileStreaming`), with an `arrayBuffer` fallback if the host doesn't serve `application/wasm`.

The two axes are independent — `xterm`/`none` × `inline`/`external` are all valid. `xterm` + `external` (default shell, separate payload) is the combination I validated on-device.

### Why

A deployed app spends its life on repeat visits, and there the inline payload is re-shipped and re-decoded every load. A separate, immutable `main.wasm` is a cache hit. Measured (headless Chromium, boot = navigation → first VM output, served compressed under COOP/COEP, medians):

| `npx serve` v14 | A cold | external cold | A warm | external warm |
|---|--:|--:|--:|--:|
| unthrottled | 1135 | 810 | 950 | 194 |
| 50 Mbps | 1889 | 1626 | 1766 | 335 |
| 20 Mbps | 3233 | 2765 | 3087 | 294 |

External wins both — cold +14–29%, warm +80–90% (warm is roughly network-flat; the payload never re-crosses the wire). Two caveats: cold-load only wins on a server that *streams* (HTTP/1.1 chunked + correct MIME) — on a server that buffers, inline is faster; and **transfer size is a wash** once both are compressed (base64 inflation is undone by gzip/brotli). The win is streaming overlap plus caching, not bytes. Validated interactively on a real iPhone over an HTTPS serve.

### How

- `lg-host-core.js` carries both load paths behind an injected `WASM_MODE`. Inline keeps the `atob`+`DecompressionStream` decode; external fetches, and — to overlap download+compile with worker spin-up — `compileStreaming`s on the main thread and posts the `WebAssembly.Module` to the worker (structured-cloneable), which only instantiates. The worker is a Blob worker, so the payload URL is resolved absolute (a relative fetch would resolve against `blob:`).
- `AssembleHTML` gains an `externalWasm` param; `wasm.go` writes `main.wasm` only in external mode; `lg.go` adds + validates `-w-wasm`.
- Goldens pin all four shapes (shell × payload); `TestMarkersGone` covers the new `__WASM_MODE__` marker. Full suite green except the pre-existing `genmanifest` staleness (nooga#41), which this doesn't touch.

### Scope / honest edges

- The payload loads from a sibling `./main.wasm`. A client-overridable URL (to host the wasm on a CDN) is the obvious next surface — left out here because the naming (`LetGoHost.wasmUrl` vs a `data-` attr) is worth settling first.
- A cross-origin payload must satisfy COEP — `Cross-Origin-Resource-Policy: cross-origin` or CORS — since the page is cross-origin-isolated for SharedArrayBuffer. Same-origin needs nothing.
- Draft because it stacks on #245 and the seams (#241, #244); the override surface above is the main open question.
