### PR TITLE
ci(gold-differential): pin the Clojure toolchain, drop the makeplus curl|make install

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,21 +91,33 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # Provide the Clojure CLI on demand via makeplus (clojure.cc/cli/) — it
-      # installs the JDK and the Clojure CLI into the runner's temp dir. Nothing
-      # (not even java) is assumed preinstalled. Record the resolved version so
-      # the cache below can detect a version change.
-      - name: Provide Clojure CLI (makeplus) and record its version
+      # Provision the Clojure CLI from pinned actions — Java first, since the CLI
+      # is a JVM tool. Replaces the previous makeplus install, which curled and
+      # `git pull`ed an unpinned remote toolchain (clojure.cc/cmd.mk ->
+      # makeplus/makes HEAD) on every run, so an upstream change there broke CI
+      # with no change in this repo. The CLI is pinned to the version the
+      # committed goldens were derived under, for reproducible re-derivation.
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.6.1
+        with:
+          cli: 1.12.4.1602
+
+      # Record the resolved version for the cache key below, and fail loudly if
+      # clojure didn't actually land on PATH (the old step echoed a captured
+      # error string and exited 0, so a broken install reported green).
+      - name: Record Clojure version
         id: clj
         run: |
-          CLJ=$(make -f <(curl -sL clojure.cc/cmd.mk) clj)
-          CLJ_BIN=$(dirname "$CLJ")
-          JAVA_BIN=$(dirname "$(find "${TMPDIR:-/tmp}/clojure-cc-cmd/local" -type f -name java -path '*/bin/*' | head -1)")
-          echo "$CLJ_BIN" >> "$GITHUB_PATH"
-          echo "$JAVA_BIN" >> "$GITHUB_PATH"
-          ver=$(PATH="$CLJ_BIN:$JAVA_BIN:$PATH" clojure --version 2>&1 | tr -cd 'A-Za-z0-9._-')
+          command -v clojure >/dev/null || { echo "::error::clojure not on PATH after setup-clojure"; exit 1; }
+          ver=$(clojure --version | tr -cd 'A-Za-z0-9._-')
           echo "version=$ver" >> "$GITHUB_OUTPUT"
-          echo "Resolved Clojure: $ver"
+          echo "Resolved Clojure: $(clojure --version)"
 
       # Cache a marker keyed on the Clojure version. A cache HIT means this exact
       # version was already verified, so the re-derive below is skipped.


### PR DESCRIPTION
## What

Replace the `gold-differential` job's Clojure provisioning with pinned actions (`actions/setup-java` + `DeLaGuardo/setup-clojure`), dropping the `curl | make` install of an unpinned remote toolchain.

## Why

`main` is red on every push right now, and it isn't the code. The gold-differential job provisioned Clojure like this:

```sh
CLJ=$(make -f <(curl -sL clojure.cc/cmd.mk) clj)
```

`clojure.cc/cmd.mk` is a Makefile that `git clone`s and **`git pull`s `makeplus/makes` HEAD on every run**, then includes its `clojure.mk`. Nothing is pinned, so an upstream change to `makeplus` broke the install with no change in this repo: `clojure` stopped landing on `PATH`, the re-derive step started failing with `clojure: command not found`, and it has stayed red since.

It went from green to permanently red rather than flickering because of a second issue: the version-record step captured `clojure --version` stderr into a variable (`2>&1`) and ended on a bare `echo`, so a missing `clojure` still exited 0 (a green check) and wrote the captured error string as the "version". That poisoned the `gold-clojure-${version}` cache key, so the version-marker cache can never hit, the re-derive runs every time, and it fails every time.

Concretely, from the run logs:

- `ad24d9b` (06-16): `Resolved Clojure: ClojureCLIversion1.12.4.1602` → cache hit → re-derive skipped → green.
- after the makeplus change (06-17): `Resolved Clojure: …sh: line 6: clojure: command not found` → cache miss → re-derive runs → fail.

## The change

```yaml
- name: Set up Java
  uses: actions/setup-java@v4
  with:
    distribution: temurin
    java-version: '21'

- name: Set up Clojure CLI
  uses: DeLaGuardo/setup-clojure@13.6.1
  with:
    cli: 1.12.4.1602

- name: Record Clojure version
  id: clj
  run: |
    command -v clojure >/dev/null || { echo "::error::clojure not on PATH after setup-clojure"; exit 1; }
    ver=$(clojure --version | tr -cd 'A-Za-z0-9._-')
    echo "version=$ver" >> "$GITHUB_OUTPUT"
    echo "Resolved Clojure: $(clojure --version)"
```

- **Java first**, then the CLI (the CLI is a JVM tool).
- **`cli: 1.12.4.1602`** is pinned deliberately, not `latest` — it's the version the committed `test/gold/*.out` were last derived under, so re-derivation stays reproducible and the goldens don't churn when Clojure cuts a release. A stable version also keeps the marker cache warm, so the re-derive only runs when it should.
- **`command -v clojure || exit 1`** removes the silent-green failure mode: a future provisioning break fails the step loudly instead of poisoning the cache.

The `Version marker cache` and `Re-derive goldens` steps are unchanged, and `steps.clj.outputs.version` is still produced for the cache key.

## Scope

Provisioning only — no change to `test/gold/*.out` or any test. This is purely about making the job able to run Clojure again.

## Verification

Validated on a fork run with the re-derive forced via `workflow_dispatch`, so it bypassed the version-marker cache and actually invoked Clojure:

- `setup-clojure` resolved `Clojure CLI version 1.12.4.1602`, the version the committed goldens were derived under.
- The re-derive ran and passed against live Clojure — `TestGoldDynvarThreadsMatchesClojure`, `TestGoldNsThreadsMatchesClojure`, and `TestGoldDynvarCallbacksMatchesClojure` all green, with no drift in `test/gold`.

On this PR the re-derive may cache-hit and skip (green either way); the forced fork run is the evidence that the install and re-derive path work.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
