### PR TITLE
fix(wasm): host.html #terminal needs min-height:0 so client content can't overflow the frame

### DIFF
--- a/pkg/rt/wasm/host.html
+++ b/pkg/rt/wasm/host.html
@@ -8,7 +8,7 @@ __LG_XTERM_CSS__
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1}
+    #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
     .xterm{height:100%}

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -8,7 +8,7 @@
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1}
+    #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
     .xterm{height:100%}

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -8,7 +8,7 @@
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1}
+    #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
     .xterm{height:100%}

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -8,7 +8,7 @@
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1}
+    #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
     .xterm{height:100%}

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -8,7 +8,7 @@
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1}
+    #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
     .xterm{height:100%}


### PR DESCRIPTION
## Problem

The `lg -w` host frame (`pkg/rt/wasm/host.html`) styles the terminal as a flex item:

```css
body{display:flex;flex-direction:column}
#terminal{flex:1}
```

A flex item defaults to `min-height:auto`, which won't let it shrink below its content's intrinsic size. The default `-w-shell xterm` shell never resizes its content, so this is dormant there. But a **client-owned shell** (`-w-shell none`, #245) that makes the terminal content taller — e.g. bumping `term.options.fontSize` and re-fitting — pushes `#terminal` past the viewport, and its sibling DOM (the client's own chrome) gets shoved below the fold. Under the frame's `overflow:hidden` it's simply gone.

Measured in a client shell at 1280×800: one font bump grew `#terminal` 743px → 920px (viewport 800), moving the client UI off-screen.

## Fix

```css
#terminal{flex:1;min-height:0}
```

One line. The flex item is pinned to its viewport share; content overflow stays inside `#terminal` instead of expanding it. No behavior change for the default shell — it only makes the frame robust to clients that resize content.

## Note (out of scope here)

There's a broader design question — whether the `-w-shell none` frame should ship *any* layout CSS, or hand the client a barer/neutral mount — but that's a separate discussion; this PR is just the latent-overflow fix. `go test ./pkg/rt/wasm` green; the four `assemble_golden*.html` fixtures are regenerated.
