### PR TITLE
fix(wasm): drop SAB key while one is still pending, don't overwrite mid-consume

### DIFF
--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -121,14 +121,23 @@ async function startWorkerMode() {
   // false if dropped (worker not started yet, or input too long >16 bytes).
   // A shell's keystrokes feed through here via LetGoHost.sendInput.
   //
-  // Non-blocking, newest-wins: write unconditionally — never wait for the
-  // consumer to drain (that wait is what froze the page on key bursts). Under
-  // load the slot coalesces to the freshest key; lossy only for *distinct* keys
-  // overlapping within one consumer read, never for same-key repeat.
+  // Non-blocking: never wait for the consumer to drain (that wait is what froze
+  // the page on key bursts). We drop rather than overwrite while a key is still
+  // pending (ready==1): overwriting concurrently would tear the consumer's
+  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
+  // would stomp our just-set ready flag and lose the accepted key.
+  //
+  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
+  // the program is waiting on input the consumer drains immediately and parks at
+  // ready==0, so the freshest key still lands (the interactive common case).
+  // Drops only happen while a prior key sits unconsumed — i.e. the program is
+  // busy and not reading keys — where keeping the first pending key (the
+  // interrupt) and dropping the rest is the behavior we want anyway.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
+    if (Atomics.load(keyInt32, 0) !== 0) return false;
     keyUint8.set(bytes);
     Atomics.store(keyInt32, 1, bytes.length);
     Atomics.store(keyInt32, 0, 1);

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -143,14 +143,23 @@ async function startWorkerMode() {
   // false if dropped (worker not started yet, or input too long >16 bytes).
   // A shell's keystrokes feed through here via LetGoHost.sendInput.
   //
-  // Non-blocking, newest-wins: write unconditionally — never wait for the
-  // consumer to drain (that wait is what froze the page on key bursts). Under
-  // load the slot coalesces to the freshest key; lossy only for *distinct* keys
-  // overlapping within one consumer read, never for same-key repeat.
+  // Non-blocking: never wait for the consumer to drain (that wait is what froze
+  // the page on key bursts). We drop rather than overwrite while a key is still
+  // pending (ready==1): overwriting concurrently would tear the consumer's
+  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
+  // would stomp our just-set ready flag and lose the accepted key.
+  //
+  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
+  // the program is waiting on input the consumer drains immediately and parks at
+  // ready==0, so the freshest key still lands (the interactive common case).
+  // Drops only happen while a prior key sits unconsumed — i.e. the program is
+  // busy and not reading keys — where keeping the first pending key (the
+  // interrupt) and dropping the rest is the behavior we want anyway.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
+    if (Atomics.load(keyInt32, 0) !== 0) return false;
     keyUint8.set(bytes);
     Atomics.store(keyInt32, 1, bytes.length);
     Atomics.store(keyInt32, 0, 1);

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -143,14 +143,23 @@ async function startWorkerMode() {
   // false if dropped (worker not started yet, or input too long >16 bytes).
   // A shell's keystrokes feed through here via LetGoHost.sendInput.
   //
-  // Non-blocking, newest-wins: write unconditionally — never wait for the
-  // consumer to drain (that wait is what froze the page on key bursts). Under
-  // load the slot coalesces to the freshest key; lossy only for *distinct* keys
-  // overlapping within one consumer read, never for same-key repeat.
+  // Non-blocking: never wait for the consumer to drain (that wait is what froze
+  // the page on key bursts). We drop rather than overwrite while a key is still
+  // pending (ready==1): overwriting concurrently would tear the consumer's
+  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
+  // would stomp our just-set ready flag and lose the accepted key.
+  //
+  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
+  // the program is waiting on input the consumer drains immediately and parks at
+  // ready==0, so the freshest key still lands (the interactive common case).
+  // Drops only happen while a prior key sits unconsumed — i.e. the program is
+  // busy and not reading keys — where keeping the first pending key (the
+  // interrupt) and dropping the rest is the behavior we want anyway.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
+    if (Atomics.load(keyInt32, 0) !== 0) return false;
     keyUint8.set(bytes);
     Atomics.store(keyInt32, 1, bytes.length);
     Atomics.store(keyInt32, 0, 1);

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -142,14 +142,23 @@ async function startWorkerMode() {
   // false if dropped (worker not started yet, or input too long >16 bytes).
   // A shell's keystrokes feed through here via LetGoHost.sendInput.
   //
-  // Non-blocking, newest-wins: write unconditionally — never wait for the
-  // consumer to drain (that wait is what froze the page on key bursts). Under
-  // load the slot coalesces to the freshest key; lossy only for *distinct* keys
-  // overlapping within one consumer read, never for same-key repeat.
+  // Non-blocking: never wait for the consumer to drain (that wait is what froze
+  // the page on key bursts). We drop rather than overwrite while a key is still
+  // pending (ready==1): overwriting concurrently would tear the consumer's
+  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
+  // would stomp our just-set ready flag and lose the accepted key.
+  //
+  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
+  // the program is waiting on input the consumer drains immediately and parks at
+  // ready==0, so the freshest key still lands (the interactive common case).
+  // Drops only happen while a prior key sits unconsumed — i.e. the program is
+  // busy and not reading keys — where keeping the first pending key (the
+  // interrupt) and dropping the rest is the behavior we want anyway.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
+    if (Atomics.load(keyInt32, 0) !== 0) return false;
     keyUint8.set(bytes);
     Atomics.store(keyInt32, 1, bytes.length);
     Atomics.store(keyInt32, 0, 1);

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -142,14 +142,23 @@ async function startWorkerMode() {
   // false if dropped (worker not started yet, or input too long >16 bytes).
   // A shell's keystrokes feed through here via LetGoHost.sendInput.
   //
-  // Non-blocking, newest-wins: write unconditionally — never wait for the
-  // consumer to drain (that wait is what froze the page on key bursts). Under
-  // load the slot coalesces to the freshest key; lossy only for *distinct* keys
-  // overlapping within one consumer read, never for same-key repeat.
+  // Non-blocking: never wait for the consumer to drain (that wait is what froze
+  // the page on key bursts). We drop rather than overwrite while a key is still
+  // pending (ready==1): overwriting concurrently would tear the consumer's
+  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
+  // would stomp our just-set ready flag and lose the accepted key.
+  //
+  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
+  // the program is waiting on input the consumer drains immediately and parks at
+  // ready==0, so the freshest key still lands (the interactive common case).
+  // Drops only happen while a prior key sits unconsumed — i.e. the program is
+  // busy and not reading keys — where keeping the first pending key (the
+  // interrupt) and dropping the rest is the behavior we want anyway.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
     if (bytes.length === 0 || bytes.length > 16) return false;
+    if (Atomics.load(keyInt32, 0) !== 0) return false;
     keyUint8.set(bytes);
     Atomics.store(keyInt32, 1, bytes.length);
     Atomics.store(keyInt32, 0, 1);


### PR DESCRIPTION
Follow-up to #276. A self-review pass (Codex) on that PR flagged a producer/consumer race the merged version still carries; this is that fix, standalone.

## The race

The non-blocking producer (`_lgKey` in `lg-host-core.js`) writes the key bytes, length, and ready flag unconditionally. The consumer (`HostKeySource.ReadKey`) wakes on the ready flag, copies the bytes one at a time across the JS/wasm boundary, then unconditionally clears the ready flag. If a new key arrives while the worker is mid-copy:

1. The concurrent `keyUint8.set` tears the consumer's byte-by-byte read, so it can assemble a mix of the old and new key.
2. Worse, the consumer's unconditional `Atomics.store(keyInt32, 0, 0)` after the copy stomps the ready flag the producer just set, so the new key is lost — the next `read-key` parks until the *following* keypress.

So an accepted key can disappear, not just coalesce.

## The fix

Drop the incoming key when one is still pending (`ready == 1`) instead of overwriting it. The slot is only pending between a write and the consumer draining it, so:

- When the program is waiting on input, the consumer drains immediately and parks at `ready == 0`; the freshest key still lands. This is the interactive common case and it's unchanged.
- Drops only happen while a prior key sits unconsumed — the program is busy and not reading keys. There, keeping the first pending key (the interrupt) and dropping the rest is the behavior we want anyway.

The tradeoff is that this is oldest-pending-wins under load rather than newest-wins coalescing. That's the simpler of the two fixes Codex suggested; a seqlock or double buffer would preserve newest-wins but isn't worth the complexity here.

## Validation

- `go test ./pkg/rt/wasm` passes; the four `assemble` goldens are regenerated (`lg-host-core.js` is shared host glue, so all four pick up the change).
- `go build ./...` clean.
