### PR TITLE
perf-tooling(fanout): gate on lg→go expansion ratio + portable os/ls walk

### DIFF
--- a/docs/perf/fanout-baseline.edn
+++ b/docs/perf/fanout-baseline.edn
@@ -1,26 +1,30 @@
-{:total-bytes 1283546
- :total-loc 49593
- :files 25
- :modules {"_wireup" {:bytes 4585 :loc 90 :files 3}
-           "edn" {:bytes 774 :loc 30 :files 1}
-           "hash" {:bytes 1826 :loc 62 :files 1}
-           "io" {:bytes 1069 :loc 39 :files 1}
-           "ir_build" {:bytes 322345 :loc 11968 :files 1}
-           "ir_data_generated" {:bytes 33347 :loc 922 :files 1}
-           "ir_dominance" {:bytes 23479 :loc 986 :files 1}
-           "ir_dump" {:bytes 54076 :loc 1933 :files 1}
-           "ir_lower" {:bytes 109950 :loc 4438 :files 1}
-           "ir_lower_go" {:bytes 321768 :loc 13510 :files 1}
-           "ir_passes" {:bytes 2454 :loc 67 :files 1}
-           "ir_passes_constfold" {:bytes 18681 :loc 914 :files 1}
-           "ir_passes_cse" {:bytes 8275 :loc 313 :files 1}
-           "ir_passes_dce" {:bytes 7161 :loc 277 :files 1}
-           "ir_passes_infer_arg_types" {:bytes 7424 :loc 339 :files 1}
-           "ir_passes_licm" {:bytes 70743 :loc 2410 :files 1}
-           "ir_passes_mutability" {:bytes 11699 :loc 465 :files 1}
-           "ir_passes_pipeline" {:bytes 97217 :loc 3220 :files 1}
-           "ir_passes_trace" {:bytes 23302 :loc 682 :files 1}
-           "ir_passes_typeinfer" {:bytes 106481 :loc 4861 :files 1}
-           "ir_validate" {:bytes 34102 :loc 1267 :files 1}
-           "test" {:bytes 3026 :loc 80 :files 1}
-           "walk" {:bytes 19762 :loc 720 :files 1}}}
+{:files 28
+ :modules {"_wireup" {:bytes 5152, :files 3, :loc 99}
+           "edn" {:bytes 6652, :files 1, :loc 203}
+           "hash" {:bytes 3768, :files 1, :loc 114}
+           "io" {:bytes 1266, :files 1, :loc 43}
+           "ir_build" {:bytes 429226, :files 1, :loc 12590}
+           "ir_data_generated" {:bytes 35966, :files 1, :loc 928}
+           "ir_dominance" {:bytes 25246, :files 1, :loc 914}
+           "ir_dump" {:bytes 54391, :files 1, :loc 1591}
+           "ir_lattice" {:bytes 125636, :files 1, :loc 3808}
+           "ir_lower" {:bytes 127116, :files 1, :loc 4084}
+           "ir_lower_go" {:bytes 754926, :files 1, :loc 23758}
+           "ir_passes" {:bytes 2875, :files 1, :loc 73}
+           "ir_passes_constfold" {:bytes 28936, :files 1, :loc 888}
+           "ir_passes_cse" {:bytes 9105, :files 1, :loc 268}
+           "ir_passes_dce" {:bytes 7828, :files 1, :loc 243}
+           "ir_passes_infer_arg_types" {:bytes 5513, :files 1, :loc 231}
+           "ir_passes_licm" {:bytes 103245, :files 1, :loc 2772}
+           "ir_passes_mutability" {:bytes 12370, :files 1, :loc 423}
+           "ir_passes_pipeline" {:bytes 266100, :files 1, :loc 7549}
+           "ir_passes_trace" {:bytes 25111, :files 1, :loc 689}
+           "ir_passes_typeinfer" {:bytes 121187, :files 1, :loc 3420}
+           "ir_structurize" {:bytes 56299, :files 1, :loc 1858}
+           "ir_validate" {:bytes 36752, :files 1, :loc 998}
+           "pprint" {:bytes 57108, :files 1, :loc 1494}
+           "test" {:bytes 28196, :files 1, :loc 694}
+           "walk" {:bytes 23522, :files 1, :loc 681}}
+ :source-bytes 535678
+ :total-bytes 2353492
+ :total-loc 70413}

--- a/scripts/fanout-ratchet.lg
+++ b/scripts/fanout-ratchet.lg
@@ -10,6 +10,7 @@
 ;; Flags:
 ;;   --go <path>        go binary for regeneration    (default "go")
 ;;   --tree-dir <dir>   lowered tree root             (default "pkg/rt/core_go_lowered")
+;;   --source-dir <dir> .lg source root (denominator) (default "pkg/rt/core")
 ;;   --baseline <path>  baseline EDN                  (default "docs/perf/fanout-baseline.edn")
 ;;   --threshold <pct>  allowed growth, integer pct   (default "5")
 ;;   --no-regen         skip regeneration (use tree as-is; for tests/fixtures)
@@ -34,6 +35,7 @@
 (def subcommand    (first argv))
 (def go-bin        (flag argv "--go" "go"))
 (def tree-dir      (flag argv "--tree-dir" "pkg/rt/core_go_lowered"))
+(def source-dir    (flag argv "--source-dir" "pkg/rt/core"))
 (def baseline-path (flag argv "--baseline" "docs/perf/fanout-baseline.edn"))
 (def threshold-pct (read-string (flag argv "--threshold" "5")))
 (def no-regen?     (has-flag? argv "--no-regen"))
@@ -49,13 +51,44 @@
 (defn file-exists? [path] (= 0 (:exit (os/sh "test" "-f" path))))
 
 ;; List *.go files under dir (recursive). Empty vec if dir missing.
-(defn list-go-files [dir]
-  (let [r (os/sh "find" dir "-name" "*.go" "-type" "f")]
-    (if (= 0 (:exit r)) (vec (re-seq #"[^\n]+" (:out r))) [])))
+;; Portable recursive directory walk via the native os/ls + os/stat primitives
+;; — NO shell `find`, so it works on targets without a shell (WASM, sandboxed,
+;; Windows). os/ls returns a vector of entry names; os/stat gives {:dir? :size}.
+(defn has-ext? [path ext]
+  (let [pl (count path) el (count ext)]
+    (and (>= pl el) (= ext (subs path (- pl el) pl)))))
+
+(defn walk-files [dir ext]
+  ;; A missing or non-directory root yields []: os/ls errors on a path that
+  ;; doesn't exist, so stat the root first and short-circuit. This preserves the
+  ;; old shell-find wrapper's "empty vec if dir missing" contract for
+  ;; show/check --no-regen against a tree that hasn't been generated yet.
+  (let [root (os/stat dir)]
+    (if (or (nil? root) (not (:dir? root)))
+      []
+      (reduce (fn [acc name]
+                (let [path (str dir "/" name)
+                      st   (os/stat path)]
+                  (cond
+                    (nil? st)           acc
+                    (:dir? st)          (into acc (walk-files path ext))
+                    (has-ext? path ext) (conj acc path)
+                    :else               acc)))
+              []
+              (os/ls dir)))))
+
+(defn list-go-files [dir] (walk-files dir ".go"))
+
+;; The .lg source corpus the lowering consumes. Used as the STABLE denominator
+;; for the expansion gate: go-output-bytes / lg-source-bytes. Anchoring to the
+;; source (which doesn't move when codegen REPRESENTATION changes, e.g.
+;; goto->structured) means the ratio reacts only to genuine output verbosity —
+;; unlike bytes/loc-of-go, whose denominator is itself a codegen artifact.
+(defn list-lg-files [dir] (walk-files dir ".lg"))
 
 ;; Size in chars (== bytes for the ASCII gofmt'd corpus). Deterministic; no
 ;; per-file subprocess.
-(defn file-size [path] (count (slurp path)))
+(defn file-size [path] (let [s (os/stat path)] (if s (:size s) 0)))
 (defn file-loc  [path] (count (re-seq #"\n" (slurp path))))
 
 ;; Parent-directory name: ".../ir/lower_go/lower_go.go" -> "lower_go".
@@ -64,6 +97,9 @@
 
 (defn module-bytes [metrics m]
   (let [e (get (:modules metrics) m)] (if e (:bytes e) 0)))
+
+(defn module-loc [metrics m]
+  (let [e (get (:modules metrics) m)] (if e (:loc e) 0)))
 
 (defn read-baseline [path]
   (when (file-exists? path) (read-string (slurp path))))
@@ -77,20 +113,43 @@
 (defn gated-total [current baseline]
   (reduce + 0 (map (fn [m] (module-bytes current m)) (keys (:modules baseline)))))
 
-(defn limit-for [baseline-bytes]
-  (quot (* baseline-bytes (+ 100 threshold-pct)) 100))
+;; EXPANSION gate. Compare CURRENT (go-bytes / lg-source-bytes) against the
+;; BASELINE expansion, with a percent band. Coverage growth — more defns
+;; lowering — adds to BOTH the go output AND the lg source, so the ratio stays
+;; flat and does NOT trip; only the generator emitting MORE Go per byte of
+;; source (the "not leveraging Go features" signal: callErr threading, dynamic
+;; invokes for keyword lookups, vm.Value everywhere) trips it.
+;; Ratio reported in milli-units (go bytes per 1000 source bytes).
+;; Integer cross-multiply to avoid float rounding:
+;;   cur_go/cur_src > base_go/base_src * (100+t)/100
+;;   <=>  cur_go * base_src * 100  >  base_go * cur_src * (100+t)
+(defn expansion-milli [go-bytes src-bytes]
+  (if (> src-bytes 0) (quot (* go-bytes 1000) src-bytes) 0))
 
 (defn compare-result [current baseline]
   (let [base-mods (keys (:modules baseline))
         cur-mods  (keys (:modules current))
-        gated     (gated-total current baseline)
-        limit     (limit-for (:total-bytes baseline))]
-    {:status   (if (> gated limit) :regression :ok)
-     :gated    gated
-     :baseline (:total-bytes baseline)
-     :limit    limit
-     :new      (sort (set-diff cur-mods base-mods))
-     :removed  (sort (set-diff base-mods cur-mods))}))
+        cur-go    (:total-bytes current)
+        cur-src   (:source-bytes current)
+        base-go   (:total-bytes baseline)
+        base-src  (:source-bytes baseline)
+        ;; A legacy baseline predating the expansion gate carries no
+        ;; :source-bytes, so the ratio is uncomputable. Gate the cross-multiply
+        ;; on a valid denominator — never feed nil to `*` — and treat an
+        ;; uncomparable baseline as in-band, leaving the next `update` to record
+        ;; source bytes.
+        comparable? (and base-src (> base-src 0) cur-src (> cur-src 0))
+        regression? (and comparable?
+                         (> (* cur-go base-src 100)
+                            (* base-go cur-src (+ 100 threshold-pct))))]
+    {:status      (if regression? :regression :ok)
+     :comparable? comparable?
+     :cur-go      cur-go
+     :cur-src     cur-src
+     :cur-ratio   (expansion-milli cur-go cur-src)
+     :base-ratio  (if (and base-src (> base-src 0)) (expansion-milli base-go base-src) 0)
+     :new         (sort (set-diff cur-mods base-mods))
+     :removed     (sort (set-diff base-mods cur-mods))}))
 
 ;; Build {module {:bytes :loc :files}} + totals over the tree + present wireup files.
 (defn collect-metrics [tree-dir wireup]
@@ -107,10 +166,11 @@
                                        :loc   (+ (:loc cur) l)
                                        :files (+ (:files cur) 1)})))
                      {} entries)]
-    {:total-bytes (reduce + 0 (map :bytes (vals modules)))
-     :total-loc   (reduce + 0 (map :loc   (vals modules)))
-     :files       (reduce + 0 (map :files (vals modules)))
-     :modules     modules}))
+    {:total-bytes  (reduce + 0 (map :bytes (vals modules)))
+     :total-loc    (reduce + 0 (map :loc   (vals modules)))
+     :files        (reduce + 0 (map :files (vals modules)))
+     :source-bytes (reduce + 0 (map file-size (list-lg-files source-dir)))
+     :modules      modules}))
 
 ;; --- deterministic, diff-friendly EDN emission (sorted module keys) ---
 ;; Deterministic, diff-friendly EDN emission via the core writer (edn/pretty):
@@ -133,13 +193,18 @@
         baseline (read-baseline baseline-path)]
     (when-not baseline (die (str "no baseline at " baseline-path " — run 'update' first")))
     (let [r (compare-result current baseline)]
-      (println (str "tracked gated bytes: " (:gated r) " / limit " (:limit r)
-                    " (baseline " (:baseline r) " +" threshold-pct "%)"))
-      (when (seq (:new r))     (println (str "NEW modules (exempt): " (:new r))))
+      (println (str "lg->go expansion: " (:cur-ratio r) " vs baseline " (:base-ratio r)
+                    " (go bytes per 1000 source bytes, +" threshold-pct "% band)"
+                    " [go " (:cur-go r) " src " (:cur-src r) "]"))
+      (when (seq (:new r))     (println (str "new modules: " (:new r))))
       (when (seq (:removed r)) (println (str "removed modules: " (:removed r))))
-      (if (= :regression (:status r))
-        (do (println "FANOUT REGRESSION: tracked modules grew beyond band.") (os/exit 1))
-        (do (println "OK: tracked fanout within band.") (os/exit 0))))))
+      (cond
+        (not (:comparable? r))
+        (do (println "OK: baseline has no :source-bytes (predates the expansion gate) — run 'update' to enable ratio gating.") (os/exit 0))
+        (= :regression (:status r))
+        (do (println "FANOUT REGRESSION: lg->go expansion grew beyond band — generator emitting more Go per byte of source (verbosity up, not just coverage).") (os/exit 1))
+        :else
+        (do (println "OK: lg->go expansion within band.") (os/exit 0))))))
 
 ;; MIN-merge current into baseline: existing modules tighten (MIN per metric),
 ;; new modules added at current size, removed modules drop. :total-bytes is
@@ -165,11 +230,14 @@
 
 (defn do-update []
   (regen!)
-  (let [current  (collect-metrics tree-dir wireup-files)
-        baseline (read-baseline baseline-path)
-        merged   (if baseline (merge-baseline current baseline) current)]
-    (spit baseline-path (metrics->edn merged))
-    (println (str "wrote " baseline-path " (total-bytes " (:total-bytes merged) ")"))
+  ;; The expansion gate is a RATIO, not a per-module byte floor, so the baseline
+  ;; is a coherent current snapshot (go totals + source totals) rather than a
+  ;; per-module MIN-merge (which would pair mismatched go/src totals).
+  (let [current (collect-metrics tree-dir wireup-files)]
+    (spit baseline-path (metrics->edn current))
+    (println (str "wrote " baseline-path " (lg->go expansion "
+                  (expansion-milli (:total-bytes current) (:source-bytes current))
+                  " per 1000 source bytes)"))
     (os/exit 0)))
 
 (cond

--- a/test/fanout_ratchet_test.go
+++ b/test/fanout_ratchet_test.go
@@ -66,6 +66,21 @@ func writeModule(t *testing.T, treeDir, module string, size int) {
 	}
 }
 
+// writeSource writes <dir>/<name>.lg with exactly `size` bytes — the denominator
+// of the expansion ratio. The script sums :source-bytes over the --source-dir
+// tree, so tests drive both numerator (--tree-dir Go bytes) and denominator
+// (--source-dir .lg bytes) to make the ratio deterministic.
+func writeSource(t *testing.T, srcDir, name string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Repeat("a", size-1) + "\n"
+	if err := os.WriteFile(filepath.Join(srcDir, name+".lg"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func writeBaseline(t *testing.T, path, edn string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(edn), 0644); err != nil {
@@ -76,7 +91,8 @@ func writeBaseline(t *testing.T, path, edn string) {
 func TestFanoutShow(t *testing.T) {
 	tree := t.TempDir()
 	writeModule(t, tree, "a", 1000)
-	out, code := runRatchet(t, "show", "--no-regen", "--no-wireup", "--tree-dir", tree)
+	src := t.TempDir() // empty source dir keeps the run hermetic and fast
+	out, code := runRatchet(t, "show", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src)
 	if code != 0 {
 		t.Fatalf("show exit=%d, want 0\n%s", code, out)
 	}
@@ -88,8 +104,28 @@ func TestFanoutShow(t *testing.T) {
 	}
 }
 
-// baseline: a=1000, b=1000, total 2000.
+// A missing tree (or source) directory must yield empty metrics, not an
+// interpreter error — the portable os/ls walker has to match the old find
+// wrapper's "empty vec if dir missing" contract.
+func TestFanoutShowMissingTree(t *testing.T) {
+	missingTree := filepath.Join(t.TempDir(), "does-not-exist")
+	missingSrc := filepath.Join(t.TempDir(), "also-missing")
+	out, code := runRatchet(t, "show", "--no-regen", "--no-wireup", "--tree-dir", missingTree, "--source-dir", missingSrc)
+	if code != 0 {
+		t.Fatalf("show exit=%d, want 0 (missing tree must not error)\n%s", code, out)
+	}
+	if strings.Contains(out, "ERROR") || strings.Contains(out, "error:") {
+		t.Errorf("missing tree produced an error instead of empty metrics:\n%s", out)
+	}
+	if !strings.Contains(out, ":total-bytes 0") {
+		t.Errorf("expected :total-bytes 0 for a missing tree:\n%s", out)
+	}
+}
+
+// Ratio baseline: go=2000 over src=1000 → expansion 2000 (go bytes per 1000
+// source bytes). The +5% band admits ratios up to 2100.
 const fixtureBaseline = `{:total-bytes 2000
+ :source-bytes 1000
  :total-loc 2
  :files 2
  :modules {
@@ -98,13 +134,16 @@ const fixtureBaseline = `{:total-bytes 2000
            }}
 `
 
+// Current go=2050 over src=1000 → ratio 2050, within the 2100 band → OK.
 func TestFanoutCheckWithinBand(t *testing.T) {
 	tree := t.TempDir()
 	writeModule(t, tree, "a", 1000)
-	writeModule(t, tree, "b", 1020) // +2% on b; gated 2020 <= limit 2100
+	writeModule(t, tree, "b", 1050) // cur-go 2050
+	src := t.TempDir()
+	writeSource(t, src, "core", 1000) // cur-src 1000 → ratio 2050 <= 2100
 	bl := filepath.Join(t.TempDir(), "base.edn")
 	writeBaseline(t, bl, fixtureBaseline)
-	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
 	if code != 0 {
 		t.Fatalf("check exit=%d, want 0 (within band)\n%s", code, out)
 	}
@@ -113,13 +152,16 @@ func TestFanoutCheckWithinBand(t *testing.T) {
 	}
 }
 
+// Current go=2200 over src=1000 → ratio 2200, beyond the 2100 band → REGRESSION.
 func TestFanoutCheckOverBand(t *testing.T) {
 	tree := t.TempDir()
 	writeModule(t, tree, "a", 1000)
-	writeModule(t, tree, "b", 1200) // gated 2200 > limit 2100
+	writeModule(t, tree, "b", 1200) // cur-go 2200
+	src := t.TempDir()
+	writeSource(t, src, "core", 1000) // cur-src 1000 → ratio 2200 > 2100
 	bl := filepath.Join(t.TempDir(), "base.edn")
 	writeBaseline(t, bl, fixtureBaseline)
-	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
 	if code != 1 {
 		t.Fatalf("check exit=%d, want 1 (over band)\n%s", code, out)
 	}
@@ -128,20 +170,64 @@ func TestFanoutCheckOverBand(t *testing.T) {
 	}
 }
 
-// The key requirement: a new module never causes failure, even when large.
-func TestFanoutCheckNewModuleExempt(t *testing.T) {
+// The headline property of the ratio gate: coverage growth — lowering a brand
+// new module — adds to BOTH the Go output and the .lg source, so the ratio
+// stays flat and the gate does NOT trip, even though absolute Go bytes double.
+// (Under the old byte-band gate this was "new modules are exempt"; under the
+// ratio gate it generalizes to "proportional growth is exempt".)
+const fixtureBaselineSingle = `{:total-bytes 2000
+ :source-bytes 1000
+ :total-loc 1
+ :files 1
+ :modules {
+            "a" {:bytes 2000 :loc 1 :files 1}
+           }}
+`
+
+func TestFanoutCheckCoverageGrowthNeutral(t *testing.T) {
+	tree := t.TempDir()
+	writeModule(t, tree, "a", 2000)
+	writeModule(t, tree, "c", 2000) // brand new module, doubles Go bytes to 4000
+	src := t.TempDir()
+	writeSource(t, src, "a", 1000)
+	writeSource(t, src, "c", 1000) // source also doubles to 2000 → ratio stays 2000
+	bl := filepath.Join(t.TempDir(), "base.edn")
+	writeBaseline(t, bl, fixtureBaselineSingle)
+	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
+	if code != 0 {
+		t.Fatalf("check exit=%d, want 0 (proportional growth exempt)\n%s", code, out)
+	}
+	if !strings.Contains(out, "new modules") || !strings.Contains(out, "c") {
+		t.Errorf("expected new module c reported:\n%s", out)
+	}
+}
+
+// A legacy baseline written before the expansion gate has no :source-bytes. The
+// ratio is then uncomputable, so check must treat it as in-band (exit 0) and
+// say so — never crash multiplying nil.
+const fixtureBaselineLegacy = `{:total-bytes 2000
+ :total-loc 2
+ :files 2
+ :modules {
+            "a" {:bytes 1000 :loc 1 :files 1}
+            "b" {:bytes 1000 :loc 1 :files 1}
+           }}
+`
+
+func TestFanoutCheckLegacyBaseline(t *testing.T) {
 	tree := t.TempDir()
 	writeModule(t, tree, "a", 1000)
-	writeModule(t, tree, "b", 1000)
-	writeModule(t, tree, "c", 50000) // brand new, huge — must NOT fail
+	writeModule(t, tree, "b", 5000) // would be way over band if it were comparable
+	src := t.TempDir()
+	writeSource(t, src, "core", 1000)
 	bl := filepath.Join(t.TempDir(), "base.edn")
-	writeBaseline(t, bl, fixtureBaseline)
-	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	writeBaseline(t, bl, fixtureBaselineLegacy)
+	out, code := runRatchet(t, "check", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
 	if code != 0 {
-		t.Fatalf("check exit=%d, want 0 (new module exempt)\n%s", code, out)
+		t.Fatalf("check exit=%d, want 0 (legacy baseline uncomparable, not a regression)\n%s", code, out)
 	}
-	if !strings.Contains(out, "NEW") || !strings.Contains(out, "c") {
-		t.Errorf("expected NEW module c reported:\n%s", out)
+	if !strings.Contains(out, "source-bytes") {
+		t.Errorf("expected a notice that the baseline lacks source-bytes:\n%s", out)
 	}
 }
 
@@ -149,9 +235,10 @@ func TestFanoutUpdateTightens(t *testing.T) {
 	tree := t.TempDir()
 	writeModule(t, tree, "a", 800) // shrank from 1000
 	writeModule(t, tree, "b", 1000)
+	src := t.TempDir()
 	bl := filepath.Join(t.TempDir(), "base.edn")
 	writeBaseline(t, bl, fixtureBaseline)
-	_, code := runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	_, code := runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
 	if code != 0 {
 		t.Fatalf("update exit=%d, want 0", code)
 	}
@@ -170,9 +257,10 @@ func TestFanoutUpdateFoldsNewModule(t *testing.T) {
 	writeModule(t, tree, "a", 1000)
 	writeModule(t, tree, "b", 1000)
 	writeModule(t, tree, "c", 500) // new module
+	src := t.TempDir()
 	bl := filepath.Join(t.TempDir(), "base.edn")
 	writeBaseline(t, bl, fixtureBaseline)
-	_, code := runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	_, code := runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
 	if code != 0 {
 		t.Fatalf("update exit=%d, want 0", code)
 	}
@@ -191,11 +279,12 @@ func TestFanoutUpdateDeterministic(t *testing.T) {
 	writeModule(t, tree, "b", 1000)
 	writeModule(t, tree, "a", 1000)
 	writeModule(t, tree, "c", 1000)
+	src := t.TempDir()
 	bl := filepath.Join(t.TempDir(), "base.edn")
 	writeBaseline(t, bl, fixtureBaseline)
-	runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
 	first, _ := os.ReadFile(bl)
-	runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--baseline", bl)
+	runRatchet(t, "update", "--no-regen", "--no-wireup", "--tree-dir", tree, "--source-dir", src, "--baseline", bl)
 	second, _ := os.ReadFile(bl)
 	if string(first) != string(second) {
 		t.Errorf("update output not byte-stable:\nfirst:\n%s\nsecond:\n%s", first, second)


### PR DESCRIPTION
## Why

The absolute-byte fanout gate trips on **coverage growth** (more defns lowering = the goal of #258), which masks the signal we actually want: is the generator emitting *more Go per byte of source* — i.e. not leveraging Go features. A density investigation (callErr threading is ~41% of the lowered tree, keyword lookups as dynamic invokes, `vm.Value` everywhere) motivated reframing the gate.

## What

1. **Gate on lg→go expansion ratio** (go-output-bytes / lg-source-bytes) instead of absolute bytes. Coverage growth adds to both numerator and denominator → ratio flat → no trip; only genuine output verbosity trips it. The `.lg` source is a **stable anchor** — unlike bytes/loc-of-go, whose denominator (go LOC) is itself a codegen artifact (the goto→structured change *removed* Go lines, so a bytes/loc gate would flag that improvement as a regression). Integer cross-multiply, no floats.

2. **Portable directory walk.** Replace the shell `find` in the file walkers with a recursive `os/ls` + `os/stat` traversal — no shell dependency, so it works on targets without one (WASM, sandboxed, Windows). `os/stat`'s `:size` also gives byte counts without reading files.

3. Baseline reset to the current expansion (**4.39×**, recorded as `:source-bytes` + totals).

## Validation
- Passes at parity (4393 vs 4393, +5% band).
- Trips correctly on a simulated verbosity increase (current 4393 vs a tighter baseline → FANOUT REGRESSION).
- Coverage-growth-immune by construction.

Companion to the codegen-quality backlog under #258 (#281–#284) — this gate is what measures progress on reducing lowered-code verbosity.