### PR TITLE
test(ir-stress): pre-declare deftype/defrecord/defprotocol generated names

### DIFF
--- a/scripts/ir-stress.lg
+++ b/scripts/ir-stress.lg
@@ -131,25 +131,45 @@
 (defn own-def-names [parsed]
   "Every top-level name this file defines: the 2nd element of any form whose
    head is a def-like special/macro (def, defn, defn-, defmacro, defonce,
-   def-, deftype, defprotocol). Used to pre-declare a file's own vars so the
-   per-defn AOT build resolves self/sibling references — exactly the state a
-   loaded namespace is in during production lowering.
+   def-, deftype, defrecord, defprotocol). Used to pre-declare a file's own
+   vars so the per-defn AOT build resolves self/sibling references — exactly
+   the state a loaded namespace is in during production lowering.
 
    The name slot may be meta-wrapped: `(def ^:private x v)` reads as
    `(def (with-meta x {:private true}) v)`, so unwrap (with-meta sym ...) to
-   the bare symbol — otherwise ^:private / ^:dynamic siblings stay unresolved."
+   the bare symbol — otherwise ^:private / ^:dynamic siblings stay unresolved.
+
+   deftype/defrecord ALSO intern generated constructors when the namespace
+   loads (->T positional, plus map->T for records), and defprotocol interns
+   each METHOD name (not just the protocol name) — so sibling defns reference
+   those generated names. Emit them too, else `(->T ...)` / `(method ...)` hits
+   'unresolved symbol' even though production lowering resolves it."
   (when (and parsed (seq? parsed))
     (->> (rest parsed)
-         (keep (fn [f]
-                 (when (and (seq? f) (>= (count f) 2))
-                   (let [h (first f)]
-                     (when (and (symbol? h)
-                                (clojure.string/starts-with? (str h) "def"))
-                       (let [raw (nth f 1)
-                             nm  (if (and (seq? raw) (= (first raw) 'with-meta))
-                                   (second raw)
-                                   raw)]
-                         (when (symbol? nm) nm)))))))
+         (mapcat (fn [f]
+                   (if (and (seq? f) (>= (count f) 2)
+                            (symbol? (first f))
+                            (clojure.string/starts-with? (str (first f)) "def"))
+                     (let [h   (str (first f))
+                           raw (nth f 1)
+                           nm  (if (and (seq? raw) (= (first raw) 'with-meta))
+                                 (second raw)
+                                 raw)]
+                       (if (symbol? nm)
+                         (cond
+                           (= h "deftype")   [nm (symbol (str "->" nm))]
+                           (= h "defrecord") [nm (symbol (str "->" nm))
+                                              (symbol (str "map->" nm))]
+                           ;; defprotocol: name + each method (first of each
+                           ;; method-spec list after the name, skipping a docstring).
+                           (= h "defprotocol")
+                           (into [nm] (->> (drop 2 f)
+                                           (filter seq?)
+                                           (map first)
+                                           (filter symbol?)))
+                           :else             [nm])
+                         []))
+                     [])))
          (vec))))
 
 (defn declare-own-defns! [parsed]


### PR DESCRIPTION
## Problem

The ir-stress AOT harness lowers each defn in isolation, pre-declaring a file's own top-level names (`declare-own-defns!`) so self/sibling references resolve — mirroring a loaded namespace. But `own-def-names` captured only a def-form's **2nd element**, i.e. the type/protocol name, and missed the names those forms **generate** on load:

- `(deftype T …)` → `->T` (positional constructor)
- `(defrecord T …)` → `->T`, `map->T`
- `(defprotocol P (m [..]) …)` → each method `m`

So a sibling defn calling `(->T …)` or a protocol method hit `unresolved symbol ->T` / `unresolved symbol <method>` — a **pre-declare gap, not a lowering gap** (production lowering resolves all of these, since the namespace is fully loaded/interned before lowering).

## Fix

Extend `own-def-names` (scripts/ir-stress.lg) to also emit the generated constructor/method names for `deftype`/`defrecord`/`defprotocol`.

## Result

- Closes the same-file deftype-constructor bucket (~13 `->T` rows) **plus** the protocol-method residuals it exposed.
- All 5 `test/gogen/deftype_*.lg` fixtures now lower; full corpus +~14 (no new failures — verified the failure set is a strict subset).
- `declare-own-defns!` still gates on `resolve`, so already-bound names are never clobbered — no regression risk.

Harness-accuracy only; no runtime/codegen change.