### PR TITLE
test(ir-stress): eval top-level (require ...) forms so deps load (#258)

### DIFF
--- a/scripts/ir-stress.lg
+++ b/scripts/ir-stress.lg
@@ -186,6 +186,23 @@
               :else nil)
             (catch e nil)))))))
 
+(defn require-top-level! [parsed]
+  "Eval every top-level (require ...) / (use ...) form in a file so deps
+   pulled in OUTSIDE an (ns ...) form load and their :as aliases register.
+   require-deps! only covers the ns-form :require clause; many corpus files
+   require at top level (scripts/generate.lg -> let-go.semver :as sv,
+   sort-defns.lg -> graph :as g, fusion-analysis.lg -> string :as str),
+   and files with an ns form sometimes add an extra top-level require too.
+   Without this the alias is never bound and the lowering reports a bogus
+   'unresolved symbol <alias>/...' gap instead of resolving the sibling.
+   Runs after in-ns so the alias lands in the file's own namespace,
+   mirroring how the namespace is fully loaded before production lowering."
+  (when (and parsed (seq? parsed))
+    (doseq [f (rest parsed)]
+      (when (and (seq? f) (symbol? (first f))
+                 (let [h (str (first f))] (or (= h "require") (= h "use"))))
+        (try (eval f) (catch e nil))))))
+
 (defn defn-forms [src-form]
   (when (and src-form (seq? src-form))
     (filter (fn [f] (and (seq? f)
@@ -540,6 +557,7 @@
             (eval (list 'in-ns (list 'quote ns-sym)))
             (catch e nil)))
         (require-deps! ns-form-)
+        (require-top-level! parsed)
         (declare-own-defns! parsed)
         (let [results (mapv (fn [d]
                               (let [name (nth d 1)
@@ -572,6 +590,7 @@
       (when ns-sym
         (try (eval (list 'in-ns (list 'quote ns-sym))) (catch e nil)))
       (require-deps! ns-form-)
+      (require-top-level! parsed)
       (let [defns      (vec (defn-forms parsed))
             target     (first (filter (fn [d] (= (nth d 1) trace-defn-name)) defns))]
         (when (nil? target)
@@ -600,6 +619,7 @@
           (when ns-sym
             (eval (list 'in-ns (list 'quote ns-sym))))
           (require-deps! ns-form-)
+          (require-top-level! parsed)
           (declare-own-defns! parsed))
         (catch e nil)))  ;; Silently skip load errors; we'll catch them per-fixture
     (let [t1 (System/nanoTime)


### PR DESCRIPTION
## Problem

The IR self-AOT stress harness reported a cluster of `unresolved symbol <alias>/...` failures that looked like distinct lowering gaps:

- `scripts/generate.lg` → `sv/gt?`
- `scripts/sort-defns.lg` → `g/sccs`
- `scripts/fusion-analysis.lg` → `str/join`, `str/includes?`
- `examples/ys-on-let-go/{01,02,03}_*.lg` → `say`

## Root cause (single)

`require-deps!` only walks the `(ns … (:require …))` clause. Every file above pulls its dependency in via a **top-level** `(require '[x :as y])` form (common in `scripts/`, and the ys examples require `ys-runtime` which defines the `say` macro). Those forms were never evaluated, so the `:as` alias never registered — and the unresolved alias surfaced as a bogus *lowering* gap instead of a dropped dep. Production lowering doesn't hit this because the namespace is fully loaded (all requires evaluated) before lowering.

## Fix

Add `require-top-level!`: walk every top-level `(require …)` / `(use …)` form and `eval` it after `in-ns`, mirroring how the namespace is loaded in production. Wired into all three harness load paths (`stress-file`, `trace-mode-run`, the upfront load loop).

## Verification (same `lg` binary, script-only change)

Ran main's `ir-stress.lg` vs the patched one on an identical `lg` built from main:

| | ok | fail |
|---|---|---|
| main (no fix) | 1157 | 42 |
| + fix | **1164** | **35** |

- **7 cleared**, **0 new failures** (strict subset): the 4 named aliases + `str/includes?` + 3× `say`.
- Diff is `scripts/ir-stress.lg` only (+20 lines). No core `.lg` touched → no bundle regen.

Part of the self-AOT close-out under #258. Remaining residuals are covered by the other open PRs (#280 timeouts, #286 gogen-on-path / unquote, #287 `->T` ctors) or are genuine codegen gaps (#281–284).