### PR TITLE
fix(wasm): host.html viewport meta + dvh height for mobile

### DIFF
--- a/pkg/rt/wasm/host.html
+++ b/pkg/rt/wasm/host.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
 __LG_XTERM_CSS__
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
     #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
     #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
     #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
 
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
     #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
 
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%;background:#0c0c0c;color:#e8e6df;overflow:hidden}
+    html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
     #terminal{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;


### PR DESCRIPTION
Follow-up to #277, addressing the two viewport-sizing gaps nnunley flagged in review. Both are in `host.html`, mobile-only, and non-blocking.

## Viewport meta

`<head>` shipped no `<meta name="viewport">`, so mobile browsers assume a ~980px layout viewport and scale the page down — `height:100%` and the flex column then map to a fictional viewport rather than the device. Add:

```html
<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
```

`viewport-fit=cover` is deliberate: a client shell that mounts into `#terminal` (xsofy's runs `-w-shell none`) injects its own viewport meta guarded by "only if absent". Matching `cover` here keeps that guard a no-op instead of letting a weaker frame meta shadow the shell's safe-area handling.

## Dynamic viewport height

`height:100%` is unstable on mobile as the browser chrome (URL bar) collapses and expands. Add a `100dvh` override so the column pins to the visible viewport:

```css
html,body{height:100%;height:100dvh;...}
```

The `100%` stays as the fallback for browsers without `dvh`. Chose `dvh` over `svh` after an on-device A/B — `dvh` fills the screen as chrome collapses, where `svh` leaves a strip of background. The resize churn `dvh` introduces is absorbed by the client's re-fit on resize.

## Validation

- `go test ./pkg/rt/wasm` passes; the four `assemble` goldens are regenerated (they embed `host.html`).
- `go build ./...` clean.
- The `dvh`-vs-`vh` and viewport-meta behavior was A/B'd on a phone using a standalone layout harness that mirrors `host.html`'s structure (full-viewport flex column, `#terminal` + a sibling shell). With the dynamic units the layout tracks the visible viewport through URL-bar collapse and rotation; with static `vh` the bottom slips under the chrome. `host.html` itself wasn't separately built to wasm for the phone test — the harness isolates the two CSS changes here.
