### PR TITLE
fix(ir-stress): close the (do ...) wrapper on its own line in read-all

### DIFF
--- a/scripts/ir-stress-corpus.edn
+++ b/scripts/ir-stress-corpus.edn
@@ -1,9 +1,8 @@
 {:doc
  "IR-stress lower-go corpus: every repo .lg the AOT lowering should handle. Failures against :stress are real lowering gaps - forward/mutual-ref resolution, unsupported arg patterns, gogen emission, lowering-cost timeouts. Widest net: core via go:embed all:core plus tests, examples, scripts; external deps are themselves lowered .lg so they stay IN. Consumer: make ir-stress runs lower-go on :stress minus :exclude. Regenerate the file list via scripts/ir-stress.lg."
+ ;; Nothing excluded: every listed file must read and lower.
  :exclude
- {"test/simple.lg" "harness read-string error - close-paren in a string in a line comment; see simple.lg line 63"
-  "test/hello.lg"  "harness read-string error - same class"
-  "test/perf.lg"   "harness read-string error - same class"}
+ {}
  :stress
  ["examples/async.lg"
   "examples/concurrent-primes.lg"

--- a/scripts/ir-stress.lg
+++ b/scripts/ir-stress.lg
@@ -120,7 +120,11 @@
 (defn read-all [path]
   (try
     (let [src (slurp path)]
-      (read-string (str "(do " src ")")))
+      ;; Close the wrapper on its OWN line: a file ending mid-`;;`-comment with
+      ;; no trailing newline would otherwise swallow the closing `)` into the
+      ;; comment, leaving `(do` unclosed (EOF). Keep `(do ` inline so file line
+      ;; numbers still map 1:1 into the wrapped form for error reporting.
+      (read-string (str "(do " src "\n)")))
     (catch e nil)))
 
 (defn ns-name-from [ns-form-]


### PR DESCRIPTION
## Bug

`read-all` wraps each corpus file as `(do <src>)` and `read-string`s it, but appended the closing paren with **no newline**. A file ending in a `;;` line comment without a trailing newline swallowed that `)` into the comment — leaving `(do` unclosed, so `read-string` hit EOF. The runtime file-loader doesn't wrap, so these files loaded fine standalone; only the ir-stress harness reported `READ-ERROR`.

This had been misattributed to a reader bug ("close-paren in a string in a line comment") and worked around by excluding the affected files — masking the real harness defect.

## Fix

Append the closer on its own line (`"\n)"`), keeping `(do ` inline so file line numbers still map 1:1 into the wrapped form for error reporting.

Drop `test/simple.lg`, `test/hello.lg`, `test/perf.lg` from the corpus `:exclude` list — they were excluded as "reader errors" but read correctly now (each carries 0 `defn` fixtures, which is correct). A full corpus run reports zero READ-ERRORs.
