### PR TITLE
build(lgbgen): nest lowered-Go output to mirror namespace nesting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ pkg/rt/core_compiled.lgb: $(CORE-LG-FILES) $(LGBGEN-SOURCES) $(GO)
 # the two engines silently disagree (parity-full diverges on bucket
 # hashes even when pass/fail counts match). lower_go.go is the timestamp
 # anchor for the whole tree — every regen rewrites it.
-pkg/rt/core_go_lowered/ir_lower_go/ir_lower_go.go: $(CORE-LG-FILES) $(LGBGEN-SOURCES) $(GO)
+pkg/rt/core_go_lowered/ir/lower_go/lower_go.go: $(CORE-LG-FILES) $(LGBGEN-SOURCES) $(GO)
 	go run -tags bootstrap ./cmd/lgbgen --target=go
 
 # Regenerate every committed code-gen artifact via the let-go orchestrator
@@ -92,7 +92,7 @@ PERF-SNAPSHOT ?= $(PERF-TIMELINE-DIR)/$(shell date -u +%Y%m%dT%H%M%SZ)-$(COMMIT)
 # core_go_lowered/ is stale (untagged vs gogen_ir run two different
 # versions of the IR pipeline). Caught the hard way 2026-05-28.
 check-lowered-fresh:
-	@stale=$$(find pkg/rt/core -name '*.lg' -newer pkg/rt/core_go_lowered/ir_lower_go/ir_lower_go.go 2>/dev/null); \
+	@stale=$$(find pkg/rt/core -name '*.lg' -newer pkg/rt/core_go_lowered/ir/lower_go/lower_go.go 2>/dev/null); \
 	if [ -n "$$stale" ]; then \
 		echo "ERROR: pkg/rt/core_go_lowered/ is stale relative to:"; \
 		echo "$$stale" | sed 's/^/  /'; \

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -500,12 +500,26 @@ func refreshManifest() {
 	fmt.Printf("wrote %s (%s)\n", genmanifest.ManifestRelPath, digest[:12])
 }
 
-// nsToGoPkgName converts a let-go namespace name to a valid Go package name.
-// Dots become underscores (ir.zipper → ir_zipper), hyphens become underscores.
+// nsToGoPkgName converts a let-go namespace name to a valid Go package name:
+// the LAST dot-segment, with hyphens turned into underscores
+// (ir.passes.pipeline → pipeline, ir.lower-go → lower_go, edn → edn). This is
+// both the `package` identifier and the filename stem; the directory nesting
+// that mirrors the full namespace is built by nsToGoRelDir. Mirrors Glojure's
+// mungeID(getLastNSPart(ns)).
 func nsToGoPkgName(nsName string) string {
-	s := strings.ReplaceAll(nsName, ".", "_")
-	s = strings.ReplaceAll(s, "-", "_")
-	return s
+	parts := strings.Split(nsName, ".")
+	last := parts[len(parts)-1]
+	return strings.ReplaceAll(last, "-", "_")
+}
+
+// nsToGoRelDir converts a let-go namespace name to the relative directory path
+// (under the lowered-output root) that mirrors the namespace nesting: dots
+// become path separators, hyphens become underscores
+// (ir.passes.pipeline → ir/passes/pipeline, ir.lower-go → ir/lower_go).
+// Mirrors Glojure's nsToPath.
+func nsToGoRelDir(nsName string) string {
+	s := strings.ReplaceAll(nsName, "-", "_")
+	return filepath.FromSlash(strings.ReplaceAll(s, ".", "/"))
 }
 
 // goGeneratedBanner is stamped on the first line of every Go file lgbgen
@@ -682,9 +696,13 @@ func runGoTarget(outDir string) {
 			continue
 		}
 
-		// Each namespace maps to its own Go package in a subdirectory.
+		// Each namespace maps to its own Go package in a directory that
+		// mirrors the namespace nesting (ir.passes.pipeline →
+		// ir/passes/pipeline/), with the package and filename named after the
+		// leaf segment (package pipeline, pipeline.go).
 		pkgName := nsToGoPkgName(ns.name)
-		pkgDir := filepath.Join(outDir, pkgName)
+		relDir := nsToGoRelDir(ns.name)
+		pkgDir := filepath.Join(outDir, relDir)
 		if err := os.MkdirAll(pkgDir, 0755); err != nil {
 			fmt.Fprintf(os.Stderr, "create pkg dir %s: %v\n", pkgDir, err)
 			os.Exit(1)
@@ -718,7 +736,10 @@ func runGoTarget(outDir string) {
 			os.Exit(1)
 		}
 		fmt.Printf("  wrote %s (%d bytes, %d defns)\n", filename, len(goSrc), len(defnForms))
-		generated = append(generated, pkgName)
+		// Wireup blank-imports by directory path (slash-separated), not the
+		// leaf package name — sibling namespaces share a leaf name but live at
+		// distinct paths.
+		generated = append(generated, filepath.ToSlash(relDir))
 	}
 	// Emit the //go:build gogen_ir blank-import wireup files from exactly
 	// the set we just wrote — so namespaces that were skipped or failed to

--- a/pkg/rt/core_embed_fs.go
+++ b/pkg/rt/core_embed_fs.go
@@ -22,7 +22,8 @@ var coreFS embed.FS
 // EmbeddedSource returns the source of an embedded namespace by its
 // dotted ns name.
 //
-// Naming rule (mirrors `cmd/lgbgen.nsToGoPkgName` direction-flipped):
+// Naming rule (the source-side analog of `cmd/lgbgen.nsToGoRelDir`, which
+// nests the lowered Go tree the same way):
 //   - dots are path separators: `ir.passes.dce` → `ir/passes/dce.lg`
 //   - in the *leaf* segment, hyphens map to underscores so the file
 //     name is a legal Go-style identifier: `ir.lower-go` → `ir/lower_go.lg`

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-b0b6cef4cb6f5d1f130cb6ff08ce8bc932d6f988067bb9f308065e29ef79a647
+cf0a519c79c2f86055195be97a9a08ee9d888066ec54217ae159d82938e5805e

--- a/scripts/fanout-ratchet.lg
+++ b/scripts/fanout-ratchet.lg
@@ -58,7 +58,7 @@
 (defn file-size [path] (count (slurp path)))
 (defn file-loc  [path] (count (re-seq #"\n" (slurp path))))
 
-;; Parent-directory name: ".../ir_lower_go/ir_lower_go.go" -> "ir_lower_go".
+;; Parent-directory name: ".../ir/lower_go/lower_go.go" -> "lower_go".
 (defn parent-dir [path]
   (let [m (re-find #"([^/]+)/[^/]+$" path)] (if m (second m) "_root")))
 

--- a/scripts/gogen-trampoline.lg
+++ b/scripts/gogen-trampoline.lg
@@ -66,17 +66,24 @@
 
 (defn- ns-form? [form] (and (seq? form) (= 'ns (first form))))
 
+;; Go package name = leaf namespace segment (hyphens→_); the lowered tree mirrors
+;; namespace nesting, so the package and filename are the last segment only.
 (defn- nsname->pkg [ns-name]
-  (string/replace (string/replace (str ns-name) "." "_") "-" "_"))
+  (string/replace (last (string/split (str ns-name) #"\.")) "-" "_"))
 
-;; The lowered Go package name for a fixture, read independently of lowering so
-;; cleanup can remove it even when lowering/building threw.
-(defn fixture-pkg [fixture]
+;; Relative dir under core_go_lowered/ that mirrors the namespace (dots→/,
+;; hyphens→_): ir.passes.pipeline → ir/passes/pipeline. Matches cmd/lgbgen.nsToGoRelDir.
+(defn- nsname->reldir [ns-name]
+  (string/replace (string/replace (str ns-name) "-" "_") "." "/"))
+
+;; The lowered Go package's relative dir for a fixture, read independently of
+;; lowering so cleanup can remove the tree even when lowering/building threw.
+(defn fixture-reldir [fixture]
   (let [forms (read-string (str "[" (slurp fixture) "]"))
         nsd   (first (filter ns-form? forms))]
-    (when nsd (nsname->pkg (second nsd)))))
+    (when nsd (nsname->reldir (second nsd)))))
 
-;; Lower one fixture FILE into <out-dir>/<pkg>/<pkg>.go and return {:ns :pkg}.
+;; Lower one fixture FILE into <out-dir>/<reldir>/<pkg>.go and return {:ns :pkg :reldir}.
 ;; Establishes lower-ns-to-go's precondition by evaluating the whole fixture
 ;; first (so build-fn can resolve the fixture's own ->T / protocol / sibling
 ;; names) — the native Go is emitted separately from the captured forms.
@@ -87,11 +94,12 @@
     (when (nil? ns-name) (die (str "no (ns ...) form in " fixture)))
     (doseq [form forms] (eval form))
     (let [pkg     (nsname->pkg ns-name)
+          reldir  (nsname->reldir ns-name)
           go-src  (ir.passes.pipeline/lower-ns-to-go pkg ns-name (vec (filter lowerable? forms)))
-          pkg-dir (str out-dir "/" pkg)]
-      (mkdir pkg-dir)
+          pkg-dir (str out-dir "/" reldir)]
+      (os/sh "mkdir" "-p" pkg-dir)
       (spit (str pkg-dir "/" pkg ".go") go-src)
-      {:ns ns-name :pkg pkg})))
+      {:ns ns-name :pkg pkg :reldir reldir})))
 
 ;; Run the (run) entry under a binary, requiring the fixture from src-root.
 ;; Returns {:result <str> :native <bool>} — :native reflects whether the entry
@@ -109,26 +117,25 @@
 (def WIREUP "zz_lg_trampoline_gen.go")        ; //go:build lg_trampoline (gitignored)
 (def work   (trim-tail (str (:out (os/sh "mktemp" "-d")))))
 
-(defn cleanup [pkg]
+(defn cleanup [reldir]
   (os/sh "rm" "-f" WIREUP)
-  (when pkg (os/sh "rm" "-rf" (str "pkg/rt/core_go_lowered/" pkg)))
+  (when reldir (os/sh "rm" "-rf" (str "pkg/rt/core_go_lowered/" reldir)))
   (os/sh "rm" "-rf" work))
 
 (defn trampoline-one [fixture]
-  (let [{:keys [ns pkg]} (lower-fixture! fixture "pkg/rt/core_go_lowered")
+  (let [{:keys [ns pkg reldir]} (lower-fixture! fixture "pkg/rt/core_go_lowered")
         ;; stage the fixture on a source path matching its ns so `require` finds it
-        rel      (string/replace (string/replace (str ns) "." "/") "-" "_")
         src-root (str work "/src-" pkg)
         driver   (str work "/driver-" pkg ".lg")]
-    (os/sh "mkdir" "-p" (str src-root "/" (or (re-find #"^.*/" rel) "")))
-    (spit (str src-root "/" rel ".lg") (slurp fixture))
+    (os/sh "mkdir" "-p" (str src-root "/" (or (re-find #"^.*/" reldir) "")))
+    (spit (str src-root "/" reldir ".lg") (slurp fixture))
     (spit driver (str "(require '" ns ")\n"
                       "(println \"RESULT\" (" ns "/run))\n"
                       "(println \"FNREPR\" (str " ns "/run))\n"))
     ;; wire ONLY this package in under the lg_trampoline tag; build a tagged binary
     (spit WIREUP (str "//go:build lg_trampoline\n\n"
                       "package main\n\n"
-                      "import _ \"github.com/nooga/let-go/pkg/rt/core_go_lowered/" pkg "\"\n"))
+                      "import _ \"github.com/nooga/let-go/pkg/rt/core_go_lowered/" reldir "\"\n"))
     (let [tagged (str work "/lg-" pkg)
           br (os/sh go-bin "build" "-tags" "lg_trampoline" "-o" tagged ".")]
       (os/sh "rm" "-f" WIREUP)
@@ -149,12 +156,12 @@
 (println "gogen-trampoline: go =" go-bin "| lg =" lg-bin "| fixtures =" (count fixtures))
 
 (let [results (mapv (fn [fixture]
-                      ;; pkg is read up front so cleanup removes the lowered
+                      ;; reldir is read up front so cleanup removes the lowered
                       ;; package even when lowering or the tagged build throws.
-                      (let [pkg (try (fixture-pkg fixture) (catch _ nil))
+                      (let [reldir (try (fixture-reldir fixture) (catch _ nil))
                             r   (try (trampoline-one fixture)
                                      (catch e (println (str "  " fixture " ERROR: " e)) {:ok false}))]
-                        (cleanup pkg)
+                        (cleanup reldir)
                         r))
                     fixtures)]
   (if (every? :ok results)


### PR DESCRIPTION
Reorganizes the `gogen_ir` lowered-Go output so the file tree mirrors namespace nesting instead of flat underscore-joined names.

## Before / after

```
ir.passes.pipeline
  before:  core_go_lowered/ir_passes_pipeline/ir_passes_pipeline.go   (package ir_passes_pipeline)
  after:   core_go_lowered/ir/passes/pipeline/pipeline.go             (package pipeline)
```

- **Directory** = full namespace path (dots→`/`, hyphens→`_`).
- **Package + file** = the leaf segment.
- **One package per namespace** — siblings never share a package, so no symbol collisions. Go allows a directory to hold both a file and subpackages, so the leaf+parent case is clean (`ir/passes/passes.go` beside `ir/passes/cse/cse.go`). `ir.lower` and `ir.lower-go` land in distinct packages, so the prior `lower`/`lower` clash cannot occur.

This mirrors Glojure's scheme (`pkg/runtime/codegen.go`: `nsToPath` + `mungeID(getLastNSPart)`) and standard Clojure/JVM, which never merge two namespaces into one compiled artifact.

## Why it's a small diff

The change is **organizational only** — lowered packages are blank-imported by the wireup files and never import each other (cross-namespace calls go through `rt.CachedVarFn` runtime lookup), so the build, binary, and runtime are unchanged. The lowered tree itself is gitignored and regenerated, so the committed diff is just:

- `cmd/lgbgen/main.go` — `nsToGoPkgName` now returns the leaf segment; new `nsToGoRelDir` builds the nested path; `runGoTarget` writes to the nested dir and blank-imports by path.
- `Makefile` — the lowered-tree mtime anchor moves to `pkg/rt/core_go_lowered/ir/lower_go/lower_go.go`.
- `pkg/rt/core_embed_fs.go` — comment repointed to `nsToGoRelDir`.
- `pkg/rt/generated.sums` — digest refreshed (main.go is a hashed source).
- `scripts/gogen-trampoline.lg` — dev harness updated to the nested layout.
- `scripts/fanout-ratchet.lg` — comment fix.

## Verification

- `go build -tags gogen_ir ./...` and plain `go build ./...` — green (real guard for leaf package-name sanity).
- `make generate` + `make check-generated` — bundle + lowered tree in sync; dispatches natively under `gogen_ir`.
- `make check-lowered-fresh`, `go test ./pkg/genmanifest/...`, `go test ./test ./pkg/ir ./pkg/rt`.
- `go test -tags gogen_ir ./test -run TestClojureTestSuite` and `go test -tags gogen_ir ./pkg/ir` — parity unchanged.