### PR TITLE
test(determinism): add lowering determinism property test (#175)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,14 +62,18 @@ jobs:
       # default: they run each script under let-go and compare to the committed
       # test/gold/*.out goldens. Re-deriving those goldens from a LIVE Clojure is
       # done in the dedicated `gold-differential` job (no JVM dependency here).
+      # TEMPORARY (#299): per-package test timeout raised 60s→180s so the
+      # lowering-determinism harness (runs lgbgen twice, ~60-120s on CI) fits.
+      # Revert to 60s once that test is moved to a dedicated long-timeout step.
       - name: Test with bundled bytecode stdlib
-        run: go test -v -timeout 60s ./... -skip TestClojureTestSuite
+        run: go test -v -timeout 180s ./... -skip TestClojureTestSuite
 
       - name: Clojure compatibility test suite with bundled bytecode stdlib
         run: go test ./test/ -count=1 -run TestClojureTestSuite -v
 
+      # TEMPORARY (#299): see note on the bytecode step above.
       - name: Test with source stdlib bootstrap
-        run: go test -tags bootstrap -v -timeout 60s ./... -skip TestClojureTestSuite
+        run: go test -tags bootstrap -v -timeout 180s ./... -skip TestClojureTestSuite
 
       - name: Clojure compatibility test suite with source stdlib bootstrap
         run: go test -tags bootstrap ./test/ -count=1 -run TestClojureTestSuite -v

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ REPORT-SCRIPT := scripts/clojure_compat_report.sh
 # matches CI's per-package timeout so runaway tests die locally too.
 # Override on the command line: make test GOMEMLIMIT=4GiB.
 GOMEMLIMIT ?= 2GiB
-GO-TEST-TIMEOUT ?= 60s
+# TEMPORARY (#299): 60s→180s so the lowering-determinism harness (runs lgbgen
+# twice) fits. Revert once that test moves to a dedicated long-timeout step.
+GO-TEST-TIMEOUT ?= 180s
 
 # Export the heap cap to EVERY recipe's environment, not just `make test`.
 # The bootstrap/lowering targets (generate, lowered, parity) shell out to

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -354,11 +354,19 @@ func main() {
 	var target string
 	var cpuProfilePath string
 	var memProfilePath string
+	// codeDir is the base directory for the generated //go:build gogen_ir wireup
+	// files (lg_gogen_ir.go, cmd/lgbgen/main_gogen_ir.go, pkg/ir/...). It defaults
+	// to "" = the repo root, the canonical generation target. Callers that lower
+	// into a throwaway directory (e.g. the determinism test) set it so lgbgen
+	// never rewrites the real checkout's wireup. When set, the manifest refresh
+	// is skipped too, keeping the run side-effect-free outside codeDir/outDir.
+	var codeDir string
 
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.StringVar(&target, "target", "", "generation target: go, both, or empty for bundle-only")
 	fs.StringVar(&cpuProfilePath, "cpuprofile", "", "write Go CPU profile for the lgbgen process")
 	fs.StringVar(&memProfilePath, "memprofile", "", "write Go allocation profile (allocs) for the lgbgen process")
+	fs.StringVar(&codeDir, "code-dir", "", "base dir for generated gogen_ir wireup files (default: repo root)")
 	fs.Parse(os.Args[1:])
 
 	switch target {
@@ -494,13 +502,17 @@ func main() {
 	// runGoTarget re-pipelines the same loaded namespaces, so the order is
 	// immaterial and both artifacts come from one core compile.
 	if targetGo {
-		runGoTarget(goOutDir)
-		refreshManifest()
+		runGoTarget(goOutDir, codeDir)
+		// Skip the manifest refresh when lowering into a throwaway codeDir —
+		// the canonical generated.sums must only move under a real regen.
+		if codeDir == "" {
+			refreshManifest()
+		}
 		return
 	}
 	if targetBoth {
 		writeBundle(outPath, consts, nsChunks, nsOrder)
-		runGoTarget(goOutDir)
+		runGoTarget(goOutDir, codeDir)
 		return
 	}
 
@@ -680,8 +692,9 @@ func pruneEmptyDirs(root string) {
 }
 
 // runGoTarget re-pipelines each namespace's defn forms through the Go
-// lowering pipeline and writes .go source files to outDir.
-func runGoTarget(outDir string) {
+// lowering pipeline and writes .go source files to outDir. The gogen_ir
+// wireup files go under codeDir ("" = repo root, the canonical target).
+func runGoTarget(outDir, codeDir string) {
 	var failed []string
 	var generated []string // Go package names successfully written, for the wireup files.
 	pipelineVar := rt.LookupVar("ir.passes.pipeline", "lower-ns-to-go")
@@ -805,7 +818,7 @@ func runGoTarget(outDir string) {
 	// Emit the //go:build gogen_ir blank-import wireup files from exactly
 	// the set we just wrote — so namespaces that were skipped or failed to
 	// lower are never imported (which would break the tagged build).
-	writeGogenWireup(generated)
+	writeGogenWireup(generated, codeDir)
 	if len(failed) > 0 {
 		fmt.Fprintf(os.Stderr, "lgbgen: %d namespace(s) failed: %v\n", len(failed), failed)
 		os.Exit(1)
@@ -828,7 +841,7 @@ func runGoTarget(outDir string) {
 // All carry a "Code generated … DO NOT EDIT." banner and are kept in
 // lockstep with runGoTarget's output; the import set tracks the generated
 // tree exactly, including the exclusion of namespaces that failed to lower.
-func writeGogenWireup(pkgNames []string) {
+func writeGogenWireup(pkgNames []string, codeDir string) {
 	sorted := append([]string(nil), pkgNames...)
 	sort.Strings(sorted)
 
@@ -857,11 +870,21 @@ func writeGogenWireup(pkgNames []string) {
 		{filepath.Join("pkg", "ir", "zz_gogen_ir_wire_test.go"), "ir_test", "gogen_ir"},
 	}
 	for _, f := range files {
-		if err := os.WriteFile(f.path, []byte(render(f.pkg, f.buildTag)), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "write %s: %v\n", f.path, err)
+		// codeDir defaults to "" (repo root); a caller lowering into a throwaway
+		// tree sets it so the wireup never lands on the real checkout. Subdirs
+		// (cmd/lgbgen, pkg/ir) are created under codeDir as needed.
+		outPath := filepath.Join(codeDir, f.path)
+		if dir := filepath.Dir(outPath); dir != "." {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				fmt.Fprintf(os.Stderr, "mkdir %s: %v\n", dir, err)
+				os.Exit(1)
+			}
+		}
+		if err := os.WriteFile(outPath, []byte(render(f.pkg, f.buildTag)), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "write %s: %v\n", outPath, err)
 			os.Exit(1)
 		}
-		fmt.Printf("  wrote %s (%d pkgs)\n", f.path, len(sorted))
+		fmt.Printf("  wrote %s (%d pkgs)\n", outPath, len(sorted))
 	}
 }
 

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-d44f6f6ce27236db93bee089f1ecb0bdda4fa173c7a9da91c52ac1be4a025fd3
+e9a190c9c07a7b055f7f86a2147d49b32eb9b1758fc9d4a62bf2043a570762ae

--- a/test/e2e/lowering_determinism_test.go
+++ b/test/e2e/lowering_determinism_test.go
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// TestLoweringDeterminism verifies that the gogen_ir lowering process is
+// deterministic: two runs of lgbgen produce identical byte-for-byte output.
+//
+// This is a property test that commits to the determinism invariant. The
+// lowering encodes inferred types and generated code into Go source files,
+// so any non-determinism in token positions, type inference, or code generation
+// would produce different bytes across runs. This test guards against regressions.
+//
+// Skipped under testing.Short() since it runs lgbgen twice (expensive).
+// Run explicitly via `make test` for full validation.
+func TestLoweringDeterminism(t *testing.T) {
+	if testing.Short() {
+		t.Skip("lowering determinism harness runs lgbgen twice; run via `make test` or `go test ./test/e2e/`")
+	}
+
+	root := repoRoot(t)
+
+	// Build lgbgen once and invoke the binary twice. `go run` would recompile
+	// the tool on every call, and that compile dominates the wall clock for a
+	// two-run test; building once keeps the harness inside the package test
+	// timeout.
+	bin := buildLgbgen(t, root)
+
+	// Each run is fully output-isolated (its own --target tree and --code-dir
+	// wireup under a private temp dir), so the two share no state and run
+	// CONCURRENTLY — roughly halving wall clock vs sequential. Errors are
+	// collected and reported from the test goroutine (t.Fatalf is unsafe from
+	// a spawned goroutine).
+	base := t.TempDir()
+	dirs := make([]string, 2)
+	errs := make([]error, 2)
+	var wg sync.WaitGroup
+	for i, label := range []string{"run1", "run2"} {
+		wg.Add(1)
+		go func(i int, label string) {
+			defer wg.Done()
+			dirs[i], errs[i] = generateLoweredTree(root, bin, filepath.Join(base, label))
+		}(i, label)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("lgbgen run %d: %v", i+1, err)
+		}
+	}
+
+	// Compare all generated files recursively.
+	diffs := compareDirectories(t, dirs[0], dirs[1])
+	if len(diffs) > 0 {
+		t.Errorf("Lowering is non-deterministic: %d files differ between runs", len(diffs))
+		for _, diff := range diffs[:min(len(diffs), 5)] {
+			t.Logf("  DIFF: %s", diff)
+		}
+		if len(diffs) > 5 {
+			t.Logf("  ... and %d more", len(diffs)-5)
+		}
+		t.FailNow()
+	}
+}
+
+// buildLgbgen compiles the bootstrap lgbgen tool once into a temp path so the
+// determinism harness can invoke the binary twice without paying the Go
+// compile on each run.
+func buildLgbgen(t *testing.T, repoRoot string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "lgbgen")
+
+	cmd := exec.Command("go", "build", "-tags", "bootstrap", "-o", bin, "./cmd/lgbgen")
+	cmd.Dir = repoRoot
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build lgbgen: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	return bin
+}
+
+// generateLoweredTree runs lgbgen with the lowered tree (--target=go) and the
+// gogen_ir wireup files (--code-dir) both directed under runDir, fully isolating
+// the run from the real checkout: it never rewrites the tracked
+// pkg/rt/core_go_lowered tree OR the wireup files (lg_gogen_ir.go, …) that
+// `go test ./...` builds elsewhere (e.g. TestGogenAOTDiff's -tags gogen_ir
+// build). The full isolation is also what lets two runs execute concurrently.
+//
+// Takes no *testing.T because it is called from goroutines, where t.Fatalf is
+// unsafe; it returns the lowered-tree dir and an error instead.
+func generateLoweredTree(repoRoot, bin, runDir string) (string, error) {
+	outDir := filepath.Join(runDir, "tree")
+	codeDir := filepath.Join(runDir, "code")
+
+	// cmd.Dir is the repo root so lgbgen can read the .lg sources, but the
+	// lowered tree and wireup both go to absolute temp dirs under runDir.
+	cmd := exec.Command(bin, "--target=go", "--code-dir", codeDir, outDir)
+	cmd.Dir = repoRoot
+
+	// Capture stderr (timing summary / warnings) for the failure message.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\nstderr:\n%s", err, stderr.String())
+	}
+
+	return outDir, nil
+}
+
+// compareDirectories recursively compares two directory trees and returns
+// a list of relative paths that differ in content or presence.
+func compareDirectories(t *testing.T, dir1, dir2 string) []string {
+	t.Helper()
+	var diffs []string
+
+	err := filepath.Walk(dir1, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(dir1, path)
+		other := filepath.Join(dir2, rel)
+
+		if info.IsDir() {
+			return nil // Walk handles recursion
+		}
+
+		// Compare file contents.
+		b1, err1 := os.ReadFile(path)
+		b2, err2 := os.ReadFile(other)
+
+		if err1 != nil || err2 != nil || !bytes.Equal(b1, b2) {
+			diffs = append(diffs, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk dir1: %v", err)
+	}
+
+	// Also check for files in dir2 that don't exist in dir1.
+	err = filepath.Walk(dir2, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(dir2, path)
+		other := filepath.Join(dir1, rel)
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if _, err := os.Stat(other); os.IsNotExist(err) {
+			diffs = append(diffs, rel+" (missing in run1)")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk dir2: %v", err)
+	}
+
+	sort.Strings(diffs)
+	return diffs
+}
+
+// min returns the minimum of two integers.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

Adds a regression test for the lowering determinism fix to guard against future non-deterministic code generation.

The test verifies that two runs of `lgbgen --target=go` produce byte-for-byte identical `pkg/rt/core_go_lowered/` output, which is critical because the lowering encodes inferred types and generated code into Go source files. Non-determinism in token positions, type inference, or code generation would break reproducible builds.

This test is informed by the determinism fix (ctx-gensym threading + per-fn renumbering) and ensures that fix remains stable.

## Test plan

- [x] Runs `TestLoweringDeterminism` directly: `go test ./test/e2e/ -run TestLowering`
- [x] Skipped under `testing.Short()` (runs lgbgen twice, expensive)
- [x] Full test via `make test` or `go test ./test/e2e/`

---
<!-- issue-ref -->
Part of #175.