### PR TITLE
perf(vm): PersistentMap.Equals walks in place instead of materializing nodeSeq

### DIFF
--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"runtime/pprof"
 	"sort"
 	"strings"
@@ -305,10 +306,12 @@ func main() {
 	goOutDir := "pkg/rt/core_go_lowered"
 	var target string
 	var cpuProfilePath string
+	var memProfilePath string
 
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.StringVar(&target, "target", "", "generation target: go, both, or empty for bundle-only")
 	fs.StringVar(&cpuProfilePath, "cpuprofile", "", "write Go CPU profile for the lgbgen process")
+	fs.StringVar(&memProfilePath, "memprofile", "", "write Go allocation profile (allocs) for the lgbgen process")
 	fs.Parse(os.Args[1:])
 
 	switch target {
@@ -361,6 +364,20 @@ func main() {
 			os.Exit(130)
 		}()
 		defer stopProfile()
+	}
+	if memProfilePath != "" {
+		defer func() {
+			f, err := os.Create(memProfilePath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "create memprofile %s: %v\n", memProfilePath, err)
+				return
+			}
+			defer f.Close()
+			runtime.GC() // materialize up-to-date allocation stats
+			if err := pprof.Lookup("allocs").WriteTo(f, 0); err != nil {
+				fmt.Fprintf(os.Stderr, "write memprofile %s: %v\n", memProfilePath, err)
+			}
+		}()
 	}
 
 	// rt.init() has already run — native builtins are registered in CoreNS.

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-349644e85d207f8ce2ef558e0b2125e9ed82afba9edeae66142629de8e73930b
+10abca6228dcf87765d1efd21dc5ef82c68629f7d85944c29068231cb1afba55

--- a/pkg/vm/persistent_map.go
+++ b/pkg/vm/persistent_map.go
@@ -45,6 +45,10 @@ type hmapNode interface {
 	assoc(shift uint, hash uint32, key Value, val Value, addedLeaf *bool) hmapNode
 	dissoc(shift uint, hash uint32, key Value) hmapNode
 	nodeSeq() []MapEntry
+	// each visits every (key, value) pair in place without allocating an
+	// entry slice. It returns false as soon as fn returns false (allowing
+	// short-circuit), true once the whole subtree has been visited.
+	each(fn func(key, val Value) bool) bool
 }
 
 // MapEntry is a key-value pair.
@@ -259,6 +263,24 @@ func (n *hmapBitmapNode) nodeSeq() []MapEntry {
 		}
 	}
 	return entries
+}
+
+func (n *hmapBitmapNode) each(fn func(key, val Value) bool) bool {
+	nSlots := len(n.array) / 2
+	for i := 0; i < nSlots; i++ {
+		keyOrNil := n.array[2*i]
+		valOrNode := n.array[2*i+1]
+		if keyOrNil != nil {
+			if !fn(keyOrNil.(Value), valOrNode.(Value)) {
+				return false
+			}
+		} else if valOrNode != nil {
+			if !valOrNode.(hmapNode).each(fn) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (n *hmapBitmapNode) cloneAndSet(i int, val any) *hmapBitmapNode {
@@ -488,6 +510,15 @@ func (n *hmapCollisionNode) nodeSeq() []MapEntry {
 		entries[i] = MapEntry{Key: n.array[2*i].(Value), Value: n.array[2*i+1].(Value)}
 	}
 	return entries
+}
+
+func (n *hmapCollisionNode) each(fn func(key, val Value) bool) bool {
+	for i := 0; i < n.count; i++ {
+		if !fn(n.array[2*i].(Value), n.array[2*i+1].(Value)) {
+			return false
+		}
+	}
+	return true
 }
 
 func (n *hmapCollisionNode) findIndex(key Value) int {
@@ -797,16 +828,16 @@ func (m *PersistentMap) Equals(other Value) bool {
 	if m.count != o.count {
 		return false
 	}
-	if m.root == nil && o.root == nil {
+	// count equality + the invariant (count == 0 ⟺ root == nil) means both
+	// roots are non-nil past this point.
+	if m.count == 0 {
 		return true
 	}
-	// Check that every entry in m exists with the same value in o
-	entries := m.root.nodeSeq()
-	for _, e := range entries {
-		v, found := o.root.find(0, hashValue(e.Key), e.Key)
-		if !found || !valueEquiv(e.Value, v) {
-			return false
-		}
-	}
-	return true
+	// Walk m in place (no entry-slice materialization — the old nodeSeq()
+	// here dominated lowering allocation): every key in m must exist in o
+	// with an equiv value. Sizes already match, so this is sufficient.
+	return m.root.each(func(k, v Value) bool {
+		ov, found := o.root.find(0, hashValue(k), k)
+		return found && valueEquiv(v, ov)
+	})
 }

--- a/pkg/vm/persistent_map_test.go
+++ b/pkg/vm/persistent_map_test.go
@@ -258,6 +258,58 @@ func TestPersistentMapEquals(t *testing.T) {
 	}
 }
 
+// TestPersistentMapEqualsDeep exercises Equals over maps deep enough to force
+// HAMT sub-nodes (and thus the recursive walk), guarding the non-materializing
+// rewrite of Equals against regressions: equal-but-differently-built maps,
+// single-value divergence, single-key divergence, and size divergence.
+func TestPersistentMapEqualsDeep(t *testing.T) {
+	const n = 400 // > 32 forces multiple HAMT levels
+	build := func(skip int, bumpKey, bumpVal int) *PersistentMap {
+		kvs := make([]Value, 0, 2*n)
+		for i := 0; i < n; i++ {
+			if i == skip {
+				continue
+			}
+			k := i
+			if i == bumpKey {
+				k = i + 100000
+			}
+			v := i
+			if i == bumpVal {
+				v = i + 1
+			}
+			kvs = append(kvs, Int(k), Int(v))
+		}
+		return NewPersistentMap(kvs)
+	}
+
+	base := build(-1, -1, -1)
+
+	// Same contents, inserted in reverse order — must be Equal.
+	rev := make([]Value, 0, 2*n)
+	for i := n - 1; i >= 0; i-- {
+		rev = append(rev, Int(i), Int(i))
+	}
+	if !base.Equals(NewPersistentMap(rev)) {
+		t.Error("deep maps with identical contents (reverse insert) should be equal")
+	}
+	if !base.Equals(base) {
+		t.Error("map should equal itself")
+	}
+	// One value differs.
+	if base.Equals(build(-1, -1, 137)) {
+		t.Error("maps differing in one value should not be equal")
+	}
+	// One key differs (same size).
+	if base.Equals(build(-1, 213, -1)) {
+		t.Error("maps differing in one key should not be equal")
+	}
+	// One key missing (size differs).
+	if base.Equals(build(50, -1, -1)) {
+		t.Error("maps of different size should not be equal")
+	}
+}
+
 func TestPersistentMapString(t *testing.T) {
 	m := EmptyPersistentMap
 	if m.String() != "{}" {


### PR DESCRIPTION
## What

`PersistentMap.Equals` called `m.root.nodeSeq()` to iterate, which **materializes the entire map into a `[]MapEntry` slice** (recursively allocating a slice per HAMT node) on *every* comparison. The IR typeinfer fixpoint compares maps constantly.

A heap profile of one bootstrap lowering pass (`go run -tags bootstrap ./cmd/lgbgen --target=go`) showed `hmapBitmapNode.nodeSeq` at **30 GB — 53% of all allocation**, of which **98.95% was driven by `Equals`**.

## Change

- Add an in-place `each(fn func(key, val Value) bool) bool` visitor to the `hmapNode` interface and both node types (`hmapBitmapNode`, `hmapCollisionNode`).
- Rewrite `Equals` to walk one map calling the other's `find()` per entry — **zero slice materialization**. Sizes are compared first, so one-directional containment is sufficient.
- Add a `-memprofile` flag to `lgbgen` (mirrors the existing `-cpuprofile`), used to capture the profile.

## Measured (one lowering pass)

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| Allocated | 56.2 GB | 27.2 GB | **−52%** |
| Wall time | ~106s | ~50s | **−53%** |
| GC (`gcBgMarkWorker`) | 41.5s | 21.5s | **−48%** |

The generated `core_go_lowered/` tree is **byte-identical** before/after — semantics unchanged. Existing `pkg/vm` tests pass; added `TestPersistentMapEqualsDeep` exercising multi-level HAMT, value/key/size divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)