### PR TITLE
perf(vm): O(1)-amortized PersistentVector.pop (was O(n) Unbox+rebuild)

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -4206,9 +4206,8 @@ func installLangNS() {
 			if v.RawCount() < 1 {
 				return vm.NIL, fmt.Errorf("can't pop empty vector")
 			}
-			// Rebuild without last element
-			vals := v.Unbox().([]vm.Value)
-			return vm.NewPersistentVector(vals[:len(vals)-1]), nil
+			// O(1)-amortized structural pop (was O(n) Unbox()+rebuild).
+			return v.Pop(), nil
 		case vm.ArrayVector:
 			v := vs[0].(vm.ArrayVector)
 			if v.RawCount() < 1 {

--- a/pkg/vm/persistent_vector.go
+++ b/pkg/vm/persistent_vector.go
@@ -396,6 +396,105 @@ func newPath(level uint, tail []Value) *vnode {
 	return ret
 }
 
+// Pop returns a new vector with the last element removed, in O(1) amortized
+// time (mirrors Clojure's PersistentVector.pop). The previous behavior — the
+// `pop` builtin doing Unbox()+NewPersistentVector(all-but-last) — was O(n) per
+// call, which made vector-as-stack uses (e.g. the typeinfer worklist drain via
+// peek/pop) O(n^2) and a major allocation source. Returns the empty vector for
+// count <= 1; callers that must reject popping an empty vector check count
+// first.
+func (v PersistentVector) Pop() PersistentVector {
+	if v.count <= 1 {
+		return v.Empty().(PersistentVector)
+	}
+	// More than one element in the tail: just shrink the tail (O(tail) <= 32).
+	if len(v.tail) > 1 {
+		newTail := make([]Value, len(v.tail)-1)
+		copy(newTail, v.tail[:len(v.tail)-1])
+		return PersistentVector{
+			count:   v.count - 1,
+			shift:   v.shift,
+			root:    v.root,
+			tail:    newTail,
+			tailOff: v.tailOff,
+			meta:    v.meta,
+		}
+	}
+	// The tail holds 0 or 1 elements, so the new tail is pulled from the
+	// rightmost trie leaf. (NewPersistentVector leaves an empty tail when the
+	// count is a multiple of nodeCap, so the empty case is real.) removeIdx is
+	// the index of an element in that leaf: count-2 when the tail had the last
+	// element, count-1 when the last element lives in the leaf itself.
+	removeIdx := v.count - 1 - len(v.tail)
+	newTail := v.leafArrayFor(removeIdx)
+	if len(v.tail) == 0 {
+		// The popped element was the last of this leaf — drop it from the tail.
+		newTail = newTail[:len(newTail)-1]
+	}
+	newShift := v.shift
+	newRoot := v.popTail(v.shift, v.root, removeIdx)
+	if newRoot == nil {
+		newRoot = newNode()
+	}
+	// Collapse a now-redundant root level (only one child left).
+	if v.shift > shift && len(newRoot.array) == 1 {
+		newRoot = newRoot.array[0].(*vnode)
+		newShift -= shift
+	}
+	return PersistentVector{
+		count:   v.count - 1,
+		shift:   newShift,
+		root:    newRoot,
+		tail:    newTail,
+		tailOff: (v.count - 1) - len(newTail),
+		meta:    v.meta,
+	}
+}
+
+// leafArrayFor returns a fresh []Value copy of the leaf array holding index i
+// (i must be in the trie portion, i.e. i < tailOff).
+func (v PersistentVector) leafArrayFor(i int) []Value {
+	node := v.root
+	for level := v.shift; level > 0; level -= shift {
+		node = node.array[(i>>level)&nodeMask].(*vnode)
+	}
+	out := make([]Value, len(node.array))
+	for j, x := range node.array {
+		out[j] = x.(Value)
+	}
+	return out
+}
+
+// popTail removes the leaf containing idx from the trie rooted at node,
+// returning the new subtree (nil when it becomes empty). Mirrors Clojure's
+// popTail, adapted to the dynamically-sized node arrays used here: the
+// rightmost child is dropped by truncation rather than nulled in a fixed
+// 32-slot array.
+func (v PersistentVector) popTail(level uint, node *vnode, idx int) *vnode {
+	subidx := (idx >> level) & nodeMask
+	if level > shift {
+		newChild := v.popTail(level-shift, node.array[subidx].(*vnode), idx)
+		if newChild == nil && subidx == 0 {
+			return nil
+		}
+		ret := &vnode{array: make([]any, len(node.array))}
+		copy(ret.array, node.array)
+		if newChild == nil {
+			ret.array = ret.array[:subidx]
+		} else {
+			ret.array[subidx] = newChild
+		}
+		return ret
+	}
+	if subidx == 0 {
+		return nil
+	}
+	// Leaf-parent level: drop the rightmost leaf.
+	ret := &vnode{array: make([]any, subidx)}
+	copy(ret.array, node.array[:subidx])
+	return ret
+}
+
 // Nth implements Indexed: positional access by integer index.
 func (v PersistentVector) Nth(i int) Value { return v.ValueAt(Int(i)) }
 

--- a/pkg/vm/persistent_vector_pop_test.go
+++ b/pkg/vm/persistent_vector_pop_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+func mkVec(n int) PersistentVector {
+	vals := make([]Value, n)
+	for i := range vals {
+		vals[i] = Int(i)
+	}
+	return NewPersistentVector(vals).(PersistentVector)
+}
+
+// TestPersistentVectorPopBoundaries pops one element at sizes that straddle the
+// tail/trie boundary (32), the second trie level (1024), and height growth.
+func TestPersistentVectorPopBoundaries(t *testing.T) {
+	for _, n := range []int{2, 31, 32, 33, 34, 63, 64, 65, 1023, 1024, 1025, 2000} {
+		v := mkVec(n)
+		p := v.Pop()
+		if p.RawCount() != n-1 {
+			t.Fatalf("n=%d: popped count = %d, want %d", n, p.RawCount(), n-1)
+		}
+		for i := 0; i < n-1; i++ {
+			if p.ValueAt(Int(i)) != Int(i) {
+				t.Fatalf("n=%d: after pop, index %d = %v, want %d", n, i, p.ValueAt(Int(i)), i)
+			}
+		}
+		// Original is unchanged (persistence).
+		if v.RawCount() != n || v.ValueAt(Int(n-1)) != Int(n-1) {
+			t.Fatalf("n=%d: pop mutated the original", n)
+		}
+	}
+}
+
+// TestPersistentVectorPopFullDrain drains a large vector one element at a time,
+// verifying count and every remaining index at each step. This exercises
+// popTail, leafArrayFor, every tail/trie boundary on the way down, and the
+// root height-collapse path.
+func TestPersistentVectorPopFullDrain(t *testing.T) {
+	const n = 2000
+	v := mkVec(n)
+	for remaining := n; remaining > 0; remaining-- {
+		if v.RawCount() != remaining {
+			t.Fatalf("expected count %d, got %d", remaining, v.RawCount())
+		}
+		// Verify every remaining index — bulletproof against any popTail /
+		// height-collapse / tail-pull mistake at any boundary on the way down.
+		for i := 0; i < remaining; i++ {
+			if v.ValueAt(Int(i)) != Int(i) {
+				t.Fatalf("remaining=%d: index %d = %v, want %d", remaining, i, v.ValueAt(Int(i)), i)
+			}
+		}
+		v = v.Pop()
+	}
+	if v.RawCount() != 0 {
+		t.Fatalf("fully drained vector should be empty, got count %d", v.RawCount())
+	}
+}
+
+func TestPersistentVectorPopToEmpty(t *testing.T) {
+	v := mkVec(1)
+	p := v.Pop()
+	if p.RawCount() != 0 {
+		t.Fatalf("pop of single-element vector should be empty, got count %d", p.RawCount())
+	}
+	// pop of empty returns empty (callers guard count==0 themselves).
+	if p.Pop().RawCount() != 0 {
+		t.Fatalf("pop of empty should stay empty")
+	}
+}


### PR DESCRIPTION
## What

The `pop` builtin's `PersistentVector` case did:

```go
vals := v.Unbox().([]vm.Value)                          // materialize the WHOLE vector
return vm.NewPersistentVector(vals[:len(vals)-1]), nil  // rebuild it from scratch
```

That's **O(n) per pop**. Anything using a vector as a stack pays O(n²) — notably the typeinfer worklist, which drains via `(peek queue)`/`(pop queue)` under the comment "O(1) on a vector" (it wasn't). A heap profile of one bootstrap lowering pass showed this single builtin at **~7.5 GB**, with its `Unbox`+`NewPersistentVector` the #1 allocator after the Equals fix (#300).

## Change

Add `PersistentVector.Pop()` implementing Clojure's structural `pop` (tail shrink, else pull the rightmost trie leaf via `popTail`/`leafArrayFor` with root height-collapse), adapted to this impl's dynamically-sized node arrays. Point the `pop` builtin at it. Handles the empty-tail representation `NewPersistentVector` produces when count % 32 == 0.

Pure VM change (`pkg/vm` + `pkg/rt/lang.go`) — no `.lg`, no regeneration.

## Impact (heap profile, one lowering pass, measured on top of #300)

| | Allocated | Wall |
|---|---|---|
| #300 only | 27.2 GB | ~50s |
| #300 + this | **19.9 GB** | **~41s** |

`pop`'s allocation: **7.47 GB → 0.25 GB** (−97%). Cumulative from `main`: **−65% allocation, −61% wall time.**

## Tests

`TestPersistentVectorPopBoundaries` (sizes straddling 32 / 1024 / height growth, incl. the empty-tail reps), `TestPersistentVectorPopFullDrain` (drains 2000 elements, verifying **every** index at each step), `TestPersistentVectorPopToEmpty`. Full `pkg/vm` suite green; language-level `pop`/`peek` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)