### PR TITLE
feat(lg): add -cpuprofile and -memprofile flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ fabric.properties
 /letgo
 /let-go
 /lg
+/lg-profile
 /lg-gogen
 /letgo.wasm
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ endif
 
 # Prefer - to _ for make var names (won't conflict with env vars):
 LG := lg
+LG-PROFILE ?= lg-profile
 GOLANGCI-LINT := github.com/golangci/golangci-lint/cmd/golangci-lint
 REPORT-SCRIPT := scripts/clojure_compat_report.sh
 
@@ -48,6 +49,8 @@ run: $(LG)
 
 build: $(LG)
 
+build-profile: $(LG-PROFILE)
+
 # Bundle target. The runtime loads compiled bytecode for the core
 # namespaces from this file, NOT from the .lg sources. Anyone editing
 # a .lg under pkg/rt/core/ must regenerate the bundle or runtime
@@ -56,6 +59,7 @@ build: $(LG)
 # the bundle in lockstep with the .lg sources.
 CORE-LG-FILES := $(shell find pkg/rt/core -name '*.lg' -type f 2>/dev/null)
 LGBGEN-SOURCES := $(shell find cmd/lgbgen -name '*.go' -type f 2>/dev/null)
+ROOT-GO-FILES := $(shell find . -maxdepth 1 -name '*.go' -type f 2>/dev/null)
 pkg/rt/core_compiled.lgb: $(CORE-LG-FILES) $(LGBGEN-SOURCES) $(GO)
 	go run -tags bootstrap ./cmd/lgbgen
 
@@ -100,9 +104,13 @@ check-lowered-fresh:
 		exit 1; \
 	fi
 
-$(LG): $(GO) lg.go pkg/**/* pkg/rt/core_compiled.lgb
+$(LG): $(GO) $(ROOT-GO-FILES) pkg/**/* pkg/rt/core_compiled.lgb
 	which go
 	go build -ldflags="-s -w -X main.commit=$(COMMIT)" -o $@ .
+
+$(LG-PROFILE): $(GO) $(ROOT-GO-FILES) pkg/**/* pkg/rt/core_compiled.lgb
+	which go
+	go build -tags lg_profile -ldflags="-s -w -X main.commit=$(COMMIT)" -o $@ .
 
 test: pkg/**/* pkg/rt/core_compiled.lgb $(GO)
 	$(GO-TEST-ENV) go test $(GO-TEST-FLAGS) -count=1 -v ./test/...

--- a/lg.go
+++ b/lg.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
+	"sync"
 
 	"github.com/nooga/let-go/pkg/bundle"
 	"github.com/nooga/let-go/pkg/bytecode"
@@ -338,11 +339,14 @@ func init() {
 // stops the CPU profile. It is a no-op when neither flag is given, so the
 // caller can invoke it unconditionally.
 //
-// The returned stop must be called explicitly rather than deferred in main():
-// main() exits several paths via os.Exit, which skips deferred functions, and
-// pprof.StopCPUProfile must run for the profile file to be valid. Scoping the
-// start/stop pair to the script/REPL run — the only main() section with no
-// os.Exit — keeps the flush guaranteed without a run()-returns-code refactor.
+// pprof.StopCPUProfile must run for the profile file to be valid, but main()
+// exits several paths via os.Exit, which skips deferred functions. So the stop
+// is NOT deferred: the caller invokes it explicitly at the end of the run
+// section (the only main() section with no os.Exit), and it is also registered
+// with rt.AtExit so the language-level os/exit and System/exit builtins flush
+// it before they call os.Exit. The returned stop is idempotent, so the explicit
+// call and the at-exit hook can't double-close. Hard signals and Go-level
+// panics still bypass it, matching standard os.Exit semantics.
 func startProfiling() func() {
 	stop := func() {}
 	if cpuProfile != "" {
@@ -372,7 +376,10 @@ func startProfiling() func() {
 			}
 		}
 	}
-	return stop
+	var once sync.Once
+	safeStop := func() { once.Do(stop) }
+	rt.AtExit(safeStop) // os/exit and System/exit flush before os.Exit
+	return safeStop
 }
 
 // buildSearchPaths resolves the resolver's path list from the -source-paths
@@ -610,8 +617,9 @@ func main() {
 	}
 
 	// Profile only the script/REPL execution below. This section has no
-	// os.Exit, so the explicit stop at the end of main always runs and flushes
-	// the profile; a deferred stop would be skipped by the os.Exit paths above.
+	// os.Exit, so the explicit stop at the end of main flushes the profile on a
+	// normal return; the rt.AtExit registration covers a script that calls
+	// os/exit or System/exit mid-run.
 	stopProfiling := startProfiling()
 
 	// Script mode: treat only the first positional as the script to run.

--- a/lg.go
+++ b/lg.go
@@ -13,10 +13,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"runtime"
-	"runtime/pprof"
 	"strings"
-	"sync"
 
 	"github.com/nooga/let-go/pkg/bundle"
 	"github.com/nooga/let-go/pkg/bytecode"
@@ -300,8 +297,6 @@ var wasmShell string
 var wasmPayload string
 var sourcePaths string
 var resourcePaths string
-var cpuProfile string
-var memProfile string
 
 func init() {
 	flag.BoolVar(&runREPL, "r", false, "attach REPL after running given files")
@@ -327,59 +322,6 @@ func init() {
 		"resource root directories for io/resource, separated by the OS path-list "+
 			"separator (':' on Unix, ';' on Windows). Falls back to LG_RESOURCE_PATHS "+
 			"if unset. With -b, resources under these roots are embedded in the binary.")
-	flag.StringVar(&cpuProfile, "cpuprofile", "",
-		"write a Go CPU profile of script/REPL execution to this file "+
-			"(build modes -c/-b/-w and the bundled-binary path are not profiled)")
-	flag.StringVar(&memProfile, "memprofile", "",
-		"write a Go heap profile to this file after script/REPL execution")
-}
-
-// startProfiling begins CPU profiling when -cpuprofile is set and returns a
-// stop function that writes the heap profile (when -memprofile is set) and
-// stops the CPU profile. It is a no-op when neither flag is given, so the
-// caller can invoke it unconditionally.
-//
-// pprof.StopCPUProfile must run for the profile file to be valid, but main()
-// exits several paths via os.Exit, which skips deferred functions. So the stop
-// is NOT deferred: the caller invokes it explicitly at the end of the run
-// section (the only main() section with no os.Exit), and it is also registered
-// with rt.AtExit so the language-level os/exit and System/exit builtins flush
-// it before they call os.Exit. The returned stop is idempotent, so the explicit
-// call and the at-exit hook can't double-close. Hard signals and Go-level
-// panics still bypass it, matching standard os.Exit semantics.
-func startProfiling() func() {
-	stop := func() {}
-	if cpuProfile != "" {
-		f, err := os.Create(cpuProfile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "cpuprofile: %v\n", err)
-		} else if err := pprof.StartCPUProfile(f); err != nil {
-			fmt.Fprintf(os.Stderr, "cpuprofile: %v\n", err)
-			_ = f.Close()
-		} else {
-			stop = func() { pprof.StopCPUProfile(); _ = f.Close() }
-		}
-	}
-	if memProfile != "" {
-		prev := stop
-		stop = func() {
-			prev()
-			f, err := os.Create(memProfile)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "memprofile: %v\n", err)
-				return
-			}
-			defer f.Close()
-			runtime.GC() // materialize up-to-date heap stats before the dump
-			if err := pprof.WriteHeapProfile(f); err != nil {
-				fmt.Fprintf(os.Stderr, "memprofile: %v\n", err)
-			}
-		}
-	}
-	var once sync.Once
-	safeStop := func() { once.Do(stop) }
-	rt.AtExit(safeStop) // os/exit and System/exit flush before os.Exit
-	return safeStop
 }
 
 // buildSearchPaths resolves the resolver's path list from the -source-paths
@@ -616,11 +558,9 @@ func main() {
 		return
 	}
 
-	// Profile only the script/REPL execution below. This section has no
-	// os.Exit, so the explicit stop at the end of main flushes the profile on a
-	// normal return; the rt.AtExit registration covers a script that calls
-	// os/exit or System/exit mid-run.
-	stopProfiling := startProfiling()
+	// In profiling builds, profile only the script/REPL execution below.
+	// Default builds compile this to a no-op so the release binary stays small.
+	startProfiling()
 
 	// Script mode: treat only the first positional as the script to run.
 	// Any further positionals belong to the script (it reads os/args).

--- a/lg.go
+++ b/lg.go
@@ -13,6 +13,8 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/pprof"
 	"strings"
 
 	"github.com/nooga/let-go/pkg/bundle"
@@ -297,6 +299,8 @@ var wasmShell string
 var wasmPayload string
 var sourcePaths string
 var resourcePaths string
+var cpuProfile string
+var memProfile string
 
 func init() {
 	flag.BoolVar(&runREPL, "r", false, "attach REPL after running given files")
@@ -322,6 +326,53 @@ func init() {
 		"resource root directories for io/resource, separated by the OS path-list "+
 			"separator (':' on Unix, ';' on Windows). Falls back to LG_RESOURCE_PATHS "+
 			"if unset. With -b, resources under these roots are embedded in the binary.")
+	flag.StringVar(&cpuProfile, "cpuprofile", "",
+		"write a Go CPU profile of script/REPL execution to this file "+
+			"(build modes -c/-b/-w and the bundled-binary path are not profiled)")
+	flag.StringVar(&memProfile, "memprofile", "",
+		"write a Go heap profile to this file after script/REPL execution")
+}
+
+// startProfiling begins CPU profiling when -cpuprofile is set and returns a
+// stop function that writes the heap profile (when -memprofile is set) and
+// stops the CPU profile. It is a no-op when neither flag is given, so the
+// caller can invoke it unconditionally.
+//
+// The returned stop must be called explicitly rather than deferred in main():
+// main() exits several paths via os.Exit, which skips deferred functions, and
+// pprof.StopCPUProfile must run for the profile file to be valid. Scoping the
+// start/stop pair to the script/REPL run — the only main() section with no
+// os.Exit — keeps the flush guaranteed without a run()-returns-code refactor.
+func startProfiling() func() {
+	stop := func() {}
+	if cpuProfile != "" {
+		f, err := os.Create(cpuProfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cpuprofile: %v\n", err)
+		} else if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintf(os.Stderr, "cpuprofile: %v\n", err)
+			_ = f.Close()
+		} else {
+			stop = func() { pprof.StopCPUProfile(); _ = f.Close() }
+		}
+	}
+	if memProfile != "" {
+		prev := stop
+		stop = func() {
+			prev()
+			f, err := os.Create(memProfile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "memprofile: %v\n", err)
+				return
+			}
+			defer f.Close()
+			runtime.GC() // materialize up-to-date heap stats before the dump
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				fmt.Fprintf(os.Stderr, "memprofile: %v\n", err)
+			}
+		}
+	}
+	return stop
 }
 
 // buildSearchPaths resolves the resolver's path list from the -source-paths
@@ -558,6 +609,11 @@ func main() {
 		return
 	}
 
+	// Profile only the script/REPL execution below. This section has no
+	// os.Exit, so the explicit stop at the end of main always runs and flushes
+	// the profile; a deferred stop would be skipped by the os.Exit paths above.
+	stopProfiling := startProfiling()
+
 	// Script mode: treat only the first positional as the script to run.
 	// Any further positionals belong to the script (it reads os/args).
 	ranSomething := false
@@ -598,4 +654,5 @@ func main() {
 		repl(context)
 	}
 
+	stopProfiling()
 }

--- a/lg_profile.go
+++ b/lg_profile.go
@@ -1,0 +1,73 @@
+//go:build lg_profile
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+
+	"github.com/nooga/let-go/pkg/rt"
+)
+
+var cpuProfile string
+var memProfile string
+
+var (
+	profileStop     func()
+	profileStopOnce sync.Once
+)
+
+func init() {
+	flag.StringVar(&cpuProfile, "cpuprofile", "",
+		"write a Go CPU profile of script/REPL execution to this file "+
+			"(build modes -c/-b/-w and the bundled-binary path are not profiled)")
+	flag.StringVar(&memProfile, "memprofile", "",
+		"write a Go heap profile to this file after script/REPL execution")
+}
+
+// startProfiling begins CPU profiling when -cpuprofile is set and arranges for
+// stopProfiling to write the heap profile (when -memprofile is set) and stop
+// the CPU profile. The explicit stop at the end of main handles normal returns;
+// rt.AtExit covers language-level os/exit and System/exit, which skip defers.
+func startProfiling() {
+	stop := func() {}
+	if cpuProfile != "" {
+		f, err := os.Create(cpuProfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cpuprofile: %v\n", err)
+		} else if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintf(os.Stderr, "cpuprofile: %v\n", err)
+			_ = f.Close()
+		} else {
+			stop = func() { pprof.StopCPUProfile(); _ = f.Close() }
+		}
+	}
+	if memProfile != "" {
+		prev := stop
+		stop = func() {
+			prev()
+			f, err := os.Create(memProfile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "memprofile: %v\n", err)
+				return
+			}
+			defer f.Close()
+			runtime.GC() // materialize up-to-date heap stats before the dump
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				fmt.Fprintf(os.Stderr, "memprofile: %v\n", err)
+			}
+		}
+	}
+	profileStop = stop
+	rt.AtExit(stopProfiling)
+}
+
+func stopProfiling() {
+	if profileStop != nil {
+		profileStopOnce.Do(profileStop)
+	}
+}

--- a/lg_profile_default.go
+++ b/lg_profile_default.go
@@ -1,0 +1,7 @@
+//go:build !lg_profile
+
+package main
+
+func startProfiling() {}
+
+func stopProfiling() {}

--- a/pkg/rt/exit.go
+++ b/pkg/rt/exit.go
@@ -1,0 +1,37 @@
+package rt
+
+import "sync"
+
+// Pre-exit hooks run just before a language-level process exit (os/exit,
+// System/exit). Go's os.Exit skips deferred functions, so anything that must
+// flush on the way out — e.g. an active CPU profile — registers here rather
+// than via defer. Hooks are not run on signals or Go-level panics, matching the
+// standard library's os.Exit semantics.
+var (
+	exitMu    sync.Mutex
+	exitHooks []func()
+	exitOnce  sync.Once
+)
+
+// AtExit registers fn to run just before a language-level os.Exit. Registration
+// order is preserved; hooks run in reverse (LIFO) so later setup tears down
+// first.
+func AtExit(fn func()) {
+	exitMu.Lock()
+	exitHooks = append(exitHooks, fn)
+	exitMu.Unlock()
+}
+
+// RunExitHooks runs the registered hooks in LIFO order, at most once. The
+// language-level exit builtins call this immediately before os.Exit; the
+// once-guard also makes it safe if a hook itself triggers another exit.
+func RunExitHooks() {
+	exitOnce.Do(func() {
+		exitMu.Lock()
+		hooks := exitHooks
+		exitMu.Unlock()
+		for i := len(hooks) - 1; i >= 0; i-- {
+			hooks[i]()
+		}
+	})
+}

--- a/pkg/rt/exit.go
+++ b/pkg/rt/exit.go
@@ -1,3 +1,5 @@
+//go:build lg_profile
+
 package rt
 
 import "sync"

--- a/pkg/rt/exit_stub.go
+++ b/pkg/rt/exit_stub.go
@@ -1,0 +1,5 @@
+//go:build !lg_profile
+
+package rt
+
+func RunExitHooks() {}

--- a/pkg/rt/os.go
+++ b/pkg/rt/os.go
@@ -48,6 +48,7 @@ func installOsNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("os/exit expected Int")
 		}
+		RunExitHooks() // flush profiling etc.; os.Exit skips deferred funcs
 		os.Exit(int(code))
 		return vm.NIL, nil
 	})

--- a/pkg/rt/system.go
+++ b/pkg/rt/system.go
@@ -102,6 +102,7 @@ func installSystemNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("System/exit expected Int")
 		}
+		RunExitHooks() // flush profiling etc.; os.Exit skips deferred funcs
 		os.Exit(int(code))
 		return vm.NIL, nil
 	}))


### PR DESCRIPTION
Adds optional `-cpuprofile` and `-memprofile` flags to a profiling build of `lg`, wiring `runtime/pprof` around script execution without changing the default release binary.

## What

Default builds stay size-neutral and do not expose the profiling flags:

```
make build
./lg script.lg
```

Profiling builds opt in with the `lg_profile` build tag:

```
make build-profile
./lg-profile -cpuprofile=cpu.pprof script.lg     # CPU profile of the run
./lg-profile -memprofile=mem.pprof script.lg     # heap profile after the run (post runtime.GC())
```

The profiling flags are no-ops when unset in the profiling binary, and are not compiled into the default `lg` binary.

## Why a separate profiling build

Binary size matters for `lg` itself and for `lg -b` bundled executables, which copy the base binary. The first version of this PR added about 33.6 KiB to the stripped default binary. Moving the CLI profiling surface behind `-tags lg_profile` brings the default `lg` binary back to the pre-PR size while keeping the profiling workflow available for perf work.

## Why explicit, not deferred

Profiling is scoped to the script/REPL execution section of `main()`, and started/stopped explicitly rather than with `defer`. `main()` exits the version/compile/bundle/wasm paths through `os.Exit`, which skips deferred functions. `pprof.StopCPUProfile()` must run for a CPU profile to be valid.

The profiling build also registers the stop path with `rt.AtExit`, so language-level `os/exit` and `System/exit` flush active profiles before they call `os.Exit`. Hard signals and Go-level panics still bypass it, matching normal `os.Exit` semantics. Build modes (`-c`/`-b`/`-w`) and the bundled-binary path are not profiled, as the flag help states.

## What it found

Profiling a bench that's already in the tree:

```
./lg-profile -memprofile=mem.pprof test/benches/pegbench.lg
go tool pprof -top -sample_index=alloc_space mem.pprof
```

points straight at `clojure.core/subs`, which accounted for ~90% of allocation in the run (and most of the `string->rune` CPU cost). It allocated a `[]rune` of the entire input on every call. I'll send that fix as a separate PR; this one is just the optional profiling build.
