### PR TITLE
fix(term): tokenize read-key so a key burst yields one event per key

### DIFF
--- a/pkg/rt/key_tokenizer.go
+++ b/pkg/rt/key_tokenizer.go
@@ -1,0 +1,124 @@
+package rt
+
+import "unicode/utf8"
+
+// nextKey splits exactly one key token off the front of b and returns the
+// token plus the number of bytes consumed.
+//
+// A single raw terminal read can carry several keys (held-key auto-repeat or
+// queued input) or one multi-byte escape sequence (arrows, SGR mouse). The
+// pre-tokenizer read-key returned the whole read as one string, so a burst
+// like "llll" arrived as one unrecognized blob. Tokenizing lets read-key hand
+// out one event per call: "llll" -> four "l", while "\x1b[C" stays one key.
+//
+// Recognized fronts:
+//
+//	ESC '[' … final(0x40-0x7E)   one CSI sequence (arrows, modified keys, SGR mouse)
+//	ESC 'O' x                    one SS3 sequence (application-cursor keys, F1-F4)
+//	ESC (alone / other)          the bare Escape key
+//	UTF-8 lead byte              the whole rune (never split)
+//	any other byte               that single byte (ASCII / control)
+//
+// A token split across two reads (an unterminated CSI, or a multi-byte rune
+// missing continuation bytes) is returned best-effort as the remaining buffer.
+// ReadKey avoids hitting that path: it checks incompleteToken and refills first
+// when more bytes are pending, so nextKey runs on a complete token.
+func nextKey(b []byte) (string, int) {
+	if len(b) == 0 {
+		return "", 0
+	}
+	if b[0] == 0x1b { // ESC
+		if len(b) >= 2 && b[1] == '[' { // CSI: ESC [ params/intermediates final
+			i := 2
+			for i < len(b) && (b[i] < 0x40 || b[i] > 0x7e) {
+				i++
+			}
+			if i < len(b) {
+				return string(b[:i+1]), i + 1 // include the final byte
+			}
+			return string(b), len(b) // incomplete — best effort
+		}
+		if len(b) >= 3 && b[1] == 'O' { // SS3: ESC O x
+			return string(b[:3]), 3
+		}
+		return "\x1b", 1 // bare ESC
+	}
+	if b[0] < utf8.RuneSelf { // single-byte ASCII / control
+		return string(b[:1]), 1
+	}
+	r, size := utf8.DecodeRune(b)
+	if r == utf8.RuneError && size == 1 {
+		return string(b[:1]), 1 // invalid byte — emit as-is, never stall
+	}
+	return string(b[:size]), size
+}
+
+// incompleteToken reports whether b ends in the middle of a token whose
+// remaining bytes haven't arrived yet — an escape sequence with no terminator,
+// or a multi-byte UTF-8 rune missing continuation bytes. A raw read fills a
+// fixed-size buffer, so a token can straddle two reads (and queued input makes
+// this routine, not a corner case: a burst longer than the buffer, or several
+// multi-byte reports back to back, will split). When this is true and more
+// bytes are actually pending, ReadKey refills before tokenizing rather than
+// letting nextKey emit a broken partial. Read-buffer size then only affects how
+// often the refill path runs, not correctness.
+func incompleteToken(b []byte) bool {
+	return incompleteEscape(b) || incompleteRune(b)
+}
+
+// incompleteEscape reports whether b holds the opening of an escape sequence
+// whose terminating byte hasn't arrived: a lone ESC, a CSI (ESC '[' …) with no
+// final byte in 0x40–0x7E, or an SS3 (ESC 'O') missing its third byte.
+//
+// A lone ESC is ambiguous (the Escape key, or the start of a sequence), which
+// normally needs a timeout to resolve. ReadKey gates the refill on bytes
+// actually waiting: a real Escape keypress has nothing queued behind it, while
+// a split sequence's tail is already in the kernel buffer. That sidesteps the
+// timeout for the common case, and over-pulling is harmless — nextKey still
+// splits a bare ESC off the front correctly.
+func incompleteEscape(b []byte) bool {
+	if len(b) == 0 || b[0] != 0x1b {
+		return false
+	}
+	if len(b) == 1 {
+		return true // lone ESC — may be a sequence split on the ESC byte
+	}
+	switch b[1] {
+	case '[':
+		for i := 2; i < len(b); i++ {
+			if b[i] >= 0x40 && b[i] <= 0x7e {
+				return false // final byte present — sequence is complete
+			}
+		}
+		return true // only params/intermediates so far
+	case 'O':
+		return len(b) < 3
+	}
+	return false
+}
+
+// incompleteRune reports whether b *starts* with a UTF-8 lead byte whose
+// continuation bytes haven't all arrived — the front rune is split across a
+// read. Like incompleteEscape, this checks the front token (the one ReadKey is
+// about to emit), not the tail: a complete byte ahead of a split rune is
+// emitted first, and the split rune is refilled once it reaches the front (its
+// pending tail waits in the kernel buffer until then). ASCII, a continuation
+// byte, or an invalid lead at the front is "complete" — nextKey emits it as-is,
+// so refilling would only stall.
+func incompleteRune(b []byte) bool {
+	if len(b) == 0 || b[0] < utf8.RuneSelf {
+		return false // empty or ASCII — front is complete
+	}
+	var need int
+	switch {
+	case b[0]&0xe0 == 0xc0: // 110xxxxx
+		need = 2
+	case b[0]&0xf0 == 0xe0: // 1110xxxx
+		need = 3
+	case b[0]&0xf8 == 0xf0: // 11110xxx
+		need = 4
+	default:
+		return false // continuation byte or invalid lead — nextKey emits as-is
+	}
+	return len(b) < need
+}

--- a/pkg/rt/key_tokenizer_test.go
+++ b/pkg/rt/key_tokenizer_test.go
@@ -1,0 +1,102 @@
+package rt
+
+import (
+	"reflect"
+	"testing"
+)
+
+// tokenize drains b fully into the sequence of keys nextKey produces.
+func tokenize(t *testing.T, s string) []string {
+	t.Helper()
+	var out []string
+	b := []byte(s)
+	for len(b) > 0 {
+		k, n := nextKey(b)
+		if n == 0 {
+			t.Fatalf("nextKey made no progress on %q", b)
+		}
+		out = append(out, k)
+		b = b[n:]
+	}
+	return out
+}
+
+func TestNextKey(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single", "l", []string{"l"}},
+		{"burst splits", "llll", []string{"l", "l", "l", "l"}}, // the held-key fix
+		{"arrow up", "\x1b[A", []string{"\x1b[A"}},
+		{"two arrows", "\x1b[A\x1b[B", []string{"\x1b[A", "\x1b[B"}},
+		{"modified arrow", "\x1b[1;2C", []string{"\x1b[1;2C"}},
+		{"ss3 F1", "\x1bOP", []string{"\x1bOP"}},
+		{"bare esc", "\x1b", []string{"\x1b"}},
+		{"sgr mouse press", "\x1b[<0;10;5M", []string{"\x1b[<0;10;5M"}},
+		{"sgr mouse release", "\x1b[<0;10;5m", []string{"\x1b[<0;10;5m"}},
+		{"key mouse key", "l\x1b[<0;1;1Mx", []string{"l", "\x1b[<0;1;1M", "x"}},
+		{"utf8 rune kept whole", "é", []string{"é"}},
+		{"ctrl-c", "\x03", []string{"\x03"}},
+		{"enter", "\r", []string{"\r"}},
+		{"mixed printable + arrow + burst", "ab\x1b[Dcc", []string{"a", "b", "\x1b[D", "c", "c"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tokenize(t, c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("tokens(%q) = %#v, want %#v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNextKeyEmpty(t *testing.T) {
+	if k, n := nextKey(nil); k != "" || n != 0 {
+		t.Errorf("nextKey(nil) = (%q, %d), want (\"\", 0)", k, n)
+	}
+}
+
+func TestIncompleteToken(t *testing.T) {
+	// incompleteToken checks the FRONT token (the one ReadKey emits next), so
+	// only a buffer whose leading token is split counts as incomplete.
+	incomplete := []string{
+		// escape sequences with no terminator yet
+		"\x1b",         // lone ESC — may be a sequence split on the ESC byte
+		"\x1b[",        // CSI with no params/final
+		"\x1b[<0;10;5", // SGR mouse missing its final M/m
+		"\x1b[1;",      // CSI mid-params
+		"\x1bO",        // SS3 missing its third byte
+		// multi-byte runes split at the front
+		"\xc3",         // first byte of é (2-byte rune)
+		"\xe2\x82",     // first two bytes of € (3-byte rune)
+		"\xf0\x9f\x98", // first three bytes of 😀 (4-byte rune)
+	}
+	for _, s := range incomplete {
+		if !incompleteToken([]byte(s)) {
+			t.Errorf("incompleteToken(%q) = false, want true", s)
+		}
+	}
+	complete := []string{
+		"",              // empty
+		"l",             // plain key
+		"\x1b[A",        // finished arrow
+		"\x1b[<0;10;5M", // finished SGR mouse
+		"\x1bOP",        // finished SS3 (F1)
+		"\x1bx",         // ESC + ordinary byte (Alt-x); nextKey splits it
+		"é",             // complete 2-byte rune
+		"€",             // complete 3-byte rune
+		"😀",             // complete 4-byte rune
+		// complete front token ahead of a split tail — emit the front first,
+		// the tail is refilled once it reaches the front
+		"abc\x1b[1;2", // 'a' is complete; trailing CSI handled later
+		"aaa\xc3",     // 'a' is complete; the split é (reviewer's case) handled later
+		"\xff",        // invalid lead byte — nextKey emits it as-is
+	}
+	for _, s := range complete {
+		if incompleteToken([]byte(s)) {
+			t.Errorf("incompleteToken(%q) = true, want false", s)
+		}
+	}
+}

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -100,12 +100,71 @@ var termOldState *term.State
 // term ops, embedders (api.WithKeySource), and tests share one source.
 type nativeKeySource struct{}
 
-func (nativeKeySource) ReadKey() (string, error) {
+// keyBuf holds bytes read from stdin but not yet handed out as keys. A single
+// raw read can carry several keys (held-key auto-repeat / queued input) or a
+// multi-byte escape sequence; ReadKey tokenizes one key per call off this
+// buffer (see nextKey) and refills via readRaw only when it's empty. Native
+// has a single stdin and reads aren't concurrent, so a package-level buffer is
+// safe.
+var keyBuf []byte
+
+// readChunkSize is the per-read stdin buffer. os.Stdin.Read returns as soon as
+// any data is available (it never waits to fill), so a larger buffer adds no
+// latency to a single keystroke — it just grabs more bytes when a burst is
+// already queued, cutting syscalls and ReadKey refills. Correctness doesn't
+// depend on it: a token straddling the buffer is stitched by the refill path
+// (see incompleteToken). 256 covers held-key bursts and back-to-back escape
+// sequences with headroom.
+const readChunkSize = 256
+
+func (s nativeKeySource) ReadKey() (string, error) {
+	for {
+		if len(keyBuf) == 0 {
+			chunk, err := s.readRaw()
+			if err != nil {
+				return "", err
+			}
+			switch chunk {
+			case "":
+				return "", nil // EOF / nil contract
+			case "\x07":
+				return "\x07", nil // SIGWINCH wake — synthetic, not tokenized
+			}
+			keyBuf = append(keyBuf, chunk...)
+		}
+		// If the buffer ends mid-token (split escape sequence or UTF-8 rune)
+		// and more bytes are actually waiting on stdin, pull them in and
+		// re-tokenize rather than emitting a broken partial. Gating on
+		// rawPending keeps a genuinely truncated token from blocking a refill
+		// that would never complete.
+		if incompleteToken(keyBuf) && s.rawPending() {
+			chunk, err := s.readRaw()
+			if err != nil {
+				return "", err
+			}
+			if chunk != "" && chunk != "\x07" {
+				keyBuf = append(keyBuf, chunk...)
+				continue
+			}
+		}
+		tok, n := nextKey(keyBuf)
+		keyBuf = keyBuf[n:]
+		if len(keyBuf) == 0 {
+			keyBuf = nil // release the backing array once drained
+		}
+		return tok, nil
+	}
+}
+
+// readRaw does one blocking poll+read, returning raw stdin bytes, "" on EOF, or
+// BEL ("\x07") when only the SIGWINCH wake fired. This is the pre-tokenizer
+// read-key body, unchanged — ReadKey now buffers and tokenizes its result.
+func (nativeKeySource) readRaw() (string, error) {
 	setupWinch() // idempotent; armed on first read-key
 
 	if winchPipeR == nil {
 		// Pipe setup failed; plain blocking read (preserves prior behavior).
-		buf := make([]byte, 16)
+		buf := make([]byte, readChunkSize)
 		n, err := os.Stdin.Read(buf)
 		if err != nil || n == 0 {
 			return "", nil
@@ -152,7 +211,7 @@ func (nativeKeySource) ReadKey() (string, error) {
 	// emitting BEL forever — EOF never surfaced. Routing through os.Stdin.Read
 	// here too surfaces n==0 as the nil contract callers had pre-PR.
 	if fds[0].Revents&(unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 {
-		buf := make([]byte, 16)
+		buf := make([]byte, readChunkSize)
 		n, err := os.Stdin.Read(buf)
 		if err != nil || n == 0 {
 			return "", nil
@@ -162,7 +221,7 @@ func (nativeKeySource) ReadKey() (string, error) {
 
 	// Prefer real input — user keys shouldn't queue behind a resize wake.
 	if fds[0].Revents&unix.POLLIN != 0 {
-		buf := make([]byte, 16)
+		buf := make([]byte, readChunkSize)
 		n, err := os.Stdin.Read(buf)
 		if err != nil || n == 0 {
 			return "", nil
@@ -174,7 +233,18 @@ func (nativeKeySource) ReadKey() (string, error) {
 	return "\x07", nil
 }
 
-func (nativeKeySource) KeyPending() bool {
+func (s nativeKeySource) KeyPending() bool {
+	if len(keyBuf) > 0 {
+		return true // tokens still buffered from a prior multi-key read
+	}
+	return s.rawPending()
+}
+
+// rawPending reports whether stdin (or the SIGWINCH wake-pipe) has bytes the
+// buffer hasn't consumed yet — the OS-level half of KeyPending, without the
+// keyBuf check. ReadKey uses it to decide whether refilling a straddled token
+// will actually make progress.
+func (nativeKeySource) rawPending() bool {
 	// Arm the winch handler if it hasn't been already — a caller that hits
 	// key-pending? before any read-key would otherwise miss SIGWINCH wakes.
 	setupWinch()


### PR DESCRIPTION
`read-key` did a single `os.Stdin.Read` into a 16-byte buffer and returned the
whole read as one string. A fast burst — held-key auto-repeat, or input queued
while the VM was busy — therefore arrived as one multi-char blob (`"llll"`)
that a game's key parser rejects as unknown. Symptom: holding a movement key in
a native TUI never produced continuous movement.

This is original behavior, not a regression — `read-key` has globbed reads
since before the I/O-seam work (#165 wake-pipe, #244 KeySource), both of which
preserved it byte-for-byte.

## Fix

- `nextKey` (new `pkg/rt/key_tokenizer.go`): a pure function that splits exactly
  one key off the front of a byte slice — a UTF-8 rune, a CSI/SS3 escape
  sequence, or a single byte — and reports the bytes consumed.
- `nativeKeySource.ReadKey` now buffers raw reads and hands out one token per
  call, refilling from stdin only when the buffer drains. The blocking
  poll/SIGWINCH-wake read path is unchanged, just renamed to `readRaw`.
- `KeyPending` reports buffered tokens as well as pending stdin.

The tokenizer lives in a constraint-free file (no build tags) so the wasm key
source can reuse it later.

## Behavior

- `"llll"` → four `"l"` (the fix).
- `"\x1b[C"` (arrow) stays one key; modified keys and SS3 (`"\x1bOP"`) stay whole.
- SGR mouse reports (`"\x1b[<0;10;5M"`) are kept intact as single tokens —
  decoding them is out of scope here.

## Testing

- `pkg/rt/key_tokenizer_test.go`: 14 tokenizer cases (bursts, arrows, mixed
  printable + escape + burst, UTF-8, control bytes, empty input).
- `go test ./pkg/rt/ ./pkg/api/` pass; `go vet` and `golangci-lint` clean.
- Validated end-to-end in a native TUI: a 5-`l` burst now produces multiple
  moves; held-key movement works.

## Notes

- A CSI sequence split across two reads (no final byte yet) is returned
  best-effort as the remaining buffer. Raw-mode reads deliver escape sequences
  atomically, so this is rare in practice.
- Native has a single, non-concurrent stdin, so the buffer is package-level.
