### PR TITLE
fix(term): flush on piped stdout

### DIFF
--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -579,12 +579,15 @@ func installTermNS() {
 			err = os.Stdout.Sync()
 			fileBacked = true
 		}
-		// fsync on a terminal returns ENOTTY (macOS/BSD); flushing a TTY is a
-		// no-op, so swallow it. Only for a file-backed *out* — an embedder
-		// writer's Sync goes through Flush() and must surface its own errors.
-		// A regular file's fsync never returns ENOTTY, so real I/O errors
-		// (EIO, ENOSPC, …) still propagate.
-		if fileBacked && errors.Is(err, syscall.ENOTTY) {
+		// fsync on terminals and pipes returns ENOTTY, EBADF, or EINVAL
+		// depending on the platform; flushing those fds is a no-op, so swallow
+		// them. Only for a file-backed *out* -- an embedder writer's Sync goes
+		// through Flush() and must surface its own errors. A regular file's
+		// fsync never returns these, so real I/O errors (EIO, ENOSPC, etc.)
+		// still propagate.
+		if fileBacked && (errors.Is(err, syscall.ENOTTY) ||
+			errors.Is(err, syscall.EBADF) ||
+			errors.Is(err, syscall.EINVAL)) {
 			err = nil
 		}
 		return vm.NIL, err

--- a/test/e2e/term_flush_pipe_test.go
+++ b/test/e2e/term_flush_pipe_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
+ * SPDX-License-Identifier: MIT
+ */
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTermFlushWithPipedStdout(t *testing.T) {
+	bin := buildLG(t)
+	script := filepath.Join(t.TempDir(), "flush.lg")
+	if err := os.WriteFile(script, []byte(`(term/write "ok") (term/flush)`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command(bin, script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("term/flush with piped stdout failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "ok" {
+		t.Fatalf("got %q, want ok", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #308 by treating stdout fsync errors from non-syncable file-backed streams as best-effort no-ops in `term/flush`.

## Root Cause

`term/flush` propagates `Sync()` from the active file-backed `*out*`. When stdout is a pipe, `fsync` is not meaningful and can return `EBADF`/`EINVAL` instead of completing successfully. That made captured or piped runs fail even though the terminal bytes had already been written.

## Changes

- Swallow `ENOTTY`, `EBADF`, and `EINVAL` only for file-backed `term/flush` syncs.
- Preserve error propagation for real file sync failures and embedder writer `Flush()` failures.
- Add an e2e regression test that runs `lg` with pipe-backed stdout.

## Validation

- `go test -run TestTermFlushWithPipedStdout -count=1 -v ./test/e2e`
- `go test -run 'TestRunner/term_out_binding_test\.lg' -count=1 -v ./test`

Note: `go test -count=1 ./test/e2e` still fails on an existing unrelated `TestGogenAOTDiff` / `pipeline_dump_ir.lg` divergence.

Co-authored with Codex.
