### PR TITLE
feat(term): SGR mouse input — enable/disable primitives + decode

### DIFF
--- a/pkg/rt/key_tokenizer.go
+++ b/pkg/rt/key_tokenizer.go
@@ -1,6 +1,10 @@
 package rt
 
-import "unicode/utf8"
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
 
 type keyScanResult int
 
@@ -79,4 +83,67 @@ func nextKey(b []byte) (string, int) {
 		return "", 0
 	}
 	return string(b[:n]), n
+}
+
+// MouseEvent is a decoded SGR (1006) mouse report. Click-only scope: press and
+// release of the three buttons plus wheel up/down, with Shift/Ctrl/Meta from the
+// button byte. Drag/motion (the 1002/1003 modes) is out of scope, so the motion
+// bit is ignored here — those modes are never enabled.
+type MouseEvent struct {
+	Action            string // "press" | "release"
+	Button            string // "left" | "middle" | "right" | "wheel-up" | "wheel-down" | "none"
+	X, Y              int    // 1-based cell coordinates
+	Shift, Ctrl, Meta bool
+}
+
+// decodeSGRMouse parses one SGR (1006) mouse report:
+//
+//	ESC '[' '<' Cb ';' Cx ';' Cy ('M'|'m')   M = press, m = release
+//
+// Cb is the button byte: low two bits select the button, bit 2/3/4 carry
+// Shift/Meta/Ctrl, bit 6 marks a wheel event. Returns the decoded event and
+// true, or a zero event and false if s is not a well-formed SGR mouse report.
+// nextKey keeps such a report intact as a single token, so this runs on exactly
+// one report at a time.
+func decodeSGRMouse(s string) (MouseEvent, bool) {
+	if !strings.HasPrefix(s, "\x1b[<") || len(s) < 4 {
+		return MouseEvent{}, false
+	}
+	final := s[len(s)-1]
+	if final != 'M' && final != 'm' {
+		return MouseEvent{}, false
+	}
+	parts := strings.Split(s[3:len(s)-1], ";")
+	if len(parts) != 3 {
+		return MouseEvent{}, false
+	}
+	cb, err1 := strconv.Atoi(parts[0])
+	x, err2 := strconv.Atoi(parts[1])
+	y, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return MouseEvent{}, false
+	}
+
+	ev := MouseEvent{
+		X: x, Y: y,
+		Shift: cb&4 != 0,
+		Meta:  cb&8 != 0,
+		Ctrl:  cb&16 != 0,
+	}
+	if final == 'M' {
+		ev.Action = "press"
+	} else {
+		ev.Action = "release"
+	}
+	switch {
+	case cb&64 != 0: // wheel
+		if cb&1 == 0 {
+			ev.Button = "wheel-up"
+		} else {
+			ev.Button = "wheel-down"
+		}
+	default:
+		ev.Button = []string{"left", "middle", "right", "none"}[cb&3]
+	}
+	return ev, true
 }

--- a/pkg/rt/key_tokenizer_test.go
+++ b/pkg/rt/key_tokenizer_test.go
@@ -108,3 +108,51 @@ func TestScanKeyReady(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeSGRMouse(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want MouseEvent
+	}{
+		{"left press", "\x1b[<0;10;5M", MouseEvent{Action: "press", Button: "left", X: 10, Y: 5}},
+		{"left release", "\x1b[<0;10;5m", MouseEvent{Action: "release", Button: "left", X: 10, Y: 5}},
+		{"middle press", "\x1b[<1;3;4M", MouseEvent{Action: "press", Button: "middle", X: 3, Y: 4}},
+		{"right press", "\x1b[<2;7;8M", MouseEvent{Action: "press", Button: "right", X: 7, Y: 8}},
+		{"shift+left", "\x1b[<4;1;1M", MouseEvent{Action: "press", Button: "left", X: 1, Y: 1, Shift: true}},
+		{"meta+left", "\x1b[<8;1;1M", MouseEvent{Action: "press", Button: "left", X: 1, Y: 1, Meta: true}},
+		{"ctrl+left", "\x1b[<16;1;1M", MouseEvent{Action: "press", Button: "left", X: 1, Y: 1, Ctrl: true}},
+		{"ctrl+shift+right", "\x1b[<22;2;2M", MouseEvent{Action: "press", Button: "right", X: 2, Y: 2, Shift: true, Ctrl: true}},
+		{"wheel up", "\x1b[<64;9;9M", MouseEvent{Action: "press", Button: "wheel-up", X: 9, Y: 9}},
+		{"wheel down", "\x1b[<65;9;9M", MouseEvent{Action: "press", Button: "wheel-down", X: 9, Y: 9}},
+		{"large coords", "\x1b[<0;220;140M", MouseEvent{Action: "press", Button: "left", X: 220, Y: 140}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := decodeSGRMouse(c.in)
+			if !ok {
+				t.Fatalf("decodeSGRMouse(%q) returned ok=false", c.in)
+			}
+			if got != c.want {
+				t.Errorf("decodeSGRMouse(%q) = %+v, want %+v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDecodeSGRMouseRejects(t *testing.T) {
+	// Non-mouse tokens and malformed reports must report ok=false so read-key
+	// falls through to returning them as plain key strings.
+	for _, in := range []string{
+		"l",             // plain key
+		"\x1b[A",        // arrow (CSI, no '<')
+		"\x1b[<0;10;5",  // missing final M/m
+		"\x1b[<0;10M",   // only two params
+		"\x1b[<x;10;5M", // non-numeric param
+		"\x1b[<",        // truncated
+	} {
+		if ev, ok := decodeSGRMouse(in); ok {
+			t.Errorf("decodeSGRMouse(%q) = %+v, ok=true; want ok=false", in, ev)
+		}
+	}
+}

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -276,6 +276,30 @@ func (nativeKeySource) rawPending() bool {
 	return false
 }
 
+// mouseEventMap renders a decoded SGR mouse report as the tagged map read-key
+// hands to Clojure: {:type :mouse :action :press :button :left :x 10 :y 5
+// :mods #{:shift}}. :mods is an empty set when no modifier is held.
+func mouseEventMap(ev MouseEvent) vm.Value {
+	var mods []vm.Value
+	if ev.Shift {
+		mods = append(mods, vm.Keyword("shift"))
+	}
+	if ev.Ctrl {
+		mods = append(mods, vm.Keyword("ctrl"))
+	}
+	if ev.Meta {
+		mods = append(mods, vm.Keyword("meta"))
+	}
+	m := vm.EmptyPersistentMap
+	m = m.Assoc(vm.Keyword("type"), vm.Keyword("mouse")).(*vm.PersistentMap)
+	m = m.Assoc(vm.Keyword("action"), vm.Keyword(ev.Action)).(*vm.PersistentMap)
+	m = m.Assoc(vm.Keyword("button"), vm.Keyword(ev.Button)).(*vm.PersistentMap)
+	m = m.Assoc(vm.Keyword("x"), vm.MakeInt(ev.X)).(*vm.PersistentMap)
+	m = m.Assoc(vm.Keyword("y"), vm.MakeInt(ev.Y)).(*vm.PersistentMap)
+	m = m.Assoc(vm.Keyword("mods"), vm.NewPersistentSet(mods)).(*vm.PersistentMap)
+	return m
+}
+
 func init() { RegisterInstaller(installTermNS) }
 
 // nolint
@@ -361,6 +385,12 @@ func installTermNS() {
 		}
 		if s == "" {
 			return vm.NIL, nil
+		}
+		// Hybrid return: plain keys stay strings (no caller churn), an SGR
+		// mouse report becomes a tagged map. Mouse reports only arrive once
+		// enable-mouse has been called, so string-only callers are unaffected.
+		if ev, ok := decodeSGRMouse(s); ok {
+			return mouseEventMap(ev), nil
 		}
 		return vm.String(s), nil
 	})
@@ -637,6 +667,23 @@ func installTermNS() {
 		return vm.NIL, WriteToOut(ec, "\033[?1049l")
 	})
 	ns.Def("main-screen", mainScreen)
+
+	// enable-mouse — turn on SGR mouse reporting (1000 button tracking + 1006
+	// SGR extended coords). Reports then arrive through read-key as tagged maps
+	// (see decodeSGRMouse). Click-only: drag/motion modes (1002/1003) are not
+	// enabled. The same sequence works through xterm.js for the WASM build.
+	// Callers must pair this with disable-mouse in their cleanup, alongside
+	// restore-mode!, or the terminal is left emitting click escapes.
+	enableMouse := vm.NewCtxNativeFn("enable-mouse", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1000;1006h")
+	})
+	ns.Def("enable-mouse", enableMouse)
+
+	// disable-mouse — turn off the reporting that enable-mouse switched on.
+	disableMouse := vm.NewCtxNativeFn("disable-mouse", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1000;1006l")
+	})
+	ns.Def("disable-mouse", disableMouse)
 
 	// flush — sync the active *out* binding so flush hits the same sink the
 	// term/* bytes did. File-backed handles fsync; buffered embedder writers

--- a/pkg/rt/term_wasm.go
+++ b/pkg/rt/term_wasm.go
@@ -268,6 +268,23 @@ func installTermNS() {
 	})
 	ns.Def("main-screen", mainScreen)
 
+	// enable-mouse / disable-mouse — same SGR mouse-reporting escapes as the
+	// native term ns (term.go). xterm.js honors \e[?1000;1006h and forwards
+	// clicks back through onData → the SAB → read-key. The WASM read-key does
+	// not yet decode the report into a tagged map (Phase 3), so a click surfaces
+	// as the raw escape string — enough for "any key/click" prompts like the
+	// title screen; in-game click-to-move needs the decode. Defined here so the
+	// shared xsofy lifecycle (init/shutdown-terminal) resolves them in WASM too.
+	enableMouse := vm.NewCtxNativeFn("enable-mouse", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1000;1006h")
+	})
+	ns.Def("enable-mouse", enableMouse)
+
+	disableMouse := vm.NewCtxNativeFn("disable-mouse", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		return vm.NIL, WriteToOut(ec, "\033[?1000;1006l")
+	})
+	ns.Def("disable-mouse", disableMouse)
+
 	// flush — sync the active *out* binding, then drive the JS-side transport
 	// flush so the default screen path still reaches xterm.js. A rebound
 	// (buffered/embedder) *out* is flushed by Sync(); _lgFlush then no-ops on


### PR DESCRIPTION
Builds on the `read-key` tokenizer (#307) to add click-only mouse input. That
work is what makes this possible: a mouse report is a multi-byte escape sequence
arriving in a high-frequency stream, which the old whole-read-as-one-key path
could not separate. With one event per `read-key` call in place, mouse reports
decode cleanly.

## What

- `term/enable-mouse` / `term/disable-mouse` write `\e[?1000;1006h` / `…l`
  (1000 button tracking + 1006 SGR extended coordinates). Callers pair
  `disable-mouse` with `restore-mode!` in cleanup. Defined in both the native
  term namespace (`term.go`) and the wasm one (`term_wasm.go`) so a shared host
  lifecycle resolves on either target; the identical escapes drive xterm.js in
  the browser.
- `decodeSGRMouse` parses `\e[<b;x;y M|m` into a `MouseEvent` — action, button,
  1-based x/y, Shift/Ctrl/Meta, wheel up/down. It lives in the constraint-free
  tokenizer file so the wasm key source can reuse it.
- `read-key` return is hybrid on native: plain keys stay strings, a mouse report
  becomes a tagged map, `{:type :mouse :action :press :button :left :x 10 :y 5
  :mods #{:shift}}`. Reports only arrive after `enable-mouse`, so string-only
  callers are unaffected.

## Scope: click and wheel only

Drag/motion modes (1002/1003) are not enabled. Press, release, and wheel keep
coordinates within a fixed range and avoid a high-rate motion stream. Drag is a
later addition if a use case needs it.

## Native vs wasm

The native path decodes to the tagged map above. The wasm `read-key` still
returns the raw report string — decoding it into the map there is a follow-up.
That is enough for "press any key" prompts in the browser, not yet for in-game
targeting.

Multi-read reports decode intact: the tokenizer already stitches escape
sequences that straddle a read boundary (see #307), so a mouse report split
across two stdin reads reassembles before decode.

## Tests

`decodeSGRMouse` unit tests cover buttons, modifiers, wheel, and malformed-report
rejection. Validated end to end: native bursts of mouse reports across read
boundaries decode intact, and the wasm build boots with mouse reports arriving
through xterm.js.
