### PR TITLE
enh(term): refactor term key tokenizer scanner

### DIFF
--- a/pkg/rt/key_tokenizer.go
+++ b/pkg/rt/key_tokenizer.go
@@ -2,13 +2,20 @@ package rt
 
 import "unicode/utf8"
 
-// nextKey splits exactly one key token off the front of b and returns the
-// token plus the number of bytes consumed.
+type keyScanResult int
+
+const (
+	keyReady keyScanResult = iota
+	keyNeedMore
+)
+
+// scanKey classifies exactly one key token off the front of b and returns the
+// token status plus the number of bytes to consume when the token is emitted.
 //
 // A single raw terminal read can carry several keys (held-key auto-repeat or
 // queued input) or one multi-byte escape sequence (arrows, SGR mouse). The
 // pre-tokenizer read-key returned the whole read as one string, so a burst
-// like "llll" arrived as one unrecognized blob. Tokenizing lets read-key hand
+// like "llll" arrived as one unrecognized blob. Scanning lets read-key hand
 // out one event per call: "llll" -> four "l", while "\x1b[C" stays one key.
 //
 // Recognized fronts:
@@ -19,106 +26,57 @@ import "unicode/utf8"
 //	UTF-8 lead byte              the whole rune (never split)
 //	any other byte               that single byte (ASCII / control)
 //
-// A token split across two reads (an unterminated CSI, or a multi-byte rune
-// missing continuation bytes) is returned best-effort as the remaining buffer.
-// ReadKey avoids hitting that path: it checks incompleteToken and refills first
-// when more bytes are pending, so nextKey runs on a complete token.
-func nextKey(b []byte) (string, int) {
+// A token split across two reads returns keyNeedMore with the bytes currently
+// held for that front token. ReadKey refills first when more bytes are pending;
+// otherwise it emits those bytes best-effort rather than stalling forever on a
+// genuinely truncated sequence.
+func scanKey(b []byte) (keyScanResult, int) {
 	if len(b) == 0 {
-		return "", 0
+		return keyReady, 0
 	}
 	if b[0] == 0x1b { // ESC
-		if len(b) >= 2 && b[1] == '[' { // CSI: ESC [ params/intermediates final
+		if len(b) == 1 {
+			return keyNeedMore, 1
+		}
+		switch b[1] {
+		case '[': // CSI: ESC [ params/intermediates final
 			i := 2
 			for i < len(b) && (b[i] < 0x40 || b[i] > 0x7e) {
 				i++
 			}
 			if i < len(b) {
-				return string(b[:i+1]), i + 1 // include the final byte
+				return keyReady, i + 1 // include the final byte
 			}
-			return string(b), len(b) // incomplete — best effort
+			return keyNeedMore, len(b)
+		case 'O': // SS3: ESC O x
+			if len(b) < 3 {
+				return keyNeedMore, len(b)
+			}
+			return keyReady, 3
 		}
-		if len(b) >= 3 && b[1] == 'O' { // SS3: ESC O x
-			return string(b[:3]), 3
-		}
-		return "\x1b", 1 // bare ESC
+		return keyReady, 1 // bare ESC
 	}
 	if b[0] < utf8.RuneSelf { // single-byte ASCII / control
-		return string(b[:1]), 1
+		return keyReady, 1
+	}
+	if !utf8.FullRune(b) {
+		return keyNeedMore, len(b)
 	}
 	r, size := utf8.DecodeRune(b)
 	if r == utf8.RuneError && size == 1 {
-		return string(b[:1]), 1 // invalid byte — emit as-is, never stall
+		return keyReady, 1 // invalid byte — emit as-is, never stall
 	}
-	return string(b[:size]), size
+	return keyReady, size
 }
 
-// incompleteToken reports whether b ends in the middle of a token whose
-// remaining bytes haven't arrived yet — an escape sequence with no terminator,
-// or a multi-byte UTF-8 rune missing continuation bytes. A raw read fills a
-// fixed-size buffer, so a token can straddle two reads (and queued input makes
-// this routine, not a corner case: a burst longer than the buffer, or several
-// multi-byte reports back to back, will split). When this is true and more
-// bytes are actually pending, ReadKey refills before tokenizing rather than
-// letting nextKey emit a broken partial. Read-buffer size then only affects how
-// often the refill path runs, not correctness.
-func incompleteToken(b []byte) bool {
-	return incompleteEscape(b) || incompleteRune(b)
-}
-
-// incompleteEscape reports whether b holds the opening of an escape sequence
-// whose terminating byte hasn't arrived: a lone ESC, a CSI (ESC '[' …) with no
-// final byte in 0x40–0x7E, or an SS3 (ESC 'O') missing its third byte.
-//
-// A lone ESC is ambiguous (the Escape key, or the start of a sequence), which
-// normally needs a timeout to resolve. ReadKey gates the refill on bytes
-// actually waiting: a real Escape keypress has nothing queued behind it, while
-// a split sequence's tail is already in the kernel buffer. That sidesteps the
-// timeout for the common case, and over-pulling is harmless — nextKey still
-// splits a bare ESC off the front correctly.
-func incompleteEscape(b []byte) bool {
-	if len(b) == 0 || b[0] != 0x1b {
-		return false
+// nextKey splits exactly one key token off the front of b and returns the token
+// plus the number of bytes consumed. If b contains a partial front token, it
+// emits the held bytes best-effort; ReadKey normally avoids that by refilling
+// when scanKey reports keyNeedMore and stdin has more bytes pending.
+func nextKey(b []byte) (string, int) {
+	_, n := scanKey(b)
+	if n == 0 {
+		return "", 0
 	}
-	if len(b) == 1 {
-		return true // lone ESC — may be a sequence split on the ESC byte
-	}
-	switch b[1] {
-	case '[':
-		for i := 2; i < len(b); i++ {
-			if b[i] >= 0x40 && b[i] <= 0x7e {
-				return false // final byte present — sequence is complete
-			}
-		}
-		return true // only params/intermediates so far
-	case 'O':
-		return len(b) < 3
-	}
-	return false
-}
-
-// incompleteRune reports whether b *starts* with a UTF-8 lead byte whose
-// continuation bytes haven't all arrived — the front rune is split across a
-// read. Like incompleteEscape, this checks the front token (the one ReadKey is
-// about to emit), not the tail: a complete byte ahead of a split rune is
-// emitted first, and the split rune is refilled once it reaches the front (its
-// pending tail waits in the kernel buffer until then). ASCII, a continuation
-// byte, or an invalid lead at the front is "complete" — nextKey emits it as-is,
-// so refilling would only stall.
-func incompleteRune(b []byte) bool {
-	if len(b) == 0 || b[0] < utf8.RuneSelf {
-		return false // empty or ASCII — front is complete
-	}
-	var need int
-	switch {
-	case b[0]&0xe0 == 0xc0: // 110xxxxx
-		need = 2
-	case b[0]&0xf0 == 0xe0: // 1110xxxx
-		need = 3
-	case b[0]&0xf8 == 0xf0: // 11110xxx
-		need = 4
-	default:
-		return false // continuation byte or invalid lead — nextKey emits as-is
-	}
-	return len(b) < need
+	return string(b[:n]), n
 }

--- a/pkg/rt/key_tokenizer_test.go
+++ b/pkg/rt/key_tokenizer_test.go
@@ -58,10 +58,10 @@ func TestNextKeyEmpty(t *testing.T) {
 	}
 }
 
-func TestIncompleteToken(t *testing.T) {
-	// incompleteToken checks the FRONT token (the one ReadKey emits next), so
-	// only a buffer whose leading token is split counts as incomplete.
-	incomplete := []string{
+func TestScanKeyNeedMore(t *testing.T) {
+	// scanKey checks the FRONT token (the one ReadKey emits next), so only a
+	// buffer whose leading token is split asks for more bytes.
+	needMore := []string{
 		// escape sequences with no terminator yet
 		"\x1b",         // lone ESC — may be a sequence split on the ESC byte
 		"\x1b[",        // CSI with no params/final
@@ -73,30 +73,38 @@ func TestIncompleteToken(t *testing.T) {
 		"\xe2\x82",     // first two bytes of € (3-byte rune)
 		"\xf0\x9f\x98", // first three bytes of 😀 (4-byte rune)
 	}
-	for _, s := range incomplete {
-		if !incompleteToken([]byte(s)) {
-			t.Errorf("incompleteToken(%q) = false, want true", s)
+	for _, s := range needMore {
+		status, n := scanKey([]byte(s))
+		if status != keyNeedMore || n != len(s) {
+			t.Errorf("scanKey(%q) = (%v, %d), want (%v, %d)", s, status, n, keyNeedMore, len(s))
 		}
 	}
-	complete := []string{
-		"",              // empty
-		"l",             // plain key
-		"\x1b[A",        // finished arrow
-		"\x1b[<0;10;5M", // finished SGR mouse
-		"\x1bOP",        // finished SS3 (F1)
-		"\x1bx",         // ESC + ordinary byte (Alt-x); nextKey splits it
-		"é",             // complete 2-byte rune
-		"€",             // complete 3-byte rune
-		"😀",             // complete 4-byte rune
+}
+
+func TestScanKeyReady(t *testing.T) {
+	ready := []struct {
+		in string
+		n  int
+	}{
+		{"", 0},                                 // empty
+		{"l", 1},                                // plain key
+		{"\x1b[A", 3},                           // finished arrow
+		{"\x1b[<0;10;5M", len("\x1b[<0;10;5M")}, // finished SGR mouse
+		{"\x1bOP", 3},                           // finished SS3 (F1)
+		{"\x1bx", 1},                            // ESC + ordinary byte (Alt-x); nextKey splits it
+		{"é", len("é")},                         // complete 2-byte rune
+		{"€", len("€")},                         // complete 3-byte rune
+		{"😀", len("😀")},                         // complete 4-byte rune
 		// complete front token ahead of a split tail — emit the front first,
 		// the tail is refilled once it reaches the front
-		"abc\x1b[1;2", // 'a' is complete; trailing CSI handled later
-		"aaa\xc3",     // 'a' is complete; the split é (reviewer's case) handled later
-		"\xff",        // invalid lead byte — nextKey emits it as-is
+		{"abc\x1b[1;2", 1}, // 'a' is complete; trailing CSI handled later
+		{"aaa\xc3", 1},     // 'a' is complete; the split é (reviewer's case) handled later
+		{"\xff", 1},        // invalid lead byte — nextKey emits it as-is
 	}
-	for _, s := range complete {
-		if incompleteToken([]byte(s)) {
-			t.Errorf("incompleteToken(%q) = true, want false", s)
+	for _, c := range ready {
+		status, n := scanKey([]byte(c.in))
+		if status != keyReady || n != c.n {
+			t.Errorf("scanKey(%q) = (%v, %d), want (%v, %d)", c.in, status, n, keyReady, c.n)
 		}
 	}
 }

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -103,7 +103,7 @@ type nativeKeySource struct{}
 // keyBuf holds bytes read from stdin but not yet handed out as keys. A single
 // raw read can carry several keys (held-key auto-repeat / queued input) or a
 // multi-byte escape sequence; ReadKey tokenizes one key per call off this
-// buffer (see nextKey) and refills via readRaw only when it's empty. Native
+// buffer (see scanKey) and refills via readRaw only when it's empty. Native
 // has a single stdin and reads aren't concurrent, so a package-level buffer is
 // safe.
 var keyBuf []byte
@@ -113,7 +113,7 @@ var keyBuf []byte
 // latency to a single keystroke — it just grabs more bytes when a burst is
 // already queued, cutting syscalls and ReadKey refills. Correctness doesn't
 // depend on it: a token straddling the buffer is stitched by the refill path
-// (see incompleteToken). 256 covers held-key bursts and back-to-back escape
+// (see scanKey). 256 covers held-key bursts and back-to-back escape
 // sequences with headroom.
 const readChunkSize = 256
 
@@ -124,30 +124,31 @@ func (s nativeKeySource) ReadKey() (string, error) {
 			if err != nil {
 				return "", err
 			}
-			switch chunk {
-			case "":
+			if len(chunk) == 0 {
 				return "", nil // EOF / nil contract
-			case "\x07":
+			}
+			if isWinchWake(chunk) {
 				return "\x07", nil // SIGWINCH wake — synthetic, not tokenized
 			}
-			keyBuf = append(keyBuf, chunk...)
+			keyBuf = chunk
 		}
-		// If the buffer ends mid-token (split escape sequence or UTF-8 rune)
-		// and more bytes are actually waiting on stdin, pull them in and
-		// re-tokenize rather than emitting a broken partial. Gating on
-		// rawPending keeps a genuinely truncated token from blocking a refill
-		// that would never complete.
-		if incompleteToken(keyBuf) && s.rawPending() {
+		status, n := scanKey(keyBuf)
+		// If the front token is split (escape sequence or UTF-8 rune) and more
+		// bytes are actually waiting on stdin, pull them in and scan again
+		// rather than emitting a broken partial. Gating on rawPending keeps a
+		// genuinely truncated token from blocking a refill that would never
+		// complete.
+		if status == keyNeedMore && s.rawPending() {
 			chunk, err := s.readRaw()
 			if err != nil {
 				return "", err
 			}
-			if chunk != "" && chunk != "\x07" {
+			if len(chunk) != 0 && !isWinchWake(chunk) {
 				keyBuf = append(keyBuf, chunk...)
 				continue
 			}
 		}
-		tok, n := nextKey(keyBuf)
+		tok := string(keyBuf[:n])
 		keyBuf = keyBuf[n:]
 		if len(keyBuf) == 0 {
 			keyBuf = nil // release the backing array once drained
@@ -156,10 +157,15 @@ func (s nativeKeySource) ReadKey() (string, error) {
 	}
 }
 
-// readRaw does one blocking poll+read, returning raw stdin bytes, "" on EOF, or
-// BEL ("\x07") when only the SIGWINCH wake fired. This is the pre-tokenizer
-// read-key body, unchanged — ReadKey now buffers and tokenizes its result.
-func (nativeKeySource) readRaw() (string, error) {
+func isWinchWake(b []byte) bool {
+	return len(b) == 1 && b[0] == '\x07'
+}
+
+// readRaw does one blocking poll+read, returning raw stdin bytes, nil on EOF,
+// or BEL ("\x07") when only the SIGWINCH wake fired. This is the pre-tokenizer
+// read-key body, except it now keeps input as bytes until ReadKey emits the
+// final token string.
+func (nativeKeySource) readRaw() ([]byte, error) {
 	setupWinch() // idempotent; armed on first read-key
 
 	if winchPipeR == nil {
@@ -167,9 +173,9 @@ func (nativeKeySource) readRaw() (string, error) {
 		buf := make([]byte, readChunkSize)
 		n, err := os.Stdin.Read(buf)
 		if err != nil || n == 0 {
-			return "", nil
+			return nil, nil
 		}
-		return string(buf[:n]), nil
+		return buf[:n], nil
 	}
 
 	stdinFd := int(os.Stdin.Fd())
@@ -189,7 +195,7 @@ func (nativeKeySource) readRaw() (string, error) {
 			continue
 		}
 		if err != nil {
-			return "", nil
+			return nil, nil
 		}
 		break
 	}
@@ -214,9 +220,9 @@ func (nativeKeySource) readRaw() (string, error) {
 		buf := make([]byte, readChunkSize)
 		n, err := os.Stdin.Read(buf)
 		if err != nil || n == 0 {
-			return "", nil
+			return nil, nil
 		}
-		return string(buf[:n]), nil
+		return buf[:n], nil
 	}
 
 	// Prefer real input — user keys shouldn't queue behind a resize wake.
@@ -224,13 +230,13 @@ func (nativeKeySource) readRaw() (string, error) {
 		buf := make([]byte, readChunkSize)
 		n, err := os.Stdin.Read(buf)
 		if err != nil || n == 0 {
-			return "", nil
+			return nil, nil
 		}
-		return string(buf[:n]), nil
+		return buf[:n], nil
 	}
 
 	// Only the wake fired — return BEL so the loop's term/size diff runs.
-	return "\x07", nil
+	return []byte{'\x07'}, nil
 }
 
 func (s nativeKeySource) KeyPending() bool {
@@ -242,7 +248,7 @@ func (s nativeKeySource) KeyPending() bool {
 
 // rawPending reports whether stdin (or the SIGWINCH wake-pipe) has bytes the
 // buffer hasn't consumed yet — the OS-level half of KeyPending, without the
-// keyBuf check. ReadKey uses it to decide whether refilling a straddled token
+// keyBuf check. ReadKey uses it to decide whether refilling a split token
 // will actually make progress.
 func (nativeKeySource) rawPending() bool {
 	// Arm the winch handler if it hasn't been already — a caller that hits


### PR DESCRIPTION
## Summary

- replace the separate next-key and incomplete-token decision paths with a single scanKey result: ready vs need-more plus consume length
- keep raw terminal reads as []byte until ReadKey emits the final token string, avoiding the intermediate raw-read string copy
- update tokenizer tests to assert scanner readiness directly while preserving nextKey tokenization coverage

## Rationale

The tokenizer previously encoded token completeness twice: nextKey decided what to emit, while incompleteToken independently decided whether ReadKey should refill before emitting. This refactor makes the scanner the single source of truth, so split CSI/SS3/UTF-8 tokens and best-effort passthrough behavior stay aligned.

This is mostly a maintainability/correctness cleanup. The byte-read change removes an avoidable copy, but terminal polling and reads remain the dominant cost.

## Validation

- go test ./pkg/rt ./pkg/api
- go test ./...

Co-authored by Codex (5.5-high)