### PR TITLE
ci(pages): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,8 @@ name: Deploy wasm let-go to Pages
 on:
   push:
     branches: [main]
+  # Fresh perf-data snapshots are read at deploy time.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
**Summary:** 2-line workflow change so we can trigger rebuild of performance page with new snapshots.

The Pages deploy only triggers on push to `main`. The perf-timeline charts are built from the `perf-data` branch, which the deploy fetches at build time, so a snapshot newly pushed to `perf-data` doesn't surface on the published page until a later push to `main` redeploys.

Adding `workflow_dispatch` lets a maintainer redeploy on demand (from the Actions tab or `gh workflow run pages.yml`) so the page picks up the latest `perf-data` without an empty commit to `main`.

What gets deployed is controlled by the dispatch ref: the build checks out the ref it runs on, while `perf-data` is fetched fresh regardless. So dispatching from a known-good ref (e.g. a release tag) republishes that commit's site with the latest perf snapshots (stable playground, fresh charts) rather than tying a perf refresh to `main`'s current tip.

No change to the build or deploy steps; this only adds a manual trigger alongside the existing push trigger.
