### PR TITLE
ci: bump deprecated CodeQL action v1 to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,13 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    # Required since the default GITHUB_TOKEN became read-only: the analyze
+    # step uploads results to code scanning, which needs security-events: write.
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -35,11 +42,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +71,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
The CodeQL workflow pins `github/codeql-action@v1`, which was deprecated in 2023 and now fails at the Initialize step ("This version of the CodeQL Action was deprecated ... and is no longer updated or supported"). Analysis hasn't run since.

This bumps `init`, `autobuild`, and `analyze` to `@v3`, and `actions/checkout` to `@v4`.

It also adds an explicit `permissions` block. The analyze step uploads results to code scanning, which needs `security-events: write`; with the default `GITHUB_TOKEN` now read-only, the run otherwise errors with "Resource not accessible by integration." The block grants only what the job needs: `actions: read`, `contents: read`, `security-events: write`.

Languages and build logic are unchanged — `go` with autobuild, as before.

Verified on a fork: the Analyze (go) job initializes and passes.
