### PR TITLE
perf-page: CPU-tier filter and selectable baseline; release-baseline recapture

### DIFF
--- a/cmd/perf-page/main.go
+++ b/cmd/perf-page/main.go
@@ -164,6 +164,7 @@ func main() {
 		outPath        = flag.String("out", "docs/perf/index.html", "HTML output path")
 		logoPath       = flag.String("logo", "meta/logo.svg", "logo SVG to embed")
 		cpuFilter      = flag.String("cpu", "", "keep only timeline snapshots whose machine cpu_model contains this substring (CI runs land on ≥2 CPU tiers whose ratio_to_anchor doesn't normalize across them, so a mixed timeline zig-zags ~2x; filtering to one tier gives a clean series). Empty = all.")
+		anchorName     = flag.String("anchor", "", "historical baseline to compare against, by file stem (e.g. 'v1.8.0'); empty = newest. Lets the page swap anchors — e.g. a fresh same-machine baseline for the modern suite vs the legacy v1.8.0 (Apple M3, pre-IR) reference.")
 	)
 	flag.Parse()
 
@@ -171,7 +172,7 @@ func main() {
 	if err != nil {
 		die("load baseline: %v", err)
 	}
-	reference, referenceName, err := loadLatestHistorical(*historicalPath)
+	reference, referenceName, err := loadHistoricalAnchor(*historicalPath, *anchorName)
 	if err != nil {
 		die("load historical baseline: %v", err)
 	}
@@ -298,6 +299,23 @@ func loadLatestHistorical(dir string) (Baseline, string, error) {
 		return all[i].path > all[j].path
 	})
 	return all[0].baseline, all[0].name, nil
+}
+
+// loadHistoricalAnchor selects the comparison baseline. With name empty it
+// keeps the existing behavior (newest historical). With a name (file stem,
+// e.g. "v1.8.0") it loads that specific baseline — so the page can anchor the
+// modern suite to a fresh same-machine baseline while keeping v1.8.0 available
+// as an explicit, labeled legacy reference rather than the silent default.
+func loadHistoricalAnchor(dir, name string) (Baseline, string, error) {
+	if name == "" {
+		return loadLatestHistorical(dir)
+	}
+	path := filepath.Join(dir, name+".json")
+	baseline, err := loadBaseline(path)
+	if err != nil {
+		return Baseline{}, "", fmt.Errorf("anchor %q (%s): %w", name, path, err)
+	}
+	return baseline, name, nil
 }
 
 func loadTimeline(timelineDir, historicalDir string, current Baseline) ([]Snapshot, error) {

--- a/cmd/perf-page/main.go
+++ b/cmd/perf-page/main.go
@@ -163,6 +163,7 @@ func main() {
 		timelinePath   = flag.String("timeline", "docs/perf/timeline", "timeline snapshot directory")
 		outPath        = flag.String("out", "docs/perf/index.html", "HTML output path")
 		logoPath       = flag.String("logo", "meta/logo.svg", "logo SVG to embed")
+		cpuFilter      = flag.String("cpu", "", "keep only timeline snapshots whose machine cpu_model contains this substring (CI runs land on ≥2 CPU tiers whose ratio_to_anchor doesn't normalize across them, so a mixed timeline zig-zags ~2x; filtering to one tier gives a clean series). Empty = all.")
 	)
 	flag.Parse()
 
@@ -178,6 +179,7 @@ func main() {
 	if err != nil {
 		die("load timeline: %v", err)
 	}
+	timeline = filterTimelineByCPU(timeline, *cpuFilter)
 	logo, err := logoDataURI(*logoPath)
 	if err != nil {
 		die("load logo: %v", err)
@@ -200,6 +202,44 @@ func main() {
 func die(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "perf-page: "+format+"\n", args...)
 	os.Exit(1)
+}
+
+// filterTimelineByCPU reports the CPU-tier mix of the timeline and, when sub is
+// non-empty, keeps only snapshots whose machine cpu_model contains it. The mix
+// matters because ratio_to_anchor does not normalize across CI CPU tiers (a
+// trivial ~1ns anchor can't track each microarch's cache/memory/GC profile), so
+// a mixed timeline zig-zags ~2x between tiers and a single point is unreadable.
+// Filtering to one tier yields a clean, comparable series.
+func filterTimelineByCPU(timeline []Snapshot, sub string) []Snapshot {
+	counts := map[string]int{}
+	for _, s := range timeline {
+		cpu := s.Baseline.Machine.CPUModel
+		if cpu == "" {
+			cpu = "(unknown)"
+		}
+		counts[cpu]++
+	}
+	models := make([]string, 0, len(counts))
+	for m := range counts {
+		models = append(models, m)
+	}
+	sort.Slice(models, func(i, j int) bool { return counts[models[i]] > counts[models[j]] })
+	fmt.Fprintf(os.Stderr, "timeline CPU tiers (%d snapshots):\n", len(timeline))
+	for _, m := range models {
+		fmt.Fprintf(os.Stderr, "  %3d  %s\n", counts[m], m)
+	}
+	if sub == "" {
+		return timeline
+	}
+	want := strings.ToLower(sub)
+	kept := make([]Snapshot, 0, len(timeline))
+	for _, s := range timeline {
+		if strings.Contains(strings.ToLower(s.Baseline.Machine.CPUModel), want) {
+			kept = append(kept, s)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "cpu filter %q → kept %d of %d snapshots\n", sub, len(kept), len(timeline))
+	return kept
 }
 
 func loadBaseline(path string) (Baseline, error) {

--- a/scripts/recapture-release-baseline.sh
+++ b/scripts/recapture-release-baseline.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Re-derive a historical perf baseline for an OLD release tag that predates the
+# bench-ratchet system, captured on THIS machine.
+#
+# Why this exists: BenchmarkRatchetAnchor (the calibration anchor every baseline
+# normalizes against) and the bench-ratchet tool were both introduced in #119,
+# AFTER v1.8.0. So an old tag has the pkg/vm micro-benchmarks but neither the
+# anchor benchmark nor the harness. The committed docs/perf/historical/v1.8.0.json
+# was therefore captured on a one-off (Apple M3) machine, which makes "% vs
+# v1.8.0" a cross-machine/cross-arch comparison against the amd64 CI timeline.
+#
+# To get an honest, same-machine v1.8.0 reference, graft the (self-contained)
+# anchor benchmark onto a throwaway worktree of the tag, run bench-ratchet
+# against pkg/vm only, then drop the graft. Pair this with pinning the perf job
+# to one runner so the recaptured baseline and the timeline share silicon.
+#
+# Scope: only the pkg/vm micro-benchmarks are recapturable — the modern
+# aot_native / ir_bytecode (pkg/ir) suite never existed at old tags.
+#
+# Usage: scripts/recapture-release-baseline.sh <ref> <out.json> [benchtime=2s]
+set -euo pipefail
+
+REF="${1:?usage: recapture-release-baseline.sh <ref> <out.json> [benchtime]}"
+OUT="${2:?usage: recapture-release-baseline.sh <ref> <out.json> [benchtime]}"
+BENCHTIME="${3:-2s}"
+
+# Absolute-ize OUT before we cd into the worktree.
+case "$OUT" in /*) ;; *) OUT="$PWD/$OUT" ;; esac
+mkdir -p "$(dirname "$OUT")"
+
+REPO="$(git rev-parse --show-toplevel)"
+ANCHOR="$REPO/pkg/vm/bench_ratchet_anchor_test.go"
+[ -f "$ANCHOR" ] || { echo "anchor benchmark not found at $ANCHOR" >&2; exit 1; }
+
+WT="$(mktemp -d)/recap"
+BR="$(mktemp -d)/bench-ratchet"
+cleanup() { git -C "$REPO" worktree remove --force "$WT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# --detach so it coexists with any existing checkout of the same tag.
+git -C "$REPO" worktree add --detach "$WT" "$REF" >/dev/null
+SHA="$(git -C "$REPO" rev-parse --short "$REF")"
+
+# Graft the anchor (self-contained, no project deps) so ratio_to_anchor is
+# computable; absent at pre-#119 tags. Build the current bench-ratchet — the
+# tag doesn't have it — and run it against pkg/vm in the tag's tree.
+cp "$ANCHOR" "$WT/pkg/vm/bench_ratchet_anchor_test.go"
+( cd "$REPO" && go build -o "$BR" ./cmd/bench-ratchet )
+( cd "$WT" && "$BR" -packages github.com/nooga/let-go/pkg/vm \
+    -benchtime "$BENCHTIME" -count 1 -sha "$SHA" -baseline "$OUT" snapshot )
+
+echo "recaptured $REF (pkg/vm) on $(uname -m) → $OUT"


### PR DESCRIPTION
**perf-page: CPU-tier filter and selectable baseline; release-baseline recapture**

Three related improvements to the perf timeline tooling, all tracing to one issue: `ratio_to_anchor` doesn't fully normalize across the different CPU SKUs that GitHub-hosted runners land on, so a timeline can interleave runs from several microarchitectures and read as bimodally noisy.

- **`perf-page -cpu <substr>`** — render only the snapshots whose `machine.cpu_model` contains the substring, so the trend stays within one CPU tier instead of mixing tiers. Each snapshot already records `cpu_model`, so this is a render-time filter with no capture-side change.
- **`perf-page -anchor <stem>`** — choose which historical baseline the page compares against, by file stem (e.g. `v1.8.0`), instead of always taking the newest. This lets the modern suite anchor to a fresh same-machine baseline while keeping older release baselines as labeled legacy references. Empty keeps the current behavior (newest).
- **`scripts/recapture-release-baseline.sh`** — re-derive a baseline for an old release tag that predates `bench-ratchet`. `BenchmarkRatchetAnchor` and the harness both arrived after the earliest tags, so those tags have the `pkg/vm` micro-benchmarks but not the anchor; a baseline shipped from a one-off machine then compares cross-architecture against the CI timeline. The script grafts the self-contained anchor onto a throwaway worktree of the tag, runs `bench-ratchet` against `pkg/vm` only, and drops the graft, giving a same-machine reference. Only the `pkg/vm` micros are recapturable; the modern `pkg/ir` suite never existed at those tags.

Each is independent and preserves existing defaults.
