### PR TITLE
feat(lg): LG_CPUPROFILE/LG_MEMPROFILE env fallback for profiling builds

### DIFF
--- a/lg_profile.go
+++ b/lg_profile.go
@@ -24,9 +24,11 @@ var (
 func init() {
 	flag.StringVar(&cpuProfile, "cpuprofile", "",
 		"write a Go CPU profile of script/REPL execution to this file "+
-			"(build modes -c/-b/-w and the bundled-binary path are not profiled)")
+			"(build modes -c/-b/-w and the bundled-binary path are not profiled; "+
+			"env LG_CPUPROFILE is the flag-free fallback)")
 	flag.StringVar(&memProfile, "memprofile", "",
-		"write a Go heap profile to this file after script/REPL execution")
+		"write a Go heap profile to this file after script/REPL execution "+
+			"(env LG_MEMPROFILE is the flag-free fallback)")
 }
 
 // startProfiling begins CPU profiling when -cpuprofile is set and arranges for
@@ -34,6 +36,16 @@ func init() {
 // the CPU profile. The explicit stop at the end of main handles normal returns;
 // rt.AtExit covers language-level os/exit and System/exit, which skip defers.
 func startProfiling() {
+	// Env fallback so profiling works for scripts that read raw os.Args and
+	// assume a fixed layout (e.g. scripts/ir-stress.lg does `(drop 2 os/args)`),
+	// where -cpuprofile / -memprofile flags would shift the positional args and
+	// break the script. Flags win when both a flag and its env var are set.
+	if cpuProfile == "" {
+		cpuProfile = os.Getenv("LG_CPUPROFILE")
+	}
+	if memProfile == "" {
+		memProfile = os.Getenv("LG_MEMPROFILE")
+	}
 	stop := func() {}
 	if cpuProfile != "" {
 		f, err := os.Create(cpuProfile)


### PR DESCRIPTION
## What

Adds an `LG_CPUPROFILE` / `LG_MEMPROFILE` environment-variable fallback to the `lg_profile`-tagged profiling build, alongside the existing `-cpuprofile` / `-memprofile` flags.

## Why

The flags work fine for the REPL and simple scripts, but they break scripts that read **raw** `os/args` with a fixed positional layout. For example `scripts/ir-stress.lg` does:

```clojure
;; os/args is [binary script user-arg user-arg...]
(def user-args (vec (drop 2 (seq os/args))))
```

Passing `-cpuprofile X -memprofile Y` shifts those positionals (the flags land in `os/args`), so the script reads `-memprofile` as its `<mode>` and aborts. There's no way to profile those harnesses today.

The env fallback sidesteps the positional layout entirely:

```sh
LG_CPUPROFILE=/tmp/cpu.prof LG_MEMPROFILE=/tmp/mem.prof \
  ./lg scripts/ir-stress.lg trace <dir> <file> <defn>
```

Explicit flags still win when both a flag and its env var are set. This was used to root-cause the LICM dominator recompute investigated in #324 (ir-stress `trace` + heap profile showed `dominators` rebuilt per `dominates?` call → 24GB churn / ~45% GC).

## Scope

- Build-tag gated (`lg_profile`); zero effect on normal/bundled builds.
- One file (`lg_profile.go`): env read in `startProfiling`, flag help mentions the fallback.
- Smoke-tested: `LG_CPUPROFILE=… LG_MEMPROFILE=… lg -e '(println (reduce + (range 1000)))'` writes both profiles with no flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
