### PR TITLE
perf(bench-ratchet): retune pr-fast to count 3 / benchtime 500ms

### DIFF
--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -613,8 +613,11 @@ const prFastFilter = `^Benchmark(RatchetAnchor|FrameDispatch|FrameAlloc|FuncInvo
 
 var profiles = map[string]profile{
 	"pr-fast": {
-		count:     6,
-		benchtime: "1s",
+		// Sized for fast PR feedback, not absolute precision: ~53 cases ×
+		// count 3 × 500ms keeps a two-pass A/B well under the old full-fleet
+		// runtime, and the 12% budget sits above the residual sub-µs jitter.
+		count:     3,
+		benchtime: "500ms",
 		budget:    0.12,
 		jobs: func(tags string) ([]captureJob, error) {
 			re, err := regexp.Compile(prFastFilter)


### PR DESCRIPTION
**perf(bench-ratchet): retune `pr-fast` to count 3 / benchtime 500ms**

The `pr-fast` profile shipped with `count 6 / benchtime 1s`, which negated the curation's runtime goal. The arithmetic shows why: 53 cases × 6 × 1s = 318 benchmark-seconds, *more* total work than the old 121-case fleet at 3 × 500ms (181). Halving the benchmark count doesn't pay for 4× per-benchmark sampling, so a two-pass A/B wasn't any faster.

Dropping to `count 3 / benchtime 500ms` (~80 benchmark-seconds) cuts a two-pass A/B to roughly half the old runtime. The 12% budget is unchanged and stays above the residual sub-microsecond jitter, since `pr-fast` already excludes the noisiest sub-ns families.
