### PR TITLE
feat(bundle,lg): bake storage store id into native bundles (v3 trailer)

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -146,10 +146,12 @@ func checkBundledLGB() (lgb []byte, res []byte, storeID string) {
 func bundleBinary(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, dst string, basePath string) error {
 	ctx.SetSource(src)
 
-	// Snapshot the resource roots and output path *before* compiling — and
-	// absolutize them against the current cwd — because CompileMultiple runs
-	// the program's top-level forms, which may change the working directory.
-	// Relative roots resolved afterward would point at the wrong place.
+	// Snapshot the resource roots, output path, and storage store id *before*
+	// compiling — and absolutize the paths against the current cwd — because
+	// CompileMultiple runs the program's top-level forms, which may change the
+	// working directory. Relative roots resolved afterward would point at the
+	// wrong place, and the store id (which falls back to the cwd basename for
+	// main.lg/init.lg) would key off the changed directory.
 	resRoots := buildResourcePaths()
 	for i, r := range resRoots {
 		if abs, aerr := filepath.Abs(r); aerr == nil {
@@ -157,6 +159,7 @@ func bundleBinary(ctx *compiler.Context, nsRes *resolver.NSResolver, src string,
 		}
 	}
 	dstAbs, _ := filepath.Abs(dst)
+	bundleStoreID := storageIDForScript(src)
 
 	f, err := os.Open(src)
 	if err != nil {
@@ -232,11 +235,12 @@ func bundleBinary(ctx *compiler.Context, nsRes *resolver.NSResolver, src string,
 		return err
 	}
 
-	// Append the lgb payload + optional resource archive + trailer. Bake the
-	// store id (explicit -storage-id, else the source basename) so the bundle
-	// keys its storage by the app rather than by whatever the binary is renamed
-	// to at runtime. Mirrors the WASM build, which bakes the same id.
-	return bundle.AppendTrailer(out, lgbData, resArc, storageIDForScript(src))
+	// Append the lgb payload + optional resource archive + trailer. The store
+	// id (explicit -storage-id, else the source basename) was snapshotted
+	// before compilation so the bundle keys its storage by the app rather than
+	// by whatever the binary is renamed to at runtime, or by a directory the
+	// compiled forms chdir'd into. Mirrors the WASM build, which bakes the same id.
+	return bundle.AppendTrailer(out, lgbData, resArc, bundleStoreID)
 }
 
 func compileLG(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, dst string) error {

--- a/lg.go
+++ b/lg.go
@@ -115,10 +115,10 @@ func runLGB(filename string) error {
 }
 
 // checkBundledLGB checks if the current executable has an appended payload.
-// Returns the LGB bytecode and (for a v2 bundle) the gzipped resource archive;
-// both are nil when no payload is found. The resource archive is nil for a
-// legacy bundle or one built without resources.
-func checkBundledLGB() (lgb []byte, res []byte) {
+// Returns the LGB bytecode, the gzipped resource archive (for a v2/v3 bundle),
+// and the baked storage store id (v3 only). The latter two are empty for a
+// legacy bundle or one built without them.
+func checkBundledLGB() (lgb []byte, res []byte, storeID string) {
 	candidates := make([]string, 0, 3)
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		candidates = append(candidates, exe)
@@ -134,11 +134,11 @@ func checkBundledLGB() (lgb []byte, res []byte) {
 			continue
 		}
 		seen[path] = true
-		if data, resData := bundle.ReadBundled(path); data != nil {
-			return data, resData
+		if data, resData, sid := bundle.ReadBundled(path); data != nil {
+			return data, resData, sid
 		}
 	}
-	return nil, nil
+	return nil, nil, ""
 }
 
 // bundleBinary creates a standalone executable by copying the lg binary
@@ -232,8 +232,11 @@ func bundleBinary(ctx *compiler.Context, nsRes *resolver.NSResolver, src string,
 		return err
 	}
 
-	// Append the lgb payload + optional resource archive + trailer.
-	return bundle.AppendTrailer(out, lgbData, resArc)
+	// Append the lgb payload + optional resource archive + trailer. Bake the
+	// store id (explicit -storage-id, else the source basename) so the bundle
+	// keys its storage by the app rather than by whatever the binary is renamed
+	// to at runtime. Mirrors the WASM build, which bakes the same id.
+	return bundle.AppendTrailer(out, lgbData, resArc, storageIDForScript(src))
 }
 
 func compileLG(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, dst string) error {
@@ -435,7 +438,7 @@ func main() {
 
 	// Check for appended LGB payload before anything else.
 	// If found, we're a standalone binary — run it directly.
-	if lgbData, resData := checkBundledLGB(); lgbData != nil {
+	if lgbData, resData, bakedStoreID := checkBundledLGB(); lgbData != nil {
 		// Set up resolver so embedded namespaces (string, set, etc.) can load
 		ctx := initCompiler(false)
 		nsResolver := resolver.NewNSResolver(ctx, buildSearchPaths())
@@ -445,7 +448,13 @@ func main() {
 		// A bundle skips flag parsing, so every arg after the program name is a
 		// user arg. Set this before any chunk runs — top-level forms read it.
 		setCommandLineArgs(os.Args[1:])
-		installPersistentStorage(storageIDForScript(""))
+		// Prefer the store id baked into the bundle at build time. Fall back to
+		// the exe basename for bundles built before the v3 trailer carried one.
+		bundleStoreID := bakedStoreID
+		if bundleStoreID == "" {
+			bundleStoreID = storageIDForScript("")
+		}
+		installPersistentStorage(bundleStoreID)
 
 		// Resources are self-contained in a bundle: serve io/resource from the
 		// embedded archive only, ignoring the filesystem and -resource-paths.

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -12,9 +12,12 @@
 //
 //	Legacy (no resources): [lgb data][8-byte lgbSize][4-byte 'LGBX']  (12-byte trailer)
 //	v2    (resources):     [lgb data][resource archive][8-byte lgbSize][8-byte resSize][4-byte 'LGB2']  (20-byte trailer)
+//	v3    (store id):      [lgb data][resource archive][store id][8-byte lgbSize][8-byte resSize][8-byte idSize][4-byte 'LGB3']  (28-byte trailer)
 //
-// A v2 trailer is written only when the bundle carries resources; resource-less
-// bundles keep the byte-identical legacy trailer. Readers recognize both.
+// A v3 trailer is written whenever the bundle bakes a storage store id (the
+// resource archive is still optional, so resSize may be 0). v2 is written when
+// there are resources but no baked id; resource-less, id-less bundles keep the
+// byte-identical legacy trailer. Readers recognize all three.
 package bundle
 
 import (
@@ -29,6 +32,7 @@ import (
 
 var bundleMagic = [4]byte{'L', 'G', 'B', 'X'}
 var bundleMagicV2 = [4]byte{'L', 'G', 'B', '2'}
+var bundleMagicV3 = [4]byte{'L', 'G', 'B', '3'}
 
 // bundleKind classifies a standalone binary's appended trailer.
 type bundleKind int
@@ -37,11 +41,14 @@ const (
 	bundleNone   bundleKind = iota // no recognized trailer (a plain, non-bundled binary)
 	bundleLegacy                   // 12-byte 'LGBX' trailer (lgb only)
 	bundleV2                       // 20-byte 'LGB2' trailer (lgb + resource archive)
+	bundleV3                       // 28-byte 'LGB3' trailer (lgb + resource archive + store id)
 )
 
 // trailerLen returns the on-disk size of the trailer for this kind.
 func (k bundleKind) trailerLen() int64 {
 	switch k {
+	case bundleV3:
+		return 28
 	case bundleV2:
 		return 20
 	case bundleLegacy:
@@ -57,68 +64,84 @@ func (k bundleKind) trailerLen() int64 {
 // binary). For a recognized trailer it validates that the claimed payload fits
 // within the file and returns a "corrupt bundle" error otherwise — so callers
 // never seek to a bogus offset or allocate a garbage-sized slice.
-func parseBundleTrailer(f *os.File) (kind bundleKind, lgbSize, resSize uint64, err error) {
+func parseBundleTrailer(f *os.File) (kind bundleKind, lgbSize, resSize, idSize uint64, err error) {
 	fi, err := f.Stat()
 	if err != nil {
-		return bundleNone, 0, 0, err
+		return bundleNone, 0, 0, 0, err
 	}
 	total := fi.Size()
 	if total < bundleLegacy.trailerLen() {
-		return bundleNone, 0, 0, nil
+		return bundleNone, 0, 0, 0, nil
 	}
 
 	// Discriminate by the trailing 4-byte magic.
 	if _, err := f.Seek(-4, io.SeekEnd); err != nil {
-		return bundleNone, 0, 0, err
+		return bundleNone, 0, 0, 0, err
 	}
 	var magic [4]byte
 	if _, err := io.ReadFull(f, magic[:]); err != nil {
-		return bundleNone, 0, 0, err
+		return bundleNone, 0, 0, 0, err
 	}
 
 	switch magic {
+	case bundleMagicV3:
+		if total < bundleV3.trailerLen() {
+			return bundleNone, 0, 0, 0, nil
+		}
+		if _, err := f.Seek(-bundleV3.trailerLen(), io.SeekEnd); err != nil {
+			return bundleNone, 0, 0, 0, err
+		}
+		var tr [28]byte
+		if _, err := io.ReadFull(f, tr[:]); err != nil {
+			return bundleNone, 0, 0, 0, err
+		}
+		kind = bundleV3
+		lgbSize = binary.LittleEndian.Uint64(tr[0:8])
+		resSize = binary.LittleEndian.Uint64(tr[8:16])
+		idSize = binary.LittleEndian.Uint64(tr[16:24])
 	case bundleMagicV2:
 		if total < bundleV2.trailerLen() {
-			return bundleNone, 0, 0, nil
+			return bundleNone, 0, 0, 0, nil
 		}
 		if _, err := f.Seek(-bundleV2.trailerLen(), io.SeekEnd); err != nil {
-			return bundleNone, 0, 0, err
+			return bundleNone, 0, 0, 0, err
 		}
 		var tr [20]byte
 		if _, err := io.ReadFull(f, tr[:]); err != nil {
-			return bundleNone, 0, 0, err
+			return bundleNone, 0, 0, 0, err
 		}
 		kind = bundleV2
 		lgbSize = binary.LittleEndian.Uint64(tr[0:8])
 		resSize = binary.LittleEndian.Uint64(tr[8:16])
 	case bundleMagic:
 		if _, err := f.Seek(-bundleLegacy.trailerLen(), io.SeekEnd); err != nil {
-			return bundleNone, 0, 0, err
+			return bundleNone, 0, 0, 0, err
 		}
 		var tr [12]byte
 		if _, err := io.ReadFull(f, tr[:]); err != nil {
-			return bundleNone, 0, 0, err
+			return bundleNone, 0, 0, 0, err
 		}
 		kind = bundleLegacy
 		lgbSize = binary.LittleEndian.Uint64(tr[0:8])
 	default:
-		return bundleNone, 0, 0, nil
+		return bundleNone, 0, 0, 0, nil
 	}
 
 	// Size guard: the claimed payload plus trailer must fit within the file.
 	// A crafted size that fails this can no longer reach a make([]byte, lgbSize)
 	// or a negative seek offset.
-	if !payloadFitsFile(lgbSize, resSize, kind.trailerLen(), total) {
-		return bundleNone, 0, 0, fmt.Errorf("corrupt bundle: payload size exceeds file size")
+	if !payloadFitsFile(lgbSize, resSize, idSize, kind.trailerLen(), total) {
+		return bundleNone, 0, 0, 0, fmt.Errorf("corrupt bundle: payload size exceeds file size")
 	}
-	return kind, lgbSize, resSize, nil
+	return kind, lgbSize, resSize, idSize, nil
 }
 
-// payloadFitsFile reports whether a payload of lgbSize + resSize bytes plus a
-// trailerLen-byte trailer fits within a total-byte file. It subtracts step by
-// step instead of summing, so the test can't overflow uint64 even on a huge
-// (e.g. sparse) file where the individual sizes are valid but their sum wraps.
-func payloadFitsFile(lgbSize, resSize uint64, trailerLen, total int64) bool {
+// payloadFitsFile reports whether a payload of lgbSize + resSize + idSize bytes
+// plus a trailerLen-byte trailer fits within a total-byte file. It subtracts
+// step by step instead of summing, so the test can't overflow uint64 even on a
+// huge (e.g. sparse) file where the individual sizes are valid but their sum
+// wraps.
+func payloadFitsFile(lgbSize, resSize, idSize uint64, trailerLen, total int64) bool {
 	if total < 0 || trailerLen < 0 {
 		return false
 	}
@@ -131,48 +154,60 @@ func payloadFitsFile(lgbSize, resSize uint64, trailerLen, total int64) bool {
 		return false
 	}
 	avail -= resSize
+	if idSize > avail {
+		return false
+	}
+	avail -= idSize
 	return uint64(trailerLen) <= avail
 }
 
 // ReadBundled extracts the appended payload from the file at path. It
-// recognizes both the v2 (resource-carrying) trailer and the legacy trailer;
-// res is nil for legacy bundles. Returns nil, nil for a non-bundle or corrupt
-// file.
-func ReadBundled(path string) (lgb []byte, res []byte) {
+// recognizes the v3 (store-id-carrying), v2 (resource-carrying), and legacy
+// trailers; res is nil for legacy bundles and storeID is "" for any bundle
+// built before v3. Returns nil, nil, "" for a non-bundle or corrupt file.
+func ReadBundled(path string) (lgb []byte, res []byte, storeID string) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, nil
+		return nil, nil, ""
 	}
 	defer f.Close()
 
-	kind, lgbSize, resSize, err := parseBundleTrailer(f)
+	kind, lgbSize, resSize, idSize, err := parseBundleTrailer(f)
 	if err != nil || kind == bundleNone {
-		return nil, nil // not a bundle, or a corrupt one — behave as no payload
+		return nil, nil, "" // not a bundle, or a corrupt one — behave as no payload
 	}
 
-	// Payload layout: [lgb][resArc][trailer]. Sizes are validated to fit the
-	// file, so the seek offset is a valid negative and make() can't overrun.
-	if _, err := f.Seek(-kind.trailerLen()-int64(resSize)-int64(lgbSize), io.SeekEnd); err != nil {
-		return nil, nil
+	// Payload layout: [lgb][resArc][storeID][trailer]. Sizes are validated to
+	// fit the file, so the seek offset is a valid negative and make() can't
+	// overrun.
+	if _, err := f.Seek(-kind.trailerLen()-int64(idSize)-int64(resSize)-int64(lgbSize), io.SeekEnd); err != nil {
+		return nil, nil, ""
 	}
 	lgb = make([]byte, lgbSize)
 	if _, err := io.ReadFull(f, lgb); err != nil {
-		return nil, nil
+		return nil, nil, ""
 	}
 	if resSize > 0 {
 		res = make([]byte, resSize)
 		if _, err := io.ReadFull(f, res); err != nil {
-			return nil, nil
+			return nil, nil, ""
 		}
 	}
-	return lgb, res
+	if idSize > 0 {
+		idBytes := make([]byte, idSize)
+		if _, err := io.ReadFull(f, idBytes); err != nil {
+			return nil, nil, ""
+		}
+		storeID = string(idBytes)
+	}
+	return lgb, res, storeID
 }
 
 // BaseBinarySize returns the size of the lg binary without any appended bundle,
 // so re-bundling can strip an existing payload. A corrupt trailer surfaces as
 // an error rather than a silently wrong size.
 func BaseBinarySize(f *os.File) (int64, error) {
-	kind, lgbSize, resSize, err := parseBundleTrailer(f)
+	kind, lgbSize, resSize, idSize, err := parseBundleTrailer(f)
 	if err != nil {
 		return 0, err
 	}
@@ -185,23 +220,41 @@ func BaseBinarySize(f *os.File) (int64, error) {
 		return total, nil
 	}
 	// Sizes are validated to fit the file, so this can't go negative.
-	return total - int64(lgbSize) - int64(resSize) - kind.trailerLen(), nil
+	return total - int64(lgbSize) - int64(resSize) - int64(idSize) - kind.trailerLen(), nil
 }
 
 // AppendTrailer writes the bundle payload to out: the lgb bytes, an optional
-// resource archive, and the appropriate trailer. When resArc is non-empty it
-// emits the v2 trailer; otherwise the byte-identical legacy trailer. This is the
-// only writer of the trailer format (parseBundleTrailer is the only reader).
-func AppendTrailer(out io.Writer, lgbData, resArc []byte) error {
+// resource archive, an optional baked storage store id, and the matching
+// trailer. A non-empty storeID emits the v3 trailer (resArc still optional); a
+// resource archive with no id emits v2; otherwise the byte-identical legacy
+// trailer. This is the only writer of the trailer format (parseBundleTrailer is
+// the only reader).
+func AppendTrailer(out io.Writer, lgbData, resArc []byte, storeID string) error {
 	if _, err := out.Write(lgbData); err != nil {
 		return err
 	}
 
-	// Embed the resource archive (if any) between the lgb and the trailer.
+	// Embed the resource archive (if any) between the lgb and the store id.
 	if len(resArc) > 0 {
 		if _, err := out.Write(resArc); err != nil {
 			return err
 		}
+	}
+
+	switch {
+	case storeID != "":
+		// v3 trailer: [store id][8-byte lgbSize][8-byte resSize][8-byte idSize][4-byte 'LGB3']
+		if _, err := io.WriteString(out, storeID); err != nil {
+			return err
+		}
+		var tr [28]byte
+		binary.LittleEndian.PutUint64(tr[0:8], uint64(len(lgbData)))
+		binary.LittleEndian.PutUint64(tr[8:16], uint64(len(resArc)))
+		binary.LittleEndian.PutUint64(tr[16:24], uint64(len(storeID)))
+		copy(tr[24:], bundleMagicV3[:])
+		_, err := out.Write(tr[:])
+		return err
+	case len(resArc) > 0:
 		// v2 trailer: [8-byte lgbSize][8-byte resSize][4-byte 'LGB2']
 		var tr [20]byte
 		binary.LittleEndian.PutUint64(tr[0:8], uint64(len(lgbData)))
@@ -209,14 +262,14 @@ func AppendTrailer(out io.Writer, lgbData, resArc []byte) error {
 		copy(tr[16:], bundleMagicV2[:])
 		_, err := out.Write(tr[:])
 		return err
+	default:
+		// No resources, no id: legacy trailer [8-byte lgbSize][4-byte 'LGBX'].
+		var footer [12]byte
+		binary.LittleEndian.PutUint64(footer[:8], uint64(len(lgbData)))
+		copy(footer[8:], bundleMagic[:])
+		_, err := out.Write(footer[:])
+		return err
 	}
-
-	// No resources: legacy trailer [8-byte lgbSize][4-byte 'LGBX'].
-	var footer [12]byte
-	binary.LittleEndian.PutUint64(footer[:8], uint64(len(lgbData)))
-	copy(footer[8:], bundleMagic[:])
-	_, err := out.Write(footer[:])
-	return err
 }
 
 // CollectResources returns a map of slash-relative path → file bytes for every

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -12,11 +12,12 @@ import (
 	"testing"
 )
 
-func writeTrailerFile(t *testing.T, base, lgb, res []byte, kind string, lgbSizeField, resSizeField uint64) string {
+func writeTrailerFile(t *testing.T, base, lgb, res, id []byte, kind string, lgbSizeField, resSizeField, idSizeField uint64) string {
 	t.Helper()
 	buf := append([]byte{}, base...)
 	buf = append(buf, lgb...)
 	buf = append(buf, res...)
+	buf = append(buf, id...)
 	switch kind {
 	case "lgbx":
 		var tr [12]byte
@@ -28,6 +29,13 @@ func writeTrailerFile(t *testing.T, base, lgb, res []byte, kind string, lgbSizeF
 		binary.LittleEndian.PutUint64(tr[0:8], lgbSizeField)
 		binary.LittleEndian.PutUint64(tr[8:16], resSizeField)
 		copy(tr[16:], bundleMagicV2[:])
+		buf = append(buf, tr[:]...)
+	case "lgb3":
+		var tr [28]byte
+		binary.LittleEndian.PutUint64(tr[0:8], lgbSizeField)
+		binary.LittleEndian.PutUint64(tr[8:16], resSizeField)
+		binary.LittleEndian.PutUint64(tr[16:24], idSizeField)
+		copy(tr[24:], bundleMagicV3[:])
 		buf = append(buf, tr[:]...)
 	case "none":
 		// no trailer
@@ -53,21 +61,23 @@ func TestPayloadFitsFile(t *testing.T) {
 	const maxI64 = int64(^uint64(0) >> 1) // math.MaxInt64
 	cases := []struct {
 		name           string
-		lgb, res       uint64
+		lgb, res, id   uint64
 		trailer, total int64
 		want           bool
 	}{
-		{"legacy fits", 7, 0, 12, 30, true},
-		{"v2 fits exactly", 3, 6, 20, 29, true},
-		{"lgb exceeds file", 30, 0, 12, 30, false},
-		{"huge lgb", 0xFFFFFFFFFFFFFFFF, 0, 20, 30, false},
-		// Each size <= total, but lgb+res+trailer would overflow uint64 if summed.
-		{"sum overflows uint64", uint64(maxI64), uint64(maxI64), 20, maxI64, false},
+		{"legacy fits", 7, 0, 0, 12, 30, true},
+		{"v2 fits exactly", 3, 6, 0, 20, 29, true},
+		{"v3 fits exactly", 3, 6, 4, 28, 41, true},
+		{"v3 id exceeds remainder", 3, 6, 5, 28, 41, false},
+		{"lgb exceeds file", 30, 0, 0, 12, 30, false},
+		{"huge lgb", 0xFFFFFFFFFFFFFFFF, 0, 0, 20, 30, false},
+		// Each size <= total, but lgb+res+id+trailer would overflow uint64 if summed.
+		{"sum overflows uint64", uint64(maxI64), uint64(maxI64), uint64(maxI64), 28, maxI64, false},
 	}
 	for _, c := range cases {
-		if got := payloadFitsFile(c.lgb, c.res, c.trailer, c.total); got != c.want {
-			t.Errorf("%s: payloadFitsFile(%d,%d,%d,%d) = %v, want %v",
-				c.name, c.lgb, c.res, c.trailer, c.total, got, c.want)
+		if got := payloadFitsFile(c.lgb, c.res, c.id, c.trailer, c.total); got != c.want {
+			t.Errorf("%s: payloadFitsFile(%d,%d,%d,%d,%d) = %v, want %v",
+				c.name, c.lgb, c.res, c.id, c.trailer, c.total, got, c.want)
 		}
 	}
 }
@@ -77,10 +87,10 @@ func TestParseBundleTrailer(t *testing.T) {
 
 	t.Run("valid LGBX", func(t *testing.T) {
 		lgb := []byte("LGBDATA")
-		p := writeTrailerFile(t, base, lgb, nil, "lgbx", uint64(len(lgb)), 0)
-		gotLgb, gotRes := ReadBundled(p)
-		if string(gotLgb) != "LGBDATA" || gotRes != nil {
-			t.Fatalf("ReadBundled = (%q, %v), want (LGBDATA, nil)", gotLgb, gotRes)
+		p := writeTrailerFile(t, base, lgb, nil, nil, "lgbx", uint64(len(lgb)), 0, 0)
+		gotLgb, gotRes, gotID := ReadBundled(p)
+		if string(gotLgb) != "LGBDATA" || gotRes != nil || gotID != "" {
+			t.Fatalf("ReadBundled = (%q, %v, %q), want (LGBDATA, nil, \"\")", gotLgb, gotRes, gotID)
 		}
 		if bs, err := baseSize(t, p); err != nil || bs != int64(len(base)) {
 			t.Fatalf("BaseBinarySize = (%d, %v), want (%d, nil)", bs, err, len(base))
@@ -90,21 +100,45 @@ func TestParseBundleTrailer(t *testing.T) {
 	t.Run("valid LGB2", func(t *testing.T) {
 		lgb := []byte("LGB")
 		res := []byte("RESARC")
-		p := writeTrailerFile(t, base, lgb, res, "lgb2", uint64(len(lgb)), uint64(len(res)))
-		gotLgb, gotRes := ReadBundled(p)
-		if string(gotLgb) != "LGB" || string(gotRes) != "RESARC" {
-			t.Fatalf("ReadBundled = (%q, %q), want (LGB, RESARC)", gotLgb, gotRes)
+		p := writeTrailerFile(t, base, lgb, res, nil, "lgb2", uint64(len(lgb)), uint64(len(res)), 0)
+		gotLgb, gotRes, gotID := ReadBundled(p)
+		if string(gotLgb) != "LGB" || string(gotRes) != "RESARC" || gotID != "" {
+			t.Fatalf("ReadBundled = (%q, %q, %q), want (LGB, RESARC, \"\")", gotLgb, gotRes, gotID)
 		}
 		if bs, err := baseSize(t, p); err != nil || bs != int64(len(base)) {
 			t.Fatalf("BaseBinarySize = (%d, %v), want (%d, nil)", bs, err, len(base))
 		}
 	})
 
+	t.Run("valid LGB3 with resources", func(t *testing.T) {
+		lgb := []byte("LGB")
+		res := []byte("RESARC")
+		id := []byte("my-app")
+		p := writeTrailerFile(t, base, lgb, res, id, "lgb3", uint64(len(lgb)), uint64(len(res)), uint64(len(id)))
+		gotLgb, gotRes, gotID := ReadBundled(p)
+		if string(gotLgb) != "LGB" || string(gotRes) != "RESARC" || gotID != "my-app" {
+			t.Fatalf("ReadBundled = (%q, %q, %q), want (LGB, RESARC, my-app)", gotLgb, gotRes, gotID)
+		}
+		if bs, err := baseSize(t, p); err != nil || bs != int64(len(base)) {
+			t.Fatalf("BaseBinarySize = (%d, %v), want (%d, nil)", bs, err, len(base))
+		}
+	})
+
+	t.Run("valid LGB3 without resources", func(t *testing.T) {
+		lgb := []byte("LGBDATA")
+		id := []byte("solo")
+		p := writeTrailerFile(t, base, lgb, nil, id, "lgb3", uint64(len(lgb)), 0, uint64(len(id)))
+		gotLgb, gotRes, gotID := ReadBundled(p)
+		if string(gotLgb) != "LGBDATA" || gotRes != nil || gotID != "solo" {
+			t.Fatalf("ReadBundled = (%q, %v, %q), want (LGBDATA, nil, solo)", gotLgb, gotRes, gotID)
+		}
+	})
+
 	t.Run("corrupt huge lgbSize does not panic", func(t *testing.T) {
 		lgb := []byte("x")
 		// lgbSize field claims a size far larger than the file.
-		p := writeTrailerFile(t, base, lgb, nil, "lgb2", 0xFFFFFFFFFFFFFFFF, 0)
-		gotLgb, gotRes := ReadBundled(p)
+		p := writeTrailerFile(t, base, lgb, nil, nil, "lgb2", 0xFFFFFFFFFFFFFFFF, 0, 0)
+		gotLgb, gotRes, _ := ReadBundled(p)
 		if gotLgb != nil || gotRes != nil {
 			t.Fatalf("ReadBundled on corrupt trailer = (%q, %q), want (nil, nil)", gotLgb, gotRes)
 		}
@@ -113,10 +147,24 @@ func TestParseBundleTrailer(t *testing.T) {
 		}
 	})
 
+	t.Run("corrupt huge idSize does not panic", func(t *testing.T) {
+		lgb := []byte("x")
+		id := []byte("y")
+		// idSize field claims a size far larger than the file.
+		p := writeTrailerFile(t, base, lgb, nil, id, "lgb3", uint64(len(lgb)), 0, 0xFFFFFFFFFFFFFFFF)
+		gotLgb, _, gotID := ReadBundled(p)
+		if gotLgb != nil || gotID != "" {
+			t.Fatalf("ReadBundled on corrupt v3 trailer = (%q, %q), want (nil, \"\")", gotLgb, gotID)
+		}
+		if _, err := baseSize(t, p); err == nil {
+			t.Fatalf("BaseBinarySize on corrupt v3 trailer: expected error, got nil")
+		}
+	})
+
 	t.Run("non-bundle file", func(t *testing.T) {
 		junk := []byte("just some random bytes, definitely not a bundle trailer!!")
-		p := writeTrailerFile(t, junk, nil, nil, "none", 0, 0)
-		gotLgb, _ := ReadBundled(p)
+		p := writeTrailerFile(t, junk, nil, nil, nil, "none", 0, 0, 0)
+		gotLgb, _, _ := ReadBundled(p)
 		if gotLgb != nil {
 			t.Fatalf("ReadBundled on non-bundle = %q, want nil", gotLgb)
 		}


### PR DESCRIPTION
## Summary

Follow-up to #315. Native bundles derived their storage store id at runtime from the executable basename, so two bundles both named `lg` shared one store, and renaming the binary moved a player's saves out from under them. The WASM build already bakes the id at build time from the source basename; this closes that asymmetry by baking it for native bundles too.

## Why a trailer change

A native bundle is built by copying the `lg` binary and appending a trailer — there's no recompile step, unlike the WASM path which generates and compiles a fresh `main.go` and can inject a build-time constant. So the appended trailer is the only channel from build to runtime, and carrying a baked id means a new trailer variant.

I ruled out the two cheaper-looking alternatives: a build-time Go constant is impossible without a recompile, and deriving the id from the program content (a hash of the bytecode) would orphan every save on any code change, which breaks the "saves survive app updates" expectation. A baked source basename is both stable across updates and distinct per app.

## What changed

A v3 (`LGB3`) trailer variant:

```
v3: [lgb][resArc][store id][8:lgbSize][8:resSize][8:idSize][4:'LGB3']
```

- A non-empty id selects v3; the resource archive stays optional. A resource-only bundle still writes v2, and an id-less, resource-less bundle keeps the byte-identical legacy trailer.
- Readers recognize all three formats, so bundles built before this read back unchanged with an empty id — at which point the runtime keeps the old exe-basename behavior.
- `bundleBinary` bakes `storageIDForScript(src)` — an explicit `-storage-id`, else the source basename. At startup a bundle prefers the baked id over the exe fallback.
- The payload-fits-file overflow guard subtracts the third size step by step like the existing two, so a crafted `idSize` can't wrap the sum or drive a bad seek or allocation.

## Validation

- `go test ./...`, `go vet ./...`, gofmt clean; linux, js/wasm, and plan9 builds; the generated-artifacts check.
- New `pkg/bundle` tests: v3 round-trip with and without resources, a corrupt-`idSize` guard, and v3 `payloadFitsFile` cases.
- End to end: bundled a `coolgame.lg`, renamed the binary to `lg`, ran it from an unrelated directory — the store keyed by `coolgame` (the baked id) rather than `lg` or the working directory.

Behavior for bundles that set neither `-storage-id` nor carry a v3 trailer is unchanged.
