### PR TITLE
perf(lgbgen): default GOGC=800 for the alloc-heavy lowering run

### DIFF
--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"runtime/pprof"
 	"sort"
 	"strings"
@@ -296,6 +297,16 @@ func sortStrings(s []string) {
 }
 
 func main() {
+	// lgbgen is a short-lived batch tool that allocates heavily (the interpreted
+	// lowering churns ~14GB of transient persistent structures), so the default
+	// GOGC=100 spends ~40-50% of the run in GC for a small live set. Raising it
+	// to 800 cut a --target=go run from min 31s to 27s (~13%, min-of-3) with
+	// negligible peak-memory cost (~hundreds of MB). Honor an explicit GOGC env
+	// so callers can tune or disable it; GC percentage never affects output.
+	if os.Getenv("GOGC") == "" {
+		debug.SetGCPercent(800)
+	}
+
 	// Parse mode: --target=go <out-dir>, --target=both [bundle-path], or
 	// default bytecode mode. `both` emits the .lgb bundle AND the gogen_ir
 	// Go tree from a single core compile (see the dispatch below). Optional

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-fc0c448d8d572fd5ab42aec6905c98962d25e01f2dc1f744df7ed8882b15b483
+f5a288bf519b1836cde0f9b69ea8912e08be1db427ac27fb2fb214b1bf2ecf93


### PR DESCRIPTION
## What
lgbgen defaults `GOGC=800` (via `debug.SetGCPercent`) at startup, honoring an explicit `GOGC` env override.

## Why
The interpreted lowering churns ~14GB of transient persistent structures per `--target=go` run, so the default `GOGC=100` spends ~40-50% of the run in GC for a small live set (confirmed via cpu+mem profiling). Raising GOGC trades a few hundred MB of peak RSS for fewer GC cycles.

## Measured
`--target=go` run, min-of-3 (contention-controlled):
- GOGC=100: 31s
- GOGC=800: 27s  (**~13% faster**)

`GOGC=off` is counterproductive (the unreclaimed heap causes OS paging — `runtime.madvise` in the profile), so 800 is the sweet spot.

Output is byte-identical (GC percentage never affects generated code); `check-generated` green. `generated.sums` updated for the lgbgen source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)