### PR TITLE
feat(docs): docs-status report for the judgement layer

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -232,7 +232,12 @@ jobs:
             echo "No docs/**/*.md changed in this PR; skipping docs-status report."
             exit 0
           fi
-          report=$(python3 scripts/docs_status.py || true)
+          # Capture the exit code without failing the step (the report is
+          # non-blocking). rc is non-zero when a doc is unreadable/malformed.
+          set +e
+          report=$(python3 scripts/docs_status.py)
+          rc=$?
+          set -e
           headline=$(printf '%s\n' "$report" | head -1)
           {
             echo '## docs-status report'
@@ -245,10 +250,11 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           # Surface the headline as an annotation + log line so the result is
-          # legible from the PR without opening the run summary: a notice when
-          # clean, a (non-blocking) warning when there's anything to look at.
+          # legible from the PR without opening the run summary. "Clean" requires
+          # both a clean exit (no read/parse errors) and zero findings — an
+          # errors-only run still prints "0 findings", so the headline alone lies.
           echo "$headline"
-          if printf '%s' "$headline" | grep -q ' 0 findings'; then
+          if [ "$rc" -eq 0 ] && printf '%s' "$headline" | grep -q ' 0 findings'; then
             echo "::notice title=docs-status::${headline} — clean"
           else
             echo "::warning title=docs-status::${headline} — see the run summary"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -208,6 +208,52 @@ jobs:
           echo "$changed"
           echo "$changed" | xargs python3 scripts/docs_frontmatter_hook.py --check
 
+  # Non-blocking judgement-layer report on docs PRs. Unlike docs-frontmatter
+  # (a per-file floor gate), this runs scripts/docs_status.py over the WHOLE
+  # docs/ tree — the supersession / authoritative-for / index checks are
+  # cross-doc and need the full corpus — and writes the result to the run's
+  # step summary plus a one-line annotation. It never fails the build:
+  # staleness and the judgement fields are reviewer signals, not gates.
+  # See docs/docs-status.md.
+  docs-status:
+    name: docs-status (report)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Report docs-status when this PR touches docs
+        run: |
+          git fetch --no-tags --depth=50 origin "${GITHUB_BASE_REF}"
+          changed=$(git diff --name-only --diff-filter=AM \
+            "origin/${GITHUB_BASE_REF}...HEAD" -- ':(glob)docs/**/*.md' || true)
+          if [ -z "$changed" ]; then
+            echo "No docs/**/*.md changed in this PR; skipping docs-status report."
+            exit 0
+          fi
+          report=$(python3 scripts/docs_status.py || true)
+          headline=$(printf '%s\n' "$report" | head -1)
+          {
+            echo '## docs-status report'
+            echo
+            echo 'Read-only judgement-layer scan over the whole `docs/` tree.'
+            echo 'Non-blocking — reviewer signals, not gate failures. See `docs/docs-status.md`.'
+            echo
+            echo '```'
+            echo "$report"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Surface the headline as an annotation + log line so the result is
+          # legible from the PR without opening the run summary: a notice when
+          # clean, a (non-blocking) warning when there's anything to look at.
+          echo "$headline"
+          if printf '%s' "$headline" | grep -q ' 0 findings'; then
+            echo "::notice title=docs-status::${headline} — clean"
+          else
+            echo "::warning title=docs-status::${headline} — see the run summary"
+          fi
+
   # Bootstrap-parity gate (deferred — runs as 'make parity-full' locally).
   # Until parity-full is wired as a CI job, `make check-generated` protects
   # the artifacts parity-full depends on.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,9 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | Real-world Clojure compat findings | `xsofy-portability-gaps.md` |
 | Clojure-test-suite (jank) workflow | `clojure-test-suite.md` |
 | Testing strategy, conformance | `testing-and-conformance.md` |
+| Docs frontmatter convention + maintenance hook | `frontmatter-hook.md` |
+| Docs judgement-layer report (stale/supersession/index) | `docs-status.md` |
+| Regenerating generated artifacts after `.lg` edits | `regenerating-generated-artifacts.md` |
 | Perf ratchet, regression checkpoints, historical baselines | `perf/ratchet.md` |
 | Babashka pods (usage) | `guide/pods.md` |
 | Babashka pods (host protocol / design) | `design/pods.md` |
@@ -58,6 +61,7 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | IR fixup / link pass | `design/els2023-ir-fixup-audit.md` |
 | Parallel IR lowering + determinism | `design/parallel-lowering-and-type-cache.md` |
 | Runtime I/O, host decoupling | `design/runtime-io-host-decoupling.md` |
+| Off-goroutine execution context threading | `design/exec-context-threading.md` |
 
 ## Reading order if starting cold
 

--- a/docs/docs-status.md
+++ b/docs/docs-status.md
@@ -37,6 +37,10 @@ from the repo root (defaults to scanning `docs/`); override with
 - **aged-human-verified** — `human-verified:` is present but older than
   `--human-stale-days` (default 365). A human vouched once, but long
   enough ago that the attestation is worth refreshing.
+- **invalid date values** — `last-verified:` or `human-verified:` is
+  present but not a valid `YYYY-MM-DD`. A typo'd date is surfaced rather
+  than silently ignored — the floor check only verifies the key exists,
+  not that the value parses.
 - **supersession** — a `superseded-by:` / `supersedes:` link that
   dangles (target file not found, or an ambiguous basename), or that the
   other doc doesn't mirror, or a `status: superseded` doc with no

--- a/docs/docs-status.md
+++ b/docs/docs-status.md
@@ -1,0 +1,75 @@
+---
+status: active
+last-verified: 2026-06-25
+authoritative-for:
+  - docs-status-report
+human-verified:
+---
+
+# docs-status — the judgement-layer report
+
+[`scripts/docs_status.py`](../scripts/docs_status.py) is a read-only
+report over `docs/**/*.md` frontmatter. It is the driver named as a
+follow-up in [`frontmatter-hook.md`](frontmatter-hook.md): the
+pre-commit hook and CI floor check keep the *mechanical* fields honest;
+this tool surfaces the *judgement* layer they deliberately leave to a
+human or agent.
+
+It never mutates anything. It reports; you apply judgement.
+
+## Running it
+
+```
+python3 scripts/docs_status.py            # text report over docs/
+python3 scripts/docs_status.py --stale-days 90 --human-stale-days 180
+```
+
+Stdlib-only Python, like the hook — no dependency to install. Run it
+from the repo root (defaults to scanning `docs/`); override with
+`--root`.
+
+## What it checks
+
+- **stale-last-verified** — `last-verified:` older than `--stale-days`
+  (default 180). The mechanical hook bumps this on every commit that
+  touches a doc, so a stale value means the doc hasn't been edited in a
+  while — a prompt to re-read it, not an error.
+- **aged-human-verified** — `human-verified:` is present but older than
+  `--human-stale-days` (default 365). A human vouched once, but long
+  enough ago that the attestation is worth refreshing.
+- **supersession** — a `superseded-by:` / `supersedes:` link that
+  dangles (target file not found, or an ambiguous basename), or that the
+  other doc doesn't mirror, or a `status: superseded` doc with no
+  `superseded-by:` link. Supersession is supposed to be stated in both
+  directions; this catches the half-done ones.
+- **authoritative-for clashes** — the same topic slug claimed by more
+  than one doc. Two docs can't both be *the* authority on a topic; one
+  should yield or the topic should be split.
+- **missing from README index** — a tracked doc whose filename never
+  appears in [`README.md`](README.md). The index is how readers are
+  routed; a doc absent from it is effectively unfindable.
+
+`human-verified:` being **blank** (never vouched) is reported only as a
+summary count, never per-doc. That field is set *only* by explicit human
+action — the tool will never write it, and neither should any other
+automation. See [`frontmatter-hook.md`](frontmatter-hook.md#the-humanagent-asymmetry).
+
+## How to use the output
+
+The tool is a checklist, not a gate. It exits 0 even with findings (only
+an unreadable or malformed doc exits non-zero), so it never blocks a
+workflow on its own.
+
+CI runs it as a **non-blocking report**: the `docs-status` job in
+[`.github/workflows/go.yml`](../.github/workflows/go.yml) runs on any PR
+that touches `docs/`, scans the whole tree, and writes the findings to
+the run's step summary plus a one-line annotation (a notice when clean, a
+warning otherwise). It never fails the build. The blocking gate is the
+separate `docs-frontmatter` floor check (frontmatter present and
+parseable); staleness and the judgement fields are reviewer signals, not
+blockers. A doc can sit stale across dates and still be correct.
+
+For an agent contributor: run it, read the findings, and propose the
+fixes (mirror a supersession link, add a README row, split a clashing
+`authoritative-for:`). Apply the freshness and `status:` judgement the
+same way a human would — and never touch `human-verified:`.

--- a/docs/frontmatter-hook.md
+++ b/docs/frontmatter-hook.md
@@ -126,6 +126,9 @@ pass. Staleness is a signal for readers (via `last-verified:` and
 - **Tombstone-on-delete** — when a doc is removed, appending a
   pointer to `docs/archived_files.md` with the SHA of the last
   containing commit. Tracked separately.
-- **`docs-status` CLI / agent skill** — a report tool surfacing stale
-  docs, contradictions, missing `authoritative-for:` claims, and
-  similar judgement-level concerns. Tracked separately.
+- **`docs-status` CLI** — **shipped.** A read-only report over the
+  judgement-layer fields (stale `last-verified:`, aged `human-verified:`,
+  dangling/asymmetric supersession links, clashing `authoritative-for:`
+  claims, docs missing from the README index). See
+  [`docs-status.md`](docs-status.md) and
+  [`scripts/docs_status.py`](../scripts/docs_status.py).

--- a/scripts/docs_status.py
+++ b/scripts/docs_status.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+docs-status: a read-only report over docs/**/*.md frontmatter.
+
+The pre-commit hook (scripts/docs_frontmatter_hook.py) and the CI floor
+check keep the *mechanical* fields honest — frontmatter present, with a
+parseable `status:` and `last-verified:`. This tool reports on the
+*judgement* layer the hook deliberately won't touch: freshness drift,
+supersession links that don't agree with each other, two docs claiming
+authority on the same topic, and docs the README index never routes to.
+
+It never mutates anything. It is the "agent skill to drive it" follow-up
+named in docs/frontmatter-hook.md: an agent (or a human) runs it, reads
+the findings, and applies judgement — the tool does not decide for them.
+
+Findings, by category:
+
+  stale-last-verified   last-verified older than --stale-days.
+  aged-human-verified   human-verified present but older than
+                        --human-stale-days (a human vouched, but long ago).
+  supersession          superseded-by/supersedes that dangles (target not
+                        found) or isn't mirrored on the other doc; status
+                        that disagrees with the links.
+  authoritative-clash   the same topic slug claimed authoritative by >1 doc.
+  missing-index         a tracked doc the README index body never mentions.
+
+`human-verified:` blank (never vouched) is reported only as a summary
+count, not per-doc noise — see docs/frontmatter-hook.md for why that
+field is special. The tool never writes it; nothing should.
+
+Exit status: 0, or 2 if a file is unreadable or malformed (or --root is
+missing). Findings never fail it — this is a report, not a gate. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+TODAY = datetime.date.today()
+DELIM = "---"
+
+# A top-level frontmatter key: no leading whitespace, `name:` then rest of line.
+KEY_RE = re.compile(r"^([A-Za-z][\w-]*)\s*:\s?(.*)$")
+# Leading filename token in a supersedes/superseded-by entry like
+# "master-plan.md (on direction — ...)". The parenthetical is human prose.
+REF_FILE_RE = re.compile(r"^(\S+\.md)")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class MalformedFrontmatter(Exception):
+    pass
+
+
+@dataclass
+class Doc:
+    path: Path
+    rel: str
+    fields: dict  # key -> str | list[str]
+
+    def scalar(self, key: str) -> str | None:
+        v = self.fields.get(key)
+        return v if isinstance(v, str) else None
+
+    def seq(self, key: str) -> list[str]:
+        v = self.fields.get(key)
+        if isinstance(v, list):
+            return v
+        return [v] if isinstance(v, str) and v else []
+
+
+def split_frontmatter(text: str) -> list[str]:
+    """Return the frontmatter lines (between the delimiters), or raise/None."""
+    lines = text.split("\n")
+    if not lines or lines[0] != DELIM:
+        return []
+    for i in range(1, len(lines)):
+        if lines[i] == DELIM:
+            return lines[1:i]
+    raise MalformedFrontmatter("opening `---` present but no closing delimiter")
+
+
+def parse_frontmatter(block: list[str]) -> dict:
+    """
+    Minimal YAML-ish parse, enough for this convention's shapes:
+      key: scalar
+      key: [a, b]          (inline sequence)
+      key:                 (block sequence on following indented `- ` lines)
+        - item
+    Deeper nesting is ignored. Stdlib only — no yaml dependency.
+    """
+    out: dict = {}
+    i = 0
+    n = len(block)
+    while i < n:
+        line = block[i]
+        m = KEY_RE.match(line)
+        if not m:
+            i += 1
+            continue
+        key, rest = m.group(1), m.group(2).strip()
+        if rest.startswith("[") and rest.endswith("]"):
+            inner = rest[1:-1].strip()
+            out[key] = [s.strip() for s in inner.split(",") if s.strip()] if inner else []
+            i += 1
+            continue
+        if rest:
+            out[key] = rest
+            i += 1
+            continue
+        # Empty value: look ahead for an indented block sequence.
+        items: list[str] = []
+        j = i + 1
+        while j < n:
+            nxt = block[j]
+            if nxt.strip() == "":
+                j += 1
+                continue
+            if not nxt.startswith((" ", "\t")):
+                break
+            item = nxt.strip()
+            if item.startswith("- "):
+                items.append(item[2:].strip())
+            j += 1
+        out[key] = items if items else ""
+        i = j if items else i + 1
+    return out
+
+
+def parse_date(value: str | None) -> datetime.date | None:
+    if not value or not DATE_RE.match(value.strip()):
+        return None
+    try:
+        return datetime.date.fromisoformat(value.strip())
+    except ValueError:
+        return None
+
+
+def load_docs(root: Path) -> tuple[list[Doc], list[str]]:
+    docs: list[Doc] = []
+    errors: list[str] = []
+    for path in sorted(root.rglob("*.md")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        rel = str(path.relative_to(root.parent) if root.parent != path else path)
+        try:
+            block = split_frontmatter(path.read_text(encoding="utf-8-sig"))
+        except (OSError, UnicodeDecodeError) as e:
+            errors.append(f"{rel}: {e}")
+            continue
+        except MalformedFrontmatter as e:
+            errors.append(f"{rel}: {e}")
+            continue
+        if not block:
+            errors.append(f"{rel}: no frontmatter")
+            continue
+        docs.append(Doc(path=path, rel=rel, fields=parse_frontmatter(block)))
+    return docs, errors
+
+
+@dataclass
+class Report:
+    stale_last_verified: list[dict] = field(default_factory=list)
+    aged_human_verified: list[dict] = field(default_factory=list)
+    supersession: list[dict] = field(default_factory=list)
+    authoritative_clash: list[dict] = field(default_factory=list)
+    missing_index: list[dict] = field(default_factory=list)
+    never_human_verified: int = 0
+    total_docs: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def finding_count(self) -> int:
+        return sum(
+            len(x)
+            for x in (
+                self.stale_last_verified,
+                self.aged_human_verified,
+                self.supersession,
+                self.authoritative_clash,
+                self.missing_index,
+            )
+        )
+
+
+def first_token(ref: str) -> str:
+    m = REF_FILE_RE.match(ref.strip())
+    return m.group(1) if m else ref.strip()
+
+
+def analyze(docs: list[Doc], root: Path, stale_days: int, human_stale_days: int) -> Report:
+    rep = Report(total_docs=len(docs))
+    by_basename: dict[str, list[Doc]] = {}
+    for d in docs:
+        by_basename.setdefault(d.path.name, []).append(d)
+
+    # Freshness.
+    for d in docs:
+        lv = parse_date(d.scalar("last-verified"))
+        if lv is not None:
+            age = (TODAY - lv).days
+            if age > stale_days:
+                rep.stale_last_verified.append(
+                    {"doc": d.rel, "last_verified": lv.isoformat(), "age_days": age}
+                )
+        hv = parse_date(d.scalar("human-verified"))
+        if hv is None:
+            rep.never_human_verified += 1
+        else:
+            age = (TODAY - hv).days
+            if age > human_stale_days:
+                rep.aged_human_verified.append(
+                    {"doc": d.rel, "human_verified": hv.isoformat(), "age_days": age}
+                )
+
+    # Supersession integrity. Resolve refs by basename within the tree.
+    def resolve(ref: str, source: Doc) -> Doc | None:
+        name = first_token(ref)
+        cands = by_basename.get(name)
+        return cands[0] if cands and len(cands) == 1 else None
+
+    for d in docs:
+        status = (d.scalar("status") or "").strip()
+        sup_by = d.seq("superseded-by")
+        sup = d.seq("supersedes")
+        for ref in sup_by:
+            target = resolve(ref, d)
+            name = first_token(ref)
+            if target is None:
+                rep.supersession.append(
+                    {"doc": d.rel, "issue": f"superseded-by '{name}' not found (or ambiguous)"}
+                )
+                continue
+            mirror = {first_token(r) for r in target.seq("supersedes")}
+            if d.path.name not in mirror:
+                rep.supersession.append(
+                    {
+                        "doc": d.rel,
+                        "issue": f"superseded-by '{target.rel}', but it does not list this doc under supersedes:",
+                    }
+                )
+        for ref in sup:
+            target = resolve(ref, d)
+            name = first_token(ref)
+            if target is None:
+                rep.supersession.append(
+                    {"doc": d.rel, "issue": f"supersedes '{name}' not found (or ambiguous)"}
+                )
+                continue
+            mirror = {first_token(r) for r in target.seq("superseded-by")}
+            if d.path.name not in mirror:
+                rep.supersession.append(
+                    {
+                        "doc": d.rel,
+                        "issue": f"supersedes '{target.rel}', but it does not list this doc under superseded-by:",
+                    }
+                )
+        if status == "superseded" and not sup_by:
+            rep.supersession.append(
+                {"doc": d.rel, "issue": "status: superseded but no superseded-by: link"}
+            )
+
+    # Authoritative-for collisions: same topic claimed by >1 doc.
+    topic_owners: dict[str, list[str]] = {}
+    for d in docs:
+        for topic in d.seq("authoritative-for"):
+            topic_owners.setdefault(topic.strip(), []).append(d.rel)
+    for topic, owners in sorted(topic_owners.items()):
+        if len(owners) > 1:
+            rep.authoritative_clash.append({"topic": topic, "docs": sorted(owners)})
+
+    # Index coverage: docs whose filename never appears in README.md body.
+    readme = root / "README.md"
+    if readme.is_file():
+        body = readme.read_text(encoding="utf-8-sig")
+        for d in docs:
+            if d.path == readme:
+                continue
+            if d.path.name not in body:
+                rep.missing_index.append({"doc": d.rel})
+
+    return rep
+
+
+def render_text(rep: Report) -> str:
+    out: list[str] = [
+        f"docs-status: {rep.total_docs} docs scanned, {rep.finding_count()} findings",
+        "",
+    ]
+
+    def section(title: str, rows: list[str]) -> None:
+        if not rows:
+            return
+        out.append(f"## {title} ({len(rows)})")
+        out.extend(rows)
+        out.append("")
+    section(
+        "stale last-verified",
+        [f"  {r['doc']} — {r['last_verified']} ({r['age_days']}d)" for r in rep.stale_last_verified],
+    )
+    section(
+        "aged human-verified",
+        [f"  {r['doc']} — {r['human_verified']} ({r['age_days']}d)" for r in rep.aged_human_verified],
+    )
+    section("supersession", [f"  {r['doc']}: {r['issue']}" for r in rep.supersession])
+    section(
+        "authoritative-for clashes",
+        [f"  '{r['topic']}' claimed by: {', '.join(r['docs'])}" for r in rep.authoritative_clash],
+    )
+    section("missing from README index", [f"  {r['doc']}" for r in rep.missing_index])
+    out.append(
+        f"note: {rep.never_human_verified}/{rep.total_docs} docs have a blank human-verified "
+        "(never vouched by a human). This is informational — the field is set only by "
+        "explicit human action; do not stamp it."
+    )
+    if rep.errors:
+        out.append("")
+        out.append("## errors")
+        out.extend(f"  {e}" for e in rep.errors)
+    return "\n".join(out)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.add_argument("--root", default="docs", help="docs root to scan (default: docs)")
+    parser.add_argument("--stale-days", type=int, default=180)
+    parser.add_argument("--human-stale-days", type=int, default=365)
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"docs-status: root not found: {root}", file=sys.stderr)
+        return 2
+
+    docs, errors = load_docs(root)
+    rep = analyze(docs, root, args.stale_days, args.human_stale_days)
+    rep.errors = errors
+
+    print(render_text(rep))
+    return 2 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/docs_status.py
+++ b/scripts/docs_status.py
@@ -18,6 +18,8 @@ Findings, by category:
   stale-last-verified   last-verified older than --stale-days.
   aged-human-verified   human-verified present but older than
                         --human-stale-days (a human vouched, but long ago).
+  invalid-date          last-verified or human-verified present but not a
+                        valid YYYY-MM-DD (a typo'd date, not a missing one).
   supersession          superseded-by/supersedes that dangles (target not
                         found) or isn't mirrored on the other doc; status
                         that disagrees with the links.
@@ -166,6 +168,7 @@ def load_docs(root: Path) -> tuple[list[Doc], list[str]]:
 class Report:
     stale_last_verified: list[dict] = field(default_factory=list)
     aged_human_verified: list[dict] = field(default_factory=list)
+    invalid_date: list[dict] = field(default_factory=list)
     supersession: list[dict] = field(default_factory=list)
     authoritative_clash: list[dict] = field(default_factory=list)
     missing_index: list[dict] = field(default_factory=list)
@@ -179,6 +182,7 @@ class Report:
             for x in (
                 self.stale_last_verified,
                 self.aged_human_verified,
+                self.invalid_date,
                 self.supersession,
                 self.authoritative_clash,
                 self.missing_index,
@@ -197,24 +201,32 @@ def analyze(docs: list[Doc], root: Path, stale_days: int, human_stale_days: int)
     for d in docs:
         by_basename.setdefault(d.path.name, []).append(d)
 
-    # Freshness.
+    # Freshness. A present-but-unparseable date is a finding, not silently
+    # dropped (last-verified) or mis-bucketed as never-vouched (human-verified).
     for d in docs:
-        lv = parse_date(d.scalar("last-verified"))
-        if lv is not None:
-            age = (TODAY - lv).days
-            if age > stale_days:
-                rep.stale_last_verified.append(
-                    {"doc": d.rel, "last_verified": lv.isoformat(), "age_days": age}
-                )
-        hv = parse_date(d.scalar("human-verified"))
-        if hv is None:
+        lv_raw = d.scalar("last-verified")
+        lv = parse_date(lv_raw)
+        if lv is None and lv_raw and lv_raw.strip():
+            rep.invalid_date.append(
+                {"doc": d.rel, "field": "last-verified", "value": lv_raw.strip()}
+            )
+        elif lv is not None and (TODAY - lv).days > stale_days:
+            rep.stale_last_verified.append(
+                {"doc": d.rel, "last_verified": lv.isoformat(), "age_days": (TODAY - lv).days}
+            )
+
+        hv_raw = d.scalar("human-verified")
+        hv = parse_date(hv_raw)
+        if hv is None and hv_raw and hv_raw.strip():
+            rep.invalid_date.append(
+                {"doc": d.rel, "field": "human-verified", "value": hv_raw.strip()}
+            )
+        elif hv is None:
             rep.never_human_verified += 1
-        else:
-            age = (TODAY - hv).days
-            if age > human_stale_days:
-                rep.aged_human_verified.append(
-                    {"doc": d.rel, "human_verified": hv.isoformat(), "age_days": age}
-                )
+        elif (TODAY - hv).days > human_stale_days:
+            rep.aged_human_verified.append(
+                {"doc": d.rel, "human_verified": hv.isoformat(), "age_days": (TODAY - hv).days}
+            )
 
     # Supersession integrity. Resolve refs by basename within the tree.
     def resolve(ref: str, source: Doc) -> Doc | None:
@@ -286,10 +298,10 @@ def analyze(docs: list[Doc], root: Path, stale_days: int, human_stale_days: int)
 
 
 def render_text(rep: Report) -> str:
-    out: list[str] = [
-        f"docs-status: {rep.total_docs} docs scanned, {rep.finding_count()} findings",
-        "",
-    ]
+    summary = f"docs-status: {rep.total_docs} docs scanned, {rep.finding_count()} findings"
+    if rep.errors:
+        summary += f", {len(rep.errors)} errors"
+    out: list[str] = [summary, ""]
 
     def section(title: str, rows: list[str]) -> None:
         if not rows:
@@ -304,6 +316,10 @@ def render_text(rep: Report) -> str:
     section(
         "aged human-verified",
         [f"  {r['doc']} — {r['human_verified']} ({r['age_days']}d)" for r in rep.aged_human_verified],
+    )
+    section(
+        "invalid date values",
+        [f"  {r['doc']}: {r['field']} = {r['value']!r}" for r in rep.invalid_date],
     )
     section("supersession", [f"  {r['doc']}: {r['issue']}" for r in rep.supersession])
     section(


### PR DESCRIPTION
`docs/frontmatter-hook.md` lists a follow-up under "Out of scope": a `docs-status` report over the judgement-layer frontmatter fields. This adds it.

The convention already has a mechanical floor — the pre-commit hook stubs and bumps `last-verified:`, and the `docs-frontmatter` CI check rejects missing or unparseable frontmatter. Nothing drives the fields the hook deliberately leaves to a human: whether a doc is still current, whether a supersession link has its other half, whether two docs claim the same `authoritative-for:` topic, whether the README index routes to a doc at all.

## The tool

`scripts/docs_status.py` is a read-only report over `docs/**/*.md` frontmatter. Stdlib-only, like the existing hook — nothing to install. It never mutates; it reports and leaves judgement to a reader. Six checks:

- stale `last-verified:` — older than a threshold; the hook bumps it on every touch, so a stale value means the doc is untouched, not wrong
- aged `human-verified:` — a human vouched, but long enough ago to be worth refreshing
- invalid date values — a `last-verified:`/`human-verified:` that's present but not a valid `YYYY-MM-DD`, so a typo'd date surfaces instead of being silently ignored
- supersession integrity — a `superseded-by:` / `supersedes:` link that dangles or isn't mirrored on the other doc
- `authoritative-for:` clashes — one topic claimed by more than one doc
- docs missing from the README index

`human-verified:` is treated specially: a blank value is reported only as a count, never per-doc. It records that a human vouched for a doc and is set only by explicit human action, so the tool never writes it.

## CI

A non-blocking `docs-status` job runs on PRs that touch `docs/`, scans the whole tree (the supersession, clash, and index checks are cross-document), and writes the report to the run's step summary plus a one-line annotation — a notice when clean, a warning otherwise. It never fails the build; `docs-frontmatter` stays the only gate. Staleness and the judgement fields are reviewer signals, not blockers.

## Index updates

Routes four docs the index didn't reach: `frontmatter-hook.md`, `docs-status.md`, `exec-context-threading.md`, and `regenerating-generated-artifacts.md`.

The tool also flags `docs/perf/microbench/README.md` as unindexed. I left that one alone — whether the top-level index should route to a sub-area README is your call, and the tool's job is to surface it, not decide.
