### PR TITLE
feat: add js/url-param for reading the launch URL from a WASM bundle

### DIFF
--- a/pkg/rt/js.go
+++ b/pkg/rt/js.go
@@ -75,5 +75,25 @@ func installJSNS() {
 	})
 	ns.Def("emit", emitFn)
 
+	// (js/url-param name) -> string-or-nil. Reads a query parameter from the
+	// page URL that loaded the bundle; nil if absent or off-browser. Lets .lg
+	// boot code parameterize from the URL (?seed=42, ?bench=fast) without JS
+	// plumbing. The page URL reaches the worker via the host seam below
+	// (see hostURLParam).
+	urlParamFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, nil
+		}
+		name, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, nil
+		}
+		if v, ok := hostURLParam(string(name)); ok {
+			return vm.String(v), nil
+		}
+		return vm.NIL, nil
+	})
+	ns.Def("url-param", urlParamFn)
+
 	RegisterNS(ns)
 }

--- a/pkg/rt/urlparam_default.go
+++ b/pkg/rt/urlparam_default.go
@@ -1,0 +1,13 @@
+//go:build !(js && wasm)
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ *
+ * hostURLParam off-browser: there is no page URL, so (js/url-param ...)
+ * always returns nil. Keeps the primitive callable in native dev/tests.
+ */
+
+package rt
+
+func hostURLParam(string) (string, bool) { return "", false }

--- a/pkg/rt/urlparam_js_wasm.go
+++ b/pkg/rt/urlparam_js_wasm.go
@@ -1,0 +1,27 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ *
+ * hostURLParam is the WASM side of (js/url-param ...). WASM runs in a Web
+ * Worker whose own `location` is the worker script URL, not the page that
+ * loaded the bundle — so the host shell forwards window.location.search into
+ * the worker as the _lgUrlSearch global, which we parse here.
+ */
+
+package rt
+
+import "syscall/js"
+
+func hostURLParam(name string) (string, bool) {
+	search := js.Global().Get("_lgUrlSearch")
+	if search.IsUndefined() || search.IsNull() {
+		return "", false
+	}
+	v := js.Global().Get("URLSearchParams").New(search).Call("get", name)
+	if v.IsNull() || v.IsUndefined() {
+		return "", false
+	}
+	return v.String(), true
+}

--- a/pkg/rt/urlparam_test.go
+++ b/pkg/rt/urlparam_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// Off-browser there is no page URL, so hostURLParam yields nothing for any
+// name. The wasm side that parses _lgUrlSearch runs in a browser, not here.
+func TestHostURLParamDefaultStub(t *testing.T) {
+	for _, name := range []string{"seed", "bench", "missing", ""} {
+		if v, ok := hostURLParam(name); ok || v != "" {
+			t.Fatalf("hostURLParam(%q) = %q, %v; want \"\", false", name, v, ok)
+		}
+	}
+}
+
+// (js/url-param ...) is registered on the js namespace and returns nil rather
+// than erroring on bad arity or a non-string name — boot code reading an
+// optional param shouldn't crash. Off-browser, a present name also yields nil.
+func TestURLParamFn(t *testing.T) {
+	v := NS("js").Lookup(vm.Symbol("url-param"))
+	if v == nil {
+		t.Fatal("js/url-param not registered")
+	}
+	fn, ok := v.(*vm.Var).Deref().(vm.Fn)
+	if !ok {
+		t.Fatalf("js/url-param is not an Fn: %T", v)
+	}
+	cases := [][]vm.Value{
+		{},                               // arity 0
+		{vm.String("a"), vm.String("b")}, // arity 2
+		{vm.NIL},                         // non-string name
+		{vm.String("seed")},              // valid name, absent off-browser
+	}
+	for _, args := range cases {
+		got, err := fn.Invoke(args)
+		if err != nil {
+			t.Fatalf("Invoke(%v): unexpected error %v", args, err)
+		}
+		if got != vm.NIL {
+			t.Fatalf("Invoke(%v) = %v; want nil", args, got)
+		}
+	}
+}

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -198,9 +198,12 @@ async function startWorkerMode() {
     };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
-      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;
+      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
       globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      // Page URL search string, forwarded from the main thread (the worker's
+      // own location is the blob URL, not the page). Read by js/url-param.
+      globalThis._lgUrlSearch = urlSearch || '';
       // Load wasm_exec.js in worker scope
       eval(wasmExecJS);
       const go = new Go();
@@ -254,7 +257,7 @@ async function startWorkerMode() {
     }
   };
 
-  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };
+  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS, urlSearch: location.search };
   if (WASM_MODE === 'external') {
     initMsg.wasmModule = await modPromise; // compiled on the main thread
   } else {
@@ -313,6 +316,9 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread path runs on the page itself, so its location IS the page —
+  // expose the search string for js/url-param (matches the worker path).
+  globalThis._lgUrlSearch = location.search;
   // Main-thread side of the output bridge — the Go HostWriter calls
   // _lgOutput; feed it straight into LetGoHost (no worker round-trip).
   globalThis._lgOutput = function(s) {

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -221,9 +221,12 @@ async function startWorkerMode() {
     };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
-      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;
+      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
       globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      // Page URL search string, forwarded from the main thread (the worker's
+      // own location is the blob URL, not the page). Read by js/url-param.
+      globalThis._lgUrlSearch = urlSearch || '';
       // Load wasm_exec.js in worker scope
       eval(wasmExecJS);
       const go = new Go();
@@ -277,7 +280,7 @@ async function startWorkerMode() {
     }
   };
 
-  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };
+  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS, urlSearch: location.search };
   if (WASM_MODE === 'external') {
     initMsg.wasmModule = await modPromise; // compiled on the main thread
   } else {
@@ -336,6 +339,9 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread path runs on the page itself, so its location IS the page —
+  // expose the search string for js/url-param (matches the worker path).
+  globalThis._lgUrlSearch = location.search;
   // Main-thread side of the output bridge — the Go HostWriter calls
   // _lgOutput; feed it straight into LetGoHost (no worker round-trip).
   globalThis._lgOutput = function(s) {

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -221,9 +221,12 @@ async function startWorkerMode() {
     };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
-      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;
+      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
       globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      // Page URL search string, forwarded from the main thread (the worker's
+      // own location is the blob URL, not the page). Read by js/url-param.
+      globalThis._lgUrlSearch = urlSearch || '';
       // Load wasm_exec.js in worker scope
       eval(wasmExecJS);
       const go = new Go();
@@ -277,7 +280,7 @@ async function startWorkerMode() {
     }
   };
 
-  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };
+  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS, urlSearch: location.search };
   if (WASM_MODE === 'external') {
     initMsg.wasmModule = await modPromise; // compiled on the main thread
   } else {
@@ -336,6 +339,9 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread path runs on the page itself, so its location IS the page —
+  // expose the search string for js/url-param (matches the worker path).
+  globalThis._lgUrlSearch = location.search;
   // Main-thread side of the output bridge — the Go HostWriter calls
   // _lgOutput; feed it straight into LetGoHost (no worker round-trip).
   globalThis._lgOutput = function(s) {

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -220,9 +220,12 @@ async function startWorkerMode() {
     };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
-      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;
+      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
       globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      // Page URL search string, forwarded from the main thread (the worker's
+      // own location is the blob URL, not the page). Read by js/url-param.
+      globalThis._lgUrlSearch = urlSearch || '';
       // Load wasm_exec.js in worker scope
       eval(wasmExecJS);
       const go = new Go();
@@ -276,7 +279,7 @@ async function startWorkerMode() {
     }
   };
 
-  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };
+  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS, urlSearch: location.search };
   if (WASM_MODE === 'external') {
     initMsg.wasmModule = await modPromise; // compiled on the main thread
   } else {
@@ -335,6 +338,9 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread path runs on the page itself, so its location IS the page —
+  // expose the search string for js/url-param (matches the worker path).
+  globalThis._lgUrlSearch = location.search;
   // Main-thread side of the output bridge — the Go HostWriter calls
   // _lgOutput; feed it straight into LetGoHost (no worker round-trip).
   globalThis._lgOutput = function(s) {

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -220,9 +220,12 @@ async function startWorkerMode() {
     };
     onmessage = async (e) => {
       if (e.data.t !== 'init') return;
-      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;
+      const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
       globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      // Page URL search string, forwarded from the main thread (the worker's
+      // own location is the blob URL, not the page). Read by js/url-param.
+      globalThis._lgUrlSearch = urlSearch || '';
       // Load wasm_exec.js in worker scope
       eval(wasmExecJS);
       const go = new Go();
@@ -276,7 +279,7 @@ async function startWorkerMode() {
     }
   };
 
-  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };
+  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS, urlSearch: location.search };
   if (WASM_MODE === 'external') {
     initMsg.wasmModule = await modPromise; // compiled on the main thread
   } else {
@@ -335,6 +338,9 @@ async function startMainThreadMode() {
     unlink(p,cb){cb(null);}, utimes(p,a,m,cb){cb(null);},
   };
   globalThis._lgFlush = function(){};
+  // Main-thread path runs on the page itself, so its location IS the page —
+  // expose the search string for js/url-param (matches the worker path).
+  globalThis._lgUrlSearch = location.search;
   // Main-thread side of the output bridge — the Go HostWriter calls
   // _lgOutput; feed it straight into LetGoHost (no worker round-trip).
   globalThis._lgOutput = function(s) {


### PR DESCRIPTION
## What

Adds `(js/url-param name)` to the `js` namespace: reads a query parameter from the
page URL that loaded a WASM bundle, returning its value as a string, or nil if the
param is absent or the code is running off-browser.

## Why

A WASM bundle has no first-class way to read its own launch URL, so parameterizing
one — a seed, a mode flag — means hand-writing JS around the host. `js/url-param`
lets `.lg` boot code do it directly:

```clojure
(let [seed (or (some-> (js/url-param "seed") read-string) (default-seed))]
  ...)
```

It sits in the same host-seam family as `js/emit` (#241) and the storage seam
(#315): a small, capability-scoped bridge to the page.

## How

- `pkg/rt/js.go` registers the primitive on the unified `js` namespace. Bad arity
  or a non-string name returns nil rather than erroring, so an optional-param read
  in boot code can't crash.
- `urlparam_default.go` (non-wasm) is a nil-returning stub, keeping the primitive
  callable in native dev and tests.
- `urlparam_js_wasm.go` parses the page URL. WASM runs in a Web Worker whose own
  `location` is the worker script, not the launching page, so the host shell
  forwards `window.location.search` into the worker as the `_lgUrlSearch` global
  (`lg-host-core.js`), and the primitive reads it via `URLSearchParams`.

## Tests

`urlparam_test.go` covers the native stub contract and the primitive's registration
plus argument handling (arity, non-string name, absent name). The wasm parsing path
runs in a browser and isn't unit-tested here, matching how the emit and storage host
seams are tested. The assemble golden fixtures are updated for the new host
forwarding.
