### PR TITLE
feat(wasm): add -w-host-eval to call into a live image via LetGoHost.eval

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -321,7 +321,7 @@ func init() {
 	flag.StringVar(&wasmOutput, "w", "", "build .lg file into a WASM web app (specify output directory)")
 	flag.StringVar(&wasmShell, "w-shell", "xterm", "shell for -w: 'xterm' (default) or 'none' (emit core only; client supplies its own shell via window.LetGoHost)")
 	flag.StringVar(&wasmPayload, "w-wasm", "inline", "wasm delivery for -w: 'inline' (default; gzip-base64 baked into index.html) or 'external' (emit a separate main.wasm the loader fetches + streams)")
-	flag.BoolVar(&wasmHostEval, "w-host-eval", false, "for -w: expose window.Eval(code) to call into the loaded image and keep it live (park after the program's main returns); pair with -w-shell none. Main-thread only — serve without cross-origin isolation")
+	flag.BoolVar(&wasmHostEval, "w-host-eval", false, "for -w: expose LetGoHost.eval(code) to call into the loaded image and keep it live (park after the program's main returns); works in both boot modes. Pair with -w-shell none")
 	flag.StringVar(&storageID, "storage-id", "", "logical storage store id for the storage namespace (default: script name, or current directory for main.lg)")
 	flag.StringVar(&sourcePaths, "source-paths", "",
 		"namespace search paths separated by the OS path-list separator "+

--- a/lg.go
+++ b/lg.go
@@ -302,6 +302,7 @@ var bundleBase string
 var wasmOutput string
 var wasmShell string
 var wasmPayload string
+var wasmHostEval bool
 var storageID string
 var sourcePaths string
 var resourcePaths string
@@ -320,6 +321,7 @@ func init() {
 	flag.StringVar(&wasmOutput, "w", "", "build .lg file into a WASM web app (specify output directory)")
 	flag.StringVar(&wasmShell, "w-shell", "xterm", "shell for -w: 'xterm' (default) or 'none' (emit core only; client supplies its own shell via window.LetGoHost)")
 	flag.StringVar(&wasmPayload, "w-wasm", "inline", "wasm delivery for -w: 'inline' (default; gzip-base64 baked into index.html) or 'external' (emit a separate main.wasm the loader fetches + streams)")
+	flag.BoolVar(&wasmHostEval, "w-host-eval", false, "for -w: expose window.Eval(code) to call into the loaded image and keep it live (park after the program's main returns); pair with -w-shell none. Main-thread only — serve without cross-origin isolation")
 	flag.StringVar(&storageID, "storage-id", "", "logical storage store id for the storage namespace (default: script name, or current directory for main.lg)")
 	flag.StringVar(&sourcePaths, "source-paths", "",
 		"namespace search paths separated by the OS path-list separator "+
@@ -589,7 +591,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: -w-wasm must be 'inline' or 'external', got %q\n", wasmPayload)
 			os.Exit(1)
 		}
-		if err := buildWasm(context, nsResolver, files[0], wasmOutput, wasmShell == "xterm", wasmPayload == "external", storageIDForScript(files[0])); err != nil {
+		if err := buildWasm(context, nsResolver, files[0], wasmOutput, wasmShell == "xterm", wasmPayload == "external", wasmHostEval, storageIDForScript(files[0])); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}

--- a/pkg/rt/wasm/assemble_test.go
+++ b/pkg/rt/wasm/assemble_test.go
@@ -31,14 +31,16 @@ func TestAssembleHTMLGolden(t *testing.T) {
 		name     string
 		shell    bool
 		external bool
+		hostEval bool
 		golden   string
 	}{
-		{"xterm shell, inline wasm", true, false, "assemble_golden.html"},
-		{"shell-less core, inline wasm", false, false, "assemble_golden_shellless.html"},
-		{"xterm shell, external wasm", true, true, "assemble_golden_external.html"},
-		{"shell-less core, external wasm", false, true, "assemble_golden_shellless_external.html"},
+		{"xterm shell, inline wasm", true, false, false, "assemble_golden.html"},
+		{"shell-less core, inline wasm", false, false, false, "assemble_golden_shellless.html"},
+		{"xterm shell, external wasm", true, true, false, "assemble_golden_external.html"},
+		{"shell-less core, external wasm", false, true, false, "assemble_golden_shellless_external.html"},
+		{"shell-less core, external wasm, host-eval", false, true, true, "assemble_golden_hosteval.html"},
 	} {
-		got := AssembleHTML(wasmExecJS, wasmGzB64, tc.shell, tc.external)
+		got := AssembleHTML(wasmExecJS, wasmGzB64, tc.shell, tc.external, tc.hostEval)
 		goldenPath := filepath.Join("testdata", tc.golden)
 
 		if *updateGolden {
@@ -72,17 +74,20 @@ func TestAssembleHTMLGolden(t *testing.T) {
 func TestMarkersGone(t *testing.T) {
 	for _, shell := range []bool{true, false} {
 		for _, external := range []bool{true, false} {
-			got := AssembleHTML("anything", "whatever", shell, external)
-			for _, m := range []string{
-				"__WASM_EXEC_JS__",
-				"__WASM_MODE__",
-				"__WASM_GZ_B64__",
-				"__LG_HOST_JS_BODY_PLACEHOLDER__",
-				"__LG_XTERM_CSS__",
-				"__LG_XTERM_JS__",
-			} {
-				if contains(got, m) {
-					t.Errorf("shell=%v external=%v: marker %q still present in assembled output", shell, external, m)
+			for _, hostEval := range []bool{true, false} {
+				got := AssembleHTML("anything", "whatever", shell, external, hostEval)
+				for _, m := range []string{
+					"__WASM_EXEC_JS__",
+					"__WASM_MODE__",
+					"__WASM_GZ_B64__",
+					"__LG_HOST_EVAL__",
+					"__LG_HOST_JS_BODY_PLACEHOLDER__",
+					"__LG_XTERM_CSS__",
+					"__LG_XTERM_JS__",
+				} {
+					if contains(got, m) {
+						t.Errorf("shell=%v external=%v hostEval=%v: marker %q still present in assembled output", shell, external, hostEval, m)
+					}
 				}
 			}
 		}

--- a/pkg/rt/wasm/embed.go
+++ b/pkg/rt/wasm/embed.go
@@ -43,9 +43,10 @@ const (
 // client binds its own shell to window.LetGoHost. With externalWasm == true
 // the payload is delivered as a separate main.wasm the loader fetches and
 // streams (wasmGzB64 is ignored); otherwise it is gzip-base64 inlined into the
-// page. Pure function: same inputs produce same output. Tested via golden
-// files in testdata/.
-func AssembleHTML(wasmExecJS, wasmGzB64 string, shell, externalWasm bool) string {
+// page. With hostEval == true the page exposes LetGoHost.eval (the -w-host-eval
+// bundle); when false it is omitted, so feature detection stays honest. Pure
+// function: same inputs produce same output. Tested via golden files in testdata/.
+func AssembleHTML(wasmExecJS, wasmGzB64 string, shell, externalWasm, hostEval bool) string {
 	execJSON, _ := json.Marshal(wasmExecJS)
 
 	// WASM_MODE selects the loader path; in external mode the inline payload
@@ -57,10 +58,12 @@ func AssembleHTML(wasmExecJS, wasmGzB64 string, shell, externalWasm bool) string
 	}
 	modeJSON, _ := json.Marshal(mode)
 	b64JSON, _ := json.Marshal(wasmGzB64)
+	hostEvalJSON, _ := json.Marshal(hostEval) // true | false -> gates LetGoHost.eval
 
 	hostJS := mustReplaceOnce(lgHostCoreJS, "__WASM_EXEC_JS__", string(execJSON))
 	hostJS = mustReplaceOnce(hostJS, "__WASM_MODE__", string(modeJSON))
 	hostJS = mustReplaceOnce(hostJS, "__WASM_GZ_B64__", string(b64JSON))
+	hostJS = mustReplaceOnce(hostJS, "__LG_HOST_EVAL__", string(hostEvalJSON))
 
 	css, js := "", ""
 	if shell {

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -119,6 +119,14 @@ const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
+// Worker-path safety net: a worker crash or dropped message means the
+// 'eval-result' reply never arrives, so without this the pending entry leaks
+// and the caller's Promise hangs forever. The timer rejects + removes the entry
+// so the leak is bounded and the caller sees a failure. A late reply arriving
+// after the timeout is harmless — its id is already gone from evalPending and
+// the result is dropped. Generous by design: the worker runs eval synchronously,
+// so this guards lost responses, not slow-but-valid evaluation.
+const EVAL_TIMEOUT_MS = 30000;
 if (HOST_EVAL) {
   window.LetGoHost.eval = function(code) {
     return runtimeReady.then(() => evalImpl(code));
@@ -296,16 +304,25 @@ async function startWorkerMode() {
     // matched to its request id. evalImpl is installed here (not at startup) so
     // it only exists once the worker's runtime is actually ready.
     if (e.data.t === 'host-eval-ready') {
-      evalImpl = (code) => new Promise((resolve) => {
+      evalImpl = (code) => new Promise((resolve, reject) => {
         const id = ++evalSeq;
-        evalPending.set(id, resolve);
+        const timer = setTimeout(() => {
+          if (evalPending.delete(id)) {
+            reject(new Error('LetGoHost.eval: no worker response within ' + EVAL_TIMEOUT_MS + 'ms'));
+          }
+        }, EVAL_TIMEOUT_MS);
+        evalPending.set(id, { resolve, timer });
         worker.postMessage({t:'eval', id, code});
       });
       runtimeReadyResolve();
     }
     if (e.data.t === 'eval-result') {
-      const resolve = evalPending.get(e.data.id);
-      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
+      const pending = evalPending.get(e.data.id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        evalPending.delete(e.data.id);
+        pending.resolve(e.data.result);
+      }
     }
   };
 

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -23,6 +23,7 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 const WASM_EXEC_JS = __WASM_EXEC_JS__;
 const WASM_MODE = __WASM_MODE__;
 const WASM_GZ_B64 = __WASM_GZ_B64__; // inline payload; "" in external mode
+const HOST_EVAL = __LG_HOST_EVAL__;  // built with -w-host-eval? gates LetGoHost.eval
 // External mode resolves the payload to an absolute URL so the Blob-URL worker
 // (whose relative base is the blob, not the page) can fetch it. A client can
 // override this to point at its own CDN.
@@ -104,23 +105,25 @@ window.LetGoHost = (function() {
   };
 })();
 
-// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// --- LetGoHost.eval plumbing (-w-host-eval bundles only) ---
 // runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
-// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
-// so a caller can't hit an undefined hook before the program's main has run.
-// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
-// main thread, or a worker round-trip when cross-origin isolated.
+// called _lgRuntimeReady (wired per boot mode below). evalImpl is installed by
+// whichever boot mode runs: a direct _lgEval call on the main thread, or a worker
+// round-trip when cross-origin isolated. The vars stay declared in every bundle
+// (the boot relays below reference them), but eval is exposed only when the bundle
+// was built with -w-host-eval: a default bundle never calls _lgRuntimeReady, so an
+// installed eval would await a ready signal that never comes (hang) and would lie
+// to feature detection. Omitting it keeps `typeof LetGoHost.eval` honest.
 let runtimeReadyResolve;
 const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
-window.LetGoHost.eval = function(code) {
-  return runtimeReady.then(() => {
-    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
-    return evalImpl(code);
-  });
-};
+if (HOST_EVAL) {
+  window.LetGoHost.eval = function(code) {
+    return runtimeReady.then(() => evalImpl(code));
+  };
+}
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -54,6 +54,9 @@ async function decompressWasm(b64) {
 //   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
 //   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
 //   setSize(c, r)     advertise a new terminal size to the VM
+//   eval(code)        -w-host-eval bundles only: run code in the loaded image,
+//                     -> Promise<string> (stringified value or error). Direct
+//                     call on the main thread, worker round-trip when isolated.
 //
 // wake() is intentionally NOT in this slice. Unblocking a parked read-key
 // without sending real input requires a SAB-level protocol change (a
@@ -100,6 +103,24 @@ window.LetGoHost = (function() {
     _ready(mode) { readyMode = mode; if (readyCb) readyCb(mode); },
   };
 })();
+
+// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
+// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
+// so a caller can't hit an undefined hook before the program's main has run.
+// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
+// main thread, or a worker round-trip when cross-origin isolated.
+let runtimeReadyResolve;
+const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
+let evalImpl = null;
+let evalSeq = 0;
+const evalPending = new Map();
+window.LetGoHost.eval = function(code) {
+  return runtimeReady.then(() => {
+    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
+    return evalImpl(code);
+  });
+};
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.
@@ -196,7 +217,20 @@ async function startWorkerMode() {
     globalThis._lgEmit = function(name, dataJson) {
       postMessage({t:'emit', name, data: dataJson});
     };
+    // Host-eval (worker): the runtime sets globalThis._lgEval, then calls this to
+    // announce readiness; relay to the main thread so it can resolve the gate.
+    globalThis._lgRuntimeReady = function() {
+      postMessage({t:'host-eval-ready'});
+    };
     onmessage = async (e) => {
+      if (e.data.t === 'eval') {
+        // Runs synchronously even while the program is parked on go.run: an
+        // async onmessage doesn't block the worker, and the _lgEval FuncOf
+        // returns its value on the calling stack.
+        const r = globalThis._lgEval ? globalThis._lgEval(e.data.code) : 'error: runtime not ready';
+        postMessage({t:'eval-result', id: e.data.id, result: r});
+        return;
+      }
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
@@ -254,6 +288,21 @@ async function startWorkerMode() {
     if (e.data.t === 'emit') {
       try { window.LetGoHost._emit(e.data.name, JSON.parse(e.data.data)); }
       catch (err) { console.error('lg emit relay:', err); }
+    }
+    // Host-eval relay: the worker runs the eval and posts the string back,
+    // matched to its request id. evalImpl is installed here (not at startup) so
+    // it only exists once the worker's runtime is actually ready.
+    if (e.data.t === 'host-eval-ready') {
+      evalImpl = (code) => new Promise((resolve) => {
+        const id = ++evalSeq;
+        evalPending.set(id, resolve);
+        worker.postMessage({t:'eval', id, code});
+      });
+      runtimeReadyResolve();
+    }
+    if (e.data.t === 'eval-result') {
+      const resolve = evalPending.get(e.data.id);
+      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
     }
   };
 
@@ -329,6 +378,12 @@ async function startMainThreadMode() {
   globalThis._lgEmit = function(name, dataJson) {
     try { window.LetGoHost._emit(name, JSON.parse(dataJson)); }
     catch (err) { console.error('lg emit:', err); }
+  };
+  // Host-eval (main thread): the runtime sets window._lgEval, then calls this to
+  // announce readiness. Eval runs in-page, so dispatch is a direct call.
+  globalThis._lgRuntimeReady = function() {
+    evalImpl = (code) => window._lgEval(code);
+    runtimeReadyResolve();
   };
 
   // Load wasm_exec.js

--- a/pkg/rt/wasm/rendermain.go
+++ b/pkg/rt/wasm/rendermain.go
@@ -106,18 +106,21 @@ __LG_HOST_EVAL_BODY__
 `
 
 // wasmHostEvalSnippet is spliced into wasmMainTmpl at __LG_HOST_EVAL_BODY__ when
-// -w-host-eval is set. It exposes window.Eval(code) — compile + run a string in
-// the loaded image, returning a stringified value (FormatError on failure) — and
-// then parks so the runtime stays live. The program's main chunk has already run
-// (typically just definitions); without parking the wasm would exit and Eval
-// would be unreachable. Structured data returns out-of-band via (js/emit ...).
+// -w-host-eval is set. After the program's main chunk runs, it installs an
+// internal _lgEval hook — compile + run a string in the loaded image, returning
+// a stringified value (FormatError on failure) — signals readiness, then parks
+// so the runtime stays callable.
 //
-// Main-thread only: a worker-mode (cross-origin-isolated) bundle would set Eval
-// on the worker's global scope, not window. -w-host-eval bundles are meant to be
-// served without COI; pair with -w-shell none (the client drives the runtime).
-const wasmHostEvalSnippet = `	eval := js.FuncOf(func(this js.Value, args []js.Value) any {
+// _lgEval is the internal hook (like _lgKey / _lgEmit); lg-host-core.js wraps it
+// as the public LetGoHost.eval(code), calling it directly on the main thread or
+// relaying through the worker in cross-origin-isolated mode, so one API works in
+// both boot modes. The host installs _lgRuntimeReady; calling it resolves the
+// LetGoHost.eval ready gate (main thread) or posts the ready message (worker),
+// closing the race where a client could call eval before the runtime is up.
+// Structured data returns out-of-band via (js/emit ...).
+const wasmHostEvalSnippet = `	hostEval := js.FuncOf(func(this js.Value, args []js.Value) any {
 		if len(args) < 1 {
-			return "error: Eval expects one string argument"
+			return "error: eval expects one string argument"
 		}
 		chunk, cerr := ctx.Compile(args[0].String())
 		if cerr != nil {
@@ -131,7 +134,10 @@ const wasmHostEvalSnippet = `	eval := js.FuncOf(func(this js.Value, args []js.Va
 		}
 		return result.String()
 	})
-	js.Global().Set("Eval", eval)
+	js.Global().Set("_lgEval", hostEval)
+	if ready := js.Global().Get("_lgRuntimeReady"); ready.Type() == js.TypeFunction {
+		ready.Invoke()
+	}
 	select {}`
 
 // RenderMain fills wasmMainTmpl's placeholders: the storage-id, and the

--- a/pkg/rt/wasm/rendermain.go
+++ b/pkg/rt/wasm/rendermain.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package wasm
+
+import (
+	"strconv"
+	"strings"
+)
+
+// wasmMainTmpl is the generated main.go for a `lg -w` bundle: it decodes the
+// embedded program.lgb, runs each namespace chunk, then the main chunk. The
+// __LG_* markers are filled by RenderMain.
+const wasmMainTmpl = `package main
+
+import (
+	_ "embed"
+	"bytes"
+	"fmt"
+	"os"
+__LG_HOST_EVAL_IMPORTS__
+
+	"github.com/nooga/let-go/pkg/bytecode"
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/resolver"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+//go:embed program.lgb
+var lgbData []byte
+
+func main() {
+	consts := vm.NewConsts()
+	ns := rt.NS("user")
+	ctx := compiler.NewCompiler(consts, ns)
+	nsResolver := resolver.NewNSResolver(ctx, []string{"."})
+	rt.SetNSLoader(nsResolver)
+
+	// Route *out*/*err* to the JS host via _lgOutput (HostWriter), instead of
+	// os.Stdout/Stderr + the bundle's fs.writeSync fd interception. SetRoot,
+	// not a per-Run binding, because this generated main drives bytecode
+	// directly rather than through pkg/api. Guarded: if the core I/O vars
+	// aren't installed yet, output falls back to os.Stdout.
+	hostWriter := rt.NewHostWriter()
+	if v := rt.LookupCoreVar("*out*"); v != nil {
+		v.SetRoot(vm.NewBoxed(rt.NewWriterHandle("host-stdout", hostWriter)))
+	}
+	if v := rt.LookupCoreVar("*err*"); v != nil {
+		v.SetRoot(vm.NewBoxed(rt.NewWriterHandle("host-stderr", hostWriter)))
+	}
+
+	// Route (js/emit ...) to the JS host via _lgEmit (HostEmitter), the dual
+	// of the HostWriter *out* routing above. Same SetRoot rationale.
+	hostEmitter := rt.NewHostEmitter()
+	if v := rt.LookupCoreVar("*emit*"); v != nil {
+		v.SetRoot(vm.NewBoxed(hostEmitter))
+	}
+
+	// Route storage through browser localStorage, scoped by the bundle's
+	// host-selected store id so guest keys remain app-local.
+	hostStorage := rt.NewHostStorage(__LG_STORAGE_ID__)
+	if v := rt.LookupCoreVar("*storage*"); v != nil {
+		v.SetRoot(vm.NewBoxed(hostStorage))
+	}
+
+	resolve := func(nsName, name string) *vm.Var {
+		n := rt.DefNSBare(nsName)
+		v := n.LookupLocal(vm.Symbol(name))
+		if v == nil {
+			return n.DefStub(name)
+		}
+		return v
+	}
+
+	unit, err := bytecode.DecodeToExecUnit(bytes.NewReader(lgbData), resolve)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %%v\n", err)
+		return
+	}
+
+	for _, name := range unit.NSOrder {
+		chunk := unit.NSChunks[name]
+		if chunk == nil || chunk == unit.MainChunk {
+			continue
+		}
+		f := vm.NewFrame(chunk, nil)
+		_, err := f.RunProtected()
+		vm.ReleaseFrame(f)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error loading %%s: %%v\n", name, err)
+			return
+		}
+	}
+
+	f := vm.NewFrame(unit.MainChunk, nil)
+	_, err = f.RunProtected()
+	vm.ReleaseFrame(f)
+	if err != nil {
+		fmt.Fprint(os.Stderr, vm.FormatError(err))
+	}
+__LG_HOST_EVAL_BODY__
+}
+`
+
+// wasmHostEvalSnippet is spliced into wasmMainTmpl at __LG_HOST_EVAL_BODY__ when
+// -w-host-eval is set. It exposes window.Eval(code) — compile + run a string in
+// the loaded image, returning a stringified value (FormatError on failure) — and
+// then parks so the runtime stays live. The program's main chunk has already run
+// (typically just definitions); without parking the wasm would exit and Eval
+// would be unreachable. Structured data returns out-of-band via (js/emit ...).
+//
+// Main-thread only: a worker-mode (cross-origin-isolated) bundle would set Eval
+// on the worker's global scope, not window. -w-host-eval bundles are meant to be
+// served without COI; pair with -w-shell none (the client drives the runtime).
+const wasmHostEvalSnippet = `	eval := js.FuncOf(func(this js.Value, args []js.Value) any {
+		if len(args) < 1 {
+			return "error: Eval expects one string argument"
+		}
+		chunk, cerr := ctx.Compile(args[0].String())
+		if cerr != nil {
+			return vm.FormatError(cerr)
+		}
+		frame := vm.NewFrame(chunk, nil)
+		result, rerr := frame.RunProtected()
+		vm.ReleaseFrame(frame)
+		if rerr != nil {
+			return vm.FormatError(rerr)
+		}
+		return result.String()
+	})
+	js.Global().Set("Eval", eval)
+	select {}`
+
+// RenderMain fills wasmMainTmpl's placeholders: the storage-id, and the
+// -w-host-eval splice (the window.Eval bridge + park, plus its syscall/js
+// import). With hostEval false the marker lines are removed whole, so the
+// default bundle's generated main is byte-identical to the pre-flag output.
+func RenderMain(storeID string, hostEval bool) string {
+	s := strings.ReplaceAll(wasmMainTmpl, "__LG_STORAGE_ID__", strconv.Quote(storeID))
+	if hostEval {
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_IMPORTS__", "\t\"syscall/js\"")
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_BODY__", wasmHostEvalSnippet)
+	} else {
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_IMPORTS__\n", "")
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_BODY__\n", "")
+	}
+	return s
+}

--- a/pkg/rt/wasm/rendermain_test.go
+++ b/pkg/rt/wasm/rendermain_test.go
@@ -24,18 +24,18 @@ func TestRenderMainSubstitutesAllMarkers(t *testing.T) {
 // syscall/js unused would fail to compile, and the bundle should stay as it was.
 func TestRenderMainHostEvalOff(t *testing.T) {
 	got := RenderMain("s", false)
-	for _, leak := range []string{"syscall/js", `Set("Eval"`, "select {}"} {
+	for _, leak := range []string{"syscall/js", "_lgEval", "select {}"} {
 		if strings.Contains(got, leak) {
 			t.Fatalf("host-eval code leaked into default bundle: %q", leak)
 		}
 	}
 }
 
-// With -w-host-eval the generated main imports syscall/js, exposes window.Eval,
-// and parks so the runtime stays callable.
+// With -w-host-eval the generated main imports syscall/js, installs the _lgEval
+// hook, signals readiness, and parks so the runtime stays callable.
 func TestRenderMainHostEvalOn(t *testing.T) {
 	got := RenderMain("s", true)
-	for _, want := range []string{`"syscall/js"`, `js.Global().Set("Eval", eval)`, "select {}"} {
+	for _, want := range []string{`"syscall/js"`, `js.Global().Set("_lgEval", hostEval)`, "_lgRuntimeReady", "select {}"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("host-eval output missing %q", want)
 		}

--- a/pkg/rt/wasm/rendermain_test.go
+++ b/pkg/rt/wasm/rendermain_test.go
@@ -1,4 +1,4 @@
-package main
+package wasm
 
 import (
 	"go/format"
@@ -6,11 +6,11 @@ import (
 	"testing"
 )
 
-// renderWasmMain must always substitute every placeholder — a leaked
-// __LG_* marker would be a syntax error in the generated main.go.
-func TestRenderWasmMainSubstitutesAllMarkers(t *testing.T) {
+// RenderMain must always substitute every placeholder — a leaked __LG_* marker
+// would be a syntax error in the generated main.go.
+func TestRenderMainSubstitutesAllMarkers(t *testing.T) {
 	for _, hostEval := range []bool{false, true} {
-		got := renderWasmMain("store-x", hostEval)
+		got := RenderMain("store-x", hostEval)
 		if strings.Contains(got, "__LG_") {
 			t.Fatalf("hostEval=%v: unsubstituted marker remains:\n%s", hostEval, got)
 		}
@@ -22,8 +22,8 @@ func TestRenderWasmMainSubstitutesAllMarkers(t *testing.T) {
 
 // Default (no -w-host-eval) must not pull in the eval bridge or its import —
 // syscall/js unused would fail to compile, and the bundle should stay as it was.
-func TestRenderWasmMainHostEvalOff(t *testing.T) {
-	got := renderWasmMain("s", false)
+func TestRenderMainHostEvalOff(t *testing.T) {
+	got := RenderMain("s", false)
 	for _, leak := range []string{"syscall/js", `Set("Eval"`, "select {}"} {
 		if strings.Contains(got, leak) {
 			t.Fatalf("host-eval code leaked into default bundle: %q", leak)
@@ -33,8 +33,8 @@ func TestRenderWasmMainHostEvalOff(t *testing.T) {
 
 // With -w-host-eval the generated main imports syscall/js, exposes window.Eval,
 // and parks so the runtime stays callable.
-func TestRenderWasmMainHostEvalOn(t *testing.T) {
-	got := renderWasmMain("s", true)
+func TestRenderMainHostEvalOn(t *testing.T) {
+	got := RenderMain("s", true)
 	for _, want := range []string{`"syscall/js"`, `js.Global().Set("Eval", eval)`, "select {}"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("host-eval output missing %q", want)
@@ -47,9 +47,9 @@ func TestRenderWasmMainHostEvalOn(t *testing.T) {
 // it — a syntax error from the splice fails here. (Exact gofmt equality isn't
 // asserted: wasmMainTmpl predates this change and isn't gofmt-sorted, e.g. the
 // `_ "embed"` import; that's upstream's to normalize, not this flag's.)
-func TestRenderWasmMainIsValidGo(t *testing.T) {
+func TestRenderMainIsValidGo(t *testing.T) {
 	for _, hostEval := range []bool{false, true} {
-		if _, err := format.Source([]byte(renderWasmMain("store-x", hostEval))); err != nil {
+		if _, err := format.Source([]byte(RenderMain("store-x", hostEval))); err != nil {
 			t.Fatalf("hostEval=%v: generated main is not valid Go: %v", hostEval, err)
 		}
 	}

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -142,6 +142,14 @@ const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
+// Worker-path safety net: a worker crash or dropped message means the
+// 'eval-result' reply never arrives, so without this the pending entry leaks
+// and the caller's Promise hangs forever. The timer rejects + removes the entry
+// so the leak is bounded and the caller sees a failure. A late reply arriving
+// after the timeout is harmless — its id is already gone from evalPending and
+// the result is dropped. Generous by design: the worker runs eval synchronously,
+// so this guards lost responses, not slow-but-valid evaluation.
+const EVAL_TIMEOUT_MS = 30000;
 if (HOST_EVAL) {
   window.LetGoHost.eval = function(code) {
     return runtimeReady.then(() => evalImpl(code));
@@ -319,16 +327,25 @@ async function startWorkerMode() {
     // matched to its request id. evalImpl is installed here (not at startup) so
     // it only exists once the worker's runtime is actually ready.
     if (e.data.t === 'host-eval-ready') {
-      evalImpl = (code) => new Promise((resolve) => {
+      evalImpl = (code) => new Promise((resolve, reject) => {
         const id = ++evalSeq;
-        evalPending.set(id, resolve);
+        const timer = setTimeout(() => {
+          if (evalPending.delete(id)) {
+            reject(new Error('LetGoHost.eval: no worker response within ' + EVAL_TIMEOUT_MS + 'ms'));
+          }
+        }, EVAL_TIMEOUT_MS);
+        evalPending.set(id, { resolve, timer });
         worker.postMessage({t:'eval', id, code});
       });
       runtimeReadyResolve();
     }
     if (e.data.t === 'eval-result') {
-      const resolve = evalPending.get(e.data.id);
-      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
+      const pending = evalPending.get(e.data.id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        evalPending.delete(e.data.id);
+        pending.resolve(e.data.result);
+      }
     }
   };
 

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -77,6 +77,9 @@ async function decompressWasm(b64) {
 //   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
 //   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
 //   setSize(c, r)     advertise a new terminal size to the VM
+//   eval(code)        -w-host-eval bundles only: run code in the loaded image,
+//                     -> Promise<string> (stringified value or error). Direct
+//                     call on the main thread, worker round-trip when isolated.
 //
 // wake() is intentionally NOT in this slice. Unblocking a parked read-key
 // without sending real input requires a SAB-level protocol change (a
@@ -123,6 +126,24 @@ window.LetGoHost = (function() {
     _ready(mode) { readyMode = mode; if (readyCb) readyCb(mode); },
   };
 })();
+
+// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
+// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
+// so a caller can't hit an undefined hook before the program's main has run.
+// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
+// main thread, or a worker round-trip when cross-origin isolated.
+let runtimeReadyResolve;
+const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
+let evalImpl = null;
+let evalSeq = 0;
+const evalPending = new Map();
+window.LetGoHost.eval = function(code) {
+  return runtimeReady.then(() => {
+    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
+    return evalImpl(code);
+  });
+};
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.
@@ -219,7 +240,20 @@ async function startWorkerMode() {
     globalThis._lgEmit = function(name, dataJson) {
       postMessage({t:'emit', name, data: dataJson});
     };
+    // Host-eval (worker): the runtime sets globalThis._lgEval, then calls this to
+    // announce readiness; relay to the main thread so it can resolve the gate.
+    globalThis._lgRuntimeReady = function() {
+      postMessage({t:'host-eval-ready'});
+    };
     onmessage = async (e) => {
+      if (e.data.t === 'eval') {
+        // Runs synchronously even while the program is parked on go.run: an
+        // async onmessage doesn't block the worker, and the _lgEval FuncOf
+        // returns its value on the calling stack.
+        const r = globalThis._lgEval ? globalThis._lgEval(e.data.code) : 'error: runtime not ready';
+        postMessage({t:'eval-result', id: e.data.id, result: r});
+        return;
+      }
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
@@ -277,6 +311,21 @@ async function startWorkerMode() {
     if (e.data.t === 'emit') {
       try { window.LetGoHost._emit(e.data.name, JSON.parse(e.data.data)); }
       catch (err) { console.error('lg emit relay:', err); }
+    }
+    // Host-eval relay: the worker runs the eval and posts the string back,
+    // matched to its request id. evalImpl is installed here (not at startup) so
+    // it only exists once the worker's runtime is actually ready.
+    if (e.data.t === 'host-eval-ready') {
+      evalImpl = (code) => new Promise((resolve) => {
+        const id = ++evalSeq;
+        evalPending.set(id, resolve);
+        worker.postMessage({t:'eval', id, code});
+      });
+      runtimeReadyResolve();
+    }
+    if (e.data.t === 'eval-result') {
+      const resolve = evalPending.get(e.data.id);
+      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
     }
   };
 
@@ -352,6 +401,12 @@ async function startMainThreadMode() {
   globalThis._lgEmit = function(name, dataJson) {
     try { window.LetGoHost._emit(name, JSON.parse(dataJson)); }
     catch (err) { console.error('lg emit:', err); }
+  };
+  // Host-eval (main thread): the runtime sets window._lgEval, then calls this to
+  // announce readiness. Eval runs in-page, so dispatch is a direct call.
+  globalThis._lgRuntimeReady = function() {
+    evalImpl = (code) => window._lgEval(code);
+    runtimeReadyResolve();
   };
 
   // Load wasm_exec.js

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -46,6 +46,7 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
 const WASM_MODE = "external";
 const WASM_GZ_B64 = ""; // inline payload; "" in external mode
+const HOST_EVAL = false;  // built with -w-host-eval? gates LetGoHost.eval
 // External mode resolves the payload to an absolute URL so the Blob-URL worker
 // (whose relative base is the blob, not the page) can fetch it. A client can
 // override this to point at its own CDN.
@@ -127,23 +128,25 @@ window.LetGoHost = (function() {
   };
 })();
 
-// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// --- LetGoHost.eval plumbing (-w-host-eval bundles only) ---
 // runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
-// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
-// so a caller can't hit an undefined hook before the program's main has run.
-// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
-// main thread, or a worker round-trip when cross-origin isolated.
+// called _lgRuntimeReady (wired per boot mode below). evalImpl is installed by
+// whichever boot mode runs: a direct _lgEval call on the main thread, or a worker
+// round-trip when cross-origin isolated. The vars stay declared in every bundle
+// (the boot relays below reference them), but eval is exposed only when the bundle
+// was built with -w-host-eval: a default bundle never calls _lgRuntimeReady, so an
+// installed eval would await a ready signal that never comes (hang) and would lie
+// to feature detection. Omitting it keeps `typeof LetGoHost.eval` honest.
 let runtimeReadyResolve;
 const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
-window.LetGoHost.eval = function(code) {
-  return runtimeReady.then(() => {
-    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
-    return evalImpl(code);
-  });
-};
+if (HOST_EVAL) {
+  window.LetGoHost.eval = function(code) {
+    return runtimeReady.then(() => evalImpl(code));
+  };
+}
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -142,6 +142,14 @@ const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
+// Worker-path safety net: a worker crash or dropped message means the
+// 'eval-result' reply never arrives, so without this the pending entry leaks
+// and the caller's Promise hangs forever. The timer rejects + removes the entry
+// so the leak is bounded and the caller sees a failure. A late reply arriving
+// after the timeout is harmless — its id is already gone from evalPending and
+// the result is dropped. Generous by design: the worker runs eval synchronously,
+// so this guards lost responses, not slow-but-valid evaluation.
+const EVAL_TIMEOUT_MS = 30000;
 if (HOST_EVAL) {
   window.LetGoHost.eval = function(code) {
     return runtimeReady.then(() => evalImpl(code));
@@ -319,16 +327,25 @@ async function startWorkerMode() {
     // matched to its request id. evalImpl is installed here (not at startup) so
     // it only exists once the worker's runtime is actually ready.
     if (e.data.t === 'host-eval-ready') {
-      evalImpl = (code) => new Promise((resolve) => {
+      evalImpl = (code) => new Promise((resolve, reject) => {
         const id = ++evalSeq;
-        evalPending.set(id, resolve);
+        const timer = setTimeout(() => {
+          if (evalPending.delete(id)) {
+            reject(new Error('LetGoHost.eval: no worker response within ' + EVAL_TIMEOUT_MS + 'ms'));
+          }
+        }, EVAL_TIMEOUT_MS);
+        evalPending.set(id, { resolve, timer });
         worker.postMessage({t:'eval', id, code});
       });
       runtimeReadyResolve();
     }
     if (e.data.t === 'eval-result') {
-      const resolve = evalPending.get(e.data.id);
-      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
+      const pending = evalPending.get(e.data.id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        evalPending.delete(e.data.id);
+        pending.resolve(e.data.result);
+      }
     }
   };
 

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -77,6 +77,9 @@ async function decompressWasm(b64) {
 //   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
 //   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
 //   setSize(c, r)     advertise a new terminal size to the VM
+//   eval(code)        -w-host-eval bundles only: run code in the loaded image,
+//                     -> Promise<string> (stringified value or error). Direct
+//                     call on the main thread, worker round-trip when isolated.
 //
 // wake() is intentionally NOT in this slice. Unblocking a parked read-key
 // without sending real input requires a SAB-level protocol change (a
@@ -123,6 +126,24 @@ window.LetGoHost = (function() {
     _ready(mode) { readyMode = mode; if (readyCb) readyCb(mode); },
   };
 })();
+
+// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
+// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
+// so a caller can't hit an undefined hook before the program's main has run.
+// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
+// main thread, or a worker round-trip when cross-origin isolated.
+let runtimeReadyResolve;
+const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
+let evalImpl = null;
+let evalSeq = 0;
+const evalPending = new Map();
+window.LetGoHost.eval = function(code) {
+  return runtimeReady.then(() => {
+    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
+    return evalImpl(code);
+  });
+};
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.
@@ -219,7 +240,20 @@ async function startWorkerMode() {
     globalThis._lgEmit = function(name, dataJson) {
       postMessage({t:'emit', name, data: dataJson});
     };
+    // Host-eval (worker): the runtime sets globalThis._lgEval, then calls this to
+    // announce readiness; relay to the main thread so it can resolve the gate.
+    globalThis._lgRuntimeReady = function() {
+      postMessage({t:'host-eval-ready'});
+    };
     onmessage = async (e) => {
+      if (e.data.t === 'eval') {
+        // Runs synchronously even while the program is parked on go.run: an
+        // async onmessage doesn't block the worker, and the _lgEval FuncOf
+        // returns its value on the calling stack.
+        const r = globalThis._lgEval ? globalThis._lgEval(e.data.code) : 'error: runtime not ready';
+        postMessage({t:'eval-result', id: e.data.id, result: r});
+        return;
+      }
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
@@ -277,6 +311,21 @@ async function startWorkerMode() {
     if (e.data.t === 'emit') {
       try { window.LetGoHost._emit(e.data.name, JSON.parse(e.data.data)); }
       catch (err) { console.error('lg emit relay:', err); }
+    }
+    // Host-eval relay: the worker runs the eval and posts the string back,
+    // matched to its request id. evalImpl is installed here (not at startup) so
+    // it only exists once the worker's runtime is actually ready.
+    if (e.data.t === 'host-eval-ready') {
+      evalImpl = (code) => new Promise((resolve) => {
+        const id = ++evalSeq;
+        evalPending.set(id, resolve);
+        worker.postMessage({t:'eval', id, code});
+      });
+      runtimeReadyResolve();
+    }
+    if (e.data.t === 'eval-result') {
+      const resolve = evalPending.get(e.data.id);
+      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
     }
   };
 
@@ -352,6 +401,12 @@ async function startMainThreadMode() {
   globalThis._lgEmit = function(name, dataJson) {
     try { window.LetGoHost._emit(name, JSON.parse(dataJson)); }
     catch (err) { console.error('lg emit:', err); }
+  };
+  // Host-eval (main thread): the runtime sets window._lgEval, then calls this to
+  // announce readiness. Eval runs in-page, so dispatch is a direct call.
+  globalThis._lgRuntimeReady = function() {
+    evalImpl = (code) => window._lgEval(code);
+    runtimeReadyResolve();
   };
 
   // Load wasm_exec.js

--- a/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
@@ -141,6 +141,14 @@ const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
+// Worker-path safety net: a worker crash or dropped message means the
+// 'eval-result' reply never arrives, so without this the pending entry leaks
+// and the caller's Promise hangs forever. The timer rejects + removes the entry
+// so the leak is bounded and the caller sees a failure. A late reply arriving
+// after the timeout is harmless — its id is already gone from evalPending and
+// the result is dropped. Generous by design: the worker runs eval synchronously,
+// so this guards lost responses, not slow-but-valid evaluation.
+const EVAL_TIMEOUT_MS = 30000;
 if (HOST_EVAL) {
   window.LetGoHost.eval = function(code) {
     return runtimeReady.then(() => evalImpl(code));
@@ -318,16 +326,25 @@ async function startWorkerMode() {
     // matched to its request id. evalImpl is installed here (not at startup) so
     // it only exists once the worker's runtime is actually ready.
     if (e.data.t === 'host-eval-ready') {
-      evalImpl = (code) => new Promise((resolve) => {
+      evalImpl = (code) => new Promise((resolve, reject) => {
         const id = ++evalSeq;
-        evalPending.set(id, resolve);
+        const timer = setTimeout(() => {
+          if (evalPending.delete(id)) {
+            reject(new Error('LetGoHost.eval: no worker response within ' + EVAL_TIMEOUT_MS + 'ms'));
+          }
+        }, EVAL_TIMEOUT_MS);
+        evalPending.set(id, { resolve, timer });
         worker.postMessage({t:'eval', id, code});
       });
       runtimeReadyResolve();
     }
     if (e.data.t === 'eval-result') {
-      const resolve = evalPending.get(e.data.id);
-      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
+      const pending = evalPending.get(e.data.id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        evalPending.delete(e.data.id);
+        pending.resolve(e.data.result);
+      }
     }
   };
 

--- a/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
@@ -18,8 +18,7 @@
 <body>
   <div id="status">loading...</div>
   <div id="terminal" style="display:none"></div>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+
   <script>
 // --- Cross-origin isolation: prefer server headers, fall back to SW ---
 // When the dev/host server sends the COI headers itself (dev/serve.json
@@ -44,9 +43,9 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 // 'external' (a separate main.wasm fetched + stream-compiled). Both load paths
 // ship below; the build picks one via -w-wasm.
 const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
-const WASM_MODE = "inline";
-const WASM_GZ_B64 = "STUBWASMBLOBB64=="; // inline payload; "" in external mode
-const HOST_EVAL = false;  // built with -w-host-eval? gates LetGoHost.eval
+const WASM_MODE = "external";
+const WASM_GZ_B64 = ""; // inline payload; "" in external mode
+const HOST_EVAL = true;  // built with -w-host-eval? gates LetGoHost.eval
 // External mode resolves the payload to an absolute URL so the Blob-URL worker
 // (whose relative base is the blob, not the page) can fetch it. A client can
 // override this to point at its own CDN.
@@ -448,50 +447,6 @@ async function startMainThreadMode() {
     setStatus('error: ' + err);
     console.error(err);
   }
-})();
-
-// --- Default xterm.js shell ---
-// The shell `lg -w` ships unless built with -w-shell none. It owns the
-// presentation layer (the Terminal, its font/theme, the DOM) and binds to
-// the runtime purely through window.LetGoHost — the same surface a client's
-// own shell uses. Nothing in lg-host-core.js references xterm; everything
-// terminal-specific lives here.
-(function() {
-  const status = document.getElementById('status');
-  const termEl = document.getElementById('terminal');
-
-  const term = new Terminal({
-    fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
-    fontSize: 14,
-    theme: { background: '#0c0c0c', foreground: '#e8e6df', cursor: '#5ec4b6' },
-    allowProposedApi: true,
-    convertEol: true,
-  });
-  const fitAddon = new FitAddon.FitAddon();
-  term.loadAddon(fitAddon);
-
-  function showTerminal() {
-    if (status) status.style.display = 'none';
-    termEl.style.display = 'block';
-    term.open(termEl);
-    fitAddon.fit();
-    term.focus();
-  }
-
-  window.addEventListener('resize', () => fitAddon.fit());
-
-  // Bind once the core glue is wired. onOutput routes VM stdout to xterm;
-  // in worker mode the keystroke/size path is live, so advertise the
-  // initial size and forward xterm input + resizes through LetGoHost.
-  window.LetGoHost.onReady((mode) => {
-    showTerminal();
-    window.LetGoHost.onOutput((s) => term.write(s));
-    if (mode === 'worker') {
-      window.LetGoHost.setSize(term.cols, term.rows);
-      term.onResize(({cols, rows}) => window.LetGoHost.setSize(cols, rows));
-      term.onData((data) => window.LetGoHost.sendInput(data));
-    }
-  });
 })();
 
   </script>

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -141,6 +141,14 @@ const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
+// Worker-path safety net: a worker crash or dropped message means the
+// 'eval-result' reply never arrives, so without this the pending entry leaks
+// and the caller's Promise hangs forever. The timer rejects + removes the entry
+// so the leak is bounded and the caller sees a failure. A late reply arriving
+// after the timeout is harmless — its id is already gone from evalPending and
+// the result is dropped. Generous by design: the worker runs eval synchronously,
+// so this guards lost responses, not slow-but-valid evaluation.
+const EVAL_TIMEOUT_MS = 30000;
 if (HOST_EVAL) {
   window.LetGoHost.eval = function(code) {
     return runtimeReady.then(() => evalImpl(code));
@@ -318,16 +326,25 @@ async function startWorkerMode() {
     // matched to its request id. evalImpl is installed here (not at startup) so
     // it only exists once the worker's runtime is actually ready.
     if (e.data.t === 'host-eval-ready') {
-      evalImpl = (code) => new Promise((resolve) => {
+      evalImpl = (code) => new Promise((resolve, reject) => {
         const id = ++evalSeq;
-        evalPending.set(id, resolve);
+        const timer = setTimeout(() => {
+          if (evalPending.delete(id)) {
+            reject(new Error('LetGoHost.eval: no worker response within ' + EVAL_TIMEOUT_MS + 'ms'));
+          }
+        }, EVAL_TIMEOUT_MS);
+        evalPending.set(id, { resolve, timer });
         worker.postMessage({t:'eval', id, code});
       });
       runtimeReadyResolve();
     }
     if (e.data.t === 'eval-result') {
-      const resolve = evalPending.get(e.data.id);
-      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
+      const pending = evalPending.get(e.data.id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        evalPending.delete(e.data.id);
+        pending.resolve(e.data.result);
+      }
     }
   };
 

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -45,6 +45,7 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
 const WASM_MODE = "inline";
 const WASM_GZ_B64 = "STUBWASMBLOBB64=="; // inline payload; "" in external mode
+const HOST_EVAL = false;  // built with -w-host-eval? gates LetGoHost.eval
 // External mode resolves the payload to an absolute URL so the Blob-URL worker
 // (whose relative base is the blob, not the page) can fetch it. A client can
 // override this to point at its own CDN.
@@ -126,23 +127,25 @@ window.LetGoHost = (function() {
   };
 })();
 
-// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// --- LetGoHost.eval plumbing (-w-host-eval bundles only) ---
 // runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
-// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
-// so a caller can't hit an undefined hook before the program's main has run.
-// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
-// main thread, or a worker round-trip when cross-origin isolated.
+// called _lgRuntimeReady (wired per boot mode below). evalImpl is installed by
+// whichever boot mode runs: a direct _lgEval call on the main thread, or a worker
+// round-trip when cross-origin isolated. The vars stay declared in every bundle
+// (the boot relays below reference them), but eval is exposed only when the bundle
+// was built with -w-host-eval: a default bundle never calls _lgRuntimeReady, so an
+// installed eval would await a ready signal that never comes (hang) and would lie
+// to feature detection. Omitting it keeps `typeof LetGoHost.eval` honest.
 let runtimeReadyResolve;
 const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
-window.LetGoHost.eval = function(code) {
-  return runtimeReady.then(() => {
-    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
-    return evalImpl(code);
-  });
-};
+if (HOST_EVAL) {
+  window.LetGoHost.eval = function(code) {
+    return runtimeReady.then(() => evalImpl(code));
+  };
+}
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -76,6 +76,9 @@ async function decompressWasm(b64) {
 //   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
 //   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
 //   setSize(c, r)     advertise a new terminal size to the VM
+//   eval(code)        -w-host-eval bundles only: run code in the loaded image,
+//                     -> Promise<string> (stringified value or error). Direct
+//                     call on the main thread, worker round-trip when isolated.
 //
 // wake() is intentionally NOT in this slice. Unblocking a parked read-key
 // without sending real input requires a SAB-level protocol change (a
@@ -122,6 +125,24 @@ window.LetGoHost = (function() {
     _ready(mode) { readyMode = mode; if (readyCb) readyCb(mode); },
   };
 })();
+
+// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
+// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
+// so a caller can't hit an undefined hook before the program's main has run.
+// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
+// main thread, or a worker round-trip when cross-origin isolated.
+let runtimeReadyResolve;
+const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
+let evalImpl = null;
+let evalSeq = 0;
+const evalPending = new Map();
+window.LetGoHost.eval = function(code) {
+  return runtimeReady.then(() => {
+    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
+    return evalImpl(code);
+  });
+};
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.
@@ -218,7 +239,20 @@ async function startWorkerMode() {
     globalThis._lgEmit = function(name, dataJson) {
       postMessage({t:'emit', name, data: dataJson});
     };
+    // Host-eval (worker): the runtime sets globalThis._lgEval, then calls this to
+    // announce readiness; relay to the main thread so it can resolve the gate.
+    globalThis._lgRuntimeReady = function() {
+      postMessage({t:'host-eval-ready'});
+    };
     onmessage = async (e) => {
+      if (e.data.t === 'eval') {
+        // Runs synchronously even while the program is parked on go.run: an
+        // async onmessage doesn't block the worker, and the _lgEval FuncOf
+        // returns its value on the calling stack.
+        const r = globalThis._lgEval ? globalThis._lgEval(e.data.code) : 'error: runtime not ready';
+        postMessage({t:'eval-result', id: e.data.id, result: r});
+        return;
+      }
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
@@ -276,6 +310,21 @@ async function startWorkerMode() {
     if (e.data.t === 'emit') {
       try { window.LetGoHost._emit(e.data.name, JSON.parse(e.data.data)); }
       catch (err) { console.error('lg emit relay:', err); }
+    }
+    // Host-eval relay: the worker runs the eval and posts the string back,
+    // matched to its request id. evalImpl is installed here (not at startup) so
+    // it only exists once the worker's runtime is actually ready.
+    if (e.data.t === 'host-eval-ready') {
+      evalImpl = (code) => new Promise((resolve) => {
+        const id = ++evalSeq;
+        evalPending.set(id, resolve);
+        worker.postMessage({t:'eval', id, code});
+      });
+      runtimeReadyResolve();
+    }
+    if (e.data.t === 'eval-result') {
+      const resolve = evalPending.get(e.data.id);
+      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
     }
   };
 
@@ -351,6 +400,12 @@ async function startMainThreadMode() {
   globalThis._lgEmit = function(name, dataJson) {
     try { window.LetGoHost._emit(name, JSON.parse(dataJson)); }
     catch (err) { console.error('lg emit:', err); }
+  };
+  // Host-eval (main thread): the runtime sets window._lgEval, then calls this to
+  // announce readiness. Eval runs in-page, so dispatch is a direct call.
+  globalThis._lgRuntimeReady = function() {
+    evalImpl = (code) => window._lgEval(code);
+    runtimeReadyResolve();
   };
 
   // Load wasm_exec.js

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -141,6 +141,14 @@ const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
+// Worker-path safety net: a worker crash or dropped message means the
+// 'eval-result' reply never arrives, so without this the pending entry leaks
+// and the caller's Promise hangs forever. The timer rejects + removes the entry
+// so the leak is bounded and the caller sees a failure. A late reply arriving
+// after the timeout is harmless — its id is already gone from evalPending and
+// the result is dropped. Generous by design: the worker runs eval synchronously,
+// so this guards lost responses, not slow-but-valid evaluation.
+const EVAL_TIMEOUT_MS = 30000;
 if (HOST_EVAL) {
   window.LetGoHost.eval = function(code) {
     return runtimeReady.then(() => evalImpl(code));
@@ -318,16 +326,25 @@ async function startWorkerMode() {
     // matched to its request id. evalImpl is installed here (not at startup) so
     // it only exists once the worker's runtime is actually ready.
     if (e.data.t === 'host-eval-ready') {
-      evalImpl = (code) => new Promise((resolve) => {
+      evalImpl = (code) => new Promise((resolve, reject) => {
         const id = ++evalSeq;
-        evalPending.set(id, resolve);
+        const timer = setTimeout(() => {
+          if (evalPending.delete(id)) {
+            reject(new Error('LetGoHost.eval: no worker response within ' + EVAL_TIMEOUT_MS + 'ms'));
+          }
+        }, EVAL_TIMEOUT_MS);
+        evalPending.set(id, { resolve, timer });
         worker.postMessage({t:'eval', id, code});
       });
       runtimeReadyResolve();
     }
     if (e.data.t === 'eval-result') {
-      const resolve = evalPending.get(e.data.id);
-      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
+      const pending = evalPending.get(e.data.id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        evalPending.delete(e.data.id);
+        pending.resolve(e.data.result);
+      }
     }
   };
 

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -76,6 +76,9 @@ async function decompressWasm(b64) {
 //   onEmit(cb)        register sink for js/emit events; cb(name, parsedData)
 //   sendInput(str)    inject UTF-8 keystrokes/bytes toward the VM
 //   setSize(c, r)     advertise a new terminal size to the VM
+//   eval(code)        -w-host-eval bundles only: run code in the loaded image,
+//                     -> Promise<string> (stringified value or error). Direct
+//                     call on the main thread, worker round-trip when isolated.
 //
 // wake() is intentionally NOT in this slice. Unblocking a parked read-key
 // without sending real input requires a SAB-level protocol change (a
@@ -122,6 +125,24 @@ window.LetGoHost = (function() {
     _ready(mode) { readyMode = mode; if (readyCb) readyCb(mode); },
   };
 })();
+
+// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
+// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
+// so a caller can't hit an undefined hook before the program's main has run.
+// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
+// main thread, or a worker round-trip when cross-origin isolated.
+let runtimeReadyResolve;
+const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
+let evalImpl = null;
+let evalSeq = 0;
+const evalPending = new Map();
+window.LetGoHost.eval = function(code) {
+  return runtimeReady.then(() => {
+    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
+    return evalImpl(code);
+  });
+};
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.
@@ -218,7 +239,20 @@ async function startWorkerMode() {
     globalThis._lgEmit = function(name, dataJson) {
       postMessage({t:'emit', name, data: dataJson});
     };
+    // Host-eval (worker): the runtime sets globalThis._lgEval, then calls this to
+    // announce readiness; relay to the main thread so it can resolve the gate.
+    globalThis._lgRuntimeReady = function() {
+      postMessage({t:'host-eval-ready'});
+    };
     onmessage = async (e) => {
+      if (e.data.t === 'eval') {
+        // Runs synchronously even while the program is parked on go.run: an
+        // async onmessage doesn't block the worker, and the _lgEval FuncOf
+        // returns its value on the calling stack.
+        const r = globalThis._lgEval ? globalThis._lgEval(e.data.code) : 'error: runtime not ready';
+        postMessage({t:'eval-result', id: e.data.id, result: r});
+        return;
+      }
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
@@ -276,6 +310,21 @@ async function startWorkerMode() {
     if (e.data.t === 'emit') {
       try { window.LetGoHost._emit(e.data.name, JSON.parse(e.data.data)); }
       catch (err) { console.error('lg emit relay:', err); }
+    }
+    // Host-eval relay: the worker runs the eval and posts the string back,
+    // matched to its request id. evalImpl is installed here (not at startup) so
+    // it only exists once the worker's runtime is actually ready.
+    if (e.data.t === 'host-eval-ready') {
+      evalImpl = (code) => new Promise((resolve) => {
+        const id = ++evalSeq;
+        evalPending.set(id, resolve);
+        worker.postMessage({t:'eval', id, code});
+      });
+      runtimeReadyResolve();
+    }
+    if (e.data.t === 'eval-result') {
+      const resolve = evalPending.get(e.data.id);
+      if (resolve) { evalPending.delete(e.data.id); resolve(e.data.result); }
     }
   };
 
@@ -351,6 +400,12 @@ async function startMainThreadMode() {
   globalThis._lgEmit = function(name, dataJson) {
     try { window.LetGoHost._emit(name, JSON.parse(dataJson)); }
     catch (err) { console.error('lg emit:', err); }
+  };
+  // Host-eval (main thread): the runtime sets window._lgEval, then calls this to
+  // announce readiness. Eval runs in-page, so dispatch is a direct call.
+  globalThis._lgRuntimeReady = function() {
+    evalImpl = (code) => window._lgEval(code);
+    runtimeReadyResolve();
   };
 
   // Load wasm_exec.js

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -45,6 +45,7 @@ if (!crossOriginIsolated && window.isSecureContext && 'serviceWorker' in navigat
 const WASM_EXEC_JS = "// stub wasm_exec.js for the golden test\nconsole.log('exec stub');\n";
 const WASM_MODE = "external";
 const WASM_GZ_B64 = ""; // inline payload; "" in external mode
+const HOST_EVAL = false;  // built with -w-host-eval? gates LetGoHost.eval
 // External mode resolves the payload to an absolute URL so the Blob-URL worker
 // (whose relative base is the blob, not the page) can fetch it. A client can
 // override this to point at its own CDN.
@@ -126,23 +127,25 @@ window.LetGoHost = (function() {
   };
 })();
 
-// --- LetGoHost.eval plumbing (live only in -w-host-eval bundles) ---
+// --- LetGoHost.eval plumbing (-w-host-eval bundles only) ---
 // runtimeReady resolves once the wasm runtime has installed its _lgEval hook and
-// called _lgRuntimeReady (wired per boot mode below). LetGoHost.eval gates on it,
-// so a caller can't hit an undefined hook before the program's main has run.
-// evalImpl is installed by whichever boot mode runs: a direct _lgEval call on the
-// main thread, or a worker round-trip when cross-origin isolated.
+// called _lgRuntimeReady (wired per boot mode below). evalImpl is installed by
+// whichever boot mode runs: a direct _lgEval call on the main thread, or a worker
+// round-trip when cross-origin isolated. The vars stay declared in every bundle
+// (the boot relays below reference them), but eval is exposed only when the bundle
+// was built with -w-host-eval: a default bundle never calls _lgRuntimeReady, so an
+// installed eval would await a ready signal that never comes (hang) and would lie
+// to feature detection. Omitting it keeps `typeof LetGoHost.eval` honest.
 let runtimeReadyResolve;
 const runtimeReady = new Promise((r) => { runtimeReadyResolve = r; });
 let evalImpl = null;
 let evalSeq = 0;
 const evalPending = new Map();
-window.LetGoHost.eval = function(code) {
-  return runtimeReady.then(() => {
-    if (!evalImpl) throw new Error('LetGoHost.eval: bundle was not built with -w-host-eval');
-    return evalImpl(code);
-  });
-};
+if (HOST_EVAL) {
+  window.LetGoHost.eval = function(code) {
+    return runtimeReady.then(() => evalImpl(code));
+  };
+}
 
 // Boot status text. May be absent when a client ships its own HTML without
 // a #status element, so every use is guarded.

--- a/wasm.go
+++ b/wasm.go
@@ -171,15 +171,9 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		}
 	}
 
-	// 11. Write coi-serviceworker.js for cross-origin isolation on hosted servers.
-	// Skipped in host-eval mode: window.Eval is set on the page's global by the
-	// main-thread runtime, so the bundle must NOT become cross-origin isolated
-	// (that routes boot into a worker, where Eval would land off-window). Shipping
-	// the SW shim would let it upgrade the page to COI and silently break Eval.
-	if !hostEval {
-		if err := os.WriteFile(filepath.Join(outDir, "coi-serviceworker.js"), []byte(coiServiceWorkerJS), 0644); err != nil {
-			return err
-		}
+	// 11. Write coi-serviceworker.js for cross-origin isolation on hosted servers
+	if err := os.WriteFile(filepath.Join(outDir, "coi-serviceworker.js"), []byte(coiServiceWorkerJS), 0644); err != nil {
+		return err
 	}
 
 	fi, _ := os.Stat(outPath)

--- a/wasm.go
+++ b/wasm.go
@@ -152,7 +152,7 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	// 9. Build the HTML. shell=false emits the core glue only (no xterm shell
 	// / CDN tags). externalWasm=true emits the streaming loader and an empty
 	// inline payload (the wasm ships as main.wasm, written below).
-	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64, shell, externalWasm)
+	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64, shell, externalWasm, hostEval)
 
 	// 10. Write output
 	if err := os.MkdirAll(outDir, 0755); err != nil {

--- a/wasm.go
+++ b/wasm.go
@@ -31,6 +31,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+__LG_HOST_EVAL_IMPORTS__
 
 	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/compiler"
@@ -111,8 +112,38 @@ func main() {
 	if err != nil {
 		fmt.Fprint(os.Stderr, vm.FormatError(err))
 	}
+__LG_HOST_EVAL_BODY__
 }
 `
+
+// wasmHostEvalSnippet is spliced into wasmMainTmpl at __LG_HOST_EVAL_BODY__ when
+// -w-host-eval is set. It exposes window.Eval(code) — compile + run a string in
+// the loaded image, returning a stringified value (FormatError on failure) — and
+// then parks so the runtime stays live. The program's main chunk has already run
+// (typically just definitions); without parking the wasm would exit and Eval
+// would be unreachable. Structured data returns out-of-band via (js/emit ...).
+//
+// Main-thread only: a worker-mode (cross-origin-isolated) bundle would set Eval
+// on the worker's global scope, not window. -w-host-eval bundles are meant to be
+// served without COI; pair with -w-shell none (the client drives the runtime).
+const wasmHostEvalSnippet = `	eval := js.FuncOf(func(this js.Value, args []js.Value) any {
+		if len(args) < 1 {
+			return "error: Eval expects one string argument"
+		}
+		chunk, cerr := ctx.Compile(args[0].String())
+		if cerr != nil {
+			return vm.FormatError(cerr)
+		}
+		frame := vm.NewFrame(chunk, nil)
+		result, rerr := frame.RunProtected()
+		vm.ReleaseFrame(frame)
+		if rerr != nil {
+			return vm.FormatError(rerr)
+		}
+		return result.String()
+	})
+	js.Global().Set("Eval", eval)
+	select {}`
 
 // The HTML page and host JS live as embedded assets in pkg/rt/wasm.
 // See pkg/rt/wasm.AssembleHTML for the assembly contract.
@@ -142,7 +173,23 @@ addEventListener('fetch', e => {
 });
 `
 
-func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool, externalWasm bool, storeID string) error {
+// renderWasmMain fills wasmMainTmpl's placeholders: the storage-id, and the
+// -w-host-eval splice (the window.Eval bridge + park, plus its syscall/js
+// import). With hostEval false the marker lines are removed whole, so the
+// default bundle's generated main is byte-identical to the pre-flag output.
+func renderWasmMain(storeID string, hostEval bool) string {
+	s := strings.ReplaceAll(wasmMainTmpl, "__LG_STORAGE_ID__", strconv.Quote(storeID))
+	if hostEval {
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_IMPORTS__", "\t\"syscall/js\"")
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_BODY__", wasmHostEvalSnippet)
+	} else {
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_IMPORTS__\n", "")
+		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_BODY__\n", "")
+	}
+	return s
+}
+
+func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool, externalWasm bool, hostEval bool, storeID string) error {
 	// 1. Compile .lg → .lgb in memory
 	ctx.SetSource(src)
 	f, err := os.Open(src)
@@ -182,8 +229,7 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	if err := os.WriteFile(filepath.Join(tmpDir, "program.lgb"), lgbBuf.Bytes(), 0644); err != nil {
 		return err
 	}
-	mainSrc := strings.ReplaceAll(wasmMainTmpl, "__LG_STORAGE_ID__", strconv.Quote(storeID))
-	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(mainSrc), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(renderWasmMain(storeID, hostEval)), 0644); err != nil {
 		return err
 	}
 
@@ -260,9 +306,15 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		}
 	}
 
-	// 11. Write coi-serviceworker.js for cross-origin isolation on hosted servers
-	if err := os.WriteFile(filepath.Join(outDir, "coi-serviceworker.js"), []byte(coiServiceWorkerJS), 0644); err != nil {
-		return err
+	// 11. Write coi-serviceworker.js for cross-origin isolation on hosted servers.
+	// Skipped in host-eval mode: window.Eval is set on the page's global by the
+	// main-thread runtime, so the bundle must NOT become cross-origin isolated
+	// (that routes boot into a worker, where Eval would land off-window). Shipping
+	// the SW shim would let it upgrade the page to COI and silently break Eval.
+	if !hostEval {
+		if err := os.WriteFile(filepath.Join(outDir, "coi-serviceworker.js"), []byte(coiServiceWorkerJS), 0644); err != nil {
+			return err
+		}
 	}
 
 	fi, _ := os.Stat(outPath)

--- a/wasm.go
+++ b/wasm.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/nooga/let-go/pkg/bytecode"
@@ -24,127 +23,9 @@ import (
 	"github.com/nooga/let-go/pkg/vm"
 )
 
-const wasmMainTmpl = `package main
-
-import (
-	_ "embed"
-	"bytes"
-	"fmt"
-	"os"
-__LG_HOST_EVAL_IMPORTS__
-
-	"github.com/nooga/let-go/pkg/bytecode"
-	"github.com/nooga/let-go/pkg/compiler"
-	"github.com/nooga/let-go/pkg/resolver"
-	"github.com/nooga/let-go/pkg/rt"
-	"github.com/nooga/let-go/pkg/vm"
-)
-
-//go:embed program.lgb
-var lgbData []byte
-
-func main() {
-	consts := vm.NewConsts()
-	ns := rt.NS("user")
-	ctx := compiler.NewCompiler(consts, ns)
-	nsResolver := resolver.NewNSResolver(ctx, []string{"."})
-	rt.SetNSLoader(nsResolver)
-
-	// Route *out*/*err* to the JS host via _lgOutput (HostWriter), instead of
-	// os.Stdout/Stderr + the bundle's fs.writeSync fd interception. SetRoot,
-	// not a per-Run binding, because this generated main drives bytecode
-	// directly rather than through pkg/api. Guarded: if the core I/O vars
-	// aren't installed yet, output falls back to os.Stdout.
-	hostWriter := rt.NewHostWriter()
-	if v := rt.LookupCoreVar("*out*"); v != nil {
-		v.SetRoot(vm.NewBoxed(rt.NewWriterHandle("host-stdout", hostWriter)))
-	}
-	if v := rt.LookupCoreVar("*err*"); v != nil {
-		v.SetRoot(vm.NewBoxed(rt.NewWriterHandle("host-stderr", hostWriter)))
-	}
-
-	// Route (js/emit ...) to the JS host via _lgEmit (HostEmitter), the dual
-	// of the HostWriter *out* routing above. Same SetRoot rationale.
-	hostEmitter := rt.NewHostEmitter()
-	if v := rt.LookupCoreVar("*emit*"); v != nil {
-		v.SetRoot(vm.NewBoxed(hostEmitter))
-	}
-
-	// Route storage through browser localStorage, scoped by the bundle's
-	// host-selected store id so guest keys remain app-local.
-	hostStorage := rt.NewHostStorage(__LG_STORAGE_ID__)
-	if v := rt.LookupCoreVar("*storage*"); v != nil {
-		v.SetRoot(vm.NewBoxed(hostStorage))
-	}
-
-	resolve := func(nsName, name string) *vm.Var {
-		n := rt.DefNSBare(nsName)
-		v := n.LookupLocal(vm.Symbol(name))
-		if v == nil {
-			return n.DefStub(name)
-		}
-		return v
-	}
-
-	unit, err := bytecode.DecodeToExecUnit(bytes.NewReader(lgbData), resolve)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %%v\n", err)
-		return
-	}
-
-	for _, name := range unit.NSOrder {
-		chunk := unit.NSChunks[name]
-		if chunk == nil || chunk == unit.MainChunk {
-			continue
-		}
-		f := vm.NewFrame(chunk, nil)
-		_, err := f.RunProtected()
-		vm.ReleaseFrame(f)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error loading %%s: %%v\n", name, err)
-			return
-		}
-	}
-
-	f := vm.NewFrame(unit.MainChunk, nil)
-	_, err = f.RunProtected()
-	vm.ReleaseFrame(f)
-	if err != nil {
-		fmt.Fprint(os.Stderr, vm.FormatError(err))
-	}
-__LG_HOST_EVAL_BODY__
-}
-`
-
-// wasmHostEvalSnippet is spliced into wasmMainTmpl at __LG_HOST_EVAL_BODY__ when
-// -w-host-eval is set. It exposes window.Eval(code) — compile + run a string in
-// the loaded image, returning a stringified value (FormatError on failure) — and
-// then parks so the runtime stays live. The program's main chunk has already run
-// (typically just definitions); without parking the wasm would exit and Eval
-// would be unreachable. Structured data returns out-of-band via (js/emit ...).
+// The generated main.go template and its -w-host-eval splice live in
+// pkg/rt/wasm (RenderMain), alongside the HTML/JS build assets.
 //
-// Main-thread only: a worker-mode (cross-origin-isolated) bundle would set Eval
-// on the worker's global scope, not window. -w-host-eval bundles are meant to be
-// served without COI; pair with -w-shell none (the client drives the runtime).
-const wasmHostEvalSnippet = `	eval := js.FuncOf(func(this js.Value, args []js.Value) any {
-		if len(args) < 1 {
-			return "error: Eval expects one string argument"
-		}
-		chunk, cerr := ctx.Compile(args[0].String())
-		if cerr != nil {
-			return vm.FormatError(cerr)
-		}
-		frame := vm.NewFrame(chunk, nil)
-		result, rerr := frame.RunProtected()
-		vm.ReleaseFrame(frame)
-		if rerr != nil {
-			return vm.FormatError(rerr)
-		}
-		return result.String()
-	})
-	js.Global().Set("Eval", eval)
-	select {}`
-
 // The HTML page and host JS live as embedded assets in pkg/rt/wasm.
 // See pkg/rt/wasm.AssembleHTML for the assembly contract.
 
@@ -172,22 +53,6 @@ addEventListener('fetch', e => {
   }).catch(() => new Response(null, {status: 500})));
 });
 `
-
-// renderWasmMain fills wasmMainTmpl's placeholders: the storage-id, and the
-// -w-host-eval splice (the window.Eval bridge + park, plus its syscall/js
-// import). With hostEval false the marker lines are removed whole, so the
-// default bundle's generated main is byte-identical to the pre-flag output.
-func renderWasmMain(storeID string, hostEval bool) string {
-	s := strings.ReplaceAll(wasmMainTmpl, "__LG_STORAGE_ID__", strconv.Quote(storeID))
-	if hostEval {
-		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_IMPORTS__", "\t\"syscall/js\"")
-		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_BODY__", wasmHostEvalSnippet)
-	} else {
-		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_IMPORTS__\n", "")
-		s = strings.ReplaceAll(s, "__LG_HOST_EVAL_BODY__\n", "")
-	}
-	return s
-}
 
 func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool, externalWasm bool, hostEval bool, storeID string) error {
 	// 1. Compile .lg → .lgb in memory
@@ -229,7 +94,7 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	if err := os.WriteFile(filepath.Join(tmpDir, "program.lgb"), lgbBuf.Bytes(), 0644); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(renderWasmMain(storeID, hostEval)), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(wasmassets.RenderMain(storeID, hostEval)), 0644); err != nil {
 		return err
 	}
 

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"go/format"
+	"strings"
+	"testing"
+)
+
+// renderWasmMain must always substitute every placeholder — a leaked
+// __LG_* marker would be a syntax error in the generated main.go.
+func TestRenderWasmMainSubstitutesAllMarkers(t *testing.T) {
+	for _, hostEval := range []bool{false, true} {
+		got := renderWasmMain("store-x", hostEval)
+		if strings.Contains(got, "__LG_") {
+			t.Fatalf("hostEval=%v: unsubstituted marker remains:\n%s", hostEval, got)
+		}
+		if !strings.Contains(got, `"store-x"`) {
+			t.Fatalf("hostEval=%v: storage id not substituted", hostEval)
+		}
+	}
+}
+
+// Default (no -w-host-eval) must not pull in the eval bridge or its import —
+// syscall/js unused would fail to compile, and the bundle should stay as it was.
+func TestRenderWasmMainHostEvalOff(t *testing.T) {
+	got := renderWasmMain("s", false)
+	for _, leak := range []string{"syscall/js", `Set("Eval"`, "select {}"} {
+		if strings.Contains(got, leak) {
+			t.Fatalf("host-eval code leaked into default bundle: %q", leak)
+		}
+	}
+}
+
+// With -w-host-eval the generated main imports syscall/js, exposes window.Eval,
+// and parks so the runtime stays callable.
+func TestRenderWasmMainHostEvalOn(t *testing.T) {
+	got := renderWasmMain("s", true)
+	for _, want := range []string{`"syscall/js"`, `js.Global().Set("Eval", eval)`, "select {}"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("host-eval output missing %q", want)
+		}
+	}
+}
+
+// The generated main is never run through gofmt by the build, so a bad indent
+// or dangling token from substitution would ship as-is. format.Source parses
+// it — a syntax error from the splice fails here. (Exact gofmt equality isn't
+// asserted: wasmMainTmpl predates this change and isn't gofmt-sorted, e.g. the
+// `_ "embed"` import; that's upstream's to normalize, not this flag's.)
+func TestRenderWasmMainIsValidGo(t *testing.T) {
+	for _, hostEval := range []bool{false, true} {
+		if _, err := format.Source([]byte(renderWasmMain("store-x", hostEval))); err != nil {
+			t.Fatalf("hostEval=%v: generated main is not valid Go: %v", hostEval, err)
+		}
+	}
+}


### PR DESCRIPTION
# feat(wasm): add `-w-host-eval` to call into a live image via `LetGoHost.eval`

## The gap

`lg -w` bundles run the program's `main` and exit. That's the right default for a
batch or TUI program, but it means JS can only receive data *out* of the runtime
(`js/emit` → `LetGoHost.onEmit`) — it can't call *into* the loaded image to trigger
work. The standalone `wasm/main.go` does expose `window.Eval`, but it embeds no
program (only a bare `user` namespace), so the two capabilities never compose: you
can have your namespaces loaded, or a callable eval, but not both.

That's the missing piece for any "live wasm" let-go app (epic #259): a page that
boots the runtime once and drives it from JS (regenerate on a control change, eval
into the image for live-coding) rather than reloading per action.

## What this adds

A `-w-host-eval` flag for `-w`. When set, the generated main, *after* running the
program's main chunk (typically a set of `defn`s), installs the eval bridge and
parks so the image stays callable. The public surface is on `LetGoHost`, matching
the contract from #79/#245 (`_lg*` are internal hooks, `LetGoHost` is the one public
object):

```js
await LetGoHost.eval(code)   // run code in the loaded image
                             // → Promise<string> (value, or a formatted error)
```

Structured results still come back out-of-band through `(js/emit …)`; the string
return is for triggering and for simple values. Intended pairing is `-w-shell none`:
the client owns the UI and drives the runtime through `LetGoHost.eval`.

```
lg -w out -w-shell none -w-host-eval app.lg
# out/index.html boots the runtime, then LetGoHost.eval(code) is live
```

## Both boot modes, ready-gated

**Works in both boot modes.** `LetGoHost.eval` dispatches a direct `_lgEval` call on
the main thread, or a worker `postMessage` round-trip when the bundle is
cross-origin isolated (worker mode). So eval is reachable whether or not the page
got COI — no constraint on how the bundle is served, and the eval'd program never
calls `read-key`, so worker mode's input ring is untouched. (An earlier cut set a
bare `window.Eval` from the runtime, which only worked on the main thread and forced
the bundle to avoid COI; this replaces it.)

**Ready-gated, so there's no race.** `onReady` fires when the glue is wired, *before*
the wasm runs — and the eval hook only exists after the program's main returns. The
runtime calls `_lgRuntimeReady` once the hook is installed; `LetGoHost.eval` awaits
that, so a call made before boot queues instead of hitting an undefined hook.

One limitation by construction: the program's `main` must return. The eval hook is
installed after the main chunk runs, so a program that blocks in its own `main` (a
TUI key loop) never reaches it. Host-eval suits programs whose top level is
definitions.

## Implementation

The generated-main template, its `-w-host-eval` splice, and `RenderMain` live in
`pkg/rt/wasm` (next to `AssembleHTML` and the `lg-host-core.js` it substitutes into);
its test sits there too, clearing the repo-root test-file ban. The host-eval splice
follows the existing `__LG_STORAGE_ID__` placeholder approach: with the flag off, the
marker lines drop out whole, so the default bundle's generated main is unchanged.
`RenderMain` is unit-tested (including a `go/format` parse of the output) without
invoking the `GOOS=js` toolchain.

## Verification

Built a generator bundle (`-w-shell none -w-host-eval -w-wasm external`) and ran it
in both boot modes: served plain with the service worker blocked
(`crossOriginIsolated === false`, main-thread), and served with COOP/COEP headers
(`crossOriginIsolated === true`, worker). Both:

- `LetGoHost.eval('(+ 1 2)')` → `'3'`
- `LetGoHost.eval('(app/generate 42 2)')` triggers generation; floors arrive via
  `LetGoHost.onEmit`
- a `defn` redefinition through eval persists, so the next call uses it (live-coding)
- a bad form resolves to the formatted error string

`gofmt` clean; `go vet`, the `pkg/rt/wasm` tests (golden bundle refreshed for the
`lg-host-core.js` change), the root-test-location check, and `GOOS=linux`/`plan9`
builds pass. (`GOOS=windows` fails in `pkg/rt/term.go` on `unix.SIGWINCH` etc. —
pre-existing on `main`, unrelated to this change.)

## Scope

Deliberately minimal: a string-in / string-out trigger plus the existing emit
channel, enough to drive a live runtime. A richer return that builds real JS values
instead of a stringified one is a possible future enhancement; nothing tracks it yet.

Marked draft for design feedback on the surface (`LetGoHost.eval` shape, the
`_lgRuntimeReady` signal) before polish (a worker-mode test in CI, docs).
