### PR TITLE
feat(rt): add set-rand-seed! for reproducible rand, on math/rand/v2

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"sort"
 	"strconv"
@@ -1609,6 +1609,47 @@ func roundRatToInt(r *big.Rat, sign int, modeName string) (*big.Int, error) {
 }
 
 // nolint
+
+// rng backs the rand / rand-int / rand-nth / shuffle primitives and
+// math/random. math/rand/v2 has no global Seed by design — for a reproducible
+// (set-rand-seed! n) you hold your own source — so we keep one here. A
+// *rand.Rand is not safe for concurrent use, so rngMu guards every read and
+// the reseed, restoring the concurrency safety the top-level functions have.
+//
+// rngSeedSpread fills PCG's second state word so small/adjacent seeds
+// (0, 1, 2 …) don't produce near-identical streams.
+const rngSeedSpread = 0x9E3779B97F4A7C15
+
+var (
+	rngMu sync.Mutex
+	// Default: non-deterministic, full 128-bit entropy from the auto-seeded
+	// top-level v2 generator. (set-rand-seed! n) replaces it for repro runs.
+	rng = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
+)
+
+func rngFloat64() float64 {
+	rngMu.Lock()
+	defer rngMu.Unlock()
+	return rng.Float64()
+}
+
+func rngIntn(n int) int {
+	rngMu.Lock()
+	defer rngMu.Unlock()
+	return rng.IntN(n)
+}
+
+func rngShuffle(n int, swap func(i, j int)) {
+	rngMu.Lock()
+	defer rngMu.Unlock()
+	rng.Shuffle(n, swap)
+}
+
+func setRandSeed(seed int64) {
+	rngMu.Lock()
+	defer rngMu.Unlock()
+	rng = rand.New(rand.NewPCG(uint64(seed), rngSeedSpread))
+}
 
 func installLangNS() {
 	plus, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
@@ -4513,14 +4554,14 @@ func installLangNS() {
 	// or between 0 and n
 	randf, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) == 0 {
-			return vm.Float(rand.Float64()), nil
+			return vm.Float(rngFloat64()), nil
 		}
 		if len(vs) == 1 {
 			if n, ok := vs[0].(vm.Int); ok {
-				return vm.Float(rand.Float64() * float64(n)), nil
+				return vm.Float(rngFloat64() * float64(n)), nil
 			}
 			if n, ok := vs[0].(vm.Float); ok {
-				return vm.Float(rand.Float64() * float64(n)), nil
+				return vm.Float(rngFloat64() * float64(n)), nil
 			}
 			return vm.NIL, fmt.Errorf("rand expected number")
 		}
@@ -4539,7 +4580,7 @@ func installLangNS() {
 		if int(n) <= 0 {
 			return vm.MakeInt(0), nil
 		}
-		return vm.MakeInt(rand.Intn(int(n))), nil
+		return vm.MakeInt(rngIntn(int(n))), nil
 	})
 
 	// random-uuid: generate a random UUID v4
@@ -4572,7 +4613,7 @@ func installLangNS() {
 		if n == 0 {
 			return vm.NIL, fmt.Errorf("rand-nth called on empty collection")
 		}
-		idx := rand.Intn(n)
+		idx := rngIntn(n)
 		if l, ok := vs[0].(vm.Lookup); ok {
 			return l.ValueAt(vm.Int(idx)), nil
 		}
@@ -4609,10 +4650,27 @@ func installLangNS() {
 			s = s.Next()
 		}
 		// Fisher-Yates shuffle
-		rand.Shuffle(len(vals), func(i, j int) {
+		rngShuffle(len(vals), func(i, j int) {
 			vals[i], vals[j] = vals[j], vals[i]
 		})
 		return vm.NewArrayVector(vals), nil
+	})
+
+	// set-rand-seed!: seed the shared RNG so rand / rand-int / rand-nth /
+	// shuffle / math/random produce a reproducible sequence. Returns nil. The
+	// bang marks the process-wide mutation. For tests, benchmarks, and bug
+	// repros — NOT a gameplay-determinism mechanism (use explicit state for
+	// that). Reproducible only when rand calls happen in a deterministic order.
+	setRandSeedFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		n, ok := vs[0].(vm.Int)
+		if !ok {
+			return vm.NIL, fmt.Errorf("set-rand-seed! expected Int")
+		}
+		setRandSeed(int64(n))
+		return vm.NIL, nil
 	})
 
 	// transient: create a transient (mutable) version of a persistent collection
@@ -6428,6 +6486,7 @@ func installLangNS() {
 	ns.Def("rand-int", randInt)
 	ns.Def("rand-nth", randNth)
 	ns.Def("shuffle", shuffle)
+	ns.Def("set-rand-seed!", setRandSeedFn)
 	ns.Def("transient", transientf)
 	ns.Def("persistent!", persistentf)
 	ns.Def("conj!", conjBang)

--- a/pkg/rt/math.go
+++ b/pkg/rt/math.go
@@ -8,7 +8,6 @@ package rt
 import (
 	"fmt"
 	"math"
-	"math/rand"
 
 	"github.com/nooga/let-go/pkg/vm"
 )
@@ -443,7 +442,7 @@ func installMathInto(nsName string) {
 		if len(vs) != 0 {
 			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
 		}
-		return vm.Float(rand.Float64()), nil
+		return vm.Float(rngFloat64()), nil
 	})
 	ns.Def("random", randomf)
 

--- a/pkg/rt/rand_seed_test.go
+++ b/pkg/rt/rand_seed_test.go
@@ -1,0 +1,127 @@
+package rt
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// TestSetRandSeedReproducible pins the contract: the same seed yields the same
+// sequence, and a different seed diverges. It asserts sequence *equality*, not
+// specific generator outputs — those are an implementation detail of the RNG
+// and may change across Go / math/rand/v2 versions.
+func TestSetRandSeedReproducible(t *testing.T) {
+	draw := func() []int {
+		out := make([]int, 64)
+		for i := range out {
+			out[i] = rngIntn(1_000_000)
+		}
+		return out
+	}
+
+	setRandSeed(42)
+	a := draw()
+	setRandSeed(42)
+	b := draw()
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("same seed diverged at %d: %d != %d", i, a[i], b[i])
+		}
+	}
+
+	setRandSeed(43)
+	c := draw()
+	identical := true
+	for i := range a {
+		if a[i] != c[i] {
+			identical = false
+			break
+		}
+	}
+	if identical {
+		t.Fatal("different seeds produced an identical sequence")
+	}
+}
+
+// TestRandConcurrentNoRace hammers the shared RNG and the reseed from many
+// goroutines. Its purpose is to fail under `go test -race` if rngMu ever stops
+// guarding access — output is nondeterministic by design, so it asserts only
+// that draws stay in range and nothing panics.
+func TestRandConcurrentNoRace(t *testing.T) {
+	const goroutines = 16
+	const iters = 2000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(g int) {
+			defer wg.Done()
+			for i := range iters {
+				switch i % 4 {
+				case 0:
+					if v := rngIntn(100); v < 0 || v >= 100 {
+						t.Errorf("rngIntn out of range: %d", v)
+					}
+				case 1:
+					if v := rngFloat64(); v < 0 || v >= 1 {
+						t.Errorf("rngFloat64 out of range: %v", v)
+					}
+				case 2:
+					rngShuffle(8, func(i, j int) {})
+				case 3:
+					setRandSeed(int64(g*iters + i))
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestSetRandSeedBangThroughRuntime drives set-rand-seed! and rand-int as
+// resolved language primitives (not the Go helpers), so it covers the
+// registration and wiring end to end: reseeding to the same value through the
+// runtime reproduces the rand-int sequence.
+func TestSetRandSeedBangThroughRuntime(t *testing.T) {
+	core := NS("core")
+	getFn := func(name string) vm.Fn {
+		t.Helper()
+		v := core.Lookup(vm.Symbol(name))
+		if v == nil {
+			t.Fatalf("core/%s not found", name)
+		}
+		fn, ok := v.(*vm.Var).Deref().(vm.Fn)
+		if !ok {
+			t.Fatalf("core/%s is not an Fn", name)
+		}
+		return fn
+	}
+	setSeed := getFn("set-rand-seed!")
+	randInt := getFn("rand-int")
+
+	seq := func() []vm.Value {
+		out := make([]vm.Value, 16)
+		for i := range out {
+			v, err := randInt.Invoke([]vm.Value{vm.MakeInt(1_000_000)})
+			if err != nil {
+				t.Fatalf("rand-int: %v", err)
+			}
+			out[i] = v
+		}
+		return out
+	}
+
+	if _, err := setSeed.Invoke([]vm.Value{vm.MakeInt(7)}); err != nil {
+		t.Fatalf("set-rand-seed!: %v", err)
+	}
+	a := seq()
+	if _, err := setSeed.Invoke([]vm.Value{vm.MakeInt(7)}); err != nil {
+		t.Fatalf("set-rand-seed!: %v", err)
+	}
+	b := seq()
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("set-rand-seed! through runtime diverged at %d: %v != %v", i, a[i], b[i])
+		}
+	}
+}


### PR DESCRIPTION
`rand`, `rand-int`, `rand-nth`, `shuffle`, and `math/random` all drew from Go's package-level `math/rand` functions. Those are auto-seeded at startup and expose no usable `Seed`, so there's no way to pin a reproducible sequence for a test, a benchmark, or a bug reproduction.

This routes all of them through a single package-local `math/rand/v2` generator and adds `(set-rand-seed! n)` to reseed it.

## Why `math/rand/v2`

v2 has no global `Seed` by design: the way to get a reproducible stream is to construct your own source, which is what `set-rand-seed!` does. The [math/rand/v2 announcement](https://go.dev/blog/randv2) covers the rationale. These five primitives were also the only `math/rand` (v1) users in the tree, so the switch removes v1 entirely.

## Concurrency

A `*math/rand/v2.Rand` is not safe for concurrent use, unlike the package-level functions it replaces. A `sync.Mutex` guards every draw and the reseed, so the primitives keep the concurrency safety they had before. The default generator is seeded from the auto-seeded top-level v2 source, so it needs no `time.Now()` and keeps full entropy; `set-rand-seed!` swaps in a deterministic source.

## Scope

The trailing bang marks the process-wide mutation. This is for tests, benchmarks, and reproducible bug-repros, not a gameplay or simulation determinism mechanism. Code that needs that should thread explicit state instead. A given seed reproduces a sequence only when the rand calls happen in a deterministic order.

## Testing

`rand_seed_test.go` asserts that reseeding with the same value reproduces the sequence (it compares sequences, not specific generator outputs, which are an RNG implementation detail that can change across versions) and runs a `-race` stress over concurrent draws and reseeds. `go test -race ./...`, `go vet`, and `gofmt` are clean; linux, wasm, and plan9 builds pass.
