### PR TITLE
docs: add docs-status agent skill + Claude Code discovery shim

### DIFF
--- a/.agents/skills/docs-status/SKILL.md
+++ b/.agents/skills/docs-status/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: docs-status
+description: Audit documentation hygiene for the let-go docs/ tree — find stale or unverified docs, dangling or one-sided supersession links, duplicate authoritative-for claims, and docs missing from the README index. Use when asked to check doc freshness, run doc triage, audit docs/, find stale docs, or verify documentation hygiene before a docs PR.
+---
+
+# docs-status — documentation hygiene triage
+
+Drives `scripts/docs_status.py`, the read-only judgement-layer report over
+`docs/**/*.md` frontmatter. The pre-commit hook and CI floor check keep the
+*mechanical* fields honest (frontmatter present, `status:`/`last-verified:`
+parseable); this surfaces the *judgement* layer they leave to a human or
+agent. Full reference: `docs/docs-status.md`.
+
+## How to run
+
+From the repository root:
+
+```
+python3 scripts/docs_status.py            # text report over docs/
+```
+
+Stdlib-only Python; no install step. Override the scan root with `--root`
+and the thresholds with `--stale-days` / `--human-stale-days`.
+
+## What the findings mean, and what to do
+
+- **stale-last-verified** — the doc hasn't been touched in a while. Re-read
+  it; if still accurate, a trivial edit (or the pre-commit hook) refreshes
+  `last-verified:`. Don't bump the date without actually reviewing.
+- **aged-human-verified** — a human vouched once, long ago. Flag it for a
+  human to re-attest. Do not refresh it yourself.
+- **supersession** — mirror the missing half (`supersedes:` ↔
+  `superseded-by:`), fix a dangling target, or add the `superseded-by:`
+  link a `status: superseded` doc is missing.
+- **authoritative-for clashes** — two docs claim the same topic. Propose
+  which one yields, or split the topic. This is a judgement call — surface
+  it, don't silently rewrite.
+- **missing-index** — add a row to `docs/README.md` routing the doc.
+
+## The one hard rule
+
+**Never write `human-verified:`.** It records that a *human* reader vouched
+for a doc, and is set only by explicit human action — not by this tool, not
+by you, even when a human asks you to edit the doc's other fields. A blank
+`human-verified:` is reported only as a count, never as a per-doc task. See
+`docs/frontmatter-hook.md` for why this field is special.
+
+Apply the freshness, `status:`, and link fixes the way a human reviewer
+would — the tool reports; you exercise the judgement.

--- a/.claude/skills/docs-status
+++ b/.claude/skills/docs-status
@@ -1,0 +1,1 @@
+../../.agents/skills/docs-status

--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,11 @@ benchmark/letgo
 .lsp
 *.calva-repl
 CLAUDE.md
-.claude
+# Ignore local Claude state, but track .claude/skills/ — it holds symlinks into
+# the cross-client .agents/skills/ tree so Claude Code (which doesn't scan
+# .agents/ yet) auto-discovers committed skills. See .agents/skills/.
+.claude/*
+!.claude/skills/
 .DS_Store
 .nrepl-port
 


### PR DESCRIPTION
## Add a docs-status agent skill + Claude Code discovery shim

### What

Packages the `docs-status` report tool that merged in #338 as a skill. No tool change. Three small parts:

- `.agents/skills/docs-status/SKILL.md` — the vendor-neutral skill definition.
- `.claude/skills/docs-status` — a symlink into the `.agents/` tree.
- `.gitignore` — narrows the blanket `.claude` ignore to `.claude/*` + `!.claude/skills/`.

### Why

`scripts/docs_status.py` is meant to be run on demand by a human or a coding agent before a docs PR — it surfaces the judgement-layer findings (stale docs, one-sided supersession links, `authoritative-for` clashes, docs missing from the README index) that the pre-commit hook and the `docs-frontmatter` CI floor deliberately leave to a reader.

The tool documents itself in `docs/docs-status.md`, but an agent has to find and read that doc first, then infer the right response to each finding. The skill front-loads both: a description that tells the agent when to reach for the tool, and a per-finding guide for what to actually do (mirror the missing supersession half, route a missing doc into the README, flag — never auto-refresh — an aged human attestation). It encodes the same judgement a careful reviewer applies, so the tool gets used the way #338 intended rather than as a bare report nobody acts on.

### Why three parts, and the `.gitignore` change

`.agents/skills/` is the vendor-neutral home for a committed, agent-readable skill, and a directory the repo does not carry today. The catch: Claude Code does not scan `.agents/` yet, so the skill file alone is invisible to it. The `.claude/skills/docs-status` symlink bridges that — Claude Code reads `.claude/skills/`, follows the link into the `.agents/` tree, and discovers the skill.

That symlink is the reason for the `.gitignore` edit. The repo ignores `.claude` wholesale today; this narrows it to `.claude/*` + `!.claude/skills/`, so per-developer Claude state stays untracked but the committed skill symlink ships. It mirrors how `CLAUDE.md` and `AGENTS.md` are already handled — ignore the local state, track the shared, reviewable artifact.

Alternative: keep all agent config untracked: Drop the `.claude/` carve-out and the symlink. The `.agents/` skill stands on its own for any tool that scans that tree, and Claude Code users can add the symlink locally. Could go either way, but I think the proposed symlink-in-repo gives us better adherence.

### Testing

No code path. The file is a static skill definition; `docs_status.py` is unchanged and already covered by its CI job.
