### PR TITLE
ci(release): isolate slow lowering e2e tests in a dedicated step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,7 @@ jobs:
       # test/gold/*.out goldens. Re-deriving those goldens from a LIVE Clojure is
       # done in the dedicated `gold-differential` job (no JVM dependency here).
       # -short skips the expensive lowering harnesses (determinism, AOT diff,
-      # deftype skeleton); they run in the dedicated step below so this lane
+      # deftype skeleton); they run in dedicated CI steps below so this lane
       # stays inside a 60s per-package timeout.
       - name: Test with bundled bytecode stdlib
         run: go test -short -v -timeout 60s ./... -skip TestClojureTestSuite
@@ -78,13 +78,15 @@ jobs:
         run: go test -tags bootstrap ./test/ -count=1 -run TestClojureTestSuite -v
 
       # The expensive lowering e2e harnesses self-skip under -short, so the fast
-      # lanes above exclude them. They build their own tagged binaries via
-      # subprocess (so a single untagged run covers both stdlib modes). The
-      # determinism harness compiles the whole stdlib twice concurrently and is
-      # the slow one: ~60-120s on CI, ~200s on a contended local machine. It runs
-      # here under a generous ceiling instead of inflating every package's budget.
-      - name: Expensive lowering e2e (determinism, AOT diff, deftype skeleton)
-        run: go test -v -timeout 600s ./test/e2e/ -run 'TestLoweringDeterminism|TestGogenAOTDiff|TestDeftypeSkeletonNativeLowering'
+      # lanes above exclude them. Determinism and deftype run here; AOT diff stays
+      # in the dedicated gogen-diff job below, which regenerates the lowered tree
+      # first. These tests build their own tagged binaries via subprocess (so a
+      # single untagged run covers both stdlib modes). The determinism harness
+      # compiles the whole stdlib twice concurrently and is the slow one:
+      # ~60-120s on CI, ~200s on a contended local machine. It runs here under a
+      # generous ceiling instead of inflating every package's budget.
+      - name: Expensive lowering e2e (determinism, deftype skeleton)
+        run: go test -v -timeout 600s ./test/e2e/ -run 'TestLoweringDeterminism|TestDeftypeSkeletonNativeLowering'
 
   # Differential gold check against a LIVE Clojure. The everyday `build` job is
   # clojure-free (it compares let-go to the committed test/gold/*.out goldens);

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,21 +62,29 @@ jobs:
       # default: they run each script under let-go and compare to the committed
       # test/gold/*.out goldens. Re-deriving those goldens from a LIVE Clojure is
       # done in the dedicated `gold-differential` job (no JVM dependency here).
-      # TEMPORARY (#299): per-package test timeout raised 60s→180s so the
-      # lowering-determinism harness (runs lgbgen twice, ~60-120s on CI) fits.
-      # Revert to 60s once that test is moved to a dedicated long-timeout step.
+      # -short skips the expensive lowering harnesses (determinism, AOT diff,
+      # deftype skeleton); they run in the dedicated step below so this lane
+      # stays inside a 60s per-package timeout.
       - name: Test with bundled bytecode stdlib
-        run: go test -v -timeout 180s ./... -skip TestClojureTestSuite
+        run: go test -short -v -timeout 60s ./... -skip TestClojureTestSuite
 
       - name: Clojure compatibility test suite with bundled bytecode stdlib
         run: go test ./test/ -count=1 -run TestClojureTestSuite -v
 
-      # TEMPORARY (#299): see note on the bytecode step above.
       - name: Test with source stdlib bootstrap
-        run: go test -tags bootstrap -v -timeout 180s ./... -skip TestClojureTestSuite
+        run: go test -tags bootstrap -short -v -timeout 60s ./... -skip TestClojureTestSuite
 
       - name: Clojure compatibility test suite with source stdlib bootstrap
         run: go test -tags bootstrap ./test/ -count=1 -run TestClojureTestSuite -v
+
+      # The expensive lowering e2e harnesses self-skip under -short, so the fast
+      # lanes above exclude them. They build their own tagged binaries via
+      # subprocess (so a single untagged run covers both stdlib modes). The
+      # determinism harness compiles the whole stdlib twice concurrently and is
+      # the slow one: ~60-120s on CI, ~200s on a contended local machine. It runs
+      # here under a generous ceiling instead of inflating every package's budget.
+      - name: Expensive lowering e2e (determinism, AOT diff, deftype skeleton)
+        run: go test -v -timeout 600s ./test/e2e/ -run 'TestLoweringDeterminism|TestGogenAOTDiff|TestDeftypeSkeletonNativeLowering'
 
   # Differential gold check against a LIVE Clojure. The everyday `build` job is
   # clojure-free (it compares let-go to the committed test/gold/*.out goldens);

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,11 @@ before:
   hooks:
     - go mod tidy
     - go generate ./pkg/rt/
-    - go test -timeout 60s ./...
+    # -short skips the expensive lowering harnesses (determinism, AOT diff,
+    # deftype skeleton); those are gated in CI on every push to main, so this
+    # pre-build sanity run doesn't re-pay their ~minutes-long cost or risk the
+    # 60s timeout the determinism harness would otherwise blow.
+    - go test -short -timeout 60s ./...
 
 builds:
   - id: unix

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,15 @@ GOLANGCI-LINT := github.com/golangci/golangci-lint/cmd/golangci-lint
 REPORT-SCRIPT := scripts/clojure_compat_report.sh
 
 # Resource caps for test invocations. GOMEMLIMIT bounds the Go heap
-# (soft cap — runtime aggressively GCs to stay under). GO-TEST-TIMEOUT
-# matches CI's per-package timeout so runaway tests die locally too.
+# (soft cap — runtime aggressively GCs to stay under).
 # Override on the command line: make test GOMEMLIMIT=4GiB.
 GOMEMLIMIT ?= 2GiB
-# TEMPORARY (#299): 60s→180s so the lowering-determinism harness (runs lgbgen
-# twice) fits. Revert once that test moves to a dedicated long-timeout step.
-GO-TEST-TIMEOUT ?= 180s
+# `make test` runs the full suite, including the expensive lowering harnesses.
+# The determinism test compiles the whole stdlib twice concurrently (~60-120s
+# on CI, ~200s on a contended local machine). CI's fast lanes use -short at 60s
+# and run these in a dedicated long-timeout step; the full local run keeps a
+# generous per-package ceiling matching that step.
+GO-TEST-TIMEOUT ?= 600s
 
 # Export the heap cap to EVERY recipe's environment, not just `make test`.
 # The bootstrap/lowering targets (generate, lowered, parity) shell out to


### PR DESCRIPTION
## Why

The release workflow runs goreleaser, and its before-hook is `go test -timeout 60s ./...`. Since #299 the lowering-determinism harness compiles the stdlib twice and takes ~60–120s on CI (~200s on a contended laptop), so a `v*` tag push fails the release even though `main` is green. CI only passes because #299 temporarily raised the per-package timeout to 180s in the `go.yml` lanes, and that bump never reached the goreleaser hook. This blocks cutting v1.11.0.

## What

- Pass `-short` in the two fast CI lanes and the goreleaser before-hook, and revert them to a 60s per-package timeout.
- Run the expensive determinism and deftype-skeleton lowering harnesses in a dedicated CI step with a 600s ceiling.
- Keep the AOT diff harness in its existing `gogen-diff` job, which regenerates the lowered tree before testing.
- Drop the TEMPORARY (#299) timeout bumps in `go.yml` and the Makefile.

## Why it's safe

- All three harnesses already self-skip under `testing.Short()`, so `-short` is the existing intended lever, not a new gate.
- Each builds its own `-tags`-selected binary via subprocess, so the outer `go test` build tag doesn't change them. That's why a single untagged CI run of each harness reproduces the coverage the old bytecode and bootstrap fast lanes gave between them — collapsing two runs into one loses nothing.
- The existing `gogen-diff` job continues to gate the AOT diff harness without running it twice.

## Follow-up

Tracked separately, not in this PR. The determinism harness is the slow one, and ~200s warm is heavier than the #299 estimate. It compiles the whole stdlib twice concurrently; caching the first lowered tree or diffing a cheaper artifact would cut local `make test` time. Worth a separate issue rather than holding this fix.
