### PR TITLE
feat(aot): lg-compile AOT driver + examples on lower-all-ns-to-go (#258)

### DIFF
--- a/examples/aot/README.md
+++ b/examples/aot/README.md
@@ -1,0 +1,25 @@
+# AOT compilation examples
+
+Trials for compiling let-go `.lg`/`.clj(c)` namespaces **ahead-of-time to native
+Go**, via `scripts/lg-compile` (the multi-namespace AOT driver with direct
+cross-package calls).
+
+Driver:
+
+```
+./lg scripts/lg-compile <out-dir> <import-prefix> <file.lg>...
+```
+
+It lowers each single-arity `defn`/`defmulti`/`defmethod` to a native Go func,
+emits one Go package per namespace (canonical `gogen/ns->go-pkg` naming: leaf
+segment + nested dir), and wires direct `pkg.Fn(ec, …)` calls between the
+lowered packages. Variadic / non-coercible fns stay on runtime trampolines.
+
+| Directory | What it is |
+|---|---|
+| `cross-package/` | Minimal two-namespace demo (`lib` + `app`) exercising a direct cross-package call. The smallest reproducible AOT example. |
+| `ys-on-let-go/`  | The YS-on-let-go shim: a small YAMLScript-style stdlib plus example programs. See its own `README.md`. |
+| `yamlstar/`      | Diagnostics for AOT-compiling the real YamlStar Clojure pipeline (`ys-coverage.lg` — per-file lowerability tally; `ys-lower-report.lg` — per-fn lower/fallback report). |
+
+Generated Go output (`*/go/`, `*/go_lowered/`) is git-ignored — regenerate with
+`lg-compile`.

--- a/examples/aot/cross-package/src/app.lg
+++ b/examples/aot/cross-package/src/app.lg
@@ -1,0 +1,4 @@
+(ns app
+  (:require
+   [lib :refer [add1 greet]]))
+(defn run [x] (greet (add1 x)))

--- a/examples/aot/cross-package/src/lib.lg
+++ b/examples/aot/cross-package/src/lib.lg
@@ -1,0 +1,3 @@
+(ns lib)
+(defn greet [x] (str "hi " x))
+(defn add1 [x] (+ x 1))

--- a/examples/aot/yamlstar/ys-coverage.lg
+++ b/examples/aot/yamlstar/ys-coverage.lg
@@ -1,0 +1,55 @@
+;; ys-coverage — measure lowerability of a set of .lg/.clj(c) files WITHOUT a
+;; full compile. For each file: can the reader ingest it? Then classify each
+;; top-level form into buckets that predict AOT-lowering behavior:
+;;   native-defn   single-arity (defn/defn-)         -> lowers to a Go func
+;;   multi-defn    multi-arity defn                  -> stays on trampoline
+;;   defmulti/defmethod                              -> native (ITER-0010/0011)
+;;   def           plain def (value)                 -> emitted as var/trampoline
+;;   macro/special ns, require, defmacro, import …   -> setup, not lowered
+;;   other         everything else
+;;
+;;   ./lg scripts/ys-coverage.lg <file>...
+
+(require 'clojure.string)
+
+(def argv (vec (drop 2 (seq os/args))))
+
+(defn read-all [path]
+  (try
+    (read-string (str "(do " (slurp path) "\n)"))
+    (catch _e :READ-FAIL)))
+
+(defn single-arity-defn? [f] (boolean (some vector? (drop 2 f))))
+
+(defn classify [f]
+  (if-not (seq? f)
+    :other
+    (let [h (first f)]
+      (cond
+        (or (= h 'defn) (= h 'defn-)) (if (single-arity-defn? f) :native-defn :multi-defn)
+        (= h 'defmulti)  :defmulti
+        (= h 'defmethod) :defmethod
+        (= h 'def)       :def
+        (or (= h 'ns) (= h 'require) (= h 'import) (= h 'defmacro)
+            (= h 'in-ns) (= h 'refer) (= h 'use) (= h 'declare)) :setup
+        :else :other))))
+
+(defn tally [forms]
+  (reduce (fn [m f] (let [k (classify f)] (assoc m k (inc (get m k 0))))) {} forms))
+
+(doseq [path argv]
+  (let [parsed (read-all path)]
+    (if (= parsed :READ-FAIL)
+      (println (str path "\tREAD-FAIL"))
+      (let [forms (vec (rest parsed))
+            t     (tally forms)]
+        (println (str path
+                      "\tforms="   (count forms)
+                      "\tnative="  (get t :native-defn 0)
+                      "\tmulti="   (get t :multi-defn 0)
+                      "\tdefmulti="(get t :defmulti 0)
+                      "\tdefmethod="(get t :defmethod 0)
+                      "\tdef="     (get t :def 0)
+                      "\tsetup="   (get t :setup 0)
+                      "\tother="   (get t :other 0)))))))
+(println "done.")

--- a/examples/aot/yamlstar/ys-lower-report.lg
+++ b/examples/aot/yamlstar/ys-lower-report.lg
@@ -1,0 +1,53 @@
+;; ys-lower-report — actually ATTEMPT to lower each single-arity defn in a file
+;; and report :lowered vs fallback (with the error). Loads the file form-by-form
+;; first (so refers resolve), then runs compile-form* per lowerable form under
+;; *target* :go, catching failures.
+;;
+;;   ./lg scripts/ys-lower-report.lg <file.lg>   (one ns per invocation)
+;;
+;; Prereq namespaces must already be loadable on LG_SOURCE_PATHS.
+
+(require 'ir.data)
+(require 'ir.passes.pipeline)
+(require 'ir.passes.typeinfer)
+(require 'ir.lattice)
+(require 'ir.build)
+(require 'ir.lower-go)
+(require 'clojure.string)
+
+(def argv (vec (drop 2 (seq os/args))))
+(def path (nth argv 0))
+
+(defn read-all [p] (read-string (str "(do " (slurp p) "\n)")))
+(defn single-arity-defn? [f] (boolean (some vector? (drop 2 f))))
+(defn lowerable? [f]
+  (and (seq? f)
+       (let [h (first f)]
+         (or (and (or (= h 'defn) (= h 'defn-)) (single-arity-defn? f))
+             (= h 'defmulti) (= h 'defmethod)))))
+(defn find-ns-name [forms]
+  (some (fn [f] (when (and (seq? f) (= 'ns (first f))) (second f))) forms))
+(defn form-name [f] (str (second f)))
+
+(let [parsed (read-all path)
+      forms  (vec (rest parsed))
+      nsn    (find-ns-name forms)
+      lf     (vec (filter lowerable? forms))]
+  (println (str "file=" path " ns=" nsn " lowerable-forms=" (count lf)))
+  ;; load the ns so its internal refers resolve
+  (when-not nsn (eval (list 'ns 'ys-report-tmp)))
+  (doseq [f forms] (try (eval f) (catch _e nil)))
+  (binding [ir.passes.pipeline/*target* :go
+            *ns* (the-ns (or nsn 'ys-report-tmp))]
+    (let [r (reduce
+              (fn [acc f]
+                (let [nm  (form-name f)
+                      res (try (ir.passes.pipeline/compile-form* f)
+                               (catch e {:status :threw :err (str e)}))
+                      st  (:status res)]
+                  (cond
+                    (= st :lowered) (do (println (str "  OK   " nm)) (update acc :ok inc))
+                    (= st :threw)   (do (println (str "  THROW " nm " :: " (:err res))) (update acc :threw inc))
+                    :else           (do (println (str "  FB   " nm " :: status=" st)) (update acc :fb inc)))))
+              {:ok 0 :fb 0 :threw 0} lf)]
+      (println (str "SUMMARY " path " ok=" (:ok r) " fallback=" (:fb r) " threw=" (:threw r))))))

--- a/examples/aot/ys-on-let-go/01_hello.lg
+++ b/examples/aot/ys-on-let-go/01_hello.lg
@@ -1,0 +1,5 @@
+;; Auto-generated from 01_hello.ys via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [say ARGS]])
+(defn main [] (say "hello from let-go via yamlscript"))
+(apply main ARGS)

--- a/examples/aot/ys-on-let-go/01_hello.ys
+++ b/examples/aot/ys-on-let-go/01_hello.ys
@@ -1,0 +1,4 @@
+!yamlscript/v0
+
+defn main():
+  say: "hello from let-go via yamlscript"

--- a/examples/aot/ys-on-let-go/02_fizzbuzz.lg
+++ b/examples/aot/ys-on-let-go/02_fizzbuzz.lg
@@ -1,0 +1,17 @@
+;; Auto-generated from 02_fizzbuzz.ys via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [say ARGS]])
+(defn
+  fizzbuzz
+  [n]
+  (cond
+    (zero? (mod n 15))
+    "FizzBuzz"
+    (zero? (mod n 3))
+    "Fizz"
+    (zero? (mod n 5))
+    "Buzz"
+    :else
+    (str n)))
+(defn main [] (doseq [i (range 1 16)] (say (fizzbuzz i))))
+(apply main ARGS)

--- a/examples/aot/ys-on-let-go/02_fizzbuzz.ys
+++ b/examples/aot/ys-on-let-go/02_fizzbuzz.ys
@@ -1,0 +1,12 @@
+!yamlscript/v0
+
+defn fizzbuzz(n):
+  cond:
+    (zero? (mod n 15)): "FizzBuzz"
+    (zero? (mod n 3)):  "Fizz"
+    (zero? (mod n 5)):  "Buzz"
+    :else: (str n)
+
+defn main():
+  doseq [i (range 1 16)]:
+    say: fizzbuzz(i)

--- a/examples/aot/ys-on-let-go/03_classify.lg
+++ b/examples/aot/ys-on-let-go/03_classify.lg
@@ -1,0 +1,12 @@
+;; Auto-generated from 03_classify.ys via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [say ARGS]])
+(defn
+  classify
+  [n]
+  (cond (pos? n) "positive" (neg? n) "negative" :else "zero"))
+(defn
+  main
+  []
+  (doseq [n (range -2 3)] (say (str n " is " (classify n)))))
+(apply main ARGS)

--- a/examples/aot/ys-on-let-go/03_classify.ys
+++ b/examples/aot/ys-on-let-go/03_classify.ys
@@ -1,0 +1,11 @@
+!yamlscript/v0
+
+defn classify(n):
+  cond:
+    (pos? n): "positive"
+    (neg? n): "negative"
+    :else:    "zero"
+
+defn main():
+  doseq [n (range -2 3)]:
+    say: str(n " is " (classify n))

--- a/examples/aot/ys-on-let-go/04_data.lg
+++ b/examples/aot/ys-on-let-go/04_data.lg
@@ -1,0 +1,8 @@
+;; Auto-generated from 04_data.yaml via: ys --compile
+;; Do not edit by hand. Regenerate with: ./build.sh
+(require '[ys-runtime :refer [%]])
+(def loaded
+  (% "name" "Fido" "age" 6 "likes" ["running" "treats"]))
+(println loaded)
+(println "name:" (get loaded "name"))
+(println "likes:" (get loaded "likes"))

--- a/examples/aot/ys-on-let-go/04_data.yaml
+++ b/examples/aot/ys-on-let-go/04_data.yaml
@@ -1,0 +1,5 @@
+name: Fido
+age: 6
+likes:
+  - running
+  - treats

--- a/examples/aot/ys-on-let-go/README.md
+++ b/examples/aot/ys-on-let-go/README.md
@@ -1,0 +1,55 @@
+# Running YAMLScript (YS) on let-go
+
+[YAMLScript](https://yamlscript.org/) is a Clojure-based YAML loader and
+scripting language. Its compiler emits plain Clojure forms, which means
+the *output* of `ys --compile` can run on let-go with a small shim that
+provides the symbols from the YS standard library (`say`, `ARGS`, `%`,
+`sum`, ...).
+
+This directory contains four worked examples. The `.ys` / `.yaml` files
+are the sources; the `.lg` files are checked in so they can be run
+without `ys` installed.
+
+## Run the examples
+
+```bash
+cd examples/aot/ys-on-let-go
+
+lg -source-paths . 01_hello.lg
+lg -source-paths . 02_fizzbuzz.lg
+lg -source-paths . 03_classify.lg
+lg -source-paths . 04_data.lg
+```
+
+Each one prints the same output it would print under native `ys`.
+
+## Regenerate after editing a `.ys` source
+
+```bash
+./build.sh    # requires ys in PATH
+```
+
+## What this covers and what it doesn't
+
+The `ys-runtime.lg` shim handles enough of the YS surface to run YS
+scripts that stay inside Clojure's pure-data and simple-logic
+fragments: `defn`, `let`, `cond`, `doseq`, `range`, string
+interpolation (compiled to `str`), `apply`, `get`, `hash-map`, plus YS
+helpers like `say`/`sum`/`%`.
+
+It does not handle:
+
+- `babashka.fs` / `babashka.process` / `babashka.http-client`
+- `java-time`
+- Ordered maps (YAML round-trip preserves data but not key order; YS's
+  `%` is aliased to `hash-map` here, not `flatland.ordered/ordered-map`)
+- YS stdlib symbols whose let-go equivalents live under different
+  names (e.g. `json/load` vs let-go's `json/read-json`). For now those
+  need a hand-edit or sed pass.
+
+The compiled-output approach is the lightest of three integration
+paths discussed in [issue
+#49](https://github.com/nooga/let-go/issues/49). For full embedded
+yamlscript, SCI itself would need to be ported (SCI is `.cljc` and
+let-go already supports `:lg` reader conditionals, so that is
+tractable but not free).

--- a/examples/aot/ys-on-let-go/build.sh
+++ b/examples/aot/ys-on-let-go/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Regenerate the .lg files in this directory from their .ys / .yaml sources.
+# Requires `ys` (https://yamlscript.org) in PATH.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if ! command -v ys >/dev/null 2>&1; then
+  echo "ys not found. Install from https://yamlscript.org/install or skip — checked-in .lg files are already runnable on let-go." >&2
+  exit 1
+fi
+
+for src in 01_hello.ys 02_fizzbuzz.ys 03_classify.ys; do
+  out="${src%.ys}.lg"
+  {
+    echo ";; Auto-generated from $src via: ys --compile"
+    echo ";; Do not edit by hand. Regenerate with: ./build.sh"
+    echo "(require '[ys-runtime :refer [say ARGS]])"
+    ys --compile "$src"
+  } > "$out"
+done
+
+# Data-mode YAML: emit a driver around the compiled (% ...) form.
+{
+  echo ";; Auto-generated from 04_data.yaml via: ys --compile"
+  echo ";; Do not edit by hand. Regenerate with: ./build.sh"
+  echo "(require '[ys-runtime :refer [%]])"
+  echo "(def loaded"
+  ys --compile 04_data.yaml
+  echo ")"
+  echo "(println loaded)"
+  echo "(println \"name:\" (get loaded \"name\"))"
+  echo "(println \"likes:\" (get loaded \"likes\"))"
+} > 04_data.lg
+
+echo "Regenerated 01_hello.lg 02_fizzbuzz.lg 03_classify.lg 04_data.lg"

--- a/examples/aot/ys-on-let-go/ys-runtime.lg
+++ b/examples/aot/ys-on-let-go/ys-runtime.lg
@@ -1,0 +1,53 @@
+;
+; Copyright (c) 2026 Marcin Gasperowicz <xnooga@gmail.com>
+; SPDX-License-Identifier: MIT
+;
+
+;; ys-runtime.lg — minimal shim namespace that lets the output of
+;; `ys --compile` run on let-go. yamlscript-compiled Clojure refers to
+;; symbols from the YS stdlib (say, sum, %, ARGS, ...) which are not
+;; part of let-go. This namespace provides enough of them to run
+;; small YS programs unmodified.
+;;
+;; Coverage: pure-Clojure subset of YS. No babashka.fs / process /
+;; http-client, no java-time, no ordered maps. Suitable for scripts
+;; that stay inside YS's data + simple-logic surface.
+
+(ns ys-runtime
+  (:require
+   [clojure.string :as str]))
+
+;; --- runtime vars YS expects to be present ---------------------------
+
+(def ARGS [])
+(def ARGV [])
+(def ENV {})
+
+;; --- IO ---------------------------------------------------------------
+
+(defn say [& xs] (apply println xs))
+(defn warn [& xs] (binding [*out* *err*] (apply println xs)))
+(defn pp  [x]    (println x))
+
+;; --- arithmetic helpers YS exposes -----------------------------------
+
+(defn add [& xs] (apply + xs))
+(defn sub [& xs] (apply - xs))
+(defn mul [& xs] (apply * xs))
+(defn div [& xs] (apply / xs))
+(defn sum [xs]   (reduce + xs))
+
+;; --- string helpers ---------------------------------------------------
+
+(defn join
+  ([xs]     (apply str xs))
+  ([sep xs] (str/join sep xs)))
+
+(defn text [xs] (str/join "\n" xs))
+
+;; --- YAML data-mode constructor --------------------------------------
+
+;; YS data-mode YAML files compile to `(% k v k v ...)`. In real YS
+;; `%` is `flatland.ordered.map/ordered-map`; we fall back to
+;; `hash-map`, which preserves the data but not insertion order.
+(defn % [& kvs] (apply hash-map kvs))

--- a/pkg/rt/gogen/gogen.lg
+++ b/pkg/rt/gogen/gogen.lg
@@ -646,3 +646,25 @@
                         (->value-or-nil value)
                         comment))
     :else (throw (str "const-row: don't know how to process " (pr-str r)))))
+
+;; Namespace -> Go package/dir manglers. Single source of truth shared by the
+;; cross-package AOT path: cmd/lgbgen (cross-package packaging) and
+;; scripts/lg-compile (the multi-namespace AOT driver) name packages identically.
+;; Mirrors Glojure's mungeID(getLastNSPart(ns)) / nsToPath.
+
+(defn ns->go-pkg
+  "The Go package name for namespace `ns-name`: the LAST dot-segment with
+   hyphens turned into underscores. This is both the `package` identifier and
+   the per-namespace filename stem.
+     (gogen/ns->go-pkg \"ir.passes.pipeline\") => \"pipeline\"
+     (gogen/ns->go-pkg \"ir.lower-go\")        => \"lower_go\""
+  [ns-name]
+  (str/replace (last (str/split ns-name ".")) "-" "_"))
+
+(defn ns->go-reldir
+  "The relative directory path (under the lowered-output root) that mirrors the
+   namespace nesting: dots become path separators, hyphens become underscores.
+     (gogen/ns->go-reldir \"ir.passes.pipeline\") => \"ir/passes/pipeline\"
+     (gogen/ns->go-reldir \"ir.lower-go\")        => \"ir/lower_go\""
+  [ns-name]
+  (str/replace (str/replace ns-name "-" "_") "." "/"))

--- a/scripts/lg-compile
+++ b/scripts/lg-compile
@@ -56,6 +56,67 @@
         base (nth segs (dec (count segs)))]
     (clojure.string/replace base ".lg" "")))
 
+;; Only DEFINITIONAL forms are evaluated during compilation: lowering needs each
+;; ns set up (its require/refer/alias table) and its vars interned so cross-ns
+;; calls resolve — but NOT arbitrary top-level expressions. Evaluating e.g.
+;; `(apply main ARGS)` would run user code (side effects) at compile time, and
+;; that form isn't part of the lowered Go output anyway.
+(def definitional-heads
+  (set '(ns in-ns require use import refer load load-file
+         def defn defn- defonce defmacro defmulti defmethod defprotocol
+         deftype defrecord declare definterface defmulti- def-)))
+
+(defn definitional? [f]
+  (and (seq? f) (symbol? (first f)) (contains? definitional-heads (first f))))
+
+;; A require entry names a namespace as a bare symbol, a [ns …] vector, or either
+;; wrapped in a (quote …) (top-level `(require '[ns …])`).
+(defn dep-ns-of-entry [e]
+  (cond
+    (and (seq? e) (= 'quote (first e))) (dep-ns-of-entry (second e))
+    (vector? e)                         (first e)
+    (symbol? e)                         e
+    :else                               nil))
+
+;; The namespaces a file depends on: ns-form :require/:use clauses + top-level
+;; (require …)/(use …). Used to load inputs in dependency order so compilation is
+;; independent of the order files are passed on the command line.
+(defn spec-dep-syms [forms]
+  (let [out (atom [])]
+    (doseq [f forms]
+      (when (and (seq? f) (symbol? (first f)))
+        (cond
+          (= 'ns (first f))
+          (doseq [clause (drop 2 f)]
+            (when (and (seq? clause) (contains? #{:require :use} (first clause)))
+              (doseq [e (rest clause)]
+                (when-let [n (dep-ns-of-entry e)] (swap! out conj n)))))
+          (contains? #{'require 'use} (first f))
+          (doseq [e (rest f)]
+            (when-let [n (dep-ns-of-entry e)] (swap! out conj n))))))
+    @out))
+
+;; Topologically order specs so a namespace loads after the sibling inputs it
+;; requires (deps outside the input set are ignored — they load via the normal
+;; path). DFS marks-before-recursing, so a require cycle terminates (its members
+;; come out in discovery order) rather than looping.
+(defn topo-order-specs [specs]
+  (let [by-ns (reduce (fn [m s] (assoc m (:nsn s) s)) {} specs)
+        nsset (set (keys by-ns))
+        deps  (reduce (fn [m s]
+                        (assoc m (:nsn s) (vec (filter nsset (spec-dep-syms (:forms s))))))
+                      {} specs)
+        seen  (atom #{})
+        out   (atom [])]
+    (doseq [s specs]
+      ((fn visit [nsn]
+         (when-not (contains? @seen nsn)
+           (swap! seen conj nsn)
+           (doseq [d (get deps nsn)] (visit d))
+           (swap! out conj (get by-ns nsn))))
+       (:nsn s)))
+    @out))
+
 ;; Everything below runs in ONE top-level form so it is COMPILED in this script's
 ;; ns (all symbols resolve) BEFORE the runtime (ns ..)/eval calls switch the
 ;; global current ns.
@@ -76,12 +137,14 @@
                        :nsn (if ns-sym ns-sym (symbol nsstr))
                        :go-pkg (str import-prefix "/" reldir)}))
                   files)
-      ;; --- load every ns first, form-by-form, so cross-ns refers resolve when
-      ;;     lower-all-ns-to-go lowers them (a whole-(do ..) eval would compile
-      ;;     before the require runs; #195) ---
-      _load (doseq [s specs]
+      ;; --- load every ns first, in dependency order, evaluating ONLY
+      ;;     definitional forms, so cross-ns refers resolve when
+      ;;     lower-all-ns-to-go lowers them — regardless of input order, and
+      ;;     without running top-level user code at compile time ---
+      _load (doseq [s (topo-order-specs specs)]
               (when-not (:ns-sym s) (eval (list 'ns (:nsn s))))
-              (doseq [f (:forms s)] (eval f)))
+              (doseq [f (:forms s)]
+                (when (definitional? f) (eval f))))
       ;; --- whole-program cross-package lowering (collect-all then emit-all) ---
       gospecs (mapv (fn [s] [(:pkg s) (:nsn s) (:lf s) (:go-pkg s)]) specs)
       results (binding [ir.passes.pipeline/*target* :go]

--- a/scripts/lg-compile
+++ b/scripts/lg-compile
@@ -1,0 +1,103 @@
+;; lg-compile — AOT-compile a SET of let-go .lg files to .go packages, with
+;; DIRECT cross-package calls between them (pkg.Fn(ec, …) instead of runtime
+;; CachedVarFn trampolines) and the matching Go imports.
+;;
+;;   ./lg scripts/lg-compile <out-dir> <import-prefix> <file.lg>...
+;;
+;;   <import-prefix>  Go import path of <out-dir> (each package is
+;;                    <import-prefix>/<reldir>). e.g. for out-dir
+;;                    examples/aot/cross-package/go under module
+;;                    github.com/nooga/let-go, prefix is
+;;                    github.com/nooga/let-go/examples/aot/cross-package/go
+;;
+;; A thin CLI wrapper over ir.passes.pipeline/lower-all-ns-to-go (the
+;; whole-program cross-package lowering driver): it parses each file into a
+;; lowering spec, interns every namespace so cross-ns refers resolve, hands the
+;; whole set to lower-all-ns-to-go (which builds the cross-package registry in a
+;; collect-all/emit-all pass and emits direct pkg.Fn(ec,…) calls + imports +
+;; exported wrappers), then writes each returned Go package to disk. Variadic /
+;; non-coercible fns aren't :direct-callable?, so they stay on the trampoline.
+
+(require 'ir.data)
+(require 'ir.passes.pipeline)
+(require 'ir.passes.typeinfer)
+(require 'ir.lattice)
+(require 'ir.build)
+(require 'ir.lower-go)
+(require 'clojure.string)
+(require 'gogen)
+
+;; Evaluating a file's (ns ..) form switches the GLOBAL current ns; capture this
+;; script's ns so we can restore it after loading (else later top-level defs in
+;; this script resolve against a loaded file's ns and break).
+(def --script-ns *ns*)
+
+(def argv (vec (drop 2 (seq os/args))))
+(def out-dir (nth argv 0))
+(def import-prefix (nth argv 1))
+(def files (vec (drop 2 argv)))
+
+(defn read-all [path]
+  (read-string (str "(do " (slurp path) "\n)")))
+
+(defn single-arity-defn? [f] (boolean (some vector? (drop 2 f))))
+
+(defn lowerable? [f]
+  (and (seq? f)
+       (let [h (first f)]
+         (or (and (or (= h 'defn) (= h 'defn-)) (single-arity-defn? f))
+             (= h 'defmulti) (= h 'defmethod)))))
+
+(defn find-ns-name [forms]
+  (some (fn [f] (when (and (seq? f) (= 'ns (first f))) (second f))) forms))
+
+(defn basename-stem [path]
+  (let [segs (clojure.string/split path "/")
+        base (nth segs (dec (count segs)))]
+    (clojure.string/replace base ".lg" "")))
+
+;; Everything below runs in ONE top-level form so it is COMPILED in this script's
+;; ns (all symbols resolve) BEFORE the runtime (ns ..)/eval calls switch the
+;; global current ns.
+(let [;; --- parse all files into specs ---
+      specs (mapv (fn [path]
+                    (let [parsed (read-all path)
+                          forms  (vec (rest parsed))
+                          ns-sym (find-ns-name forms)
+                          lf     (vec (filter lowerable? forms))
+                          ;; canonical gogen naming: pkg = leaf segment,
+                          ;; reldir = nested ns path. Files lacking an (ns ..)
+                          ;; get a synthetic flat ys_<stem> for both.
+                          nsstr  (if ns-sym (str ns-sym) (str "ys-" (basename-stem path)))
+                          pkg    (gogen/ns->go-pkg nsstr)
+                          reldir (gogen/ns->go-reldir nsstr)]
+                      {:path path :forms forms :ns-sym ns-sym :lf lf
+                       :pkg pkg :reldir reldir
+                       :nsn (if ns-sym ns-sym (symbol nsstr))
+                       :go-pkg (str import-prefix "/" reldir)}))
+                  files)
+      ;; --- load every ns first, form-by-form, so cross-ns refers resolve when
+      ;;     lower-all-ns-to-go lowers them (a whole-(do ..) eval would compile
+      ;;     before the require runs; #195) ---
+      _load (doseq [s specs]
+              (when-not (:ns-sym s) (eval (list 'ns (:nsn s))))
+              (doseq [f (:forms s)] (eval f)))
+      ;; --- whole-program cross-package lowering (collect-all then emit-all) ---
+      gospecs (mapv (fn [s] [(:pkg s) (:nsn s) (:lf s) (:go-pkg s)]) specs)
+      results (binding [ir.passes.pipeline/*target* :go]
+                (ir.passes.pipeline/lower-all-ns-to-go gospecs))]
+  ;; --- write each emitted package to disk ---
+  (doseq [pair (map-indexed vector specs)]
+    (let [i  (first pair)
+          s  (second pair)
+          go (nth results i)]
+      (cond
+        (empty? (:lf s)) (println (str (:path s) ": no lowerable defns — skipped"))
+        (string? go)     (let [dir (str out-dir "/" (:reldir s))
+                               out (str dir "/" (:pkg s) ".go")]
+                           (mkdir dir)
+                           (spit out go)
+                           (println (str (:path s) " -> " out)))
+        :else            (println (str "EMIT-FAIL " (:path s) " pkg=" (:pkg s)
+                                       " returned " (clojure.core/type go))))))
+  (println "done."))


### PR DESCRIPTION
Part of Epic #258 — Lowering & cross-target codegen.

Salvages the user-namespace **AOT compile tooling** from the now-superseded #332/#335 "aot" stack, ported onto the cross-package lowering that landed via #343/#344/#345.

## What

- **`scripts/lg-compile`** — a thin CLI over `ir.passes.pipeline/lower-all-ns-to-go`. Given a set of `.lg` files it parses each into a lowering spec, interns every namespace so cross-ns refers resolve, runs the whole-program lowering (direct `pkg.Fn(ec,…)` calls + imports + exported wrappers between AOT-lowered packages), and writes one Go package per namespace.

  ```
  LG_SOURCE_PATHS=pkg/rt/core:pkg/rt/gogen \
    ./lg scripts/lg-compile <out-dir> <import-prefix> <file.lg>...
  ```

- **`gogen/ns->go-pkg` + `gogen/ns->go-reldir`** — the canonical namespace→Go package/dir manglers, so `cmd/lgbgen` and `lg-compile` name packages identically. Not used by core lowering, so `core_compiled.lgb` is unchanged (genmanifest staleness test stays green).

- **`examples/aot/`** — `cross-package/` (minimal `lib`+`app` demo), `ys-on-let-go/` (YS shim + programs), `yamlstar/` (lowerability diagnostics), and a README. Generated Go (`examples/aot/*/go/`) stays gitignored.

## Verification

`lg-compile` on the cross-package example emits `lib.LG_greet(ec, …)` as a **direct cross-package call** from `app`, and `go build ./examples/aot/cross-package/go/...` compiles clean.

Supersedes #332 and #335 (their cross-package registry / build-args / core-lowering changes landed via #343/#344/#345; this keeps only their genuinely-new tooling).
