### PR TITLE
docs: route the gogen_ir microbench README in the topical map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | Docs judgement-layer report (stale/supersession/index) | `docs-status.md` |
 | Regenerating generated artifacts after `.lg` edits | `regenerating-generated-artifacts.md` |
 | Perf ratchet, regression checkpoints, historical baselines | `perf/ratchet.md` |
+| gogen_ir native-lowering compute microbench gate | `perf/microbench/README.md` |
 | Babashka pods (usage) | `guide/pods.md` |
 | Babashka pods (host protocol / design) | `design/pods.md` |
 | Portable `.cljc` / `:lg` reader conditionals | `guide/portability.md` |


### PR DESCRIPTION
`docs/perf/microbench/README.md` was the one doc the judgement-layer report (`scripts/docs_status.py`) still flagged as unrouted. This adds a single topical-map row in `docs/README.md`, next to the perf ratchet entry, so the index covers every doc again.

## Effect

`python3 scripts/docs_status.py` now reports 31 docs scanned, 0 findings (was 1: the missing index entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)