### PR TITLE
docs: use tap install command for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ build of let-go.
 
 ### Homebrew (macOS / Linux)
 
+Primary install command:
+
 ```bash
 brew install nooga/tap/let-go
 ```

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -434,8 +434,7 @@
         <div class="install">
           <div class="box">
             <span class="label">homebrew</span>
-            <code>brew tap nooga/let-go https://github.com/nooga/let-go</code>
-            <code>brew install let-go</code>
+            <code>brew install nooga/tap/let-go</code>
           </div>
           <div class="box">
             <span class="label">go</span>


### PR DESCRIPTION
Updates the README and GitHub Pages install card to use the primary Homebrew command:

```bash
brew install nooga/tap/let-go
```