### PR TITLE
perf(bytecode): pre-size source-map / local-var slices on bundle decode

### DIFF
--- a/pkg/bytecode/decoder.go
+++ b/pkg/bytecode/decoder.go
@@ -85,6 +85,7 @@ func (d *decoder) decodeToExecUnitV1(parent *vm.Consts) (*ExecUnit, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,
@@ -187,6 +188,7 @@ func (d *decoder) decodeToExecUnitV2(parent *vm.Consts) (*ExecUnit, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,
@@ -218,6 +220,7 @@ func (d *decoder) decodeToExecUnitV2(parent *vm.Consts) (*ExecUnit, error) {
 			return nil, err
 		}
 		for i, lvs := range tables {
+			d.chunks[i].ReserveLocalVars(len(lvs))
 			for _, lv := range lvs {
 				d.chunks[i].AddLocalVar(lv.Slot, lv.Name)
 			}
@@ -314,6 +317,7 @@ func (d *decoder) readModuleV1() (*Module, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,
@@ -380,6 +384,7 @@ func (d *decoder) readModuleV2() (*Module, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,

--- a/pkg/vm/source.go
+++ b/pkg/vm/source.go
@@ -53,6 +53,18 @@ func (sm *SourceMap) Add(ip int, info SourceInfo) {
 	sm.entries = append(sm.entries, sourceMapEntry{startIP: ip, info: info})
 }
 
+// Reserve grows the backing array so that n subsequent Add calls do not
+// reallocate. The decoder knows the entry count up front (it reads a counted
+// section), so a single sized allocation replaces O(n) append-growth garbage —
+// the dominant source of startup heap churn.
+func (sm *SourceMap) Reserve(n int) {
+	if n > cap(sm.entries) {
+		grown := make([]sourceMapEntry, len(sm.entries), n)
+		copy(grown, sm.entries)
+		sm.entries = grown
+	}
+}
+
 // SourceMapEntry is the exported version of sourceMapEntry.
 type SourceMapEntry struct {
 	StartIP int

--- a/pkg/vm/source_reserve_test.go
+++ b/pkg/vm/source_reserve_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// Decoding the core bundle calls AddSourceInfo / AddLocalVar once per
+// instruction. Without a pre-sized backing array these grow by repeated
+// append, and that reallocation churn was ~47% of startup heap allocation
+// (SourceMap.Add alone was 39%). Reserve lets the decoder size the slice
+// once from the known entry count. These tests pin the no-realloc property.
+
+func TestSourceMapReserveAvoidsRealloc(t *testing.T) {
+	const n = 256
+	sm := NewSourceMap()
+	sm.Reserve(n)
+	sm.Add(0, SourceInfo{File: "a.lg"})
+	first := &sm.entries[0]
+	for i := 1; i < n; i++ {
+		sm.Add(i, SourceInfo{File: "a.lg", Line: i})
+	}
+	if &sm.entries[0] != first {
+		t.Fatalf("SourceMap reallocated despite Reserve(%d)", n)
+	}
+	if len(sm.entries) != n {
+		t.Fatalf("expected %d entries, got %d", n, len(sm.entries))
+	}
+}
+
+func TestCodeChunkReserveSourceMapAvoidsRealloc(t *testing.T) {
+	const n = 256
+	c := NewCodeChunk(NewConsts())
+	c.ReserveSourceMap(n)
+	c.AddSourceInfo(SourceInfo{File: "a.lg"})
+	first := &c.sourceMap.entries[0]
+	for i := 1; i < n; i++ {
+		c.AddSourceInfo(SourceInfo{File: "a.lg", Line: i})
+	}
+	if &c.sourceMap.entries[0] != first {
+		t.Fatalf("CodeChunk sourceMap reallocated despite ReserveSourceMap(%d)", n)
+	}
+}
+
+func TestCodeChunkReserveLocalVarsAvoidsRealloc(t *testing.T) {
+	const n = 128
+	c := NewCodeChunk(NewConsts())
+	c.ReserveLocalVars(n)
+	c.AddLocalVar(0, "x0")
+	first := &c.localVars[0]
+	for i := 1; i < n; i++ {
+		c.AddLocalVar(i, "x")
+	}
+	if &c.localVars[0] != first {
+		t.Fatalf("localVars reallocated despite ReserveLocalVars(%d)", n)
+	}
+	if len(c.localVars) != n {
+		t.Fatalf("expected %d localVars, got %d", n, len(c.localVars))
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -144,6 +144,28 @@ func (c *CodeChunk) AddLocalVar(slot int, name string) {
 	c.localVars = append(c.localVars, LocalVar{Slot: slot, Name: name})
 }
 
+// ReserveSourceMap pre-sizes the chunk's source map for n entries so the
+// per-instruction AddSourceInfo calls during bundle decode do not reallocate.
+func (c *CodeChunk) ReserveSourceMap(n int) {
+	if n <= 0 {
+		return
+	}
+	if c.sourceMap == nil {
+		c.sourceMap = NewSourceMap()
+	}
+	c.sourceMap.Reserve(n)
+}
+
+// ReserveLocalVars pre-sizes the chunk's local-variable debug table for n
+// entries so the per-slot AddLocalVar calls during decode do not reallocate.
+func (c *CodeChunk) ReserveLocalVars(n int) {
+	if n > cap(c.localVars) {
+		grown := make([]LocalVar, len(c.localVars), n)
+		copy(grown, c.localVars)
+		c.localVars = grown
+	}
+}
+
 // LocalVars returns the chunk's local-variable debug table (may be nil).
 func (c *CodeChunk) LocalVars() []LocalVar { return c.localVars }
 


### PR DESCRIPTION
## What

Decoding the precompiled core bundle (`core_compiled.lgb`) calls `AddSourceInfo` and `AddLocalVar` once per instruction. Both appended to a nil slice, so the backing array reallocated repeatedly as it grew — the dominant source of cold-start heap churn. This regressed startup as the core stdlib grew (cold start roughly doubled, ~7ms → ~15ms, and it ships in v1.11.0).

## Profile (in-process `InitFromLGB` = `lg -e nil` minus process spawn)

CPU profile: ~73% of init in GC `madvise`/`sysUsed`, driven by ~7MB / 34.7K allocs per startup.
Heap profile: `SourceMap.Add` = **39%** of allocation, per-instruction local-var tables another **8%** — both pure realloc-growth garbage, not the metadata itself.

## Fix

The decoder reads counted sections, so entry counts are known up front. Add `Reserve` to size the slices once before the per-entry loops (`SourceMap.Reserve`, `CodeChunk.ReserveSourceMap`, `CodeChunk.ReserveLocalVars`), and call them in all decode paths.

| InitFromLGB | before | after |
|---|---|---|
| time/op | 7.5 ms | **6.5 ms** (−13%) |
| bytes/op | 6.96 MB | **5.11 MB** (−1.85 MB) |
| allocs/op | 34,731 | **28,671** |

Wall-clock `lg -e nil`: ~1.2× faster same-machine.

## Safety

No behavior change — source maps and local-var tables decode identically (`Reserve` only pre-allocates capacity). Adds a no-realloc regression test for the `Reserve` methods. `pkg/vm`, `pkg/bytecode`, `pkg/compiler` suites green (309 tests).