### PR TITLE
ci(perf): track core-bundle decode (InitFromLGB) in the ratchet

### DIFF
--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -100,6 +100,15 @@ const (
 	// zz_gogen_ir_wire_test.go, so the gogen_ir variant dispatches native.
 	irCompilePackage = "github.com/nooga/let-go/pkg/ir"
 	irCompileFilter  = "^BenchmarkIRCompile$"
+
+	// Startup cost: decoding the precompiled core bundle and running its
+	// main chunk — exactly what `lg -e nil` does minus process spawn. This
+	// is the guard for startup regressions (the per-instruction source-map /
+	// local-var realloc churn that doubled cold-start). Its B/op and
+	// allocs/op are deterministic and machine-independent, so the ratchet
+	// catches a reintroduction even when ns/op is noisy.
+	initPackage = "github.com/nooga/let-go/pkg/compiler"
+	initFilter  = "^BenchmarkInitFromLGB$"
 )
 
 // defaultPackages is the scope when no -packages flag is given.
@@ -659,6 +668,10 @@ func buildJobs(packages, tags string, full, manual bool, filterRE *regexp.Regexp
 		if err != nil {
 			return nil, "", fmt.Errorf("ir-compile filter: %w", err)
 		}
+		initRE, err := regexp.Compile(initFilter)
+		if err != nil {
+			return nil, "", fmt.Errorf("init filter: %w", err)
+		}
 		jobs := []captureJob{
 			{pkg: anchorPackage, tags: tags, filter: filterRE},
 			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "bytecode", count: 1},
@@ -666,8 +679,9 @@ func buildJobs(packages, tags string, full, manual bool, filterRE *regexp.Regexp
 			{pkg: suitePackage, tags: "gogen_ir", filter: suiteRE, variant: "aot_native", count: 1, env: []string{"LG_SUITE_IR=1"}},
 			{pkg: irCompilePackage, tags: "", filter: irCompileRE, variant: "bytecode"},
 			{pkg: irCompilePackage, tags: "gogen_ir", filter: irCompileRE, variant: "gogen_ir"},
+			{pkg: initPackage, tags: "", filter: initRE, variant: "bytecode"},
 		}
-		return jobs, "full profile (vm fleet + jank ×3 + ir-compile ×2)", nil
+		return jobs, "full profile (vm fleet + jank ×3 + ir-compile ×2 + startup-init)", nil
 	default:
 		anchorRE, err := regexp.Compile(anchorFilter)
 		if err != nil {
@@ -681,6 +695,10 @@ func buildJobs(packages, tags string, full, manual bool, filterRE *regexp.Regexp
 		if err != nil {
 			return nil, "", fmt.Errorf("ir-compile filter: %w", err)
 		}
+		initRE, err := regexp.Compile(initFilter)
+		if err != nil {
+			return nil, "", fmt.Errorf("init filter: %w", err)
+		}
 		jobs := []captureJob{
 			{pkg: anchorPackage, tags: "", filter: anchorRE},
 			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "bytecode", count: 1},
@@ -688,8 +706,9 @@ func buildJobs(packages, tags string, full, manual bool, filterRE *regexp.Regexp
 			{pkg: suitePackage, tags: "gogen_ir", filter: suiteRE, variant: "aot_native", count: 1, env: []string{"LG_SUITE_IR=1"}},
 			{pkg: irCompilePackage, tags: "", filter: irCompileRE, variant: "bytecode"},
 			{pkg: irCompilePackage, tags: "gogen_ir", filter: irCompileRE, variant: "gogen_ir"},
+			{pkg: initPackage, tags: "", filter: initRE, variant: "bytecode"},
 		}
-		return jobs, "fast gate (jank ×3 + ir-compile ×2 + anchor)", nil
+		return jobs, "fast gate (jank ×3 + ir-compile ×2 + startup-init + anchor)", nil
 	}
 }
 

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -1,21 +1,123 @@
 {
   "version": 1,
-  "captured_at": "2026-05-30T21:01:32Z",
-  "captured_at_sha": "c4623afd0ef6",
+  "captured_at": "2026-06-28T23:10:26Z",
+  "captured_at_sha": "dd8f8d0cf27d",
   "machine": {
     "os": "darwin",
     "arch": "arm64",
     "num_cpu": 8,
     "cpu_model": "Apple M3",
-    "go_version": "go1.26.3"
+    "go_version": "go1.26.4"
   },
   "anchor": {
     "name": "BenchmarkRatchetAnchor",
     "package": "github.com/nooga/let-go/pkg/vm",
-    "ns_per_op": 1.8570000000000002,
-    "iterations": 642407599
+    "ns_per_op": 1.8500000000000003,
+    "iterations": 650433092,
+    "samples": [
+      {
+        "iterations": 642229246,
+        "ns_per_op": 1.8480000000000003,
+        "bytes_per_op": 0,
+        "allocs_per_op": 0,
+        "captured_at": "2026-06-28T23:10:05Z"
+      },
+      {
+        "iterations": 649395452,
+        "ns_per_op": 1.8510000000000002,
+        "bytes_per_op": 0,
+        "allocs_per_op": 0,
+        "captured_at": "2026-06-28T23:10:05Z"
+      },
+      {
+        "iterations": 650283288,
+        "ns_per_op": 1.861,
+        "bytes_per_op": 0,
+        "allocs_per_op": 0,
+        "captured_at": "2026-06-28T23:10:05Z"
+      },
+      {
+        "iterations": 650433092,
+        "ns_per_op": 1.8470000000000002,
+        "bytes_per_op": 0,
+        "allocs_per_op": 0,
+        "captured_at": "2026-06-28T23:10:05Z"
+      },
+      {
+        "iterations": 646381215,
+        "ns_per_op": 1.8470000000000002,
+        "bytes_per_op": 0,
+        "allocs_per_op": 0,
+        "captured_at": "2026-06-28T23:10:05Z"
+      },
+      {
+        "iterations": 650327780,
+        "ns_per_op": 1.8460000000000003,
+        "bytes_per_op": 0,
+        "allocs_per_op": 0,
+        "captured_at": "2026-06-28T23:10:05Z"
+      }
+    ]
   },
   "benchmarks": {
+    "github.com/nooga/let-go/pkg/compiler.BenchmarkInitFromLGB": {
+      "ns_per_op": 6445540.166666667,
+      "allocs_per_op": 28671,
+      "bytes_per_op": 5109234,
+      "ratio_to_anchor": 3484075.765765765,
+      "best_since_sha": "dd8f8d0cf27d",
+      "best_since_at": "2026-06-28T23:10:26Z",
+      "samples": [
+        {
+          "iterations": 184,
+          "ns_per_op": 6373974,
+          "bytes_per_op": 5109231,
+          "allocs_per_op": 28671,
+          "ratio_to_anchor": 3445391.3513513505,
+          "captured_at": "2026-06-28T23:10:14Z"
+        },
+        {
+          "iterations": 186,
+          "ns_per_op": 6517140,
+          "bytes_per_op": 5109230,
+          "allocs_per_op": 28671,
+          "ratio_to_anchor": 3522778.3783783778,
+          "captured_at": "2026-06-28T23:10:14Z"
+        },
+        {
+          "iterations": 182,
+          "ns_per_op": 6495405,
+          "bytes_per_op": 5109226,
+          "allocs_per_op": 28671,
+          "ratio_to_anchor": 3511029.7297297292,
+          "captured_at": "2026-06-28T23:10:14Z"
+        },
+        {
+          "iterations": 187,
+          "ns_per_op": 6449845,
+          "bytes_per_op": 5109261,
+          "allocs_per_op": 28671,
+          "ratio_to_anchor": 3486402.702702702,
+          "captured_at": "2026-06-28T23:10:14Z"
+        },
+        {
+          "iterations": 187,
+          "ns_per_op": 6422327,
+          "bytes_per_op": 5109232,
+          "allocs_per_op": 28671,
+          "ratio_to_anchor": 3471528.1081081075,
+          "captured_at": "2026-06-28T23:10:14Z"
+        },
+        {
+          "iterations": 186,
+          "ns_per_op": 6414550.000000001,
+          "bytes_per_op": 5109225,
+          "allocs_per_op": 28671,
+          "ratio_to_anchor": 3467324.3243243243,
+          "captured_at": "2026-06-28T23:10:14Z"
+        }
+      ]
+    },
     "github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [bytecode]": {
       "ns_per_op": 23970144.000000004,
       "allocs_per_op": 306882,

--- a/pkg/bytecode/decoder.go
+++ b/pkg/bytecode/decoder.go
@@ -85,6 +85,7 @@ func (d *decoder) decodeToExecUnitV1(parent *vm.Consts) (*ExecUnit, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,
@@ -187,6 +188,7 @@ func (d *decoder) decodeToExecUnitV2(parent *vm.Consts) (*ExecUnit, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,
@@ -218,6 +220,7 @@ func (d *decoder) decodeToExecUnitV2(parent *vm.Consts) (*ExecUnit, error) {
 			return nil, err
 		}
 		for i, lvs := range tables {
+			d.chunks[i].ReserveLocalVars(len(lvs))
 			for _, lv := range lvs {
 				d.chunks[i].AddLocalVar(lv.Slot, lv.Name)
 			}
@@ -314,6 +317,7 @@ func (d *decoder) readModuleV1() (*Module, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,
@@ -380,6 +384,7 @@ func (d *decoder) readModuleV2() (*Module, error) {
 		chunk.Append(cd.Code...)
 		chunk.SetMaxStack(cd.MaxStack)
 		if len(cd.SourceMap) > 0 {
+			chunk.ReserveSourceMap(len(cd.SourceMap))
 			for _, e := range cd.SourceMap {
 				chunk.AddSourceInfo(vm.SourceInfo{
 					File:      e.File,

--- a/pkg/vm/source.go
+++ b/pkg/vm/source.go
@@ -53,6 +53,18 @@ func (sm *SourceMap) Add(ip int, info SourceInfo) {
 	sm.entries = append(sm.entries, sourceMapEntry{startIP: ip, info: info})
 }
 
+// Reserve grows the backing array so that n subsequent Add calls do not
+// reallocate. The decoder knows the entry count up front (it reads a counted
+// section), so a single sized allocation replaces O(n) append-growth garbage —
+// the dominant source of startup heap churn.
+func (sm *SourceMap) Reserve(n int) {
+	if n > cap(sm.entries) {
+		grown := make([]sourceMapEntry, len(sm.entries), n)
+		copy(grown, sm.entries)
+		sm.entries = grown
+	}
+}
+
 // SourceMapEntry is the exported version of sourceMapEntry.
 type SourceMapEntry struct {
 	StartIP int

--- a/pkg/vm/source_reserve_test.go
+++ b/pkg/vm/source_reserve_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// Decoding the core bundle calls AddSourceInfo / AddLocalVar once per
+// instruction. Without a pre-sized backing array these grow by repeated
+// append, and that reallocation churn was ~47% of startup heap allocation
+// (SourceMap.Add alone was 39%). Reserve lets the decoder size the slice
+// once from the known entry count. These tests pin the no-realloc property.
+
+func TestSourceMapReserveAvoidsRealloc(t *testing.T) {
+	const n = 256
+	sm := NewSourceMap()
+	sm.Reserve(n)
+	sm.Add(0, SourceInfo{File: "a.lg"})
+	first := &sm.entries[0]
+	for i := 1; i < n; i++ {
+		sm.Add(i, SourceInfo{File: "a.lg", Line: i})
+	}
+	if &sm.entries[0] != first {
+		t.Fatalf("SourceMap reallocated despite Reserve(%d)", n)
+	}
+	if len(sm.entries) != n {
+		t.Fatalf("expected %d entries, got %d", n, len(sm.entries))
+	}
+}
+
+func TestCodeChunkReserveSourceMapAvoidsRealloc(t *testing.T) {
+	const n = 256
+	c := NewCodeChunk(NewConsts())
+	c.ReserveSourceMap(n)
+	c.AddSourceInfo(SourceInfo{File: "a.lg"})
+	first := &c.sourceMap.entries[0]
+	for i := 1; i < n; i++ {
+		c.AddSourceInfo(SourceInfo{File: "a.lg", Line: i})
+	}
+	if &c.sourceMap.entries[0] != first {
+		t.Fatalf("CodeChunk sourceMap reallocated despite ReserveSourceMap(%d)", n)
+	}
+}
+
+func TestCodeChunkReserveLocalVarsAvoidsRealloc(t *testing.T) {
+	const n = 128
+	c := NewCodeChunk(NewConsts())
+	c.ReserveLocalVars(n)
+	c.AddLocalVar(0, "x0")
+	first := &c.localVars[0]
+	for i := 1; i < n; i++ {
+		c.AddLocalVar(i, "x")
+	}
+	if &c.localVars[0] != first {
+		t.Fatalf("localVars reallocated despite ReserveLocalVars(%d)", n)
+	}
+	if len(c.localVars) != n {
+		t.Fatalf("expected %d localVars, got %d", n, len(c.localVars))
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -144,6 +144,28 @@ func (c *CodeChunk) AddLocalVar(slot int, name string) {
 	c.localVars = append(c.localVars, LocalVar{Slot: slot, Name: name})
 }
 
+// ReserveSourceMap pre-sizes the chunk's source map for n entries so the
+// per-instruction AddSourceInfo calls during bundle decode do not reallocate.
+func (c *CodeChunk) ReserveSourceMap(n int) {
+	if n <= 0 {
+		return
+	}
+	if c.sourceMap == nil {
+		c.sourceMap = NewSourceMap()
+	}
+	c.sourceMap.Reserve(n)
+}
+
+// ReserveLocalVars pre-sizes the chunk's local-variable debug table for n
+// entries so the per-slot AddLocalVar calls during decode do not reallocate.
+func (c *CodeChunk) ReserveLocalVars(n int) {
+	if n > cap(c.localVars) {
+		grown := make([]LocalVar, len(c.localVars), n)
+		copy(grown, c.localVars)
+		c.localVars = grown
+	}
+}
+
 // LocalVars returns the chunk's local-variable debug table (may be nil).
 func (c *CodeChunk) LocalVars() []LocalVar { return c.localVars }
 


### PR DESCRIPTION
## What

Adds the startup-cost benchmark — decoding `core_compiled.lgb` and running its main chunk (`lg -e nil` minus process spawn) — to `bench-ratchet`'s fast gate and full profile, with a baseline entry.

Its `allocs/op` and `bytes/op` are **deterministic and machine-independent**, so the ratchet pins them exactly; `ns/op` rides the anchor normalization like every other entry. The bar is locked at the post-fix numbers (**28,671 allocs / 5.11 MB**), so any reintroduction of per-instruction realloc churn during decode trips the gate. This is the durable guard for the cold-start regression class — it had no coverage before, which is how it crept in.

## ⚠️ Stacked on #354

The deterministic bar (28,671 allocs) only holds **with** the pre-size fix in #354. **Merge #354 first**, then rebase/merge this. Until then this PR's diff also shows #354's commit, and the ratchet check would fail on plain `main` (which still allocs 34,731).

## Notes
- Surgical baseline capture: adds exactly one entry; the other 79 are byte-identical.
- `bench-ratchet` builds + unit tests green.