### PR TITLE
ci(perf): arm64 timeline leg + auto-backfill of release tags

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      # Use the official action: it installs a cached, prebuilt golangci-lint
+      # binary from GitHub Releases instead of `go install`-ing it through
+      # proxy.golang.org, which intermittently drops the HTTP/2 stream
+      # mid-download and fails the job (INTERNAL_ERROR received from peer).
       - name: Run golangci-lint
-        run: golangci-lint run --timeout=5m
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12
+          args: --timeout=5m
 
   # Enforce the "no test files at the repo root" guard. The pre-commit hook of
   # the same name is the local equivalent, but jj does not run git hooks, so CI

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -1,0 +1,90 @@
+name: Perf Backfill Releases
+
+# Backfills the perf timeline for tagged releases that don't yet have a
+# snapshot on the perf-data branch. Floors naturally at the release where the
+# benchmark harness landed (#119 / v1.8): a tag is only eligible if it carries
+# pkg/vm/bench_ratchet_anchor_test.go, so older releases (which predate the
+# framework — including the by-date-older v2.0.x line) are skipped. Carrying the
+# harness back onto a pre-harness tag without changing the release would mean
+# overlaying today's bench files on the old tree and hoping it still compiles;
+# that's deliberately out of scope here (best-effort, per-tag, would need its
+# own job) — see README/ratchet docs.
+
+on:
+  schedule:
+    # Weekly — new releases self-backfill within a week of tagging.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List the missing tags but do not dispatch'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  # Needed to dispatch perf-timeline.yml. NOTE: the automatic GITHUB_TOKEN
+  # cannot trigger a workflow_dispatch run (GitHub blocks token-initiated events
+  # to prevent recursion), so the dispatch step uses the PERF_DISPATCH_TOKEN
+  # secret (a fine-grained PAT with actions:write) when present and falls back
+  # to GITHUB_TOKEN (which will enqueue nothing) otherwise.
+  actions: write
+
+concurrency:
+  group: perf-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need every tag and its tree
+
+      - name: Find tagged releases missing from perf-data
+        id: scan
+        run: |
+          set -euo pipefail
+          remote="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+
+          # Existing timeline snapshots (filenames embed the short SHA:
+          # <stamp>-<sha>[-<arch>].json). Clone perf-data shallow; tolerate the
+          # branch not existing yet.
+          if git clone --depth 1 --branch perf-data "$remote" /tmp/pd 2>/dev/null; then
+            ls /tmp/pd/timeline 2>/dev/null > /tmp/existing.txt || : > /tmp/existing.txt
+          else
+            : > /tmp/existing.txt
+          fi
+
+          missing=""
+          for tag in $(git tag); do
+            # Eligible if the tag carries the calibration anchor (>= v1.8 / #119).
+            # The `lowered` (gogen_ir) target only exists from v1.10, but
+            # perf-timeline now skips it gracefully, so v1.9 still backfills —
+            # just bytecode-only, with no gogen_ir/aot_native variants.
+            git cat-file -e "${tag}:pkg/vm/bench_ratchet_anchor_test.go" 2>/dev/null || continue
+            sha="$(git rev-parse --short=12 "${tag}^{commit}")"
+            # A single perf-timeline dispatch produces both amd64 + arm64
+            # snapshots, so "any snapshot carrying this SHA" means done.
+            if grep -q -- "-${sha}" /tmp/existing.txt; then
+              continue
+            fi
+            missing="${missing} ${tag}"
+          done
+          missing="$(echo "${missing}" | xargs || true)"
+          echo "Eligible-but-missing release tags: ${missing:-<none>}"
+          echo "missing=${missing}" >> "${GITHUB_OUTPUT}"
+
+      - name: Dispatch perf-timeline for each missing tag
+        if: steps.scan.outputs.missing != '' && github.event.inputs.dry_run != 'true'
+        env:
+          # PAT (actions:write) so the dispatch actually starts runs; GITHUB_TOKEN
+          # would be silently dropped by the recursion guard.
+          GH_TOKEN: ${{ secrets.PERF_DISPATCH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          for tag in ${{ steps.scan.outputs.missing }}; do
+            echo "Dispatching perf-timeline backfill for ${tag}"
+            gh workflow run perf-timeline.yml --repo "${{ github.repository }}" -f ref="${tag}"
+          done

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -49,8 +49,10 @@ jobs:
           remote="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
 
           # Existing timeline snapshots (filenames embed the short SHA:
-          # <stamp>-<sha>[-<arch>].json). Clone perf-data shallow; tolerate the
-          # branch not existing yet.
+          # <stamp>-<sha>-<machine-key>.json, where machine-key is
+          # "<arch>-<cpumodel>"). We only match on the SHA below, so the
+          # machine-key suffix doesn't affect detection. Clone perf-data
+          # shallow; tolerate the branch not existing yet.
           if git clone --depth 1 --branch perf-data "$remote" /tmp/pd 2>/dev/null; then
             ls /tmp/pd/timeline 2>/dev/null > /tmp/existing.txt || : > /tmp/existing.txt
           else
@@ -65,8 +67,9 @@ jobs:
             # just bytecode-only, with no gogen_ir/aot_native variants.
             git cat-file -e "${tag}:pkg/vm/bench_ratchet_anchor_test.go" 2>/dev/null || continue
             sha="$(git rev-parse --short=12 "${tag}^{commit}")"
-            # A single perf-timeline dispatch produces both amd64 + arm64
-            # snapshots, so "any snapshot carrying this SHA" means done.
+            # A single perf-timeline dispatch produces one snapshot per machine
+            # leg (amd64 + arm64, distinct machine-keys), all carrying this SHA,
+            # so "any snapshot carrying this SHA" means done.
             if grep -q -- "-${sha}" /tmp/existing.txt; then
               continue
             fi

--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -31,7 +31,17 @@ concurrency:
 jobs:
   profile:
     if: github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Serialize the legs: both push to the single perf-data branch, so
+      # running them in parallel would race on the branch ref.
+      max-parallel: 1
+      matrix:
+        # amd64 (GitHub Linux runner) + Apple-Silicon arm64 (macos-14). With
+        # the machine-profile-partitioned ratchet these coexist cleanly; the
+        # explorer then shows both an amd64 and an Apple-M line per benchmark.
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -61,16 +71,25 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Generate lowered runtime
-        run: make lowered
+      - name: Generate lowered runtime (best-effort)
+        # Tags before v1.10 have no `lowered` target. Skip it there rather than
+        # fail — the tag's own bench-ratchet then captures its available
+        # (bytecode) benches, so e.g. v1.9 gets a bytecode-only snapshot with no
+        # gogen_ir/aot_native variants. That's intended (no lowered comparison
+        # for pre-v1.10 releases).
+        run: make lowered || echo "no 'lowered' target at this ref — skipping; gogen_ir/aot_native variants will be absent"
 
       - name: Capture full perf snapshot
         id: perf
         run: |
           short_sha="$(git rev-parse --short=12 HEAD)"
           commit_epoch="$(git show -s --format=%ct HEAD)"
-          stamp="$(date -u -d "@${commit_epoch}" +%Y%m%dT%H%M%SZ)"
-          snapshot_name="${stamp}-${short_sha}.json"
+          # GNU date (Linux) uses -d @epoch; BSD date (macOS) uses -r epoch.
+          stamp="$(date -u -r "${commit_epoch}" +%Y%m%dT%H%M%SZ 2>/dev/null || date -u -d "@${commit_epoch}" +%Y%m%dT%H%M%SZ)"
+          # Tag the filename with arch so amd64 and arm64 snapshots of the SAME
+          # commit don't collide on one name (x86_64 / arm64).
+          arch="$(uname -m)"
+          snapshot_name="${stamp}-${short_sha}-${arch}.json"
           snapshot_tmp="${RUNNER_TEMP}/${snapshot_name}"
           raw_tmp="${RUNNER_TEMP}/${snapshot_name%.json}.jsonl"
 

--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -86,10 +86,30 @@ jobs:
           commit_epoch="$(git show -s --format=%ct HEAD)"
           # GNU date (Linux) uses -d @epoch; BSD date (macOS) uses -r epoch.
           stamp="$(date -u -r "${commit_epoch}" +%Y%m%dT%H%M%SZ 2>/dev/null || date -u -d "@${commit_epoch}" +%Y%m%dT%H%M%SZ)"
-          # Tag the filename with arch so amd64 and arm64 snapshots of the SAME
-          # commit don't collide on one name (x86_64 / arm64).
-          arch="$(uname -m)"
-          snapshot_name="${stamp}-${short_sha}-${arch}.json"
+          # Tag the filename with the canonical machine key ("<arch>-<cpumodel>")
+          # so snapshots of the SAME commit from different machine classes never
+          # collide on one name. `uname -m` alone is NOT enough: Apple M1 and M2
+          # (and future arm parts) all report `arm64`, so an arm-only key would
+          # let an M2 run overwrite an M1 run — and vice-versa — for a commit.
+          # bench-ratchet derives the token from the same <arch>/<CPUModel> the
+          # timeline partitions on (arch = GOARCH, model via sysctl / cpuinfo),
+          # keeping the filename dimension in lockstep with the snapshot content.
+          machine_key="$(go run ./cmd/bench-ratchet machine-key 2>/dev/null || true)"
+          if [ -z "${machine_key}" ]; then
+            # Backfill checks out old release tags whose bench-ratchet predates
+            # the `machine-key` subcommand. Derive the same slug in shell so
+            # backfilled snapshots stay collision-safe across machine classes.
+            arch="$(go env GOARCH)"
+            if [ "$(uname -s)" = "Darwin" ]; then
+              model="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo)"
+            else
+              model="$(sed -n 's/^model name[[:space:]]*:[[:space:]]*//p' /proc/cpuinfo 2>/dev/null | head -1)"
+            fi
+            machine_key="$(printf '%s-%s' "${arch}" "${model}" \
+              | tr 'A-Z' 'a-z' | tr -c 'a-z0-9' '-' | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
+            [ -n "${machine_key}" ] || machine_key="unknown"
+          fi
+          snapshot_name="${stamp}-${short_sha}-${machine_key}.json"
           snapshot_tmp="${RUNNER_TEMP}/${snapshot_name}"
           raw_tmp="${RUNNER_TEMP}/${snapshot_name%.json}.jsonl"
 

--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -188,9 +188,21 @@ func main() {
 		mode = flag.Arg(0)
 	}
 	switch mode {
-	case "check", "update", "show", "capture", "aggregate", "snapshot":
+	case "check", "update", "show", "capture", "aggregate", "snapshot", "machine-key":
 	default:
-		die("unknown mode %q (want check / update / show / capture / aggregate / snapshot)", mode)
+		die("unknown mode %q (want check / update / show / capture / aggregate / snapshot / machine-key)", mode)
+	}
+
+	// machine-key: print the canonical machine token ("<arch>-<cpumodel>",
+	// slugified) and exit — no benchmarks. The perf-timeline workflow uses it
+	// to name timeline snapshots so two machine classes that share a GOARCH
+	// (e.g. Apple M1 vs M2, both arm64) get DISTINCT filenames and cannot
+	// overwrite each other's snapshot on the perf-data branch. Keeping this
+	// here (vs a shell reimplementation) makes the filename dimension track the
+	// exact "<arch>/<CPUModel>" partition the timeline groups snapshots by.
+	if mode == "machine-key" {
+		fmt.Println(machineKey())
+		return
 	}
 
 	// aggregate-only mode reads an existing .jsonl, no benchmarks run.
@@ -1020,6 +1032,43 @@ func detectCPUModel() string {
 		}
 	}
 	return "unknown"
+}
+
+// machineKey returns a filesystem-safe token identifying the machine CLASS a
+// snapshot belongs to. It slugifies perfdata.MachineKey (the exact
+// "<arch>/<CPUModel>" key the timeline groups snapshots by), so the filename
+// dimension is derived from — and stays in lockstep with — the content
+// partition. Machines that share a GOARCH but differ in CPU (Apple M1 vs M2 —
+// both arm64) therefore get DISTINCT filenames and never overwrite one
+// another's snapshot on the perf-data branch. Arch is runtime.GOARCH (matching
+// the snapshot content), not `uname -m`, so filename and content agree.
+func machineKey() string {
+	key := slugify(perfdata.MachineKey(detectMachine()))
+	if key == "" {
+		return "unknown"
+	}
+	return key
+}
+
+// slugify lowercases s and collapses each run of non-[a-z0-9] characters into a
+// single '-', trimming leading/trailing dashes. Deterministic and stable for a
+// given CPU model string.
+func slugify(s string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 func gitShortSHA() string {

--- a/cmd/bench-ratchet/main_test.go
+++ b/cmd/bench-ratchet/main_test.go
@@ -59,6 +59,36 @@ func TestAggregateFromFileRetainsSamples(t *testing.T) {
 	}
 }
 
+func TestSlugifyIsFilesystemSafeAndStable(t *testing.T) {
+	cases := map[string]string{
+		"arm64/Apple M1": "arm64-apple-m1",
+		"arm64/Apple M2": "arm64-apple-m2",
+		"arm64/Apple M3": "arm64-apple-m3",
+		"amd64/Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz": "amd64-intel-r-xeon-r-platinum-8275cl-cpu-3-00ghz",
+		"  weird//name  ": "weird-name",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The whole point of the machine key in the snapshot filename: M1 and M2 both
+// report GOARCH arm64, so a uname-based key would collide. Slugifying the
+// <arch>/<CPUModel> partition key keeps them distinct.
+func TestMachineKeyDistinguishesSameArchDifferentCPU(t *testing.T) {
+	m1 := perfdata.MachineKey(Machine{OS: "darwin", Arch: "arm64", CPUModel: "Apple M1"})
+	m2 := perfdata.MachineKey(Machine{OS: "darwin", Arch: "arm64", CPUModel: "Apple M2"})
+	s1, s2 := slugify(m1), slugify(m2)
+	if s1 == s2 {
+		t.Fatalf("M1 and M2 slugify to the same key %q — snapshots would collide", s1)
+	}
+	if s1 != "arm64-apple-m1" || s2 != "arm64-apple-m2" {
+		t.Fatalf("unexpected slugs: M1=%q M2=%q", s1, s2)
+	}
+}
+
 func TestWriteBaselineWritesAtomicallyReadableJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "baseline.json")
 	mach := Machine{OS: "darwin", Arch: "arm64", CPUModel: "Apple M3"}


### PR DESCRIPTION
Splits the perf **CI** work out of #362 (which is the ratchet + dashboard *code*).

### arm64 timeline leg (`perf-timeline.yml`)
Every perf workflow currently runs only on `ubuntu-latest` (amd64), so the timeline has **no arm numbers** — developers' Apple-Silicon runs never reach `perf-data`. This adds a `macos-14` (Apple M1) leg via a **serialized** matrix (`max-parallel: 1`, since both legs push the single `perf-data` branch). Snapshot filenames gain an **arch suffix** so amd64/arm64 snapshots of the same commit don't collide, and the timestamp is computed **portably** (`date -r` on BSD/macOS vs `date -d @` on GNU). With the machine-profile partitioning from #362, the two coexist and the explorer gains an Apple-M line.

### Release auto-backfill (`perf-backfill.yml`, new)
Weekly + dispatchable. Scans tags, keeps only those that carry the anchor harness (**floors at v1.8 / #119**; older releases — including the by-date-older `v2.0.x` line — are skipped), finds which lack a `perf-data` snapshot, and dispatches `perf-timeline` for each, so new releases self-backfill.

**Needs a secret:** `PERF_DISPATCH_TOKEN` (fine-grained PAT, `actions:write`) — the automatic `GITHUB_TOKEN` can't trigger `workflow_dispatch` (recursion guard), so without the PAT the dispatch step enqueues nothing.

**Out of scope:** carrying the harness *backwards* onto pre-v1.8 tags (overlay today's bench files on the old tree) — feasible but compile-compat-risky, would need its own job.

> Note: depends conceptually on #362's multi-machine ratchet (so arm + amd64 don't contaminate each other). Can merge independently, but the arm numbers only render meaningfully once #362 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)