### PR TITLE
fix(json,transit): serialize Float32 instead of panicking

### DIFF
--- a/pkg/rt/json.go
+++ b/pkg/rt/json.go
@@ -102,7 +102,9 @@ func fromValue(v vm.Value) (any, error) {
 	case vm.IntType:
 		return int(v.(vm.Int)), nil
 	case vm.FloatType:
-		return float64(v.(vm.Float)), nil
+		// Float and Float32 both report FloatType; assert via Unbox so a Float32
+		// (e.g. from `(float x)`) doesn't panic the float64 type assertion.
+		return v.Unbox().(float64), nil
 	case vm.BooleanType:
 		return bool(v.(vm.Boolean)), nil
 	case vm.MapType, vm.PersistentMapType:

--- a/pkg/rt/transit.go
+++ b/pkg/rt/transit.go
@@ -385,7 +385,9 @@ func (e *TransitEncoder) encodeValue(v vm.Value) (any, error) {
 		}
 		return n, nil
 	case vm.FloatType:
-		return float64(v.(vm.Float)), nil
+		// Float and Float32 both report FloatType; assert via Unbox so a Float32
+		// (e.g. from `(float x)`) doesn't panic the float64 type assertion.
+		return v.Unbox().(float64), nil
 	case vm.StringType:
 		s := string(v.(vm.String))
 		if len(s) > 0 && (s[0] == '~' || s[0] == '^') {

--- a/test/json_test.lg
+++ b/test/json_test.lg
@@ -71,3 +71,16 @@
           parsed (read-json json-str {:keywords? true})]
       (is (= 9.99 (:price parsed)))
       (is (= 3 (:qty parsed))))))
+
+(deftest json-write-float32
+  ;; (float x) yields a Float32, which reports FloatType but is a distinct
+  ;; concrete type from Float (float64). write-json used to panic asserting it
+  ;; straight to float64; values chosen exact in float32 to avoid drift.
+  (testing "float32 scalar"
+    (is (= "1.5" (write-json (float 1.5)))))
+
+  (testing "float32 nested in a map"
+    (is (= "{\"rate\":0.25}" (write-json {:rate (float 0.25)}))))
+
+  (testing "float32 in a vector"
+    (is (= "[2.5]" (write-json [(float 2.5)])))))


### PR DESCRIPTION
# fix(json,transit): serialize Float32 instead of panicking

## What

`write-json` panics with a Go type-assertion error on any `Float32` value:

```clojure
(write-json (float 1.5))
;; interface conversion: vm.Value is vm.Float32, not vm.Float
```

Because `(float x)` returns a `Float32`, this hits any payload built with the idiomatic float coercion — a map or vector with a single `(float …)` value anywhere in it is unencodable. `write-transit` has the identical defect.

## Why it happens

`Float` and `Float32` both report `FloatType`, so they share the one `case vm.FloatType` in `fromValue`. But that case asserted the concrete type straight to `Float` (float64):

```go
case vm.FloatType:
    return float64(v.(vm.Float)), nil   // panics when v is a Float32
```

A `Float32` matches the type tag but not the concrete assertion, so it panics instead of round-tripping.

## Fix

Assert through `Unbox()`. Both float types implement it and return `float64`, so either serializes:

```go
case vm.FloatType:
    return v.Unbox().(float64), nil
```

Same one-line change at both sites — `pkg/rt/json.go` and `pkg/rt/transit.go`. Added a `json` regression test covering a `(float …)` value as a scalar, nested in a map, and in a vector (values chosen exact in float32 so there's no representation drift to mask a regression).

## Scope note

The other direct `v.(vm.Float)` asserts in the runtime are in `pkg/rt/lang.go`, and they already use the comma-ok form (`if f, ok := v.(vm.Float); ok`), so they degrade gracefully rather than panicking. The two serializers were the only unguarded sites.
