### PR TITLE
fix(bench): per-goroutine sink in Parallel VarDeref benchmarks

### DIFF
--- a/pkg/vm/var_deref_bench_test.go
+++ b/pkg/vm/var_deref_bench_test.go
@@ -8,6 +8,7 @@ package vm
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -56,9 +57,14 @@ func BenchmarkVarDerefRoot(b *testing.B) {
 func BenchmarkVarDerefRootParallel(b *testing.B) {
 	v := newRootVar()
 	b.RunParallel(func(pb *testing.PB) {
+		// Per-goroutine local sink: the deref path is lock-free, so a shared
+		// package-global sink would be the only contended cache line —
+		// measuring cache-coherence ping-pong, not deref cost.
+		var sink Value
 		for pb.Next() {
-			derefSink = v.Deref()
+			sink = v.Deref()
 		}
+		runtime.KeepAlive(sink)
 	})
 }
 
@@ -75,9 +81,11 @@ func BenchmarkVarDerefPreviouslyBound(b *testing.B) {
 func BenchmarkVarDerefPreviouslyBoundParallel(b *testing.B) {
 	v := newPreviouslyBoundVar()
 	b.RunParallel(func(pb *testing.PB) {
+		var sink Value
 		for pb.Next() {
-			derefSink = v.Deref()
+			sink = v.Deref()
 		}
+		runtime.KeepAlive(sink)
 	})
 }
 
@@ -95,9 +103,11 @@ func BenchmarkVarDerefBoundParallel(b *testing.B) {
 	v := newBoundVar()
 	b.Cleanup(v.PopBinding)
 	b.RunParallel(func(pb *testing.PB) {
+		var sink Value
 		for pb.Next() {
-			derefSink = v.Deref()
+			sink = v.Deref()
 		}
+		runtime.KeepAlive(sink)
 	})
 }
 
@@ -106,9 +116,11 @@ func BenchmarkVarDerefBoundParallel(b *testing.B) {
 func BenchmarkVarDerefDistinctParallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		v := newRootVar()
+		var sink Value
 		for pb.Next() {
-			derefSink = v.Deref()
+			sink = v.Deref()
 		}
+		runtime.KeepAlive(sink)
 	})
 }
 


### PR DESCRIPTION
## What

The `BenchmarkVarDeref*Parallel` variants wrote every deref result to a single package-global `derefSink`. Under `b.RunParallel`, all goroutines hammered that one cache line on every iteration — reintroducing the exact cross-core coherence contention the ExecContext threading removed from the deref path. **The benchmark was measuring sink cache-line ping-pong, not deref cost.**

This replaces the shared sink with a per-goroutine local + `runtime.KeepAlive` in all four Parallel variants. The non-Parallel benchmarks keep the shared sink (no contention with one goroutine).

## Evidence

Measured on Apple M3 (8-core, arm64), shared sink vs local sink:

| Benchmark | Shared sink | Local sink | Improvement |
|---|---|---|---|
| `BoundParallel` | 2.24ns | 0.39ns | **5.7x** |
| `PreviouslyBoundParallel` | 1.78ns | 0.37ns | **4.8x** |
| `RootParallel` | 0.71ns | 0.32ns | **2.2x** |
| `DistinctParallel` | 0.72ns | 0.32ns | **2.2x** |

The Parallel numbers now match the pre-ExecContext baseline (~0.3ns), confirming the deref path itself is lock-free and fast.

## Root cause of the timeline signal

The perf timeline (`perf-data` branch) showed `BenchmarkVarDeref*Parallel` regressing from ~0.27ns to 6-16ns in `ratio_to_anchor` on the 4-vCPU amd64 CI runners. The timeline bisect:

1. **May 30** `a898a39d` (#122): lock-free per-Var atomic `Deref` — 0.27ns, zero shared state in the deref path
2. **Jun 13** `439b6036` (#210): ExecContext threading — replaced per-Var atomics with `RootExecContext.deref` → global binding stack; the shared `derefSink` now had company (`globalBindingStack.head`) as a contended cache line, and CI coherence latency amplified both
3. **Jun 15** `fa20c7b8` (#220): lock-free persistent frame-list — fixed the binding stack lock but `derefSink` stayed shared, so Parallel stayed elevated through the latest snapshot (Jun 29)

The anchor (`BenchmarkRatchetAnchor`) stayed flat at 1.245–1.251ns across the entire timeline, confirming this is a real absolute regression, not an anchor-speed artifact.

**The runtime was never broken.** The `deref` path (via `ExecContext.deref` → `bindingStack.current`) is lock-free: an atomic head load + immutable frame walk. The regression was the benchmark harness reintroducing shared-state contention through its sink.

## CI facts

All 105 timeline snapshots were captured on `ubuntu-latest` GitHub-hosted runners with `num_cpu=4` (GOMAXPROCS defaults to `NumCPU=4`). The EPYC 7763 / 9V74 / Xeon 8370C strings are the Azure VM host CPU model; the runner gets 4 vCPUs. 4 vCPUs is real parallelism — enough to expose cache-line contention, which the EPYC VM's cross-core coherence latency amplifies relative to Apple Silicon's unified L2.

## Verification

- `go vet ./pkg/vm/` — clean
- `go test ./pkg/vm -run TestVar -race` — pass
- `go test ./pkg/vm/` — full suite pass
- Benchmarks reproduced before/after (numbers above)

## Scope

One file: `pkg/vm/var_deref_bench_test.go`. No runtime code touched. Unrelated to #362 (`perf/ratchet-multimachine`).