### PR TITLE
[codex] Derive lg metadata from Go build info

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	runtimeDebug "runtime/debug"
 	"strings"
 
 	"github.com/nooga/let-go/pkg/bundle"
@@ -31,6 +32,98 @@ func versionString() string {
 		return fmt.Sprintf("%s (%s)", version, commit[:7])
 	}
 	return version
+}
+
+func applyBuildInfoMetadata() {
+	info, ok := runtimeDebug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	version, commit = resolveBuildMetadata(version, commit, info)
+}
+
+func resolveBuildMetadata(stampedVersion, stampedCommit string, info *runtimeDebug.BuildInfo) (string, string) {
+	resolvedVersion := stampedVersion
+	resolvedCommit := stampedCommit
+	if info == nil {
+		return resolvedVersion, resolvedCommit
+	}
+
+	if resolvedVersion == "dev" && !buildInfoModified(info) {
+		if buildVersion := buildInfoVersion(info.Main.Version); buildVersion != "" {
+			resolvedVersion = buildVersion
+		}
+	}
+	if resolvedCommit == "none" {
+		if vcsRevision := buildInfoVCSRevision(info); vcsRevision != "" {
+			resolvedCommit = vcsRevision
+		} else if pseudoRevision := pseudoVersionRevision(info.Main.Version); pseudoRevision != "" {
+			resolvedCommit = pseudoRevision
+		}
+	}
+	return resolvedVersion, resolvedCommit
+}
+
+func buildInfoVersion(moduleVersion string) string {
+	if moduleVersion == "" || moduleVersion == "(devel)" {
+		return ""
+	}
+	return strings.TrimPrefix(moduleVersion, "v")
+}
+
+func buildInfoVCSRevision(info *runtimeDebug.BuildInfo) string {
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" && setting.Value != "" {
+			return setting.Value
+		}
+	}
+	return ""
+}
+
+func buildInfoModified(info *runtimeDebug.BuildInfo) bool {
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.modified" && setting.Value == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func pseudoVersionRevision(moduleVersion string) string {
+	parts := strings.Split(moduleVersion, "-")
+	if len(parts) < 3 {
+		return ""
+	}
+	revision := parts[len(parts)-1]
+	timePart := parts[len(parts)-2]
+	if dot := strings.LastIndex(timePart, "."); dot >= 0 {
+		timePart = timePart[dot+1:]
+	}
+	if len(timePart) != 14 || !allDigits(timePart) {
+		return ""
+	}
+	if len(revision) != 12 || !allHex(revision) {
+		return ""
+	}
+	return revision
+}
+
+func allDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
+}
+
+func allHex(s string) bool {
+	for _, r := range s {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return s != ""
 }
 
 func motd() {
@@ -444,6 +537,8 @@ func emitRuntimeStats() {
 }
 
 func runMain() int {
+	applyBuildInfoMetadata()
+
 	// Propagate version metadata to runtime so System/getProperty exposes it.
 	rt.Version = version
 	rt.Commit = commit

--- a/lg.go
+++ b/lg.go
@@ -16,6 +16,7 @@ import (
 	runtimeDebug "runtime/debug"
 	"strings"
 
+	"github.com/nooga/let-go/pkg/buildmeta"
 	"github.com/nooga/let-go/pkg/bundle"
 	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/compiler"
@@ -39,91 +40,7 @@ func applyBuildInfoMetadata() {
 	if !ok {
 		return
 	}
-	version, commit = resolveBuildMetadata(version, commit, info)
-}
-
-func resolveBuildMetadata(stampedVersion, stampedCommit string, info *runtimeDebug.BuildInfo) (string, string) {
-	resolvedVersion := stampedVersion
-	resolvedCommit := stampedCommit
-	if info == nil {
-		return resolvedVersion, resolvedCommit
-	}
-
-	if resolvedVersion == "dev" && !buildInfoModified(info) {
-		if buildVersion := buildInfoVersion(info.Main.Version); buildVersion != "" {
-			resolvedVersion = buildVersion
-		}
-	}
-	if resolvedCommit == "none" {
-		if vcsRevision := buildInfoVCSRevision(info); vcsRevision != "" {
-			resolvedCommit = vcsRevision
-		} else if pseudoRevision := pseudoVersionRevision(info.Main.Version); pseudoRevision != "" {
-			resolvedCommit = pseudoRevision
-		}
-	}
-	return resolvedVersion, resolvedCommit
-}
-
-func buildInfoVersion(moduleVersion string) string {
-	if moduleVersion == "" || moduleVersion == "(devel)" {
-		return ""
-	}
-	return strings.TrimPrefix(moduleVersion, "v")
-}
-
-func buildInfoVCSRevision(info *runtimeDebug.BuildInfo) string {
-	for _, setting := range info.Settings {
-		if setting.Key == "vcs.revision" && setting.Value != "" {
-			return setting.Value
-		}
-	}
-	return ""
-}
-
-func buildInfoModified(info *runtimeDebug.BuildInfo) bool {
-	for _, setting := range info.Settings {
-		if setting.Key == "vcs.modified" && setting.Value == "true" {
-			return true
-		}
-	}
-	return false
-}
-
-func pseudoVersionRevision(moduleVersion string) string {
-	parts := strings.Split(moduleVersion, "-")
-	if len(parts) < 3 {
-		return ""
-	}
-	revision := parts[len(parts)-1]
-	timePart := parts[len(parts)-2]
-	if dot := strings.LastIndex(timePart, "."); dot >= 0 {
-		timePart = timePart[dot+1:]
-	}
-	if len(timePart) != 14 || !allDigits(timePart) {
-		return ""
-	}
-	if len(revision) != 12 || !allHex(revision) {
-		return ""
-	}
-	return revision
-}
-
-func allDigits(s string) bool {
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return s != ""
-}
-
-func allHex(s string) bool {
-	for _, r := range s {
-		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
-			return false
-		}
-	}
-	return s != ""
+	version, commit = buildmeta.Resolve(version, commit, info)
 }
 
 func motd() {

--- a/lg_build_metadata_test.go
+++ b/lg_build_metadata_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package main
+
+import (
+	runtimeDebug "runtime/debug"
+	"testing"
+)
+
+func TestResolveBuildMetadataPreservesStampedValues(t *testing.T) {
+	info := &runtimeDebug.BuildInfo{
+		Main: runtimeDebug.Module{Version: "v1.11.1"},
+		Settings: []runtimeDebug.BuildSetting{
+			{Key: "vcs.revision", Value: "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a"},
+		},
+	}
+
+	gotVersion, gotCommit := resolveBuildMetadata("1.99.0", "feedface", info)
+
+	if gotVersion != "1.99.0" {
+		t.Fatalf("version = %q, want stamped value", gotVersion)
+	}
+	if gotCommit != "feedface" {
+		t.Fatalf("commit = %q, want stamped value", gotCommit)
+	}
+}
+
+func TestResolveBuildMetadataUsesTaggedModuleVersion(t *testing.T) {
+	info := &runtimeDebug.BuildInfo{
+		Main: runtimeDebug.Module{Version: "v1.11.1"},
+	}
+
+	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+
+	if gotVersion != "1.11.1" {
+		t.Fatalf("version = %q, want tag without v prefix", gotVersion)
+	}
+	if gotCommit != "none" {
+		t.Fatalf("commit = %q, want unchanged unknown commit", gotCommit)
+	}
+}
+
+func TestResolveBuildMetadataKeepsDirtyBuildVersionUnknown(t *testing.T) {
+	info := &runtimeDebug.BuildInfo{
+		Main: runtimeDebug.Module{Version: "v1.11.1+dirty"},
+		Settings: []runtimeDebug.BuildSetting{
+			{Key: "vcs.modified", Value: "true"},
+			{Key: "vcs.revision", Value: "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a"},
+		},
+	}
+
+	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+
+	if gotVersion != "dev" {
+		t.Fatalf("version = %q, want unchanged dev version for dirty build", gotVersion)
+	}
+	if gotCommit != "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a" {
+		t.Fatalf("commit = %q, want vcs.revision", gotCommit)
+	}
+}
+
+func TestResolveBuildMetadataUsesVCSRevision(t *testing.T) {
+	info := &runtimeDebug.BuildInfo{
+		Main: runtimeDebug.Module{Version: "(devel)"},
+		Settings: []runtimeDebug.BuildSetting{
+			{Key: "vcs.revision", Value: "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a"},
+		},
+	}
+
+	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+
+	if gotVersion != "dev" {
+		t.Fatalf("version = %q, want unchanged dev version", gotVersion)
+	}
+	if gotCommit != "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a" {
+		t.Fatalf("commit = %q, want vcs.revision", gotCommit)
+	}
+}
+
+func TestResolveBuildMetadataUsesPseudoVersionRevision(t *testing.T) {
+	info := &runtimeDebug.BuildInfo{
+		Main: runtimeDebug.Module{Version: "v1.10.1-0.20260628062305-25ccf5505588"},
+	}
+
+	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+
+	if gotVersion != "1.10.1-0.20260628062305-25ccf5505588" {
+		t.Fatalf("version = %q, want pseudo-version without v prefix", gotVersion)
+	}
+	if gotCommit != "25ccf5505588" {
+		t.Fatalf("commit = %q, want pseudo-version revision", gotCommit)
+	}
+}
+
+func TestPseudoVersionRevisionRejectsNonPseudoVersions(t *testing.T) {
+	cases := []string{
+		"",
+		"(devel)",
+		"v1.11.1",
+		"v1.11.1-alpha.1",
+		"v1.10.1-0.20260628062305-nothexvalue",
+		"v1.10.1-0.notatime-25ccf5505588",
+	}
+
+	for _, tc := range cases {
+		if got := pseudoVersionRevision(tc); got != "" {
+			t.Fatalf("pseudoVersionRevision(%q) = %q, want empty", tc, got)
+		}
+	}
+}

--- a/pkg/buildmeta/buildmeta.go
+++ b/pkg/buildmeta/buildmeta.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package buildmeta
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Resolve fills missing let-go version/commit metadata from Go build info.
+// Explicit ldflag-stamped values always take precedence.
+func Resolve(stampedVersion, stampedCommit string, info *debug.BuildInfo) (string, string) {
+	resolvedVersion := stampedVersion
+	resolvedCommit := stampedCommit
+	if info == nil {
+		return resolvedVersion, resolvedCommit
+	}
+
+	if resolvedVersion == "dev" && !modified(info) {
+		if buildVersion := version(info.Main.Version); buildVersion != "" {
+			resolvedVersion = buildVersion
+		}
+	}
+	if resolvedCommit == "none" {
+		if vcsRevision := vcsRevision(info); vcsRevision != "" {
+			resolvedCommit = vcsRevision
+		} else if pseudoRevision := pseudoVersionRevision(info.Main.Version); pseudoRevision != "" {
+			resolvedCommit = pseudoRevision
+		}
+	}
+	return resolvedVersion, resolvedCommit
+}
+
+func version(moduleVersion string) string {
+	if moduleVersion == "" || moduleVersion == "(devel)" {
+		return ""
+	}
+	return strings.TrimPrefix(moduleVersion, "v")
+}
+
+func vcsRevision(info *debug.BuildInfo) string {
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" && setting.Value != "" {
+			return setting.Value
+		}
+	}
+	return ""
+}
+
+func modified(info *debug.BuildInfo) bool {
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.modified" && setting.Value == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func pseudoVersionRevision(moduleVersion string) string {
+	parts := strings.Split(moduleVersion, "-")
+	if len(parts) < 3 {
+		return ""
+	}
+	revision := parts[len(parts)-1]
+	timePart := parts[len(parts)-2]
+	if dot := strings.LastIndex(timePart, "."); dot >= 0 {
+		timePart = timePart[dot+1:]
+	}
+	if len(timePart) != 14 || !allDigits(timePart) {
+		return ""
+	}
+	if len(revision) != 12 || !allHex(revision) {
+		return ""
+	}
+	return revision
+}
+
+func allDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
+}
+
+func allHex(s string) bool {
+	for _, r := range s {
+		if !hexDigit(r) {
+			return false
+		}
+	}
+	return s != ""
+}
+
+func hexDigit(r rune) bool {
+	return (r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'f') ||
+		(r >= 'A' && r <= 'F')
+}

--- a/pkg/buildmeta/buildmeta_test.go
+++ b/pkg/buildmeta/buildmeta_test.go
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: MIT
  */
 
-package main
+package buildmeta
 
 import (
-	runtimeDebug "runtime/debug"
+	"runtime/debug"
 	"testing"
 )
 
-func TestResolveBuildMetadataPreservesStampedValues(t *testing.T) {
-	info := &runtimeDebug.BuildInfo{
-		Main: runtimeDebug.Module{Version: "v1.11.1"},
-		Settings: []runtimeDebug.BuildSetting{
+func TestResolvePreservesStampedValues(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "v1.11.1"},
+		Settings: []debug.BuildSetting{
 			{Key: "vcs.revision", Value: "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a"},
 		},
 	}
 
-	gotVersion, gotCommit := resolveBuildMetadata("1.99.0", "feedface", info)
+	gotVersion, gotCommit := Resolve("1.99.0", "feedface", info)
 
 	if gotVersion != "1.99.0" {
 		t.Fatalf("version = %q, want stamped value", gotVersion)
@@ -28,12 +28,12 @@ func TestResolveBuildMetadataPreservesStampedValues(t *testing.T) {
 	}
 }
 
-func TestResolveBuildMetadataUsesTaggedModuleVersion(t *testing.T) {
-	info := &runtimeDebug.BuildInfo{
-		Main: runtimeDebug.Module{Version: "v1.11.1"},
+func TestResolveUsesTaggedModuleVersion(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "v1.11.1"},
 	}
 
-	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+	gotVersion, gotCommit := Resolve("dev", "none", info)
 
 	if gotVersion != "1.11.1" {
 		t.Fatalf("version = %q, want tag without v prefix", gotVersion)
@@ -43,16 +43,16 @@ func TestResolveBuildMetadataUsesTaggedModuleVersion(t *testing.T) {
 	}
 }
 
-func TestResolveBuildMetadataKeepsDirtyBuildVersionUnknown(t *testing.T) {
-	info := &runtimeDebug.BuildInfo{
-		Main: runtimeDebug.Module{Version: "v1.11.1+dirty"},
-		Settings: []runtimeDebug.BuildSetting{
+func TestResolveKeepsDirtyBuildVersionUnknown(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "v1.11.1+dirty"},
+		Settings: []debug.BuildSetting{
 			{Key: "vcs.modified", Value: "true"},
 			{Key: "vcs.revision", Value: "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a"},
 		},
 	}
 
-	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+	gotVersion, gotCommit := Resolve("dev", "none", info)
 
 	if gotVersion != "dev" {
 		t.Fatalf("version = %q, want unchanged dev version for dirty build", gotVersion)
@@ -62,15 +62,15 @@ func TestResolveBuildMetadataKeepsDirtyBuildVersionUnknown(t *testing.T) {
 	}
 }
 
-func TestResolveBuildMetadataUsesVCSRevision(t *testing.T) {
-	info := &runtimeDebug.BuildInfo{
-		Main: runtimeDebug.Module{Version: "(devel)"},
-		Settings: []runtimeDebug.BuildSetting{
+func TestResolveUsesVCSRevision(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+		Settings: []debug.BuildSetting{
 			{Key: "vcs.revision", Value: "25ccf5505588cfd6fd0c1ed7e870446ae1ec4a2a"},
 		},
 	}
 
-	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+	gotVersion, gotCommit := Resolve("dev", "none", info)
 
 	if gotVersion != "dev" {
 		t.Fatalf("version = %q, want unchanged dev version", gotVersion)
@@ -80,12 +80,12 @@ func TestResolveBuildMetadataUsesVCSRevision(t *testing.T) {
 	}
 }
 
-func TestResolveBuildMetadataUsesPseudoVersionRevision(t *testing.T) {
-	info := &runtimeDebug.BuildInfo{
-		Main: runtimeDebug.Module{Version: "v1.10.1-0.20260628062305-25ccf5505588"},
+func TestResolveUsesPseudoVersionRevision(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "v1.10.1-0.20260628062305-25ccf5505588"},
 	}
 
-	gotVersion, gotCommit := resolveBuildMetadata("dev", "none", info)
+	gotVersion, gotCommit := Resolve("dev", "none", info)
 
 	if gotVersion != "1.10.1-0.20260628062305-25ccf5505588" {
 		t.Fatalf("version = %q, want pseudo-version without v prefix", gotVersion)


### PR DESCRIPTION
## Summary

This adds a best-effort metadata fallback for `lg` binaries that are built without release ldflags. At startup, `lg` now keeps stamped `main.version` / `main.commit` when present, otherwise reads Go build info to populate missing metadata.

The fallback covers:

- `go install github.com/nooga/let-go@<tag>`: derive the runtime version from `debug.ReadBuildInfo().Main.Version`.
- source checkout builds: derive the runtime commit from `vcs.revision`.
- `go install github.com/nooga/let-go@<untagged-sha>`: derive a 12-character commit prefix from the module pseudo-version suffix.

Dirty source builds intentionally keep version as `dev`, while still exposing the base VCS revision, so local modified builds do not masquerade as a clean release.

## Impact if left as-is

- `require-letgo` SHA pins remain non-enforcing for common CI installs using `go install ...@<sha>`.
- A wrong pinned binary can warn-and-pass when commit metadata is `none`, so source-level compatibility checks can give false confidence.
- Tagged `go install` binaries report `lg dev`, so semver-based `require-letgo` guards also skip instead of enforcing.
- Consumers need a documented custom build step with `-ldflags` to make SHA pins meaningful.

## Impact of this fix

- Tagged `go install` binaries can satisfy semver guards without release artifacts.
- Untagged `go install @sha` binaries can satisfy 7-12 character SHA-prefix guards when Go exposes the pseudo-version.
- Local checkout builds expose `vcs.revision`, so SHA guards work for checked-out builds even without manual ldflags.
- Release builds remain unchanged because ldflags still take precedence.

Full 40-character SHA enforcement for module-proxy `go install @sha` is still not guaranteed unless Go embeds `vcs.revision`; in my repro it did not. For that case, a stamped/source-checkout build is still the exact solution.

## Validation

- `go test .`
- Built patched `lg` locally and verified:
  - `lg -version` reports `lg dev (79b96e5)` for a dirty source checkout.
  - `require-letgo "79b96e5"` returns `nil`.
  - `require-letgo "deadbee"` hard-fails with the running commit.

Addresses #312.
