### PR TITLE
feat(rt): spit/write! accept a byte-array (write raw bytes)

### DIFF
--- a/pkg/rt/asbytes_test.go
+++ b/pkg/rt/asbytes_test.go
@@ -2,6 +2,8 @@ package rt
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nooga/let-go/pkg/vm"
@@ -26,5 +28,49 @@ func TestAsBytes(t *testing.T) {
 	// A non-byte typed array is not byte-coercible.
 	if _, ok := asBytes(vm.NewIntArrayFrom([]int64{1, 2})); ok {
 		t.Fatal("int-array should not be byte-coercible")
+	}
+}
+
+func TestSpitWritesByteArrayVerbatim(t *testing.T) {
+	want := []byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xc8}
+	path := filepath.Join(t.TempDir(), "out.bin")
+
+	spit := LookupCoreVar("spit")
+	if spit == nil {
+		t.Fatal("core/spit not found")
+	}
+	if _, err := spit.Invoke([]vm.Value{
+		vm.String(path),
+		vm.NewByteArrayFrom(append([]byte(nil), want...)),
+	}); err != nil {
+		t.Fatalf("spit: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("spit wrote %v, want %v", got, want)
+	}
+}
+
+func TestWriteWritesByteArrayVerbatim(t *testing.T) {
+	want := []byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xc8}
+	var dst bytes.Buffer
+
+	write := LookupCoreVar("write!")
+	if write == nil {
+		t.Fatal("core/write! not found")
+	}
+	if _, err := write.Invoke([]vm.Value{
+		vm.NewBoxed(NewWriterHandle("test", &dst)),
+		vm.NewByteArrayFrom(append([]byte(nil), want...)),
+	}); err != nil {
+		t.Fatalf("write!: %v", err)
+	}
+
+	if got := dst.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("write! wrote %v, want %v", got, want)
 	}
 }

--- a/pkg/rt/asbytes_test.go
+++ b/pkg/rt/asbytes_test.go
@@ -1,0 +1,30 @@
+package rt
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// asBytes backs the binary file/stream sinks (spit, write!). The byte-array case
+// is the one that used to be impossible: a byte-array handed to spit/write! would
+// stringify to its #byte-array[…] repr, so bytes >127 could never be written.
+func TestAsBytes(t *testing.T) {
+	// String → its bytes verbatim, including a high byte.
+	if b, ok := asBytes(vm.String("hi\xff")); !ok || string(b) != "hi\xff" {
+		t.Fatalf("String: got %q ok=%v", b, ok)
+	}
+
+	// byte-array → raw bytes, high bytes preserved (PNG signature + 0xFF/0xC8).
+	want := []byte{137, 80, 78, 71, 0, 255, 200}
+	ba := vm.NewByteArrayFrom(append([]byte(nil), want...))
+	if b, ok := asBytes(ba); !ok || !bytes.Equal(b, want) {
+		t.Fatalf("byte-array: got %v ok=%v want %v", b, ok, want)
+	}
+
+	// A non-byte typed array is not byte-coercible.
+	if _, ok := asBytes(vm.NewIntArrayFrom([]int64{1, 2})); ok {
+		t.Fatal("int-array should not be byte-coercible")
+	}
+}

--- a/pkg/rt/iort.go
+++ b/pkg/rt/iort.go
@@ -220,9 +220,12 @@ func installIOBuiltins(ns *vm.Namespace) {
 		if err != nil {
 			return vm.NIL, err
 		}
+		// A String writes its bytes verbatim, and a byte-array writes its raw bytes
+		// (not its #byte-array[…] repr) so binary output works; anything else falls
+		// back to its printed form.
 		var s string
-		if str, ok := vs[1].(vm.String); ok {
-			s = string(str)
+		if b, ok := asBytes(vs[1]); ok {
+			s = string(b)
 		} else {
 			s = vs[1].String()
 		}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -274,6 +274,23 @@ func ClearTaps() {
 	tapsMu.Unlock()
 }
 
+// asBytes returns the raw bytes of a String or a byte-array (an ArrayByte
+// TypedArray) for the binary file/stream sinks (spit, write!). A let-go String
+// already holds arbitrary bytes — read-bytes/read-file return one — but there was
+// no way to *write* a byte-array's bytes: it would stringify to its #byte-array[…]
+// repr. This is the inverse of the `bytes` coercion. ok is false for other values.
+func asBytes(v vm.Value) ([]byte, bool) {
+	switch c := v.(type) {
+	case vm.String:
+		return []byte(string(c)), true
+	case *vm.TypedArray:
+		if c.Kind() == vm.ArrayByte {
+			return c.Unbox().([]byte), true
+		}
+	}
+	return nil, false
+}
+
 // nsAliases maps alternative namespace names to canonical names.
 // e.g. "clojure.core" → "core", "clojure.test" → "test", "clojure.string" → "string"
 // Both names resolve to the same *Namespace object.
@@ -3480,11 +3497,11 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("spit expected String")
 		}
-		contents, ok := vs[1].(vm.String)
+		contents, ok := asBytes(vs[1])
 		if !ok {
-			return vm.NIL, fmt.Errorf("spit expected String")
+			return vm.NIL, fmt.Errorf("spit expected String or byte-array")
 		}
-		err := os.WriteFile(string(filename), []byte(contents), 0644)
+		err := os.WriteFile(string(filename), contents, 0644)
 		if err != nil {
 			return vm.NIL, fmt.Errorf("spit failed: %w", err)
 		}


### PR DESCRIPTION
A let-go `String` stores raw bytes, although text-producing operations encode characters as UTF-8. Consequently, `(str (char 200))` produces the two bytes `0xC3 0x88`, so it cannot be used to construct an arbitrary single byte such as `0xC8`. Byte arrays can represent arbitrary binary data, but the existing output sinks could not write their contents directly.

Specifically:
- `spit` requires a `String` (`spit expected String`).
- `write!` falls back to `vs[1].String()` for a non-String, i.e. a byte-array serializes to its `#byte-array[10 20 …]` *repr*, not its bytes.

So emitting any binary — encoding a PNG, a wasm asset, a zip, a checksum digest — was impossible from pure let-go without shelling out to an external decoder. This is asymmetric: the **read** side already moves raw bytes through a `String` (`read-bytes`/`read-file`/`slurp` return `vm.String(rawbytes)`), and `(bytes "str")` coerces String → byte-array. Only the inverse write was missing.

## Change

Add a package-level helper — the inverse of the `bytes` coercion — and route the two binary sinks through it:

```go
// asBytes returns the raw bytes of a String or a byte-array (ArrayByte TypedArray).
func asBytes(v vm.Value) ([]byte, bool) {
	switch c := v.(type) {
	case vm.String:
		return []byte(string(c)), true
	case *vm.TypedArray:
		if c.Kind() == vm.ArrayByte {
			return c.Unbox().([]byte), true
		}
	}
	return nil, false
}
```

- `spit` (`pkg/rt/lang.go`): `contents, ok := asBytes(vs[1])` instead of a String assertion; error becomes `spit expected String or byte-array`.
- `write!` (`pkg/rt/iort.go`): try `asBytes` first, else fall back to the printed form (unchanged for non-binary values).

Net: `(spit "x.png" (byte-array data))` and `(write! h (byte-array data))` write the bytes verbatim. Existing String behavior is unchanged. `spit` newly accepts byte-arrays, while `write!` intentionally changes byte-array handling from writing the printed `#byte-array[…]` representation to writing its raw bytes.


## Why a helper, not just per-sink code

`asBytes` keeps `spit`/`write!` one-liners and is the spot to later extend the same widening to `io/spit` (`pkg/rt/ions.go`) and `syscall/write-file` (`pkg/rt/syscall_*.go`), which still take String-only. Left those out to keep this PR tight — easy follow-up.

## Tests

`pkg/rt/asbytes_test.go` — `TestAsBytes`: String (incl. a high byte), byte-array (PNG signature + `0xFF`/`0xC8`), and a non-byte typed array (not coercible). Full `pkg/rt` and `pkg/vm` suites pass; `go vet ./pkg/rt/` clean.

## Verified downstream

With a locally-built lg carrying this, a path-tracer demo's headless bench writes a valid `out.png` directly — no temp file, no `openssl` — and `xxd` shows byte-exact output (`8950 4e47 00ff c80d 0a00` for `[137 80 78 71 0 255 200 13 10 0]`).

## Design question

Widen the existing sinks rather than introduce a `bytes->string` constructor. This keeps binary data typed as a byte-array through the I/O boundary and avoids requiring callers to construct a raw-byte String.