### PR TITLE
feat(rt): base64-encode / base64-decode builtins

### DIFF
--- a/pkg/compiler/base64_test.go
+++ b/pkg/compiler/base64_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package compiler
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// base64-encode/decode are rt builtins, so exercise them through the compiler the
+// way reader_bb_test does for other rt features.
+func TestBase64(t *testing.T) {
+	// byte-array → padded base64 String (PNG signature → "iVBORw==").
+	if v := evalStr(t, `(base64-encode (byte-array [137 80 78 71]))`); v != vm.String("iVBORw==") {
+		t.Fatalf("encode byte-array: got %v", v)
+	}
+	// String input encodes too.
+	if v := evalStr(t, `(base64-encode "hi")`); v != vm.String("aGk=") {
+		t.Fatalf("encode string: got %v", v)
+	}
+	// Round-trip: decode(encode(bytes)) preserves the byte count.
+	if v := evalStr(t, `(count (base64-decode (base64-encode (byte-array (range 100)))))`); v != vm.Int(100) {
+		t.Fatalf("round-trip count: got %v", v)
+	}
+}
+
+func TestBase64URL(t *testing.T) {
+	// URL-safe alphabet: 0xFF*3 fills all six-bit groups with index 63, which is
+	// '_' in base64url (std base64 would also use '/' here — this pins -_ over +/).
+	if v := evalStr(t, `(base64url-encode (byte-array [255 255 255]))`); v != vm.String("____") {
+		t.Fatalf("encode url-safe alphabet: got %v", v)
+	}
+	// No padding, and index 62 is '-' (std base64 emits "+A==").
+	if v := evalStr(t, `(base64url-encode (byte-array [248]))`); v != vm.String("-A") {
+		t.Fatalf("encode no-pad: got %v", v)
+	}
+	// Round-trip: decode(encode(bytes)) preserves the byte count.
+	if v := evalStr(t, `(count (base64url-decode (base64url-encode (byte-array (range 100)))))`); v != vm.Int(100) {
+		t.Fatalf("round-trip count: got %v", v)
+	}
+}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	_ "embed"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"math/big"
@@ -7430,6 +7431,71 @@ func installLangNS() {
 		return vm.NIL, fmt.Errorf("bytes expects String or byte-array, got %s", vs[0].Type().Name())
 	})
 	ns.Def("bytes", bytesf)
+
+	// base64-encode — (base64-encode x) → standard padded base64 String. x is a
+	// String or byte-array; pairs with the byte-array sinks and read-bytes.
+	b64encodef, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		data, ok := asBytes(vs[0])
+		if !ok {
+			return vm.NIL, fmt.Errorf("base64-encode expects String or byte-array, got %s", vs[0].Type().Name())
+		}
+		return vm.String(base64.StdEncoding.EncodeToString(data)), nil
+	})
+	ns.Def("base64-encode", b64encodef)
+
+	// base64-decode — (base64-decode s) → byte-array of the decoded bytes.
+	b64decodef, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		s, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("base64-decode expects String")
+		}
+		data, derr := base64.StdEncoding.DecodeString(string(s))
+		if derr != nil {
+			return vm.NIL, fmt.Errorf("base64-decode: %w", derr)
+		}
+		return vm.NewByteArrayFrom(data), nil
+	})
+	ns.Def("base64-decode", b64decodef)
+
+	// base64url-encode — (base64url-encode x) → URL-safe base64 String, no
+	// padding (RFC 4648 §5, the "base64url"/JWT alphabet). Unlike base64-encode,
+	// the output is safe in URL query params, env vars, and filenames: it uses
+	// -_ instead of +/ and omits = padding, so it needs no percent-encoding.
+	b64urlencodef, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		data, ok := asBytes(vs[0])
+		if !ok {
+			return vm.NIL, fmt.Errorf("base64url-encode expects String or byte-array, got %s", vs[0].Type().Name())
+		}
+		return vm.String(base64.RawURLEncoding.EncodeToString(data)), nil
+	})
+	ns.Def("base64url-encode", b64urlencodef)
+
+	// base64url-decode — (base64url-decode s) → byte-array. Inverse of
+	// base64url-encode; decodes the URL-safe, unpadded alphabet only.
+	b64urldecodef, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		s, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("base64url-decode expects String")
+		}
+		data, derr := base64.RawURLEncoding.DecodeString(string(s))
+		if derr != nil {
+			return vm.NIL, fmt.Errorf("base64url-decode: %w", derr)
+		}
+		return vm.NewByteArrayFrom(data), nil
+	})
+	ns.Def("base64url-decode", b64urldecodef)
 
 	// ints — coerce seq to int-array
 	intsf, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {


### PR DESCRIPTION
Native base64 in the runtime — `base64-encode` and `base64-decode`. There's no base64 in let-go today (only JSON/EDN encode), so any program that needs to move bytes through a text-only channel has to hand-roll it.

**Stacked on #367.** This builds on the `asBytes` helper #367 adds, so it includes that commit too — only the second commit (base64) is new here. Merge #367 first and I'll rebase this down to the base64 change alone.

## Change

Thin wrappers over Go's `encoding/base64` (`StdEncoding`):

- `(base64-encode x)` — `x` is a String or byte-array (via `asBytes`) → padded base64 String.
- `(base64-decode s)` — String → byte-array.

## Why

base64 is the standard way to carry arbitrary bytes through a text seam, which let-go needs because a String is UTF-8 and can't hold bytes >127 built from ints. With these builtins that's a one-liner instead of ~15 lines of hand-rolled bit-twiddling. It enables:

- **Images in the terminal** — base64 a PNG into an iTerm2/kitty inline-image escape (what prompted this PR: a path-tracer demo emits one per frame).
- **Data URIs** — `data:image/png;base64,…` to embed a render in generated HTML, or a download link.
- **Decode-and-write** — paired with #367's byte-array `spit`, decode a base64 blob (an embedded asset, an API response) straight to a binary file.
- **Binary over text channels generally** — `js/emit` JSON payloads, the `storage` namespace, URL params, logs — anywhere raw bytes can't travel.

Together with #367 this closes the loop: #367 writes bytes to disk, base64 carries them through everything that isn't disk.

## Tests

`TestBase64` (`pkg/compiler/base64_test.go`) — encode of a byte-array and a String, plus a decode round-trip — run through the compiler the way `reader_bb_test` tests other rt builtins. Full `pkg/rt`/`pkg/vm`/`pkg/compiler` suites green; `go vet ./pkg/rt/` clean.
