### PR TITLE
chore: remove accidentally-committed perf-page binary + gitignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,8 @@ benchmark/letgo
 .clj-kondo
 .lsp
 *.calva-repl
+# Clojure CLI (deps.edn) classpath cache
+.cpcache/
 CLAUDE.md
 # Ignore local Claude state, but track .claude/skills/ — it holds symlinks into
 # the cross-client .agents/skills/ tree so Claude Code (which doesn't scan
@@ -173,6 +175,7 @@ AGENTS.md
 /lgbgen
 /lginterop
 /bench-ratchet
+/perf-page
 
 # bench-ratchet streams per-bench results here on capture; the
 # aggregated baseline is in docs/perf/baseline.json (committed).


### PR DESCRIPTION
The #362 merge (commit 477cba3d) accidentally committed a **5.6 MB `perf-page` build binary** (macOS arm64 Mach-O) into the repo root — it's now in `main`.

This removes it and adds two ignores so an ad-hoc `go build ./cmd/perf-page` can't reintroduce it, matching the existing `/lgbgen`, `/lginterop`, `/bench-ratchet` ignores for the other perf tools:

- `/perf-page` — the build binary
- `.cpcache/` — Clojure CLI (deps.edn) classpath cache (also briefly snuck in)

No source changed; tree still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)