### PR TITLE
feat(ir,build): lowering-coverage ratchet gate (ITER-0021)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,23 @@ repos:
         types: [go]
         pass_filenames: false
         stages: [pre-push]
+
+      # Lowering-coverage ratchet (ITER-0021). ~60s, so pre-push not
+      # pre-commit, and deliberately NOT in CI. Fails if a form newly falls
+      # back to bytecode / vm dispatch (a trampoline, not a direct/native
+      # call) vs docs/perf/ir-stress-baseline.edn — or if the corpus :total
+      # drifted. always_run: a regression can come from a .lg OR a Go runtime
+      # change, so it must run on every push, not only when *.go is staged.
+      # NOTE: jj does not run git hooks — jj users gate with `make
+      # ir-stress-gate` (the same command this hook runs) before pushing.
+      - id: ir-stress-gate
+        name: ir-stress lowering-coverage ratchet (ITER-0021)
+        description: Fail if native-lowering coverage regressed vs the committed baseline
+        entry: make ir-stress-gate
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
   - repo: https://github.com/checkmake/checkmake.git
     rev: v0.2.2
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,16 @@ jank-stress: build
 	  ./lg scripts/ir-stress.lg lower-go $(JANK_SUITE_DIR) \
 	    $$(cd $(JANK_SUITE_DIR) && ls core_test/*.cljc string_test/*.cljc)
 
+# ITER-0021 lowering-coverage ratchet gate. Runs the ir-stress corpus and fails
+# (exit 1) if native-lowering failures grew vs docs/perf/ir-stress-baseline.edn —
+# a form newly failing to lower (whole-function fallback to bytecode). Reuses the
+# ir-stress fallback census; the ratchet only tightens. Automates BE-2.
+ir-stress-gate: build
+	LG_STRESS_PASSES=1 \
+	  LG_STRESS_TIMEOUT_MS=$${LG_STRESS_TIMEOUT_MS:-15000} \
+	  LG_STRESS_BASELINE=docs/perf/ir-stress-baseline.edn \
+	  ./lg scripts/ir-stress.lg corpus scripts/ir-stress-corpus.edn
+
 # Combined speed + size gates. Both ratchets need the gogen_ir lowered tree, and
 # each would otherwise regenerate it (the dominant cost). `ratchets` regenerates
 # it ONCE via `lowered`, runs the speed gate against it, then runs the size gate
@@ -335,4 +345,4 @@ ratchets-update: build lowered $(GO)
 	./lg scripts/fanout-ratchet.lg update --go "$$(command -v go)" --no-regen
 
 # PHONY targets are for ones that have conflicting files/dirs present:
-.PHONY: test clean clean-lowered
+.PHONY: test clean clean-lowered ir-stress-gate

--- a/docs/perf/ir-stress-baseline.edn
+++ b/docs/perf/ir-stress-baseline.edn
@@ -1,0 +1,22 @@
+{:failed 11
+ :total 2347
+ :passed 2336
+ :captured "2026-06-30"
+ :how "LG_STRESS_PASSES=1 make ir-stress (corpus = every shipped/test/example .lg)"
+ :note
+ "ITER-0021 lowering-coverage ratchet. `make ir-stress-gate` fails when the
+  corpus failure count exceeds :failed — i.e. a form newly fails to lower to
+  native Go and falls back to bytecode / vm dispatch (a trampoline, not a
+  direct/native call). The ratchet only tightens: after a genuine coverage
+  improvement, re-baseline :failed downward. Reuses the ir-stress fallback
+  census (scripts/ir-stress.lg) — there is no separate fallback detector. The
+  corpus list (scripts/ir-stress-corpus.edn) is part of the gate contract:
+  :total is checked against the live run, so a changed corpus is a hard GATE
+  ERROR (re-baseline), not a silent pass — this stops a removed failing fixture
+  from masking a regression."
+ :buckets
+ {"ir/build: unresolved symbol n" 7
+  "ir/build: unresolved symbol read-json" 1
+  "ir/build: unresolved symbol a" 1
+  "build-form: unrecognized form #inst" 1
+  ":other | unsupported function body shape" 1}}

--- a/scripts/ir-stress.lg
+++ b/scripts/ir-stress.lg
@@ -30,6 +30,12 @@
 ;;                          cumulative ms (aggregated across all defns).
 ;;                          Sampled from the auto-trace runs, so requires
 ;;                          LG_STRESS_AUTOTRACE=1 to populate.
+;;   LG_STRESS_BASELINE     path to a committed coverage baseline EDN
+;;                          ({:failed N :total M ...}). When set, the corpus
+;;                          run asserts native-lowering failures did not grow
+;;                          vs the baseline (ITER-0021 ratchet; exits non-zero
+;;                          on regression or corpus drift). See `make
+;;                          ir-stress-gate`.
 ;;
 ;; Examples:
 ;;   # IR-pipeline self-AOT pass rate (most common):
@@ -315,6 +321,19 @@
 ;; like `grep :missing-form ir-stress.log` answers "what's the gap?".
 (def log-path
   (let [v (System/getenv "LG_STRESS_LOG")]
+    (if (and v (not= v "")) v nil)))
+
+;; Optional coverage-ratchet gate (ITER-0021). When LG_STRESS_BASELINE points at
+;; a committed EDN baseline ({:failed N ...}), the corpus run compares its failure
+;; count to the baseline AFTER printing the summary: more failures than baseline
+;; (a form that newly fell back to bytecode / failed to lower instead of native
+;; lowering) is a regression and exits non-zero. The ratchet only tightens —
+;; fewer failures pass and should be ratcheted into the baseline. This makes the
+;; roadmap's BE-2 "ir-stress :ok non-decreasing" gate automated instead of a
+;; manual eyeball. Reuses this harness's existing fallback census — no separate
+;; fallback detector.
+(def gate-baseline-path
+  (let [v (System/getenv "LG_STRESS_BASELINE")]
     (if (and v (not= v "")) v nil)))
 
 (def log-entries (atom []))
@@ -752,6 +771,48 @@
         (when log-path
           (spit log-path (apply str @log-entries))
           (println (str "\nPer-defn log: " log-path
-                        " (" (count @log-entries) " rows)")))))))
+                        " (" (count @log-entries) " rows)")))
+
+        ;; --- ITER-0021 coverage-ratchet gate (reuses THIS fallback census;
+        ;; no separate fallback detector). Active only when LG_STRESS_BASELINE
+        ;; is set; fails the run if failures grew vs the committed baseline. ---
+        (when gate-baseline-path
+          (let [failed      (- total oks)
+                baseline    (try (read-string (slurp gate-baseline-path)) (catch e nil))
+                base-failed (or (:failed baseline) 0)
+                base-total  (:total baseline)]
+            (println (str "\n=== Coverage ratchet (baseline " gate-baseline-path ") ==="))
+            (cond
+              (nil? baseline)
+              (do (println (str "GATE ERROR: cannot read baseline " gate-baseline-path))
+                  (System/exit 2))
+              ;; Corpus-stability guard: the absolute failure count is only a
+              ;; valid ratchet if it counts the SAME corpus. A changed :total
+              ;; (a fixture added/removed) can mask a regression — e.g. drop a
+              ;; failing fixture and `failed` falls without any lowering fix. So
+              ;; a drifted corpus is a hard error: re-baseline, don't auto-pass.
+              (and base-total (not= total base-total))
+              (do (println (str "GATE ERROR: corpus size changed — " total " forms now vs "
+                                base-total " baselined."))
+                  (println "      The corpus list is part of the gate contract; a changed :total")
+                  (println "      can hide a coverage regression. Re-baseline before landing:")
+                  (println "      LG_STRESS_PASSES=1 make ir-stress, then update docs/perf/ir-stress-baseline.edn.")
+                  (System/exit 2))
+              (> failed base-failed)
+              (do
+                (println (str "FAIL: lowering coverage REGRESSED — " failed " failures vs "
+                              base-failed " baselined (" (- failed base-failed) " new)."))
+                (println "      Forms newly NOT lowering to native Go (fell back to bytecode / vm")
+                (println "      dispatch — trampolines, not direct calls). Failure buckets:")
+                (doseq [[bucket cnt] (sort-by val (fn [a b] (compare b a)) all-errs)]
+                  (println (format "  %-50s %3d" (str bucket) cnt)))
+                (System/exit 1))
+              :else
+              (println (str "OK: " oks "/" total " lower natively; failures " failed
+                            " <= baseline " base-failed
+                            (if (< failed base-failed)
+                              (str " — improved by " (- base-failed failed)
+                                   "; ratchet the baseline down")
+                              ""))))))))))
 
 (run)


### PR DESCRIPTION
## What

Adds a **lowering-coverage ratchet** that fails the build when native-lowering coverage regresses versus a committed baseline — automating BE-2 (`ir-stress :ok` non-decreasing) instead of a manual eyeball.

- `scripts/ir-stress.lg` gains an `LG_STRESS_BASELINE` gate mode: after the corpus summary it compares the live native-lowering failure count to the committed baseline `:failed`, exiting **1** on regression (naming the failure buckets) and **2** on an unreadable baseline. The ratchet only tightens — after a genuine improvement, re-baseline downward.
- `make ir-stress-gate` (`.PHONY`) wires the gate over `scripts/ir-stress-corpus.edn`.
- `docs/perf/ir-stress-baseline.edn` — committed baseline (`:failed 11`, 2336/2347 forms lower natively).

It reuses the existing ir-stress fallback census (a form that newly falls back to bytecode / vm dispatch is a trampoline, not a direct/native call) — there is no separate detector.

## Corpus-stability guard (from adversarial review)

The absolute failure count is only a valid ratchet over a *fixed* corpus. The gate checks the live `:total` against the baseline `:total` and treats corpus drift as a hard **GATE ERROR (exit 2, re-baseline)** rather than a silent pass — so a removed failing fixture can't mask a regression.

## How it gates (pre-push, not CI)

The gate is ~60s, so it runs as a **prek `pre-push` hook** in `.pre-commit-config.yaml` (alongside the existing go-test / clojure-compat pre-push checks), deliberately **not** in per-PR CI. `always_run`, since a regression can come from a `.lg` *or* a Go runtime change. jj users gate via the `jj push` alias (`jj-pre-push --checker prek`), which runs the same hook before delegating to `jj git push`.

## Evidence

- GREEN at baseline: `make ir-stress-gate` → exit 0, `2336/2347 lower natively; failures 11 <= baseline 11`.
- RED on simulated corpus drift → exit 2 (`corpus size changed`).
- RED on a simulated failure increase → exit 1 (buckets named).
- Verified live through the prek pre-push hook (`ir-stress lowering-coverage ratchet (ITER-0021) ... Passed`).