### PR TITLE
docs(perf): document the perf label / PR-time A/B workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-06-05
+last-verified: 2026-06-30
 authoritative-for:
   - docs-index
 human-verified: 2026-06-20
@@ -49,6 +49,7 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | Docs judgement-layer report (stale/supersession/index) | `docs-status.md` |
 | Regenerating generated artifacts after `.lg` edits | `regenerating-generated-artifacts.md` |
 | Perf ratchet, regression checkpoints, historical baselines | `perf/ratchet.md` |
+| Running the perf A/B on a PR (the `perf` label) | `perf/ratchet.md` (§ Running the check on a PR) |
 | gogen_ir native-lowering compute microbench gate | `perf/microbench/README.md` |
 | Babashka pods (usage) | `guide/pods.md` |
 | Babashka pods (host protocol / design) | `design/pods.md` |

--- a/docs/perf/ratchet.md
+++ b/docs/perf/ratchet.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-06-05
+last-verified: 2026-06-30
 authoritative-for:
   - benchmark-ratchet
 human-verified:
@@ -207,6 +207,34 @@ current run that don't appear in the baseline are flagged **NEW**.
 The default budget is **5%**. Raise it for noisy benchmarks via
 `-budget`. Lower it once you've improved benchmark stability (e.g.
 `-benchtime 5s -count 5`).
+
+## Running the check on a PR (the `perf` label)
+
+CI runs the A/B on a pull request only when the PR carries the **`perf`**
+label — `.github/workflows/perf-pr.yml`. Add the label to run it; it
+re-runs on each push while the label is on; remove it to stop. An
+unlabeled PR skips the job instantly, with no runner allocated, so the
+label is a deliberate opt-in for the multi-minute sweep.
+
+Guards and escape hatches:
+
+- **Path filter.** The job only fires for changes under `pkg/**` or
+  `cmd/**` (plus the workflow file itself), so a labeled doc-only PR
+  still skips.
+- **Manual dispatch.** Run against any PR by number without touching
+  labels via the workflow's `workflow_dispatch` input `pr` (needs Actions
+  access).
+
+The PR job builds with the same `-tags gogen_ir` default as local runs
+(see [Build tags](#build-tags)), so it measures the native-lowered path.
+It runs the `pr-fast` profile — the stable `pkg/vm` micro-benchmark
+families (frame dispatch, allocation, invoke, arity, record ops) plus the
+calibration anchor, sized for quick two-pass feedback. The end-to-end
+suite and the IR-compile bench are not in the PR gate; they run in the
+fuller profiles on `main`. None of the `pr-fast` families is a
+numeric/float kernel, so a change that only helps tight numeric code (e.g.
+native float unboxing) reads flat here until such a benchmark is added —
+see [Adding a new benchmark](#adding-a-new-benchmark).
 
 ## Cross-machine sanity
 


### PR DESCRIPTION
## What

Document how to run the perf A/B benchmark on a pull request. `docs/perf/ratchet.md` covered local usage and how the CI check computes deltas, but not the PR-time workflow — which is entirely gated on a label that wasn't written down anywhere.

## The gap

`.github/workflows/perf-pr.yml` runs the A/B only when a PR carries the `perf` label, but nothing in the docs said so. A contributor had no way to discover that the label exists, that it re-runs on each push, or that a path filter and a manual dispatch escape hatch exist.

## The change

A new "Running the check on a PR" section in `ratchet.md`:
- the `perf` label opt-in (add to run, re-runs on push while on, remove to stop; unlabeled PRs skip with no runner)
- the `pkg/**` | `cmd/**` path guard
- the `workflow_dispatch` escape hatch (run by PR number without a label)
- that the PR job uses the same `-tags gogen_ir` default, and that the fleet has no float/numeric-kernel workload — so a change that only helps tight numeric code reads flat until such a benchmark is added

Plus the matching topical-map row in the docs index. Docs-only; cross-references the existing "Build tags" and "Adding a new benchmark" sections rather than restating them.

## Context

Noticed while working on a narrowly-numeric IR change (#372) — I went looking for how to get perf numbers on the PR and found the mechanism only in the workflow YAML. This writes it down.
