### PR TITLE
fix(ir): chained-comparison lowering + ec/callErr name collision in gogen

### DIFF
--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -412,6 +412,14 @@
 ;; Ops whose arity-1 form is the canonical shape (no n-ary folding).
 (def unary-only-ops #{:inc :dec})
 
+;; Comparison ops are NOT associative the way +/-/*/= (arithmetic) are, so
+;; they can't go through fold-binary-chain's left fold: (<= a b c) means
+;; "b is between a and c" — pairwise checks between ADJACENT original args,
+;; ANDed — NOT (((a <= b) <= c) ...), which would feed a comparison's bool
+;; RESULT back in as an operand of the next comparison (wrong type, and
+;; wrong even if the type happened to line up). See build-comparison-chain.
+(def comparison-ops #{:lt :lte :gt :gte :eq})
+
 (defn build-args [forms ctx]
   ;; Build each arg, AND register its result as a temporary live local
   ;; under a gensym so any subsequent arg's build-if symmetric pass-
@@ -482,6 +490,28 @@
                op-kw [acc (nth args i)] nil)
              (inc i)))))
 
+(defn build-comparison-chain [op-kw args ctx]
+  "[a b c d] → (and (op a b) (op b c) (op c d)): one comparison Inst per
+   ADJACENT pair of original args, joined with real short-circuiting `if`s
+   (same shape the `and` macro expands to) instead of fold-binary-chain's
+   left fold. Reuses build-if/build-form for the join logic, so this needs
+   no new IR op — just gensym'd locals naming each pairwise comparison so
+   the synthetic `if` forms below can refer back to them by symbol."
+  (push-locals! ctx)
+  (let [pair-syms (mapv (fn [i]
+                          (let [pid (add-inst! ctx (ctx-block ctx) op-kw
+                                      [(nth args i) (nth args (inc i))] nil)
+                                sym (ctx-gensym! ctx "cmp__")]
+                            (bind-local! ctx sym pid)
+                            sym))
+                        (range (dec (count args))))
+        chain-form (reduce (fn [acc sym] (list 'if sym acc false))
+                           true
+                           (reverse pair-syms))
+        result (build-form chain-form ctx)]
+    (pop-locals! ctx)
+    result))
+
 (defn build-builtin-op [op-kw form ctx]
   ;; Builtin ops are binary (stack-effect 2→1). Fold n-ary calls.
   ;; Unary-only ops (:inc, :dec) take exactly one ref.
@@ -512,6 +542,8 @@
         :else (nth args 0))
       (= 2 (count args))
       (add-inst! ctx (ctx-block ctx) op-kw args nil)
+      (contains? comparison-ops op-kw)
+      (build-comparison-chain op-kw args ctx)
       :else
       (fold-binary-chain op-kw args ctx))))
 

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -373,7 +373,13 @@
   #{"break" "default" "func" "interface" "select" "case" "defer" "go"
     "map" "struct" "chan" "else" "goto" "package" "switch" "const"
     "fallthrough" "if" "range" "type" "continue" "for" "import"
-    "return" "var"})
+    "return" "var"
+    ;; Not Go keywords, but fixed Go identifiers this lowering itself emits
+    ;; into every generated function's own scope (the *vm.ExecContext param,
+    ;; and the shared `error` local) — a Lisp local literally named `ec` or
+    ;; `callErr` (e.g. a legmacs `end-column` destructured as `ec`) would
+    ;; otherwise redeclare them in the same block.
+    "ec" "callErr"})
 
 ;; Munge one char to a Go-identifier-safe token using `m`, with a catch-all so
 ;; nothing unmapped ever leaks through: explicit map entry wins; otherwise

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-438b9265ebbdaefd01555dc6be6a1ddd50ccbb540b3cbd5163bbb992dbd303c1
+e60ca3ceeae299348276a1d2ac021842072820a99342860af2b71a324dba8197


### PR DESCRIPTION
## What broke

Found while AOT-compiling a real-world multi-namespace program (a small
terminal editor, ~14 namespaces) to native Go via `scripts/lg-compile`.
Both bugs are in the IR build/lowering pipeline that backs the AOT Go
backend (`ir.build` / `ir.lower-go`), not anything specific to that
program — any `.lg` source hitting these patterns would miscompile the
same way.

### 1. Chained comparisons lower to a nonsensical fold

`(<= 97 c 122)`-style range checks (e.g. alnum classification) go through
`build-builtin-op`'s n-ary fallback, `fold-binary-chain`, for any op with
3+ args. That fold is correct for associative arithmetic (`+`/`-`/`*`):
`[a b c d] → (((a op b) op c) op d)`, feeding the previous result back in
as an operand. It is **wrong for comparisons** — Clojure's `(<= a b c)`
means "pairwise adjacent comparisons, ANDed" (`(and (<= a b) (<= b c))`),
not "chain the boolean result of the first comparison into the second as
if it were a number." Concretely, the generated Go for `(<= 97 c 122)`
was:

```go
v6 = rt.LeValue(vm.Int(97), c)   // bool
or__x_7 = v6 <= 122               // comparing a bool against an int literal
```

— a type error in Go (caught at `go build`), and semantically wrong even
where the types might have lined up.

### 2. `ec`/`callErr` aren't collision-checked against user locals

Every lowered function's Go signature hardcodes `ec *vm.ExecContext` as
its first parameter, and every function body declares a shared `callErr
error` local. Lisp-level local names munge straight to their Go
identifier with no check against these two fixed, non-gensym'd names.
A source local literally named `ec` (in the test case: a destructured
`end-column`, a very reasonable name to pick) redeclares the function's
own `ec` parameter in the same block — a hard `go build` error, and every
`ec.Invoke(...)` call after the shadowing assignment is now operating on
the wrong thing.

## The fixes

- **`pkg/rt/core/ir/build.lg`**: added `build-comparison-chain`, invoked
  from `build-builtin-op` when the op is one of `:lt :lte :gt :gte :eq`
  with 3+ args. It builds one comparison Inst per **adjacent pair** of the
  original args and joins them with genuinely short-circuiting `if`s — the
  same shape the `and` macro already expands source-level `and` into. No
  new IR op, no bytecode-lowering (`ir.lower`) or opcode changes needed;
  it's built entirely out of existing, already-tested `build-if`/
  `build-form` machinery, by gensym-binding each pairwise comparison to a
  local and feeding a synthesized nested-`if` form back through
  `build-form`.
- **`pkg/rt/core/ir/lower_go.lg`**: extended the existing
  `go-reserved-words` set (already used to suffix real Go keywords that
  collide with a Lisp identifier) with `"ec"` and `"callErr"` — the two
  fixed identifiers the lowering itself injects into every function's
  scope.
- Regenerated the precompiled core bundle (`go generate ./pkg/rt/`) since
  `pkg/rt/core/ir/*.lg` changed.

`go test ./... -count=1` passes. Verified end-to-end by AOT-compiling and
`go build`-ing the real program that surfaced both bugs (all 14
namespaces, direct cross-package calls) — it now builds and boots
correctly.

## Possible followups (not done here, flagging for visibility)

- The unary case `(= 1 (count args))` in `build-builtin-op` returns
  `(nth args 0)` (identity) for comparisons too, per an explicit existing
  comment ("comparisons → identity"). That means `(<= x)` returns `x`
  itself rather than `true`, which doesn't match Clojure (`(<= 5)` => `true`).
  Pre-existing, not touched here — didn't want to change documented-as-
  intentional behavior as a drive-by in a bugfix PR, and it wasn't
  exercised by the program that surfaced the two bugs above.
- The `ec`/`callErr` collision fix is a targeted allowlist of the two
  identifiers the lowering currently hardcodes. If a future change adds
  another fixed non-gensym'd identifier to every function's scope (or to
  some other shared scope), it'll need adding to `go-reserved-words` too —
  there's no structural guard preventing a new collision class from being
  introduced the same way.
- Didn't attempt to regenerate `pkg/rt/core_go_lowered/` (the separate
  gogen_ir-tagged pre-lowered core tree) — out of scope for this fix, and
  `go test ./...` already passes without it since that tree wasn't stale
  in a way any test exercises.
