### PR TITLE
feat(wasm): -w-shell accepts a custom HTML template

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nooga/let-go/pkg/nrepl"
 	"github.com/nooga/let-go/pkg/resolver"
 	"github.com/nooga/let-go/pkg/rt"
+	wasm "github.com/nooga/let-go/pkg/rt/wasm"
 	"github.com/nooga/let-go/pkg/vm"
 
 	_ "github.com/nooga/let-go/pkg/rt/corefns"
@@ -329,7 +330,7 @@ func init() {
 	flag.StringVar(&bundleOutput, "b", "", "bundle .lg file into a standalone executable (specify output path)")
 	flag.StringVar(&bundleBase, "bundle-base", "", "path to target-platform lg binary for cross-OS bundling (defaults to current executable)")
 	flag.StringVar(&wasmOutput, "w", "", "build .lg file into a WASM web app (specify output directory)")
-	flag.StringVar(&wasmShell, "w-shell", "xterm", "shell for -w: 'xterm' (default) or 'none' (emit core only; client supplies its own shell via window.LetGoHost)")
+	flag.StringVar(&wasmShell, "w-shell", "xterm", "shell for -w: 'xterm' (default), 'none' (emit core only; client supplies its own shell via window.LetGoHost), or a path to a custom HTML template containing __LG_HOST_JS_BODY_PLACEHOLDER__")
 	flag.StringVar(&wasmPayload, "w-wasm", "inline", "wasm delivery for -w: 'inline' (default; gzip-base64 baked into index.html) or 'external' (emit a separate main.wasm the loader fetches + streams)")
 	flag.BoolVar(&wasmHostEval, "w-host-eval", false, "for -w: expose LetGoHost.eval(code) to call into the loaded image and keep it live (park after the program's main returns); works in both boot modes. Pair with -w-shell none")
 	flag.StringVar(&storageID, "storage-id", "", "logical storage store id for the storage namespace (default: script name, or current directory for main.lg)")
@@ -601,15 +602,16 @@ func runMain() int {
 			fmt.Fprintln(os.Stderr, "error: -w requires exactly one input file")
 			return 1
 		}
-		if wasmShell != "xterm" && wasmShell != "none" {
-			fmt.Fprintf(os.Stderr, "error: -w-shell must be 'xterm' or 'none', got %q\n", wasmShell)
+		customShellTemplate, xtermShell, shellErr := wasm.ResolveShell(wasmShell)
+		if shellErr != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", shellErr)
 			return 1
 		}
 		if wasmPayload != "inline" && wasmPayload != "external" {
 			fmt.Fprintf(os.Stderr, "error: -w-wasm must be 'inline' or 'external', got %q\n", wasmPayload)
 			return 1
 		}
-		if err := buildWasm(context, nsResolver, files[0], wasmOutput, wasmShell == "xterm", wasmPayload == "external", wasmHostEval, storageIDForScript(files[0])); err != nil {
+		if err := buildWasm(context, nsResolver, files[0], wasmOutput, xtermShell, wasmPayload == "external", wasmHostEval, storageIDForScript(files[0]), customShellTemplate); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
 		}

--- a/pkg/rt/wasm/embed.go
+++ b/pkg/rt/wasm/embed.go
@@ -37,6 +37,32 @@ const (
   <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>`
 )
 
+// HostBodyMarker is where the assembled host JS is spliced into an HTML
+// template (the embedded host.html, or a caller's custom -w-shell template).
+const HostBodyMarker = "__LG_HOST_JS_BODY_PLACEHOLDER__"
+
+// buildHostJS assembles the host-agnostic runtime JS (wasm_exec, the inline or
+// external wasm payload, the LetGoHost surface, and the optional eval hook).
+// Shared by AssembleHTML (built-in shell) and AssembleHTMLWithTemplate (custom).
+func buildHostJS(wasmExecJS, wasmGzB64 string, externalWasm, hostEval bool) string {
+	execJSON, _ := json.Marshal(wasmExecJS)
+
+	mode := "inline"
+	if externalWasm {
+		mode = "external"
+		wasmGzB64 = ""
+	}
+	modeJSON, _ := json.Marshal(mode)
+	b64JSON, _ := json.Marshal(wasmGzB64)
+	hostEvalJSON, _ := json.Marshal(hostEval)
+
+	hostJS := mustReplaceOnce(lgHostCoreJS, "__WASM_EXEC_JS__", string(execJSON))
+	hostJS = mustReplaceOnce(hostJS, "__WASM_MODE__", string(modeJSON))
+	hostJS = mustReplaceOnce(hostJS, "__WASM_GZ_B64__", string(b64JSON))
+	hostJS = mustReplaceOnce(hostJS, "__LG_HOST_EVAL__", string(hostEvalJSON))
+	return hostJS
+}
+
 // AssembleHTML returns the full self-contained HTML page produced by
 // `lg -w`. With shell == true the default xterm shell and its CDN tags are
 // included; with shell == false only the host-agnostic core ships and the
@@ -47,36 +73,26 @@ const (
 // bundle); when false it is omitted, so feature detection stays honest. Pure
 // function: same inputs produce same output. Tested via golden files in testdata/.
 func AssembleHTML(wasmExecJS, wasmGzB64 string, shell, externalWasm, hostEval bool) string {
-	execJSON, _ := json.Marshal(wasmExecJS)
-
-	// WASM_MODE selects the loader path; in external mode the inline payload
-	// is emptied (the wasm ships as a separate main.wasm), keeping index small.
-	mode := "inline"
-	if externalWasm {
-		mode = "external"
-		wasmGzB64 = ""
-	}
-	modeJSON, _ := json.Marshal(mode)
-	b64JSON, _ := json.Marshal(wasmGzB64)
-	hostEvalJSON, _ := json.Marshal(hostEval) // true | false -> gates LetGoHost.eval
-
-	hostJS := mustReplaceOnce(lgHostCoreJS, "__WASM_EXEC_JS__", string(execJSON))
-	hostJS = mustReplaceOnce(hostJS, "__WASM_MODE__", string(modeJSON))
-	hostJS = mustReplaceOnce(hostJS, "__WASM_GZ_B64__", string(b64JSON))
-	hostJS = mustReplaceOnce(hostJS, "__LG_HOST_EVAL__", string(hostEvalJSON))
+	hostJS := buildHostJS(wasmExecJS, wasmGzB64, externalWasm, hostEval)
 
 	css, js := "", ""
 	if shell {
-		// Core first, then the shell — the shell's onReady binding needs
-		// LetGoHost to exist, and the entry point at the end of core fires
-		// after both <script> bodies have evaluated.
 		hostJS = hostJS + "\n" + lgShellXtermJS
 		css, js = xtermCSS, xtermJS
 	}
 
 	out := mustReplaceOnce(htmlTemplate, "__LG_XTERM_CSS__", css)
 	out = mustReplaceOnce(out, "__LG_XTERM_JS__", js)
-	return mustReplaceOnce(out, "__LG_HOST_JS_BODY_PLACEHOLDER__", hostJS)
+	return mustReplaceOnce(out, HostBodyMarker, hostJS)
+}
+
+// AssembleHTMLWithTemplate injects the assembled host JS into a caller-supplied
+// HTML template at HostBodyMarker. The custom template owns its own shell/markup,
+// so the built-in xterm assets are never added and no __LG_XTERM_* markers are
+// touched. externalWasm/hostEval behave as in AssembleHTML.
+func AssembleHTMLWithTemplate(template, wasmExecJS, wasmGzB64 string, externalWasm, hostEval bool) string {
+	hostJS := buildHostJS(wasmExecJS, wasmGzB64, externalWasm, hostEval)
+	return mustReplaceOnce(template, HostBodyMarker, hostJS)
 }
 
 // mustReplaceOnce panics unless marker appears exactly once in s. The

--- a/pkg/rt/wasm/embed_test.go
+++ b/pkg/rt/wasm/embed_test.go
@@ -1,0 +1,24 @@
+package wasm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAssembleHTMLWithTemplate(t *testing.T) {
+	tmpl := "<html><body><script>\n" + HostBodyMarker + "\n</script></body></html>"
+	out := AssembleHTMLWithTemplate(tmpl, "// wasm_exec", "GZB64==", false, true)
+
+	if strings.Contains(out, HostBodyMarker) {
+		t.Fatal("marker was not consumed")
+	}
+	if !strings.Contains(out, "// wasm_exec") {
+		t.Fatal("wasm_exec JS not injected")
+	}
+	if strings.Contains(out, "new Terminal") {
+		t.Fatal("custom-template output must not include the xterm shell")
+	}
+	if !strings.HasPrefix(out, "<html><body>") {
+		t.Fatal("custom template body not preserved")
+	}
+}

--- a/pkg/rt/wasm/shell.go
+++ b/pkg/rt/wasm/shell.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package wasm
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ResolveShell interprets the -w-shell flag: "xterm"/"none" pick the built-in
+// shell; any other value is a custom HTML template path, which must exist and
+// contain exactly one HostBodyMarker. Returns the custom template path ("" for
+// built-in) and whether the built-in xterm shell is selected.
+func ResolveShell(wShell string) (customTemplate string, xtermShell bool, err error) {
+	switch wShell {
+	case "xterm":
+		return "", true, nil
+	case "none":
+		return "", false, nil
+	default:
+		data, rerr := os.ReadFile(wShell)
+		if rerr != nil {
+			return "", false, fmt.Errorf("-w-shell %q is not 'xterm'/'none' and can't be read as a template: %w", wShell, rerr)
+		}
+		if strings.Count(string(data), HostBodyMarker) != 1 {
+			return "", false, fmt.Errorf("-w-shell template %q must contain exactly one %s marker", wShell, HostBodyMarker)
+		}
+		return wShell, false, nil
+	}
+}

--- a/pkg/rt/wasm/shell_test.go
+++ b/pkg/rt/wasm/shell_test.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package wasm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveShell(t *testing.T) {
+	if ct, x, err := ResolveShell("xterm"); err != nil || ct != "" || !x {
+		t.Fatalf("xterm: got (%q,%v,%v)", ct, x, err)
+	}
+	if ct, x, err := ResolveShell("none"); err != nil || ct != "" || x {
+		t.Fatalf("none: got (%q,%v,%v)", ct, x, err)
+	}
+	if _, _, err := ResolveShell("/no/such/template.html"); err == nil {
+		t.Fatal("missing template should error")
+	}
+
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.html")
+	if err := os.WriteFile(bad, []byte("<html>no marker</html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ResolveShell(bad); err == nil {
+		t.Fatal("template without marker should error")
+	}
+
+	good := filepath.Join(dir, "good.html")
+	if err := os.WriteFile(good, []byte("<script>"+HostBodyMarker+"</script>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if ct, x, err := ResolveShell(good); err != nil || ct != good || x {
+		t.Fatalf("good: got (%q,%v,%v)", ct, x, err)
+	}
+}

--- a/wasm.go
+++ b/wasm.go
@@ -54,7 +54,7 @@ addEventListener('fetch', e => {
 });
 `
 
-func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool, externalWasm bool, hostEval bool, storeID string) error {
+func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, outDir string, shell bool, externalWasm bool, hostEval bool, storeID string, customShellTemplate string) error {
 	// 1. Compile .lg → .lgb in memory
 	ctx.SetSource(src)
 	f, err := os.Open(src)
@@ -152,7 +152,16 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	// 9. Build the HTML. shell=false emits the core glue only (no xterm shell
 	// / CDN tags). externalWasm=true emits the streaming loader and an empty
 	// inline payload (the wasm ships as main.wasm, written below).
-	html := wasmassets.AssembleHTML(string(wasmExecJS), wasmB64, shell, externalWasm, hostEval)
+	var html string
+	if customShellTemplate != "" {
+		tmpl, err := os.ReadFile(customShellTemplate)
+		if err != nil {
+			return fmt.Errorf("read -w-shell template %q: %w", customShellTemplate, err)
+		}
+		html = wasmassets.AssembleHTMLWithTemplate(string(tmpl), string(wasmExecJS), wasmB64, externalWasm, hostEval)
+	} else {
+		html = wasmassets.AssembleHTML(string(wasmExecJS), wasmB64, shell, externalWasm, hostEval)
+	}
 
 	// 10. Write output
 	if err := os.MkdirAll(outDir, 0755); err != nil {


### PR DESCRIPTION
## What

Generalizes `lg -w -w-shell` from `xterm` | `none` to also accept a **custom HTML template path**. When given a template, `lg` splices the assembled host runtime JS into it natively at the `__LG_HOST_JS_BODY_PLACEHOLDER__` marker — no external post-processing step needed.

Motivation: building a client-owned browser shell (e.g. a compiler-explorer UI) currently requires `-w-shell none` followed by an out-of-band script that scrapes the emitted `<script>` and injects it into a custom page. This lets `lg` do that splice itself.

## Change

- `pkg/rt/wasm/embed.go`: extract `buildHostJS(...)` (the wasm_exec + gz-b64 + host-core + eval assembly) shared by `AssembleHTML` and the new `AssembleHTMLWithTemplate(template, ...)`, which injects host JS into a caller-supplied template at `HostBodyMarker` and does not touch the built-in `__LG_XTERM_*` markers. `AssembleHTML`'s output is byte-identical (existing golden tests unchanged).
- `lg.go`: `-w-shell` accepts a template path; new `resolveShell` validates it (must exist + contain exactly one marker) and emits a clean `error:` + exit 1 on failure (never a panic).
- `wasm.go`: `buildWasm` gains a `customShellTemplate` param and routes to `AssembleHTMLWithTemplate` when set.

## Tests

- `pkg/rt/wasm/embed_test.go`: `TestAssembleHTMLWithTemplate` (host JS injected, marker consumed, no xterm assets, custom markup preserved); existing goldens stay byte-identical.
- `wasm_test.go`: `TestResolveShell` covers xterm / none / missing / no-marker / valid.
- `go build ./...`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)