### PR TITLE
feat(wasm): neutral #app host mount

### DIFF
--- a/examples/host-eval/shell.html
+++ b/examples/host-eval/shell.html
@@ -52,8 +52,8 @@
   /* overflow:hidden clips xterm's pre-fit default grid so it can't transiently
      widen the flex row before fit() shrinks it. */
   .box { height: 300px; border: 1px solid var(--rule); border-radius: 6px; box-sizing: border-box; overflow: hidden; }
-  /* NOT #terminal — the bundle's host page already owns that id; a dupe sends
-     xterm into the hidden one. Use a unique id so our visible box gets output. */
+  /* NOT the host mount (#app) — the bundle's host page already owns that id; a
+     dupe sends xterm into the hidden one. Use a unique id so our box gets output. */
   #evalio { padding: 6px; background: var(--term-bg); }
 
   /* REPL pane: one scroll flow; the prompt is the last line (no separate box). */

--- a/pkg/rt/wasm/embed.go
+++ b/pkg/rt/wasm/embed.go
@@ -32,8 +32,9 @@ var lgShellXtermJS string
 var htmlTemplate string
 
 const (
-	xtermCSS = `  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">`
-	xtermJS  = `  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+	xtermCSS = `  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <style>.xterm{height:100%}</style>`
+	xtermJS = `  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>`
 )
 

--- a/pkg/rt/wasm/host.html
+++ b/pkg/rt/wasm/host.html
@@ -9,15 +9,14 @@ __LG_XTERM_CSS__
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1;min-height:0}
+    #app{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
-    .xterm{height:100%}
   </style>
 </head>
 <body>
   <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
+  <div id="app"></div>
 __LG_XTERM_JS__
   <script>
 __LG_HOST_JS_BODY_PLACEHOLDER__

--- a/pkg/rt/wasm/lg-shell-xterm.js
+++ b/pkg/rt/wasm/lg-shell-xterm.js
@@ -6,7 +6,7 @@
 // terminal-specific lives here.
 (function() {
   const status = document.getElementById('status');
-  const termEl = document.getElementById('terminal');
+  const termEl = document.getElementById('app');
 
   const term = new Terminal({
     fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
@@ -20,7 +20,6 @@
 
   function showTerminal() {
     if (status) status.style.display = 'none';
-    termEl.style.display = 'block';
     term.open(termEl);
     fitAddon.fit();
     term.focus();

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -5,19 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <style>.xterm{height:100%}</style>
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1;min-height:0}
+    #app{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
-    .xterm{height:100%}
   </style>
 </head>
 <body>
   <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
+  <div id="app"></div>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
   <script>
@@ -475,7 +475,7 @@ async function startMainThreadMode() {
 // terminal-specific lives here.
 (function() {
   const status = document.getElementById('status');
-  const termEl = document.getElementById('terminal');
+  const termEl = document.getElementById('app');
 
   const term = new Terminal({
     fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
@@ -489,7 +489,6 @@ async function startMainThreadMode() {
 
   function showTerminal() {
     if (status) status.style.display = 'none';
-    termEl.style.display = 'block';
     term.open(termEl);
     fitAddon.fit();
     term.focus();

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -5,19 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>let-go app</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <style>.xterm{height:100%}</style>
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1;min-height:0}
+    #app{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
-    .xterm{height:100%}
   </style>
 </head>
 <body>
   <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
+  <div id="app"></div>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
   <script>
@@ -475,7 +475,7 @@ async function startMainThreadMode() {
 // terminal-specific lives here.
 (function() {
   const status = document.getElementById('status');
-  const termEl = document.getElementById('terminal');
+  const termEl = document.getElementById('app');
 
   const term = new Terminal({
     fontFamily: '"IBM Plex Mono", "Menlo", "Consolas", monospace',
@@ -489,7 +489,6 @@ async function startMainThreadMode() {
 
   function showTerminal() {
     if (status) status.style.display = 'none';
-    termEl.style.display = 'block';
     term.open(termEl);
     fitAddon.fit();
     term.focus();

--- a/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
@@ -9,15 +9,14 @@
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1;min-height:0}
+    #app{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
-    .xterm{height:100%}
   </style>
 </head>
 <body>
   <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
+  <div id="app"></div>
 
   <script>
 // --- Cross-origin isolation: prefer server headers, fall back to SW ---

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -9,15 +9,14 @@
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1;min-height:0}
+    #app{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
-    .xterm{height:100%}
   </style>
 </head>
 <body>
   <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
+  <div id="app"></div>
 
   <script>
 // --- Cross-origin isolation: prefer server headers, fall back to SW ---

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -9,15 +9,14 @@
     *{margin:0;padding:0;box-sizing:border-box}
     html,body{height:100%;height:100dvh;background:#0c0c0c;color:#e8e6df;overflow:hidden}
     body{display:flex;flex-direction:column}
-    #terminal{flex:1;min-height:0}
+    #app{flex:1;min-height:0}
     #status{color:#5a584f;font-family:monospace;font-size:13px;padding:1rem;position:absolute;
             top:50%;left:50%;transform:translate(-50%,-50%)}
-    .xterm{height:100%}
   </style>
 </head>
 <body>
   <div id="status">loading...</div>
-  <div id="terminal" style="display:none"></div>
+  <div id="app"></div>
 
   <script>
 // --- Cross-origin isolation: prefer server headers, fall back to SW ---


### PR DESCRIPTION
## Context

`lg -w`'s generated frame emits a `#terminal` div plus terminal-presentation CSS (`#terminal{flex:1}`, `.xterm{height:100%}`) in the neutral host page. That's a leak from the runtime into the host frame: a `-w-shell none` client rendering to a canvas or audio surface is still handed a "terminal" div with terminal layout baked in. Worse, that mount ships `display:none` and is unhidden only by the xterm shell, so a shellless client (which omits that shell) renders into an invisible element.

Rebased onto #377, which added the custom `-w-shell <template>` path. A neutral, visible mount is exactly what a custom-template client binds to.

## Change

Make the frame a neutral, generically-named mount, with terminal presentation traveling with the xterm shell instead of the frame:

- **`host.html`**: the mount is `<div id="app">` with a neutral full-viewport rule (`#app{flex:1;min-height:0}`), no terminal-specific CSS. It also drops the inline `display:none`. The old `#terminal` was hidden and only the xterm shell unhid it, so a `-w-shell none` bundle rendered into an invisible mount; it now ships visible, and a shellless client gets a usable mount out of the box.
- **xterm shell CSS**: the one xterm-specific rule (`.xterm{height:100%}`) now ships in `xtermCSS`, assembled in only when the xterm shell is included. A `-w-shell none` bundle gets the bare `#app` mount with no xterm styles.
- **`lg-shell-xterm.js`**: binds `#app`, and on boot hides only the loading status. The `display` toggle is gone, since the frame no longer hides the mount for the shell to unhide.
- Goldens regenerated (all 5 variants).

Net: the frame's contract is "a visible, full-viewport mount named `#app`", and whatever shell mounts into it owns its own presentation.

## Why the rename

The mount id and CSS were the visible half of the leak, so `#app` is the fix, not a cosmetic. A canvas / audio / repl client mounting into it is no longer handed terminal semantics. This also finishes the `min-height:0` frame work from #277: the neutral `#app` carries it, and the terminal-fill behavior that used to be frame-global is scoped to the shell that wants it.

## Consumer impact

A client that mounts the frame element by id `#terminal` (rather than supplying its own container) binds `#app` instead, a one-line change per consumer, made when it updates to this let-go version. Since a build pins one let-go, its shell always matches the mount that build emits, so no compatibility shim is needed. Clients that render into their own container (a canvas demo, or a repl mounting its own div) are unaffected.

## Testing

- Goldens regenerated; the assemble test passes across all 5 variants (xterm / shell-less × inline / external wasm, plus host-eval). The shell-less goldens now carry a bare, visible `<div id="app"></div>`.
- `go test ./...` green; `gofmt` clean; builds on `linux`, `js/wasm`, and `plan9/amd64`.
- Built a `lg -w` bundle and confirmed in a browser that the default xterm shell fills the viewport on the `#app` mount with no console errors; separately confirmed a `-w-shell none` client that mounts its own div renders unaffected.
