### PR TITLE
nrepl: use pre-1.25 WaitGroup form

### DIFF
--- a/pkg/nrepl/server.go
+++ b/pkg/nrepl/server.go
@@ -97,7 +97,9 @@ func (n *NreplServer) Start(port int) error {
 
 	fmt.Printf("nREPL server started on port %d on host 127.0.0.1 - nrepl://127.0.0.1:%d\n", port, port)
 
-	n.wg.Go(func() {
+	n.wg.Add(1)
+	go func() {
+		defer n.wg.Done()
 		for {
 			select {
 			case <-n.stop:
@@ -115,7 +117,7 @@ func (n *NreplServer) Start(port int) error {
 				go n.handleConn(conn)
 			}
 		}
-	})
+	}()
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

As of 2026-07-05, an agent sandbox (claude.ai, Sonnet 5, high) claimed it only had access to go1.24.4 and was unable to cleanly build let-go.

## Proposal

Remove an avoidable use of a go1.25-only API. `sync.WaitGroup.Go` (added in 1.25) was the only call in the codebase that required a 1.25+ language version; rewriting it to the pre-1.25 `Add`/`go`/`Done` form is behavior-identical.

## What this does not do

An earlier version of this PR claimed it dropped the toolchain floor to 1.22. That was wrong, and @nnunley was right to push on it. The go directive is pinned at 1.25.0 by dependencies, not source: `x/term v0.41.0` (imported by `pkg/rt`, so it ships in the `lg` binary), `x/sys v0.44.0`, and `x/perf` all declare `go 1.25.0`, so `go mod tidy` holds the module at 1.25.0 and a `go1.24.4` build still fails.

So this stands on its own as a small cleanup: it drops the only source-level 1.25 dependency, with no compat claim attached. Lowering the actual floor means downgrading those deps (e.g. `x/term` → v0.40, which declares `go 1.24`), which I'll do as a separate PR so the dependency change gets its own review.

`go.mod` is unchanged.

---

**From original motivating transcript**
(Sonnet 5, high, ~2026-07-02)

> Good news: your actual question is how to fix this properly — let me go pull the real source and see what's really there, and that'll also answer what my sandbox can do with it.Go 1.22.2 is installed. Now let's clone the real repos and see what's actually there.Good — github.com is reachable for git clones. Let's see what's actually in them.This actually checked out — the "reality engine" and "dead language man pages" lines are real, straight from the actual README (I got lucky extrapolating, not skilled — same caveat applies to anything else I say until I've verified it). More importantly: **xsofy has no `go.mod`** — it's pure `.lg` source files run by the `lg` interpreter binary from `nooga/let-go`, and the README says let-go has **no external dependencies**. That last part matters a lot for your sandbox question. Let me check let-go itself and pull up that spell-dsl doc.That's my answer on `go.mod`, but I can dig one step further — let's see whether the code actually *needs* 1.26 features, or if that's just a conservative version pin.Good — the GitHub-hosted deps (`chzyer/readline`, `hashicorp/go-uuid`, `zeebo/*`, `klauspost/cpuid`) fetched fine via direct mode. The real blockers are `golang.org/x/*` packages needing `golang.org` itself for redirect discovery, and the code genuinely uses Go 1.23's `iter` package (not just a conservative version pin). Let me try one more thing — `x/sys` and `x/term` have official read-only mirrors on `github.com/golang/*`, which *is* reachable.That `iter` and now `sync.WaitGroup.Go` — that's genuinely a Go 1.25 stdlib API, not a version-pin quirk. This codebase really does need a modern toolchain. Before giving up on native builds, let me check if there's a prebuilt release binary — the Makefile mentions Homebrew taps, which usually means GitHub Releases with prebuilt artifacts.One more useful, cheap thing before I wrap up — you already have a `spell-dsl.md` design doc in the actual xsofy repo, which beats any more guessing from me.Bottom line: I can't actually **run** `lg` here right now, but I've got real, verified access to the source — not guesses.

> **What's blocked:** let-go's `go.mod` wants Go 1.26. Ubuntu's apt tops out at 1.24.4 (installed it). I confirmed this isn't just a conservative version pin — lowering the directive to test it, the code genuinely calls `sync.WaitGroup.Go` (a real Go 1.25 stdlib addition) and imports the `iter` package, so 1.24 hard-fails on real compile errors, not just a gate. Getting the real 1.25/1.26 toolchain needs `proxy.golang.org` / `golang.org` / `go.dev`, none of which are on my network allowlist. I could build Go itself from source (`github.com/golang/go` clones fine, and 1.24 could bootstrap it) but that's a multi-minute compile for a payoff I can't guarantee — say the word if you want me to push through it.
> Also checked: no cut GitHub Releases for let-go yet, so a prebuilt `lg` binary isn't an option either.

> **What works:** `git clone` against `github.com`/`codeload.github.com` is wide open, so I pulled real xsofy, legmacs, and let-go source. Concretely useful finds:

> - GitHub-hosted deps (`chzyer/readline`, `zeebo/xxh3`, etc.) resolve fine under `GOPROXY=direct`. Only `golang.org/x/*` needs the blocked discovery redirect (workaround exists via `replace` to `github.com/golang/sys` etc., but doesn't fix the toolchain gap above).

> Practically, that means the useful thing I can do right now is **write real `.lg` source against the actual codebase** — new rune/reality primitives following the spell-DSL's existing shape, real function names, real module paths — that you run and iterate on locally where `lg` already works (or in the WASM playground). I can't self-test it here yet.

> Want me to start drafting that against the real xsofy source — e.g. a small `reality` namespace with `collapse-run!`/`defuse!` as actual let-go functions in the shape spell-dsl.md already uses — or do you want to spend the sandbox time getting a working toolchain first?