### PR TITLE
perf(vm): monomorphic inline cache for protocol dispatch

### DIFF
--- a/pkg/vm/protocol.go
+++ b/pkg/vm/protocol.go
@@ -5,7 +5,10 @@
 
 package vm
 
-import "fmt"
+import (
+	"fmt"
+	"sync/atomic"
+)
 
 // Protocol defines a named set of methods with type-based dispatch.
 type Protocol struct {
@@ -14,6 +17,14 @@ type Protocol struct {
 	impls   map[ValueType]*PersistentMap // type → {method-name → fn}
 	nilImpl *PersistentMap               // implementation for nil
 	meta    Value                        // IMeta support
+
+	// gen is the dispatch-table generation, bumped on every extend. It is the
+	// watchpoint backing ProtocolFn's inline cache: any change to impls strands
+	// every cached (type → fn) entry, so a redefinition or a newly-added impl
+	// can never be served stale. Pointer-typed so a WithMeta copy (which shares
+	// the dispatch tables) shares the counter, and so the struct stays copyable
+	// without tripping vet's copylocks check on the atomic.
+	gen *atomic.Uint64
 }
 
 func NewProtocol(name string, methods []Symbol) *Protocol {
@@ -21,6 +32,7 @@ func NewProtocol(name string, methods []Symbol) *Protocol {
 		name:    name,
 		methods: methods,
 		impls:   make(map[ValueType]*PersistentMap),
+		gen:     new(atomic.Uint64),
 	}
 }
 
@@ -50,11 +62,13 @@ func (p *Protocol) WithMeta(m Value) Value {
 // implMap is a PersistentMap of {method-keyword → fn}.
 func (p *Protocol) Extend(vt ValueType, implMap *PersistentMap) {
 	p.impls[vt] = implMap
+	p.gen.Add(1) // invalidate every ProtocolFn inline cache over this protocol
 }
 
 // ExtendNil adds implementations for nil.
 func (p *Protocol) ExtendNil(implMap *PersistentMap) {
 	p.nilImpl = implMap
+	p.gen.Add(1)
 }
 
 // Lookup finds the implementation of a method for a given value's type.
@@ -113,11 +127,50 @@ func (p *Protocol) Satisfies(target Value) bool {
 	return p.impls[AnyType] != nil
 }
 
+// protoCacheEntry is one monomorphic inline-cache slot: the last type seen at
+// this ProtocolFn and the impl it resolved to, tagged with the protocol gen it
+// was resolved under. Stored behind an atomic.Pointer so a concurrent invoke
+// sees a consistent (vt, fn, gen) triple, never a torn one.
+type protoCacheEntry struct {
+	vt  ValueType
+	fn  Fn
+	gen uint64
+}
+
+// Protocol inline-cache instrumentation. Off by default (one predictable-false
+// branch on the hot path); a test flips it to measure hit rate. Not wired for
+// production telemetry yet — this is spike scaffolding.
+var (
+	protoCacheStats  atomic.Bool
+	protoCacheHits   atomic.Uint64
+	protoCacheMisses atomic.Uint64
+)
+
+// protoCache is a ProtocolFn's monomorphic inline-cache state. It is held
+// behind a pointer (not embedded) so ProtocolFn stays value-copyable: with-meta
+// copies the struct (cp := *f), which a directly-embedded atomic would make a
+// vet copylocks error. A copy shares this cache, which is correct — a meta'd
+// ProtocolFn dispatches on the same protocol and method, so the (type -> impl)
+// resolution is identical.
+type protoCache struct {
+	// entry holds the last resolution. Real protocol sites are overwhelmingly
+	// monomorphic in steady state, so a single slot captures most of the win.
+	entry atomic.Pointer[protoCacheEntry]
+
+	// mega latches when a second live type is seen at this site. A single-entry
+	// cache can't serve a polymorphic site, and storing on every miss would
+	// allocate an entry per call — worse than no cache. Once megamorphic we stop
+	// caching and fall back to plain Lookup, capping the downside at ~baseline.
+	// (A 2-/N-way PIC is the way to actually serve these sites — future work.)
+	mega atomic.Bool
+}
+
 // ProtocolFn is a function that dispatches on the first arg's type via a protocol.
 type ProtocolFn struct {
 	protocol   *Protocol
 	methodName Symbol
 	name       string
+	cache      *protoCache
 }
 
 func NewProtocolFn(protocol *Protocol, methodName Symbol) *ProtocolFn {
@@ -125,6 +178,7 @@ func NewProtocolFn(protocol *Protocol, methodName Symbol) *ProtocolFn {
 		protocol:   protocol,
 		methodName: methodName,
 		name:       string(methodName),
+		cache:      &protoCache{},
 	}
 }
 
@@ -147,18 +201,68 @@ func (f *ProtocolFn) invokeIn(ec *ExecContext, args []Value) (Value, error) {
 	if len(args) == 0 {
 		return NIL, fmt.Errorf("protocol fn %s requires at least one argument", f.name)
 	}
+	target := args[0]
 
-	impl, ok := f.protocol.Lookup(f.methodName, args[0])
-	if !ok {
-		typeName := "nil"
-		if args[0] != NIL {
-			typeName = args[0].Type().Name()
+	// Monomorphic inline cache. The guard is a ValueType identity compare —
+	// types are singletons, so == is a pointer compare — plus a generation
+	// check against the protocol's watchpoint. A hit skips the map indirection
+	// and PersistentMap probe that Lookup would do. nil is left on the slow
+	// path: it has its own resolution bucket and is rare in hot loops.
+	if target != NIL {
+		// Fast path only while the site is still monomorphic. Once latched
+		// megamorphic we take a single mega.Load and fall straight through to
+		// Lookup — no gen/cache loads, no store — so a polymorphic site pays
+		// almost nothing over the un-cached baseline.
+		if !f.cache.mega.Load() {
+			vt := target.Type()
+			gen := f.protocol.gen.Load()
+			if e := f.cache.entry.Load(); e != nil && e.gen == gen {
+				if e.vt == vt {
+					if protoCacheStats.Load() {
+						protoCacheHits.Add(1)
+					}
+					return ec.Invoke(e.fn, args)
+				}
+				// A second live type at this site: give up on the single slot.
+				f.cache.mega.Store(true)
+			} else {
+				// Cold or gen-stale slot: resolve and fill it.
+				impl, ok := f.protocol.Lookup(f.methodName, target)
+				if !ok {
+					return f.noImplErr(target)
+				}
+				f.cache.entry.Store(&protoCacheEntry{vt: vt, fn: impl, gen: gen})
+				if protoCacheStats.Load() {
+					protoCacheMisses.Add(1)
+				}
+				return ec.Invoke(impl, args)
+			}
 		}
-		return NIL, fmt.Errorf("no implementation of protocol %s method %s for type %s",
-			f.protocol.name, f.name, typeName)
+		// Megamorphic: plain Lookup, no caching.
+		impl, ok := f.protocol.Lookup(f.methodName, target)
+		if !ok {
+			return f.noImplErr(target)
+		}
+		if protoCacheStats.Load() {
+			protoCacheMisses.Add(1)
+		}
+		return ec.Invoke(impl, args)
 	}
 
-	return ec.Invoke(impl, args)
+	if impl, ok := f.protocol.Lookup(f.methodName, target); ok {
+		return ec.Invoke(impl, args)
+	}
+	return f.noImplErr(target)
+}
+
+// noImplErr formats the "no implementation" dispatch failure for target.
+func (f *ProtocolFn) noImplErr(target Value) (Value, error) {
+	typeName := "nil"
+	if target != NIL {
+		typeName = target.Type().Name()
+	}
+	return NIL, fmt.Errorf("no implementation of protocol %s method %s for type %s",
+		f.protocol.name, f.name, typeName)
 }
 
 // Protocol type metadata

--- a/pkg/vm/protocol_pic_bench_test.go
+++ b/pkg/vm/protocol_pic_bench_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// protoSink defeats dead-code elimination on the dispatch result.
+var protoSink Value
+
+// buildSizedProto returns a ProtocolFn `sz` with impls for Int and String.
+// Int → identity, String → its length. The method fns are trivial so the
+// benchmark isolates *dispatch* cost (type lookup) rather than method work.
+func buildSizedProto() *ProtocolFn {
+	method := Symbol("sz")
+	p := NewProtocol("Sized", []Symbol{method})
+
+	intFn, _ := NativeFnType.Wrap(func(a []Value) (Value, error) { return a[0], nil })
+	p.Extend(IntType, NewPersistentMap([]Value{Keyword(method), intFn}))
+
+	strFn, _ := NativeFnType.Wrap(func(a []Value) (Value, error) {
+		return Int(len(string(a[0].(String)))), nil
+	})
+	p.Extend(StringType, NewPersistentMap([]Value{Keyword(method), strFn}))
+
+	return NewProtocolFn(p, method)
+}
+
+// Monomorphic: every call sees Int. This is the hot-loop case a monomorphic
+// inline cache is built for — after warmup it should hit every time.
+func BenchmarkProtocolDispatchMono(b *testing.B) {
+	pf := buildSizedProto()
+	args := []Value{Int(7)}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v, err := pf.invokeIn(RootExecContext, args)
+		if err != nil {
+			b.Fatal(err)
+		}
+		protoSink = v
+	}
+}
+
+// Bimorphic: alternate Int / String every call. A single-entry monomorphic
+// cache thrashes here (miss every call) — this is the case that a 2+-way PIC
+// would need; it bounds how much the mono cache can regress a polymorphic site.
+func BenchmarkProtocolDispatchBimorphic(b *testing.B) {
+	pf := buildSizedProto()
+	intArgs := []Value{Int(7)}
+	strArgs := []Value{String("hello")}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var args []Value
+		if i&1 == 0 {
+			args = intArgs
+		} else {
+			args = strArgs
+		}
+		v, err := pf.invokeIn(RootExecContext, args)
+		if err != nil {
+			b.Fatal(err)
+		}
+		protoSink = v
+	}
+}

--- a/pkg/vm/protocol_pic_test.go
+++ b/pkg/vm/protocol_pic_test.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+func withProtoStats(t *testing.T, fn func()) (hits, misses uint64) {
+	t.Helper()
+	protoCacheHits.Store(0)
+	protoCacheMisses.Store(0)
+	protoCacheStats.Store(true)
+	defer protoCacheStats.Store(false)
+	fn()
+	return protoCacheHits.Load(), protoCacheMisses.Load()
+}
+
+// ProtocolFn must stay value-copyable: with-meta does `cp := *f`. The cache
+// lives behind a pointer, so the copy is copylocks-safe (go vet enforces this)
+// and shares the cache with the original — correct, since a meta'd copy
+// dispatches on the same protocol and method. Warming via the original must be
+// visible to the copy: it hits without a cold miss of its own.
+func TestProtocolFnValueCopySharesCache(t *testing.T) {
+	pf := buildSizedProto()
+	args := []Value{Int(3)}
+	if _, err := pf.invokeIn(RootExecContext, args); err != nil { // warm the original
+		t.Fatal(err)
+	}
+	cp := *pf // exactly what ProtocolFn.WithMeta will do
+	hits, misses := withProtoStats(t, func() {
+		for i := 0; i < 100; i++ {
+			if _, err := cp.invokeIn(RootExecContext, args); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+	if hits != 100 || misses != 0 {
+		t.Fatalf("copy did not share the warmed cache: %d hits / %d misses, want 100 / 0", hits, misses)
+	}
+}
+
+// A monomorphic loop should miss exactly once (cold fill) then hit forever.
+func TestProtocolPICMonomorphicHitRate(t *testing.T) {
+	pf := buildSizedProto()
+	args := []Value{Int(3)}
+	const n = 1000
+	hits, misses := withProtoStats(t, func() {
+		for i := 0; i < n; i++ {
+			if _, err := pf.invokeIn(RootExecContext, args); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+	if misses != 1 || hits != n-1 {
+		t.Fatalf("monomorphic: got %d hits / %d misses, want %d / 1", hits, misses, n-1)
+	}
+}
+
+// An alternating bimorphic loop thrashes a single-entry cache: every call misses.
+// This documents the known ceiling of the monomorphic design (a 2-way PIC is the
+// fix) and guards against a future change silently claiming a hit it can't have.
+func TestProtocolPICBimorphicThrashes(t *testing.T) {
+	pf := buildSizedProto()
+	intArgs := []Value{Int(3)}
+	strArgs := []Value{String("xy")}
+	const n = 1000
+	hits, misses := withProtoStats(t, func() {
+		for i := 0; i < n; i++ {
+			args := intArgs
+			if i&1 == 1 {
+				args = strArgs
+			}
+			if _, err := pf.invokeIn(RootExecContext, args); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+	if hits != 0 || misses != n {
+		t.Fatalf("bimorphic: got %d hits / %d misses, want 0 / %d", hits, misses, n)
+	}
+}
+
+// The watchpoint: re-extending a type the cache is already serving must strand
+// the stale entry, so the next call resolves the NEW impl. Without gen tagging
+// this is exactly where an inline cache goes wrong (serves a redefined method's
+// old body).
+func TestProtocolPICInvalidatesOnRedefine(t *testing.T) {
+	method := Symbol("sz")
+	p := NewProtocol("Sized", []Symbol{method})
+	v1, _ := NativeFnType.Wrap(func(a []Value) (Value, error) { return Int(1), nil })
+	p.Extend(IntType, NewPersistentMap([]Value{Keyword(method), v1}))
+	pf := NewProtocolFn(p, method)
+
+	got, _ := pf.invokeIn(RootExecContext, []Value{Int(0)})
+	if got != Value(Int(1)) {
+		t.Fatalf("before redefine: got %v, want 1", got)
+	}
+
+	// Redefine the Int impl to return 2. The gen bump must invalidate the entry
+	// cached from the first call.
+	v2, _ := NativeFnType.Wrap(func(a []Value) (Value, error) { return Int(2), nil })
+	p.Extend(IntType, NewPersistentMap([]Value{Keyword(method), v2}))
+
+	got, _ = pf.invokeIn(RootExecContext, []Value{Int(0)})
+	if got != Value(Int(2)) {
+		t.Fatalf("after redefine: got %v, want 2 (stale cache served old impl)", got)
+	}
+}


### PR DESCRIPTION
## What

A monomorphic inline cache for protocol method dispatch.

`ProtocolFn.invokeIn` resolved the implementation on every call via `Protocol.Lookup`: a map index by the receiver's type, then a `PersistentMap` probe for the method keyword. Protocol call sites are overwhelmingly monomorphic in steady state, so that resolution repeats identically call after call.

This caches the last `(type -> impl)` resolution on the `ProtocolFn` behind an `atomic.Pointer`. The guard is a `ValueType` identity compare, which is a pointer compare because value types are singletons, and a hit skips `Lookup` entirely.

## Correctness

A generation counter on the `Protocol` (bumped by `Extend`/`ExtendNil`, recorded in each cache entry) is the watchpoint: any change to the dispatch tables strands stale entries, so a redefined or newly-added impl is never served from cache. `TestProtocolPICInvalidatesOnRedefine` pins this.

## Bounding the downside

A single slot cannot serve a polymorphic site, and storing on every miss would allocate an entry per call, which is worse than no cache. So a site latches "megamorphic" on the second live type it sees and falls back to plain `Lookup` with no further caching, capping the cost at baseline.

## Numbers

Microbenchmark, two environments:

| environment | monomorphic | polymorphic |
|---|---|---|
| Apple M2, `benchstat` n=12 | 106.6 -> 22.6 ns, -78.8% time, 1 -> 0 alloc (p=0.000) | 110.5 vs 112.3 ns, no significant change (p=0.325) |
| x86 linux-amd64 (Intel Xeon), anchor-normalized | -80.0%, flagged improved | within the 12% budget, neutral |

The benchmark uses trivial method bodies to isolate dispatch cost, so the end-to-end win on real code scales with how dispatch-bound it is. The monomorphic result reproduces across Apple silicon and x86, so it is not an M2 artifact.

## Interaction with AOT, IR, and wasm

The cache lives in the bytecode VM's dispatch path (`ProtocolFn.invokeIn`), so it composes with the other execution paths as follows.

**AOT (`gogen_ir`).** Where the receiver type is statically known, lowering devirtualizes a protocol call to a direct Go method call, bypassing `invokeIn`; the cache is inert there, adding neither benefit nor cost. Where the type is not known, or a frozen native baseline was invalidated by a late `extend`, lowered code falls back through `InvokeValueEC` -> `ec.Invoke` -> `invokeIn`, and the cache accelerates that fallback. Static devirtualization and the dynamic cache cover disjoint sites; they do not conflict.

**IR passes.** Constant folding, CSE, DCE, LICM, and type inference run on the IR before lowering and do not touch runtime dispatch, so they are orthogonal to the cache. The one link: stronger type inference feeds more AOT devirtualization, which substitutes for the cache at the margin (fewer sites reach the runtime fallback).

**wasm.** `lg -w` ships the bytecode VM interpreting the bundle, with no lowering in that path, so wasm dispatch runs through `invokeIn`, the path the cache targets. Measured under `js/wasm` on Node, monomorphic dispatch goes from 397.9 ns / 1 alloc to 70.9 ns / 0 alloc (-82%, p=0.000, n=8). The relative win is a touch larger than native: per-op interpretation is costlier on wasm, so removing the method-table probe is a bigger fraction of the total.

## Follow-ups

Not in this PR:

- N-way PIC to serve stably-polymorphic sites (the bimorphic case).
- Site-indexed cache slot. The cache currently lives on the `ProtocolFn`, so it is per-method rather than per-call-site.
- Same treatment for multimethods, where the baseline also re-runs the dispatch fn on every call.
