### PR TITLE
perf(ci): wasm A/B benchmark gate (perf-wasm label)

### DIFF
--- a/.github/workflows/perf-wasm.yml
+++ b/.github/workflows/perf-wasm.yml
@@ -1,0 +1,190 @@
+name: Perf WASM
+
+# Same-runner A/B microbenchmark check under GOOS=js/wasm, run via the
+# go_js_wasm_exec shim on Node. Mirrors Perf PR (base vs head, one runner, no
+# gate) but measures the wasm bundle's execution path — the bytecode VM that
+# `lg -w` ships. Native perf can't see wasm-only regressions: different codegen,
+# single-threaded, and a GC where allocation pressure hits harder.
+#
+# Wasm is ~4-8x slower per-op and noisier than native, so this is opt-in via the
+# `perf-wasm` label, separate from the native `perf` gate. Add the label to run;
+# remove it to stop. Informational only.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'pkg/**'
+      - 'cmd/**'
+      - '.github/workflows/perf-wasm.yml'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to benchmark'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-wasm-${{ github.event.pull_request.number || github.event.inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'perf-wasm')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      pr: ${{ steps.refs.outputs.pr }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # The go_js_wasm_exec shim runs the wasm test binary under Node.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve base and head
+        id: refs
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_FROM_EVENT: ${{ github.event.pull_request.number }}
+          PR_FROM_INPUT: ${{ github.event.inputs.pr }}
+          BASE_FROM_EVENT: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            pr="$PR_FROM_INPUT"
+            [[ "$pr" =~ ^[0-9]+$ ]] || { echo "pr input must be a number, got: ${pr}" >&2; exit 1; }
+            base_ref="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .base.ref)"
+          else
+            pr="$PR_FROM_EVENT"
+            base_ref="$BASE_FROM_EVENT"
+          fi
+          git fetch --no-tags origin "$base_ref" "refs/pull/${pr}/head:pr-head"
+          head_sha="$(git rev-parse pr-head)"
+          base_sha="$(git merge-base "origin/${base_ref}" pr-head)"
+          {
+            echo "pr=${pr}"
+            echo "head=${head_sha}"
+            echo "base=${base_sha}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Base (merge-base): ${base_sha}"
+          echo "Head:              ${head_sha}"
+
+      # -wasm runs the pr-fast families under the shim and forces -tags off (the
+      # wasm bundle ships the bytecode VM, not the lowered-Go path), so there is
+      # no `make lowered` step. A wider timeout absorbs wasm's slower per-op.
+      - name: Bench merge-base (wasm)
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+        run: |
+          set -euo pipefail
+          git checkout --force "$BASE"
+          git submodule update --init --recursive
+          go run ./cmd/bench-ratchet \
+            -baseline "${RUNNER_TEMP}/base.json" \
+            -profile pr-fast -wasm -timeout 25m \
+            update
+
+      - name: Bench head and compare (wasm)
+        id: bench
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+          HEAD: ${{ steps.refs.outputs.head }}
+        run: |
+          set -euo pipefail
+          git checkout --force "$HEAD"
+          git submodule update --init --recursive
+          # -budget 0.30 overrides the native pr-fast 0.12: wasm micro-benchmarks
+          # under V8 have a higher noise floor (Go-map lookups especially can swing
+          # tens of percent run to run), so the tighter native budget flags phantom
+          # movers on untouched code. 30% suppresses the bulk of that while still
+          # surfacing real regressions. Informational only, so this tunes the
+          # report's "past budget" rows, not a pass/fail.
+          go run ./cmd/bench-ratchet \
+            -baseline "${RUNNER_TEMP}/base.json" \
+            -profile pr-fast -wasm -budget 0.30 -timeout 25m \
+            -format markdown \
+            check > "${RUNNER_TEMP}/report.md" || true
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          header() {
+            echo "## Perf (wasm micros) — base vs head, same runner"
+            echo
+            echo "Base \`${BASE:0:12}\` vs head \`${HEAD:0:12}\`, under GOOS=js/wasm on Node. Anchor-normalized; informational, not a gate."
+            echo
+          }
+
+          { header; sed -n '/\*\*bench-ratchet\*\*/,$p' "${RUNNER_TEMP}/report.md"; } > "${RUNNER_TEMP}/summary.md"
+          cat "${RUNNER_TEMP}/summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+          total="$(grep -cE '^\| `' "${RUNNER_TEMP}/report.md" || true)"
+          changed="$(grep -E '\| (REGRESSION|IMPROVED|NEW|MISSING) \|$' "${RUNNER_TEMP}/report.md" || true)"
+          shown="$(printf '%s' "$changed" | grep -c . || true)"
+          {
+            header
+            sed -n '/\*\*bench-ratchet\*\*/,/^| Benchmark/p' "${RUNNER_TEMP}/report.md"
+            echo "|---|---:|---:|---:|---:|---|---|"
+            if [ -n "$changed" ]; then
+              echo "$changed"
+            else
+              echo "| _nothing past the budget threshold_ | | | | | | |"
+            fi
+            echo
+            echo "_Showing ${shown:-0} of ${total:-0} benchmarks (past budget). [Full table in the run summary →](${run_url})_"
+          } > "${RUNNER_TEMP}/comment.md"
+
+      - name: Upload PR comment artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-wasm-comment
+          path: ${{ runner.temp }}/comment.md
+          if-no-files-found: error
+
+  comment:
+    needs: bench
+    if: needs.bench.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download PR comment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-wasm-comment
+          path: ${{ runner.temp }}/perf-wasm-comment
+
+      - name: Upsert PR comment
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          PR: ${{ needs.bench.outputs.pr }}
+          COMMENT_PATH: ${{ runner.temp }}/perf-wasm-comment/comment.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- perf-wasm-report -->';
+            const body = marker + '\n' + fs.readFileSync(process.env.COMMENT_PATH, 'utf8');
+            const {owner, repo} = context.repo;
+            const issue_number = Number(process.env.PR);
+            const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number});
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
+            } else {
+              await github.rest.issues.createComment({owner, repo, issue_number, body});
+            }

--- a/.github/workflows/perf-wasm.yml
+++ b/.github/workflows/perf-wasm.yml
@@ -85,6 +85,11 @@ jobs:
       # -wasm runs the pr-fast families under the shim and forces -tags off (the
       # wasm bundle ships the bytecode VM, not the lowered-Go path), so there is
       # no `make lowered` step. A wider timeout absorbs wasm's slower per-op.
+      - name: Build bench-ratchet runner
+        run: |
+          set -euo pipefail
+          go build -o "${RUNNER_TEMP}/bench-ratchet" ./cmd/bench-ratchet
+
       - name: Bench merge-base (wasm)
         env:
           BASE: ${{ steps.refs.outputs.base }}
@@ -92,7 +97,7 @@ jobs:
           set -euo pipefail
           git checkout --force "$BASE"
           git submodule update --init --recursive
-          go run ./cmd/bench-ratchet \
+          "${RUNNER_TEMP}/bench-ratchet" \
             -baseline "${RUNNER_TEMP}/base.json" \
             -profile pr-fast -wasm -timeout 25m \
             update
@@ -112,7 +117,7 @@ jobs:
           # movers on untouched code. 30% suppresses the bulk of that while still
           # surfacing real regressions. Informational only, so this tunes the
           # report's "past budget" rows, not a pass/fail.
-          go run ./cmd/bench-ratchet \
+          "${RUNNER_TEMP}/bench-ratchet" \
             -baseline "${RUNNER_TEMP}/base.json" \
             -profile pr-fast -wasm -budget 0.30 -timeout 25m \
             -format markdown \

--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -180,8 +180,21 @@ func main() {
 		format       = flag.String("format", "text", "report format: text (default, ANSI terminal), markdown (GitHub/Slack-friendly table), json (the raw baseline)")
 		full         = flag.Bool("full", false, "run the FULL benchmark profile: pkg/vm fleet under -tags plus jank + IR compile under both VM variants. Slow (~25 min) — for mainline profiling and manual deep-dives.")
 		profile      = flag.String("profile", "", "named benchmark profile (e.g. 'pr-fast'). Mutually exclusive with -packages/-filter/-full. Sets the job list plus default count/benchtime/budget; explicit flags still override.")
+		wasm         = flag.Bool("wasm", false, "run benchmarks under GOOS=js/wasm via the go_js_wasm_exec shim (Node), reporting the machine as js/wasm. Forces -tags off (the wasm bundle ships the bytecode VM, not the lowered-Go path). Slower and noisier than native; for the wasm A/B gate.")
 	)
 	flag.Parse()
+
+	// Wasm mode: resolve the exec shim and pin the reported machine to js/wasm.
+	// The benchmark bundle xsofy ships runs the bytecode interpreter, so drop the
+	// gogen_ir tag — it also sidesteps building the lowered-Go tree under js/wasm.
+	if *wasm {
+		shim, err := resolveWasmExec()
+		if err != nil {
+			die("wasm: %v", err)
+		}
+		wasmExec = shim
+		*tags = ""
+	}
 
 	mode := "check"
 	if flag.NArg() > 0 {
@@ -793,9 +806,18 @@ func captureOnePackage(pkg string, count int, benchtime, timeout, tags string, f
 	if tags != "" {
 		args = append(args, "-tags", tags)
 	}
+	if wasmExec != "" {
+		args = append(args, "-exec", wasmExec)
+	}
 	args = append(args, pkg)
 	cmd := exec.Command("go", args...)
-	if len(env) > 0 {
+	switch {
+	case wasmExec != "":
+		// A GOOS=js run needs a trimmed environment: the shim forwards the whole
+		// env into the wasm sandbox via Node argv, overflowing Node's arg-length
+		// limit when the parent env is large (CI, dev shells).
+		cmd.Env = wasmTestEnv(env)
+	case len(env) > 0:
 		cmd.Env = append(os.Environ(), env...)
 	}
 	stdout, err := cmd.StdoutPipe()
@@ -986,10 +1008,52 @@ func buildCurrentBaseline(results []Result, anchor Result) MachineBaseline {
 	}
 }
 
+// wasmExec is the go_js_wasm_exec shim path when running under -wasm, else "".
+// A package var (not threaded) because capture and machine detection both need
+// it and it is set once at startup.
+var wasmExec string
+
+// resolveWasmExec locates the go_js_wasm_exec shim in the active GOROOT. Go 1.21+
+// ships it under lib/wasm; older toolchains under misc/wasm.
+func resolveWasmExec() (string, error) {
+	out, err := exec.Command("go", "env", "GOROOT").Output()
+	if err != nil {
+		return "", fmt.Errorf("go env GOROOT: %w", err)
+	}
+	goroot := strings.TrimSpace(string(out))
+	for _, rel := range []string{"lib/wasm/go_js_wasm_exec", "misc/wasm/go_js_wasm_exec"} {
+		p := filepath.Join(goroot, rel)
+		if _, statErr := os.Stat(p); statErr == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("go_js_wasm_exec not found under %s (lib/wasm or misc/wasm)", goroot)
+}
+
+// wasmTestEnv builds a minimal environment for a GOOS=js `go test` run, keeping
+// only what the toolchain and the Node shim need. See the call site for why the
+// full environment cannot be forwarded.
+func wasmTestEnv(extra []string) []string {
+	e := []string{"GOOS=js", "GOARCH=wasm"}
+	for _, k := range []string{"HOME", "PATH", "GOROOT", "GOCACHE", "GOMODCACHE", "GOPATH", "TMPDIR"} {
+		if v, ok := os.LookupEnv(k); ok {
+			e = append(e, k+"="+v)
+		}
+	}
+	return append(e, extra...)
+}
+
 func detectMachine() Machine {
+	osName, arch := runtime.GOOS, runtime.GOARCH
+	if wasmExec != "" {
+		// The bench binary is native (it shells `go test`), but the benchmarks
+		// execute under js/wasm — report that, so wasm numbers key to their own
+		// machine profile and never mix with the native baseline.
+		osName, arch = "js", "wasm"
+	}
 	return Machine{
-		OS:        runtime.GOOS,
-		Arch:      runtime.GOARCH,
+		OS:        osName,
+		Arch:      arch,
 		NumCPU:    runtime.NumCPU(),
 		CPUModel:  detectCPUModel(),
 		GoVersion: runtime.Version(),


### PR DESCRIPTION
## What

A `perf-wasm` label gate: a same-runner base-vs-head microbenchmark A/B run under `GOOS=js/wasm`, mirroring the existing `perf` gate but measuring the wasm execution path. Two pieces: a `-wasm` mode on `bench-ratchet`, and `perf-wasm.yml`.

## Why a separate wasm gate

`lg -w` ships the bytecode VM interpreting the bundle, so what runs in the browser is the wasm build, not the native binary. The native gate can't see wasm-only regressions: different codegen, single-threaded, and a GC where allocation pressure hits harder. A change can be flat natively and move under wasm.

## How it works

`bench-ratchet -wasm` runs the selected profile under the `go_js_wasm_exec` shim (Node) instead of natively. Same modes (`update`/`check`/`snapshot`), same anchor normalization — the `RatchetAnchor` bench runs under wasm too, so ratios cancel Node/runner tier differences. `perf-wasm.yml` reuses the `perf-pr.yml` structure: resolve the PR's merge-base and head, bench both on one runner, post the delta to the job summary. Informational, never gates. Opt-in via the `perf-wasm` label, separate from `perf` so wasm's longer, noisier runs don't ride every perf PR.

Three design choices that aren't obvious from the diff:

- **Trimmed environment.** The shim forwards the whole environment into the wasm sandbox via Node argv, which overflows Node's arg-length limit when the parent env is large (CI, dev shells). The `GOOS=js` run keeps only what the toolchain and shim need.
- **Own machine profile.** Wasm runs report the machine as `js/wasm`, so their numbers key to a separate baseline and never mix with native ones.
- **`-tags` off.** The wasm bundle ships the bytecode VM, not the lowered-Go path, so the wasm run drops the `gogen_ir` tag (which also sidesteps building the lowered tree under `js/wasm`), and there is no `make lowered` step.

## Budget

The wasm run uses a 30% budget, wider than the native gate's 12%. Wasm micro-benchmarks under V8 have a higher noise floor: in a same-runner A/B, untouched Go-map lookups swung past 50% run to run. At 12% the report flags phantom movers on code the PR never touched; 30% suppresses the bulk of that while still surfacing real regressions. It only tunes which rows the informational report lists, not a pass/fail.

## Not in this PR

The `-wasm` mode composes with `snapshot` and arbitrary-ref dispatch, so a wasm timeline lane and a persistent wasm ratchet are natural follow-ups. Both need the machine key to also capture the Node/V8 version (a Node bump would otherwise move a persistent baseline), which the same-runner A/B here does not require.
