### PR TITLE
fix(vm): resolve empty LazySeq to nil so reduce/some don't see a phantom nil

### DIFF
--- a/pkg/vm/lazy_seq.go
+++ b/pkg/vm/lazy_seq.go
@@ -97,6 +97,19 @@ func (l *LazySeq) seq() Seq {
 			l.err = err
 			panic(&thrownPanic{err: err})
 		}
+
+		// Canonicalize a realized *empty* sequence to nil. Empty
+		// collections' Seq() (and mapLazy1's empty thunk) yield the
+		// non-nil EmptyList singleton, not nil. Without this, a LazySeq
+		// that resolves to empty leaks EmptyList to consumers whose loop
+		// invariant is "non-nil seq ⇒ at least one element" (reduce, some,
+		// Cons.Next, ChunkedCons.Next, `for s != nil`), invoking f once
+		// with a phantom NIL first element. JVM Clojure's (seq ()) is
+		// likewise nil, so every consumer of seq()/Resolve() gets the
+		// invariant they already assume.
+		if SeqIsEmpty(l.s) {
+			l.s = nil
+		}
 	}
 
 	return l.s

--- a/test/reduce_empty_lazy_test.lg
+++ b/test/reduce_empty_lazy_test.lg
@@ -1,0 +1,57 @@
+(ns test.reduce-empty-lazy-test
+  (:require
+   [test :refer :all]))
+
+;; Regression: reduce over an empty (map f (concat ...)) invoked f once with a
+;; phantom nil element, even though seq/count/vec/doall all agreed the seq was
+;; empty. Root cause: a LazySeq that realized to empty leaked the non-nil
+;; EmptyList singleton out of Resolve(), so reduce's `seq == nil` guard missed
+;; and its loop ran once with EmptyList.First() => nil. Fixed by canonicalizing
+;; a realized-empty LazySeq to nil in LazySeq.seq().
+
+(defn- reduce-calls
+  "Returns the vector of elements the reducing fn was actually called with."
+  [coll]
+  (let [seen (atom [])]
+    (reduce (fn [a x] (swap! seen conj x) a) :init coll)
+    @seen))
+
+(deftest reduce-over-empty-lazy-no-phantom
+  (testing "map over empty concat — f is never called (was: called once with nil)"
+    (is (= [] (reduce-calls (map identity (concat [] []))))))
+
+  (testing "map over single empty concat arg"
+    (is (= [] (reduce-calls (map identity (concat []))))))
+
+  (testing "map over empty filter"
+    (is (= [] (reduce-calls (map identity (filter pos? []))))))
+
+  (testing "reduce returns init for these empty lazy seqs"
+    (is (= :init (reduce (fn [a _] a) :init (map identity (concat [] [])))))
+    (is (= :init (reduce (fn [a _] a) :init (map identity (filter pos? [])))))))
+
+(deftest reduce-empty-lazy-no-init
+  (testing "no-init reduce over empty lazy seq calls f with no args (=> f's 0-arity)"
+    (is (= 0 (reduce + (map identity (concat [] [])))))))
+
+(deftest empty-lazy-seq-agrees-empty
+  (testing "seq/count/vec/doall/first/last all agree the seq is empty"
+    (is (= nil (seq   (map identity (concat [] [])))))
+    (is (= 0   (count (map identity (concat [] [])))))
+    (is (= []  (vec   (map identity (concat [] [])))))
+    (is (= nil (first (map identity (concat [] [])))))
+    (is (= nil (last  (map identity (concat [] [])))))))
+
+(deftest genuine-nil-element-still-seen
+  (testing "a real nil element must still reach the reducing fn (no over-normalization)"
+    (is (= [nil] (reduce-calls (map identity [nil]))))
+    (is (= [nil nil] (reduce-calls (map identity (concat [nil] [nil])))))))
+
+(deftest non-empty-lazy-reduce-correctness
+  (testing "non-empty map-over-concat reduces correctly"
+    (is (= 6 (reduce + 0 (map inc (concat [] [0 1 2])))))
+    (is (= [1 2 3] (reduce-calls (map inc (concat [] [0 1 2])))))))
+
+(deftest some-over-empty-lazy-no-phantom
+  (testing "some over empty lazy seq returns nil without invoking pred on phantom nil"
+    (is (= nil (some pos? (map identity (concat [] [])))))))


### PR DESCRIPTION
## Summary

Fixes #376.

`reduce` over an empty `(map f (concat …))` invoked `f` once with a phantom `nil` element, even though `seq`/`count`/`vec`/`doall` all agreed the sequence was empty.

## Root cause

A `LazySeq` that realizes to *empty* leaked the non-nil `EmptyList` singleton out of `seq()`/`Resolve()`. `reduce` guards only `seq == nil`, so its `for seq != nil` loop ran once with `EmptyList.First()` → `NIL`. `some`, `Cons.Next`, and `ChunkedCons.Next` had the identical latent bug; `vec`/`toSeq`/`forceSeq`/`seqOf` each carried a separate `== EmptyList` workaround.

## Fix

Canonicalize a realized-empty `LazySeq` to `nil` in `LazySeq.seq()`, matching JVM Clojure's `(seq ()) → nil`. This restores the invariant *"non-nil seq ⇒ at least one element"* that every consumer already assumes, so the scattered per-consumer guards become belt-and-suspenders. Every `.Resolve()`/`.Seq()` caller was audited: all either already handle `nil` or check `== EmptyList` in a branch that returns `nil` anyway, so none regress.

The fix lives in `pkg/vm/lazy_seq.go`, which is shared by both the bytecode VM and the `-tags gogen_ir` lowered-Go path — both exhibited the bug and both are fixed by this single change.

## Testing

- Adds `test/reduce_empty_lazy_test.lg` (auto-discovered by `TestRunner`) covering the affected/ok matrix from the issue, plus:
  - a genuine `[nil]` element must **still** reach the reducing fn (no over-normalization),
  - non-empty `map`-over-`concat` reduces correctly,
  - `some` over an empty lazy seq returns `nil` without a phantom call.
- Verified on both the bytecode VM and the `gogen_ir` lowered-Go path.
- Full `go test ./...` is green.