### PR TITLE
refactor(vm): drop now-dead EmptyList guards after empty-LazySeq→nil fix

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -1173,11 +1173,8 @@ func toSeq(v vm.Value) vm.Seq {
 		return nil
 	}
 	if ls, ok := v.(*vm.LazySeq); ok {
-		s := ls.Resolve()
-		if s == vm.EmptyList {
-			return nil
-		}
-		return s
+		// Resolve() returns nil (never EmptyList) for an empty lazy seq.
+		return ls.Resolve()
 	}
 	if c, ok := v.(vm.Counted); ok && c.RawCount() == 0 {
 		return nil

--- a/pkg/vm/lazy_seq.go
+++ b/pkg/vm/lazy_seq.go
@@ -174,7 +174,7 @@ func (l *LazySeq) Seq() Seq {
 
 func (l *LazySeq) Count() Value {
 	n := 0
-	for s := l.seq(); s != nil && s != EmptyList; s = s.Next() {
+	for s := l.seq(); !SeqIsEmpty(s); s = s.Next() {
 		n++
 	}
 	return Int(n)
@@ -182,7 +182,7 @@ func (l *LazySeq) Count() Value {
 
 func (l *LazySeq) RawCount() int {
 	n := 0
-	for s := l.seq(); s != nil && s != EmptyList; s = s.Next() {
+	for s := l.seq(); !SeqIsEmpty(s); s = s.Next() {
 		n++
 	}
 	return n
@@ -218,7 +218,7 @@ func (l *LazySeq) ValueAtOr(key Value, notFound Value) Value {
 	}
 	i := int(idx)
 	s := l.seq()
-	for j := 0; s != nil && s != EmptyList; j++ {
+	for j := 0; !SeqIsEmpty(s); j++ {
 		if j == i {
 			return s.First()
 		}

--- a/pkg/vm/lazy_seq.go
+++ b/pkg/vm/lazy_seq.go
@@ -97,6 +97,19 @@ func (l *LazySeq) seq() Seq {
 			l.err = err
 			panic(&thrownPanic{err: err})
 		}
+
+		// Canonicalize a realized *empty* sequence to nil. Empty
+		// collections' Seq() (and mapLazy1's empty thunk) yield the
+		// non-nil EmptyList singleton, not nil. Without this, a LazySeq
+		// that resolves to empty leaks EmptyList to consumers whose loop
+		// invariant is "non-nil seq ⇒ at least one element" (reduce, some,
+		// Cons.Next, ChunkedCons.Next, `for s != nil`), invoking f once
+		// with a phantom NIL first element. JVM Clojure's (seq ()) is
+		// likewise nil, so every consumer of seq()/Resolve() gets the
+		// invariant they already assume.
+		if SeqIsEmpty(l.s) {
+			l.s = nil
+		}
 	}
 
 	return l.s

--- a/test/reduce_empty_lazy_test.lg
+++ b/test/reduce_empty_lazy_test.lg
@@ -1,0 +1,57 @@
+(ns test.reduce-empty-lazy-test
+  (:require
+   [test :refer :all]))
+
+;; Regression: reduce over an empty (map f (concat ...)) invoked f once with a
+;; phantom nil element, even though seq/count/vec/doall all agreed the seq was
+;; empty. Root cause: a LazySeq that realized to empty leaked the non-nil
+;; EmptyList singleton out of Resolve(), so reduce's `seq == nil` guard missed
+;; and its loop ran once with EmptyList.First() => nil. Fixed by canonicalizing
+;; a realized-empty LazySeq to nil in LazySeq.seq().
+
+(defn- reduce-calls
+  "Returns the vector of elements the reducing fn was actually called with."
+  [coll]
+  (let [seen (atom [])]
+    (reduce (fn [a x] (swap! seen conj x) a) :init coll)
+    @seen))
+
+(deftest reduce-over-empty-lazy-no-phantom
+  (testing "map over empty concat — f is never called (was: called once with nil)"
+    (is (= [] (reduce-calls (map identity (concat [] []))))))
+
+  (testing "map over single empty concat arg"
+    (is (= [] (reduce-calls (map identity (concat []))))))
+
+  (testing "map over empty filter"
+    (is (= [] (reduce-calls (map identity (filter pos? []))))))
+
+  (testing "reduce returns init for these empty lazy seqs"
+    (is (= :init (reduce (fn [a _] a) :init (map identity (concat [] [])))))
+    (is (= :init (reduce (fn [a _] a) :init (map identity (filter pos? [])))))))
+
+(deftest reduce-empty-lazy-no-init
+  (testing "no-init reduce over empty lazy seq calls f with no args (=> f's 0-arity)"
+    (is (= 0 (reduce + (map identity (concat [] [])))))))
+
+(deftest empty-lazy-seq-agrees-empty
+  (testing "seq/count/vec/doall/first/last all agree the seq is empty"
+    (is (= nil (seq   (map identity (concat [] [])))))
+    (is (= 0   (count (map identity (concat [] [])))))
+    (is (= []  (vec   (map identity (concat [] [])))))
+    (is (= nil (first (map identity (concat [] [])))))
+    (is (= nil (last  (map identity (concat [] [])))))))
+
+(deftest genuine-nil-element-still-seen
+  (testing "a real nil element must still reach the reducing fn (no over-normalization)"
+    (is (= [nil] (reduce-calls (map identity [nil]))))
+    (is (= [nil nil] (reduce-calls (map identity (concat [nil] [nil])))))))
+
+(deftest non-empty-lazy-reduce-correctness
+  (testing "non-empty map-over-concat reduces correctly"
+    (is (= 6 (reduce + 0 (map inc (concat [] [0 1 2])))))
+    (is (= [1 2 3] (reduce-calls (map inc (concat [] [0 1 2])))))))
+
+(deftest some-over-empty-lazy-no-phantom
+  (testing "some over empty lazy seq returns nil without invoking pred on phantom nil"
+    (is (= nil (some pos? (map identity (concat [] [])))))))


### PR DESCRIPTION
## Summary

Follow-up cleanup, **stacked on #388** (the empty-`LazySeq`→`nil` fix). Pure refactor — no behavior change.

Once `LazySeq.seq()`/`Resolve()` canonicalize an empty lazy seq to `nil` (never the `EmptyList` singleton, per #388), several `== EmptyList` / `!= EmptyList` guards become unreachable:

- `LazySeq.Count()`, `LazySeq.RawCount()`, `LazySeq.ValueAtOr()` — the loop guard `s != nil && s != EmptyList`. Verified dead: the head from `seq()` is never `EmptyList` post-fix, and **no `Next()` implementation returns the bare `EmptyList` singleton** (all return `nil` at end of sequence — confirmed by scanning every `Next() Seq` body in `pkg/vm`). These are routed through the existing `SeqIsEmpty` helper, whose documented purpose is exactly to replace the `for s != nil && s != EmptyList` idiom.
- `toSeq()`'s `*LazySeq` branch — `if s == vm.EmptyList { return nil }` after `Resolve()`. Dead, since `Resolve()` now returns `nil` for empty; simplified to `return ls.Resolve()`.

Guards that protect against a **non-lazy** `EmptyList` sentinel (`seqOf`, `vec`, `Cons.Next`, `ChunkedCons.Next`, `mapEquals`/`setEquals`, and `toSeq`'s non-lazy `Sequable` branch) are intentionally left as-is — those are not dead.

## Why stacked (not on `main`)

On plain `main` these guards are **live** (there, `seq()` still returns `EmptyList`), so this must land on top of #388. Until #388 merges, this PR's diff will show both commits.

## Testing

Full `go test ./...` green on top of the fix; `count`/`nth`/seq-equality over empty and non-empty lazy seqs all correct.