### PR TITLE
feat(ir): combinator inlining + closure devirtualization (opt-in via *enable-inline*)

### DIFF
--- a/pkg/ir/lisp_inline_test.go
+++ b/pkg/ir/lisp_inline_test.go
@@ -7,8 +7,13 @@
 package ir_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
 )
 
 func TestInlineEligibilityUsesMutabilityAndSize(t *testing.T) {
@@ -30,6 +35,76 @@ func TestInlineEligibilityUsesMutabilityAndSize(t *testing.T) {
 		`(defn bad [x] (set! some-v x))`)
 	if got := strings.TrimSpace(lispEval(t, `(ir.passes.inline/inline-eligible? %s)`, mut)); got != "false" {
 		t.Fatalf("var-root-rebinding fn must be ineligible, got %s", got)
+	}
+}
+
+func TestInlineEligibilityRejectsSelfRecursive(t *testing.T) {
+	ensureLoader()
+
+	// A self-recursive defn must be INELIGIBLE for inlining: splicing it into
+	// itself grows IR size every round (max-inline-rounds bounds the round count,
+	// not the size), so it must be rejected up front.
+	//
+	// The self-call `(fact ...)` builds to a :load-var whose aux is a *Var*
+	// object (build.lg), not a symbol. self-recursive? must normalize the aux to
+	// a symbol (mirroring call-head-var) before comparing it to the fn name — a
+	// raw Var-vs-symbol compare never matches, so the fn would be wrongly judged
+	// non-recursive and marked inlineable.
+	selfRec := buildLispIRWith(t,
+		map[string]string{"fact": "(fn* [n] n)"},
+		`(defn fact [n] (if (< n 2) n (* n (fact (dec n)))))`)
+	if got := strings.TrimSpace(lispEval(t, `(ir.passes.inline/inline-eligible? %s)`, selfRec)); got != "false" {
+		t.Fatalf("self-recursive fn must be ineligible for inlining, got %s", got)
+	}
+}
+
+func TestInlineWithLeavesSelfRecursiveCallUnspliced(t *testing.T) {
+	ensureLoader()
+	// End-to-end guard: a caller invoking a self-recursive helper must keep the
+	// call — inline-with only splices inline-eligible? callees, and a
+	// self-recursive fn is ineligible. Before the self-recursive? Var
+	// normalization fix, the helper was wrongly eligible and would splice into
+	// itself, growing IR every round.
+	passVarCounter++
+	nsName := fmt.Sprintf("selfrectest%d", passVarCounter)
+	ns := rt.NS(nsName)
+
+	eval := func(label, expr string) vm.Value {
+		consts := vm.NewConsts()
+		c := compiler.NewCompiler(consts, ns)
+		c.SetSource(label)
+		_, res, err := c.CompileMultiple(strings.NewReader(expr))
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		return res
+	}
+	build := func(label, src string) vm.Value {
+		return eval(label, fmt.Sprintf("(ir.build/build-fn (quote %s))", src))
+	}
+
+	// Pre-define `fact` as a plain fn value so the self-reference in its body
+	// resolves at build time; then build the real self-recursive IR.
+	eval("selfrec-stub", `(def fact (fn* [n] n))`)
+	fact := build("selfrec-callee", `(defn fact [n] (if (< n 2) n (* n (fact (dec n)))))`)
+	ns.Def("*fact*", fact)
+
+	caller := build("selfrec-caller", `(defn caller [m] (fact m))`)
+	ns.Def("*caller*", caller)
+
+	consts := vm.NewConsts()
+	c := compiler.NewCompiler(consts, ns)
+	c.SetSource("selfrec-inline-with")
+	inlineExpr := fmt.Sprintf(
+		`(do (ir.passes.inline/inline-with *caller* (hash-map '%s/fact *fact*)) *caller*)`,
+		nsName)
+	_, result, err := c.CompileMultiple(strings.NewReader(inlineExpr))
+	if err != nil {
+		t.Fatalf("inline-with: %v", err)
+	}
+	dump := lispDump(t, result)
+	if !(strings.Contains(dump, "Call") || strings.Contains(dump, "Invoke")) {
+		t.Fatalf("self-recursive callee must NOT be spliced (call should survive):\n%s", dump)
 	}
 }
 

--- a/pkg/rt/core/ir/passes/inline.lg
+++ b/pkg/rt/core/ir/passes/inline.lg
@@ -43,13 +43,22 @@
         (ir/blocks f)))
 
 (defn- self-recursive? [f]
-  "True if f calls itself (either directly or via invoke)."
-  (let [nm (ir/fn-name f)]
+  "True if f references its own name via a :load-var (a direct or invoke
+   self-call). A :load-var's aux may be a Var object (a normal defn built via
+   build.lg) or a symbol (lambda-lift / qualified external refs); it MUST be
+   normalized to a symbol before comparison, exactly like call-head-var does.
+   Comparing the raw Var to the name symbol never matches, so a self-recursive
+   defn would be wrongly judged non-recursive and marked inlineable — splicing
+   it into itself then grows IR size every round (max-inline-rounds bounds the
+   round count, not the size). Names are compared unqualified, matching the
+   original intent (nm was normalized with (symbol (str nm)))."
+  (let [nm (name (symbol (str (ir/fn-name f))))]
     (boolean
       (some (fn [bid]
               (some (fn [nid]
-                      (and (#{:call :invoke :load-var} (ir/op nid f))
-                           (= (ir/aux nid f) (symbol (str nm)))))
+                      (and (= :load-var (ir/op nid f))
+                           (when-let [s (try (symbol (ir/aux nid f)) (catch e nil))]
+                             (= nm (name s)))))
                     (ir/block-insts bid f)))
             (ir/blocks f)))))
 

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-8ceb0e3c98a0abbd2aa0f094524c60ad36e81c8e98463cec0ef652328b62ed1a
+7b4b602b5220b4df8381d0403a88aeee8bc755a55d6f290b939f1bdf44e3aad4


### PR DESCRIPTION
## What

Adds combinator inlining and higher-order **closure devirtualization** to the Go-lowering pipeline, entirely **opt-in** behind `*enable-inline*` (default `false`). With the flag off, the core lowered tree is byte-unchanged and the full gate stays green.

This wires up the previously-built-but-unwired inline pass (the plan's step **B7**) and then adds the closure-devirt lever it enables — collapsing PEG/combinator-style dispatch into straight-line code.

## Pieces

- **B7 wiring** — `ir.passes.inline` gains `*inline-registry*` + `*enable-inline*` dynamic vars. `optimize-fn` runs `inline-with` when both are bound; `lower-ns-to-go` seeds a same-ns `defn` registry (`build-inline-registry`). Named same-ns calls splice inline.
- **Closure devirtualization** — a call whose callee is a locally-constructed closure literal is spliced inline instead of dispatched via `rt.InvokeValueEC`:
  - `splice-closure!` — single-block closures.
  - `splice-closure-general!` — **multi-block, general (non-tail) position**: splits the caller block into a continuation that receives the closure result as a block-param, clones the closure's blocks in (`:load-arg`→operands, `:load-closed`→captures), and rewires the closure's returns to branch into the continuation.
  - Reuses `lower-go/closure-info` (made public) to resolve the closure + captures.
- **New IR primitives** (`ir.data`, interned into `ir`): `move-inst!` (re-home an inst preserving its id/refs), `reparent-terminator!`, `replace-block-pred!`.
- Bundles the **lambda-lift** pass (capture-free closure hoisting) this builds on.

## Tests

New coverage in `pkg/ir`:
- `TestOptimizeFnInlinesWhenRegistryBound`, `TestLowerNsInlinesSameNsCall`, `TestLowerNsInlinesTypedSibling` — the B7 wiring + registry.
- `TestDevirtualizesLocalClosureCall` — single-block closure splice (`(fn [y] (+ y x)) 10` → native add, no `InvokeValueEC`).
- `TestDevirtualizesMultiBlockClosureCall` — capturing, multi-block, non-tail closure devirtualizes fully.

`make generate` + `make check-generated` green (bundle + lowered tree in lockstep, compiles + dispatches natively); full `go test ./...` passes.

## Not included / follow-up

Full PEG end-to-end collapse needs one more layer: **interprocedural devirt into nested closures** (combinator calls that live inside a returned closure, where the combinator is a *capture*). That requires recursing inline into nested fn-templates and threading a capture-environment — a distinct follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)