### PR TITLE
chore(perf): re-baseline ir-stress corpus after upstream drift (2347 -> 2366)

### DIFF
--- a/docs/perf/ir-stress-baseline.edn
+++ b/docs/perf/ir-stress-baseline.edn
@@ -1,7 +1,7 @@
 {:failed 11
- :total 2347
- :passed 2336
- :captured "2026-06-30"
+ :total 2366
+ :passed 2355
+ :captured "2026-07-06"
  :how "LG_STRESS_PASSES=1 make ir-stress (corpus = every shipped/test/example .lg)"
  :note
  "ITER-0021 lowering-coverage ratchet. `make ir-stress-gate` fails when the


### PR DESCRIPTION
## What

Re-records `docs/perf/ir-stress-baseline.edn` for the current corpus: **2366 forms** (baseline said 2347, captured 2026-06-30).

## Why

`main` currently fails its own `make ir-stress-gate`: the corpus grew by 19 forms in a post-capture merge, and since the gate is deliberately not in CI (pre-push only), the baseline was never re-recorded. Every jj/pre-push user now hard-fails on:

```
GATE ERROR: corpus size changed — 2366 forms now vs 2347 baselined.
```

## Not a coverage regression

Measured at `main` (e2e3f9e2): total **2366**, passed **2355**, failed **11** — the failure count and buckets are identical to the baselined ones (`unresolved symbol n` ×7, `#inst` ×1, `read-json` ×1, `unsupported function body shape` ×1, `unresolved symbol a` ×1). Pure corpus growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
