### PR TITLE
fix(rt): accept padded base64url input

### DIFF
--- a/pkg/compiler/base64_test.go
+++ b/pkg/compiler/base64_test.go
@@ -42,4 +42,12 @@ func TestBase64URL(t *testing.T) {
 	if v := evalStr(t, `(count (base64url-decode (base64url-encode (byte-array (range 100)))))`); v != vm.Int(100) {
 		t.Fatalf("round-trip count: got %v", v)
 	}
+	// Decoders accept both padded and unpadded URL-safe base64, keeping the new
+	// base64url builtins interoperable with the existing io namespace helpers.
+	if v := evalStr(t, `(count (base64url-decode (io/encode :base64url "x")))`); v != vm.Int(1) {
+		t.Fatalf("decode padded io/encode output: got %v", v)
+	}
+	if v := evalStr(t, `(io/decode :base64url (base64url-encode "x"))`); v != vm.String("x") {
+		t.Fatalf("io/decode raw base64url output: got %v", v)
+	}
 }

--- a/pkg/rt/base64.go
+++ b/pkg/rt/base64.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import "encoding/base64"
+
+func decodeBase64URL(s string) ([]byte, error) {
+	data, err := base64.RawURLEncoding.DecodeString(s)
+	if err == nil {
+		return data, nil
+	}
+	data, paddedErr := base64.URLEncoding.DecodeString(s)
+	if paddedErr == nil {
+		return data, nil
+	}
+	return nil, err
+}

--- a/pkg/rt/ions.go
+++ b/pkg/rt/ions.go
@@ -681,7 +681,7 @@ func installIoNS() {
 			}
 			return vm.String(b), nil
 		case "base64url":
-			b, err := base64.URLEncoding.DecodeString(data)
+			b, err := decodeBase64URL(data)
 			if err != nil {
 				return vm.NIL, err
 			}

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -7510,7 +7510,7 @@ func installLangNS() {
 	ns.Def("base64url-encode", b64urlencodef)
 
 	// base64url-decode — (base64url-decode s) → byte-array. Inverse of
-	// base64url-encode; decodes the URL-safe, unpadded alphabet only.
+	// base64url-encode; decodes URL-safe base64 with or without padding.
 	b64urldecodef, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
@@ -7519,7 +7519,7 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("base64url-decode expects String")
 		}
-		data, derr := base64.RawURLEncoding.DecodeString(string(s))
+		data, derr := decodeBase64URL(string(s))
 		if derr != nil {
 			return vm.NIL, fmt.Errorf("base64url-decode: %w", derr)
 		}


### PR DESCRIPTION
## Summary

Follow-up to #368. The new `base64url-*` runtime builtins intentionally emit unpadded URL-safe base64, but the older `io/encode :base64url` helper emits padded URL-safe base64. Before this change, each decoder rejected the other encoder's output.

This keeps encoder output unchanged and makes URL-safe base64 decoding accept both RFC 4648 padded and raw/unpadded forms:

- `base64url-decode` accepts padded `io/encode :base64url` output.
- `io/decode :base64url` accepts unpadded `base64url-encode` output.

## xsofy check

I checked the xsofy replay-code implementation before opening this. xsofy documents its replay wire format as URL-safe base64 with no padding, suitable for `?replay=` links, and its hand-rolled encoder matches the native `base64url-encode` output on representative byte vectors. This PR does not change that output. It only broadens native decode acceptance, which is useful for compatibility with existing `io/encode :base64url` output and does not break xsofy's no-padding wire format.

## Validation

- `go test ./pkg/compiler ./pkg/rt ./pkg/vm`
- `(base64url-decode (io/encode :base64url "x"))` now returns `#byte-array[120]`
- `(io/decode :base64url (base64url-encode "x"))` now returns `"x"`
- Ran patched `lg` from the xsofy checkout and confirmed the existing replay fixture still encodes/decodes to the same code: `AQAAAAAAADA5AgR3YWl0BGRvd24AAAADAAIBAQAB`
