### PR TITLE
feat(rt): zero-arg (read-line) reads current *in*

### DIFF
--- a/pkg/rt/iort.go
+++ b/pkg/rt/iort.go
@@ -180,12 +180,20 @@ func installIOBuiltins(ns *vm.Namespace) {
 		return vm.NIL, h.Close()
 	})
 
-	// read-line — (read-line handle) → String or nil at EOF
-	readLine, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		if len(vs) != 1 {
-			return vm.NIL, fmt.Errorf("read-line expects 1 arg")
+	// read-line — (read-line handle) -> String or nil at EOF.
+	// (read-line) with no args reads the current *in*, like Clojure.
+	stdinHandle := vm.NewBoxed(NewIOHandle(os.Stdin))
+	readLine := vm.NewCtxNativeFn("read-line", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		if len(vs) > 1 {
+			return vm.NIL, fmt.Errorf("read-line expects 0 or 1 args")
 		}
-		h, err := getIOHandle(vs[0])
+		src := vm.Value(stdinHandle)
+		if len(vs) == 1 {
+			src = vs[0]
+		} else if v := LookupCoreVar("*in*"); v != nil {
+			src = ec.Deref(v)
+		}
+		h, err := getIOHandle(src)
 		if err != nil {
 			return vm.NIL, err
 		}
@@ -313,7 +321,6 @@ func installIOBuiltins(ns *vm.Namespace) {
 	})
 
 	// *in*, *out*, *err* — stdin, stdout, stderr as IOHandle
-	stdinHandle := vm.NewBoxed(NewIOHandle(os.Stdin))
 	stdoutHandle := vm.NewBoxed(NewIOHandle(os.Stdout))
 	stderrHandle := vm.NewBoxed(NewIOHandle(os.Stderr))
 

--- a/test/e2e/read_line_stdin_test.go
+++ b/test/e2e/read_line_stdin_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
+ * SPDX-License-Identifier: MIT
+ */
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	userRead  os.FileMode = 1 << 8
+	userWrite os.FileMode = 1 << 7
+	groupRead os.FileMode = 1 << 5
+	otherRead os.FileMode = 1 << 2
+
+	testFilePerm = userRead | userWrite | groupRead | otherRead
+)
+
+// TestReadLineStdin verifies (read-line) with no args reads the current *in*,
+// like Clojure, while the 1-arg handle form keeps working.
+func TestReadLineStdin(t *testing.T) {
+	bin := buildLG(t)
+
+	run := func(t *testing.T, stdin string, body string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "app.lg")
+		if err := os.WriteFile(p, []byte(body), testFilePerm); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command(bin, p)
+		cmd.Stdin = strings.NewReader(stdin)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run lg: %v\n%s", err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	t.Run("no args reads stdin", func(t *testing.T) {
+		if got := run(t, "hello\n", `(println (read-line))`); got != "hello" {
+			t.Fatalf("got %q, want hello", got)
+		}
+	})
+
+	t.Run("nil at EOF", func(t *testing.T) {
+		if got := run(t, "", `(prn (read-line))`); got != "nil" {
+			t.Fatalf("got %q, want nil", got)
+		}
+	})
+
+	t.Run("explicit handle still works", func(t *testing.T) {
+		if got := run(t, "hi\n", `(println (read-line *in*))`); got != "hi" {
+			t.Fatalf("got %q, want hi", got)
+		}
+	})
+
+	t.Run("no args respects rebound *in*", func(t *testing.T) {
+		input := filepath.Join(t.TempDir(), "input.txt")
+		if err := os.WriteFile(input, []byte("from-file\n"), testFilePerm); err != nil {
+			t.Fatal(err)
+		}
+		body := fmt.Sprintf(`(let [f (open %q :read)]
+  (binding [*in* f]
+    (println (read-line))))`, input)
+		if got := run(t, "from-stdin\n", body); got != "from-file" {
+			t.Fatalf("got %q, want from-file", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- add zero-arg `(read-line)` support that reads from the current `*in*` binding
- keep the existing explicit handle form `(read-line handle)` working
- add e2e coverage for process stdin, EOF, explicit `*in*`, and rebound `*in*`

## Why

PR #400 surfaced the useful Clojure-compatible behavior that `(read-line)` should read stdin. This keeps that behavior while matching let-go's existing dynamic I/O model: standard streams are Vars, so a rebound `*in*` should be honored the same way `*out*` is honored by printing.

## Validation

- `go test -timeout 600s -count=1 -v ./test/e2e -run TestReadLineStdin`
- `go test -timeout 600s -count=1 -v ./test/e2e`
