### PR TITLE
fix(vm): explicit :refer shadows the clojure.core auto-refer baseline

### DIFF
--- a/pkg/vm/namespace.go
+++ b/pkg/vm/namespace.go
@@ -277,13 +277,36 @@ func (n *Namespace) Lookup(symbol Symbol) Value {
 		}
 		// Unqualified miss: search refers. Snapshot first so we follow each
 		// refer's target via its own lock, never holding n's lock across.
+		//
+		// Precedence (Clojure semantics): an explicit refer — (:require [lib
+		// :refer :all]) or :refer [syms], and (use lib) — SHADOWS the
+		// clojure.core auto-refer that RegisterNS installs into every ns. So we
+		// treat the core refer as a lowest-priority baseline: return the first
+		// matching explicit refer, honoring :all / :only, and only fall back to
+		// core if no explicit refer provides the symbol.
+		var coreHit *Var
 		for _, ref := range n.refersSnapshot() {
-			if v := ref.ns.localVar(sym.(Symbol)); v != nil {
-				if v.isPrivate {
-					return NIL
-				}
-				return v
+			v := ref.ns.localVar(sym.(Symbol))
+			if v == nil || v.isPrivate {
+				continue
 			}
+			isCore := coreNamespacePtr != nil && ref.ns == coreNamespacePtr
+			// The clojure.core refer is always the full auto-refer :all
+			// baseline: an explicit (:require [clojure.core :refer [...]]) is
+			// additive, never restrictive (core is trimmed via :refer-clojure
+			// :exclude, not here). For every OTHER refer, honor :refer [syms] —
+			// an :only refer contributes a symbol only when it is listed.
+			if !isCore && !ref.all && (ref.only == nil || !ref.only[sym.(Symbol)]) {
+				continue
+			}
+			if isCore {
+				coreHit = v
+				continue
+			}
+			return v
+		}
+		if coreHit != nil {
+			return coreHit
 		}
 		return NIL
 	}

--- a/test/ns/refer_shadows_core_test.lg
+++ b/test/ns/refer_shadows_core_test.lg
@@ -1,0 +1,30 @@
+;; Clojure compat: an explicit (:require [lib :refer :all]) — and :refer [syms]
+;; — must SHADOW the auto-refer'd clojure.core mappings, matching JVM Clojure.
+;;
+;; This is the exact class of bug reported for lg: clojure.core carries lg-only
+;; extras (gt/lt/ge/le), and a lib refer'd :all that re-exports those names kept
+;; resolving to clojure.core instead of the referred lib (e.g. ys.std/ys.dwim).
+
+(ns mylib.core)
+(defn gt [& _] :mylib-gt)             ;; shadows clojure.core/gt via :refer :all
+(defn lt [& _] :mylib-lt)             ;; shadows clojure.core/lt via :refer :all
+
+(ns mylib.only)
+(defn le [& _] :mylib-le)             ;; brought in via :refer [le]
+(defn hidden [_] :should-not-leak)    ;; NOT listed in :refer — must not leak
+
+(ns refer-shadow.app
+  (:require [mylib.core :refer :all]
+            [mylib.only :refer [le]]
+            [test :refer :all]))
+
+(deftest refer-all-shadows-core
+  (testing ":refer :all shadows clojure.core mappings"
+    (is (= :mylib-gt (gt 1 2)))
+    (is (= :mylib-lt (lt 1 2))))
+  (testing ":refer [sym] shadows core only for the listed symbol"
+    (is (= :mylib-le (le 1 2)))
+    ;; `hidden` was not in the :refer list, so it must not leak in unqualified.
+    (is (nil? (resolve 'hidden))))
+  (testing "unshadowed core symbols still resolve to clojure.core"
+    (is (= 3 (+ 1 2)))))


### PR DESCRIPTION
## Problem

An explicit `(:require [lib :refer :all])` (or `:refer [syms]`, or `use`) did **not** shadow the auto-refer'd `clojure.core`, diverging from JVM Clojure. A symbol defined by both `clojure.core` and a refer'd lib resolved **nondeterministically** — `Namespace.Lookup` iterated the `refers` **map** (unordered) with no precedence rule, and in practice `clojure.core` usually won.

Concretely, a program re-exporting a `clojure.core` name (e.g. `ys.std`/`ys.dwim` redefining `gt`/`le`, or any lib redefining `inc`) kept resolving to `clojure.core`:

```clojure
(ns ys.std) (defn gt [a b] {:ys-gt [a b]})
(ns app (:require [ys.std :refer :all]))
(gt 3 4)   ; => false  (clojure.core/gt)   ❌ expected {:ys-gt [3 4]}
```

This also affects compiled calls, since the compiler resolves unqualified call symbols through `CurrentNS().Lookup`.

## Fix

`pkg/vm/namespace.go` `Namespace.Lookup`: treat the `clojure.core` refer as a **lowest-priority baseline**. Explicit (non-core) refers are returned first, honoring `:refer :all` / `:refer [syms]`; the core mapping is used only if no explicit refer provides the symbol. The core refer stays a full-`:all` baseline (an explicit `:refer` of core is additive, matching Clojure — core is trimmed via `:refer-clojure :exclude`, not here).

```clojure
(gt 3 4)   ; => {:ys-gt [3 4]}   ✅
```

## Tests

`test/ns/refer_shadows_core_test.lg` — `:refer :all` and `:refer [sym]` shadow core; unlisted `:only` names don't leak; unshadowed names still resolve to core. Verified RED→GREEN (RED failed nondeterministically, exposing the underlying map-order bug).

Suites green on this branch: `pkg/vm` + `pkg/rt` + `pkg/compiler` (378), full `.lg` suite (171). Also validated against the external xsofy corpus (281 tests / 2733 assertions / 0 fail).

## Note

The local `ir-stress` pre-push ratchet currently fails on a **corpus-size drift** (2347→2366 forms) from other merged work — failure count is unchanged (11) and this change adds none. It's a stale-baseline / repo-health item, unrelated to this fix.
