### PR TITLE
fix(cli): exit nonzero when script or -e fails

### DIFF
--- a/lg.go
+++ b/lg.go
@@ -625,15 +625,18 @@ func runMain() int {
 	// Script mode: treat only the first positional as the script to run.
 	// Any further positionals belong to the script (it reads os/args).
 	ranSomething := false
+	runFailed := false
 	if len(files) >= 1 {
 		script := files[0]
 		if filepath.Ext(script) == ".lgb" {
 			if err := runLGB(script); err != nil {
 				fmt.Print(vm.FormatError(err))
+				runFailed = true
 			}
 		} else {
 			if err := runFile(context, script); err != nil {
 				fmt.Print(vm.FormatError(err))
+				runFailed = true
 			}
 		}
 		ranSomething = true
@@ -644,6 +647,7 @@ func runMain() int {
 		val, err := runForm(context, expr)
 		if err != nil {
 			fmt.Print(vm.FormatError(err))
+			runFailed = true
 		} else {
 			fmt.Println(val)
 		}
@@ -663,6 +667,11 @@ func runMain() int {
 	}
 
 	stopProfiling()
+	// A failed script or -e expression exits nonzero, but an interactive
+	// session (-r) that recovered in the REPL still exits clean.
+	if runFailed && !runREPL {
+		return 1
+	}
 	return 0
 }
 

--- a/lg.go
+++ b/lg.go
@@ -125,6 +125,16 @@ func runLGB(filename string) error {
 	return err
 }
 
+// runScript dispatches a positional script to the .lgb loader or the source
+// runner. Split out so the caller's error/exit-code handling stays flat rather
+// than nesting the format-dispatch inside it.
+func runScript(ctx *compiler.Context, script string) error {
+	if filepath.Ext(script) == ".lgb" {
+		return runLGB(script)
+	}
+	return runFile(ctx, script)
+}
+
 // checkBundledLGB checks if the current executable has an appended payload.
 // Returns the LGB bytecode, the gzipped resource archive (for a v2/v3 bundle),
 // and the baked storage store id (v3 only). The latter two are empty for a
@@ -627,17 +637,9 @@ func runMain() int {
 	ranSomething := false
 	runFailed := false
 	if len(files) >= 1 {
-		script := files[0]
-		if filepath.Ext(script) == ".lgb" {
-			if err := runLGB(script); err != nil {
-				fmt.Print(vm.FormatError(err))
-				runFailed = true
-			}
-		} else {
-			if err := runFile(context, script); err != nil {
-				fmt.Print(vm.FormatError(err))
-				runFailed = true
-			}
+		if err := runScript(context, files[0]); err != nil {
+			fmt.Print(vm.FormatError(err))
+			runFailed = true
 		}
 		ranSomething = true
 	}

--- a/test/e2e/exit_code_test.go
+++ b/test/e2e/exit_code_test.go
@@ -91,4 +91,21 @@ func TestErrorExitCode(t *testing.T) {
 			t.Fatalf("want exit 0, got %d; output:\n%s", code, out)
 		}
 	})
+
+	// The one carve-out in runMain: a failing script under -r drops into the
+	// REPL, which recovers and exits clean. Feeding /dev/null gives the REPL an
+	// immediate EOF so it returns instead of blocking.
+	t.Run("failing script with -r exits zero", func(t *testing.T) {
+		app := writeScript(t, `(undefined-fn-xyz)`)
+		cmd := exec.Command(bin, "-r", app)
+		cmd.Stdin = nil // nil Stdin reads from the null device -> EOF
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			var ee *exec.ExitError
+			if !errors.As(err, &ee) {
+				t.Fatalf("run lg -r %s: %v\n%s", app, err, out)
+			}
+			t.Fatalf("want exit 0, got %d; output:\n%s", ee.ExitCode(), out)
+		}
+	})
 }

--- a/test/e2e/exit_code_test.go
+++ b/test/e2e/exit_code_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
+ * SPDX-License-Identifier: MIT
+ */
+
+package e2e
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	exitCodeUserRead  os.FileMode = 1 << 8
+	exitCodeUserWrite os.FileMode = 1 << 7
+	exitCodeGroupRead os.FileMode = 1 << 5
+	exitCodeOtherRead os.FileMode = 1 << 2
+
+	exitCodeTestFilePerm = exitCodeUserRead | exitCodeUserWrite | exitCodeGroupRead | exitCodeOtherRead
+)
+
+// TestErrorExitCode verifies lg exits nonzero when a script or -e expression
+// fails with a runtime error, and zero when it succeeds. Previously runtime
+// errors were printed but the process still exited 0, so shell pipelines and
+// CI runs could not detect failure.
+func TestErrorExitCode(t *testing.T) {
+	bin := buildLG(t)
+
+	writeScript := func(t *testing.T, body string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "app.lg")
+		if err := os.WriteFile(p, []byte(body), exitCodeTestFilePerm); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// run executes lg and returns its exit code and combined output.
+	run := func(t *testing.T, args ...string) (int, string) {
+		t.Helper()
+		out, err := exec.Command(bin, args...).CombinedOutput()
+		if err != nil {
+			var ee *exec.ExitError
+			if !errors.As(err, &ee) {
+				t.Fatalf("run lg %v: %v\n%s", args, err, out)
+			}
+			return ee.ExitCode(), string(out)
+		}
+		return 0, string(out)
+	}
+
+	t.Run("failing script exits nonzero", func(t *testing.T) {
+		app := writeScript(t, `(undefined-fn-xyz)`)
+		if code, out := run(t, app); code == 0 {
+			t.Fatalf("want nonzero exit, got 0; output:\n%s", out)
+		}
+	})
+
+	t.Run("throwing script exits nonzero", func(t *testing.T) {
+		app := writeScript(t, `(throw (ex-info "boom" {}))`)
+		if code, out := run(t, app); code == 0 {
+			t.Fatalf("want nonzero exit, got 0; output:\n%s", out)
+		}
+	})
+
+	t.Run("succeeding script exits zero", func(t *testing.T) {
+		app := writeScript(t, `(println :ok)`)
+		if code, out := run(t, app); code != 0 {
+			t.Fatalf("want exit 0, got %d; output:\n%s", code, out)
+		}
+	})
+
+	t.Run("failing -e exits nonzero", func(t *testing.T) {
+		if code, out := run(t, "-e", `(undefined-fn-xyz)`); code == 0 {
+			t.Fatalf("want nonzero exit, got 0; output:\n%s", out)
+		}
+	})
+
+	t.Run("succeeding -e exits zero", func(t *testing.T) {
+		if code, out := run(t, "-e", `(+ 1 2)`); code != 0 {
+			t.Fatalf("want exit 0, got %d; output:\n%s", code, out)
+		}
+	})
+
+	t.Run("caught error still exits zero", func(t *testing.T) {
+		app := writeScript(t, `(println (try (throw (ex-info "boom" {})) (catch e :caught)))`)
+		if code, out := run(t, app); code != 0 {
+			t.Fatalf("want exit 0, got %d; output:\n%s", code, out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- make `lg` exit nonzero when a script fails with an uncaught runtime error
- make `lg -e` exit nonzero when expression evaluation fails
- keep successful scripts, successful `-e`, and caught errors exiting zero

## Why

Runtime errors were printed but still returned process exit code 0. That makes shell scripts, pipelines, and CI unable to distinguish a failed `lg` run from a successful one.

This is split out from the related fix in #400 as a standalone CLI behavior change. Credit: @ingydotnet 

## Validation

- `go test -timeout 600s -count=1 -v ./test/e2e -run TestErrorExitCode`
- `go test -timeout 600s -count=1 -v ./test/e2e`
