### PR TITLE
fix(compiler): allow an empty catch body with a qualified class name

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -859,22 +859,23 @@ func tryCompiler(c *Context, form vm.Value) error {
 						return NewCompileError("catch requires a binding symbol")
 					}
 					// Clojure-compatible form: (catch ClassSym bind-sym body...)
-					// vs let-go's bare (catch bind-sym body...).
-					// Disambiguate by counting forms: Clojure requires a body,
-					// so the class form has 3+ tokens after `catch`. If we see
-					// at least 3 tokens and the first two are both symbols,
-					// drop the leading class symbol (catch is catch-all here).
+					// vs let-go's bare (catch bind-sym body...). A binding is
+					// always a simple unqualified symbol, so a qualified/dotted
+					// first token can only be a class name — that disambiguates
+					// even with an empty catch body, e.g.
+					// (catch java.io.FileNotFoundException _). For a simple class
+					// name, fall back to the token count: the Clojure form needs
+					// class + binding + body (3+ tokens, first two symbols).
 					restCount := 0
 					for s := rest; s != nil; s = s.Next() {
 						restCount++
 					}
-					if restCount >= 3 {
-						first := rest.First()
-						afterRest := rest.Next()
-						if _, isSym := first.(vm.Symbol); isSym {
-							if _, secondIsSym := afterRest.First().(vm.Symbol); secondIsSym {
-								rest = afterRest
-							}
+					if restCount >= 2 {
+						firstSym, firstIsSym := rest.First().(vm.Symbol)
+						_, secondIsSym := rest.Next().First().(vm.Symbol)
+						qualified := firstIsSym && strings.ContainsAny(string(firstSym), "./")
+						if firstIsSym && secondIsSym && (qualified || restCount >= 3) {
+							rest = rest.Next() // drop the leading class symbol
 						}
 					}
 					bindSym, ok := rest.First().(vm.Symbol)

--- a/test/catch_class_test.lg
+++ b/test/catch_class_test.lg
@@ -14,6 +14,16 @@
   (testing "binding symbol is still bound to the thrown value"
     (is (= "boom" (try (throw "boom") (catch Throwable e (str e)))))))
 
+(deftest catch-empty-body
+  (testing "a qualified class + binding with an empty body catches and returns nil"
+    ;; (catch java.io.FileNotFoundException _) — no body. A binding is always a
+    ;; simple symbol, so the dotted first token is unambiguously the class.
+    ;; weavejester/integrant's try-require uses exactly this form.
+    (is (nil? (try (throw "boom") (catch java.io.FileNotFoundException _))))
+    (is (= 1 (try 1 (catch java.io.FileNotFoundException _)))))
+  (testing "the bare one-body-form still returns that form, not nil"
+    (is (= :ok (try (throw "boom") (catch e :ok))))))
+
 (deftest catch-with-finally
   (testing "finally still runs"
     (let [a (atom 0)]


### PR DESCRIPTION
(catch java.io.FileNotFoundException _) has no body, but the Clojure-form disambiguation required class+binding+body (3+ tokens after catch), so it misparsed the class as the binding and the binding as the body:

    CompileError: Can't resolve _ in this context

A catch binding is always a simple unqualified symbol, so a qualified or dotted first token can only be the class name — key the disambiguation on that, so an empty catch body parses. Adds test/catch_class_test.lg coverage.

Resolves: #412 