### PR TITLE
feat(rt): add find-var and get-method

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5383,6 +5383,50 @@ func installLangNS() {
 		return vm.NewMap(kvs), nil
 	})
 
+	// find-var: (find-var 'ns/name) -> the interned var in that namespace, or
+	// nil if the namespace or the name is not found. integrant's default
+	// init-key resolves a component fn from a qualified keyword via
+	// (some-> (find-var sym) var-get).
+	findVar, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		sym, ok := vs[0].(vm.Symbol)
+		if !ok {
+			return vm.NIL, fmt.Errorf("find-var expected a symbol")
+		}
+		nsV, nameV := sym.Namespaced()
+		nsSym, ok1 := nsV.(vm.Symbol)
+		nameSym, ok2 := nameV.(vm.Symbol)
+		if !ok1 || !ok2 {
+			return vm.NIL, fmt.Errorf("find-var expects a fully-qualified symbol: %s", sym)
+		}
+		nsMu.RLock()
+		targetNS := nsRegistry[resolveNSAlias(string(nsSym))]
+		nsMu.RUnlock()
+		if targetNS == nil {
+			return vm.NIL, nil
+		}
+		if v := targetNS.LookupLocal(nameSym); v != nil {
+			return v, nil
+		}
+		return vm.NIL, nil
+	})
+
+	// get-method: (get-method multifn dispatch-val) -> the method fn that value
+	// would select (exact match, else the default method), or nil. integrant's
+	// can-expand-key? uses it to test whether a key has an expand-key method.
+	getMethod, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 2 {
+			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+		}
+		mf, ok := vs[0].(*vm.MultiFn)
+		if !ok {
+			return vm.NIL, fmt.Errorf("get-method expected a multimethod")
+		}
+		return mf.GetMethod(vs[1]), nil
+	})
+
 	// lazy-seq* creates a LazySeq from a thunk function
 	lazySeq, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
@@ -6605,6 +6649,8 @@ func installLangNS() {
 	ns.Def("the-ns", theNs)
 	ns.Def("ns-name", nsName)
 	ns.Def("ns-publics", nsPublics)
+	ns.Def("find-var", findVar)
+	ns.Def("get-method", getMethod)
 
 	ns.Def("peek", peek)
 	ns.Def("pop", pop)

--- a/pkg/vm/multifn.go
+++ b/pkg/vm/multifn.go
@@ -122,6 +122,18 @@ func (m *MultiFn) Methods() *PersistentMap {
 	return m.methods
 }
 
+// GetMethod returns the method fn that dispatch value dv would select — the
+// exact match, else the default method, else NIL. Mirrors invokeIn's method
+// selection (let-go multimethods dispatch on exact value + default, not the
+// isa? hierarchy). Backs the core get-method fn.
+func (m *MultiFn) GetMethod(dv Value) Value {
+	method := m.methods.ValueAt(dv)
+	if method == NIL {
+		method = m.methods.ValueAt(m.defaultVal)
+	}
+	return method
+}
+
 // FreezeNative marks this MultiFn as the captured baseline for generated
 // native dispatch arms. Done once, in place, at namespace-load completion
 // (rt.ApplyGoOverrides) — the var still points at this exact pointer, and any

--- a/test/integrant_compat_test.go
+++ b/test/integrant_compat_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+// evalIntegrant compiles and evaluates one expression against the core NS,
+// mirroring evalMedley — used to check that find-var / get-method resolve.
+// Runtime behavior is covered by test/integrant_compat_test.lg.
+func evalIntegrant(expr string) (vm.Value, error) {
+	ctx := compiler.NewCompiler(vm.NewConsts(), rt.NS(rt.NameCoreNS))
+	_, out, err := ctx.CompileMultiple(strings.NewReader(expr))
+	if err != nil {
+		return vm.NIL, err
+	}
+	return out, nil
+}
+
+// TestFindVarGetMethodCompat checks the var/multimethod introspection fns
+// resolve. weavejester/integrant references find-var (default init-key) and
+// get-method (can-expand-key?); an unresolved symbol there fails the whole
+// namespace compile.
+func TestFindVarGetMethodCompat(t *testing.T) {
+	t.Run("find-var resolves", func(t *testing.T) {
+		_, err := evalIntegrant(`(defn f [s] (find-var s))`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("get-method resolves", func(t *testing.T) {
+		_, err := evalIntegrant(`(defn f [m v] (get-method m v))`)
+		assert.NoError(t, err)
+	})
+}

--- a/test/integrant_compat_test.lg
+++ b/test/integrant_compat_test.lg
@@ -1,0 +1,36 @@
+;; Runtime behavior of the fns integrant needs beyond bare resolution:
+;; find-var (default init-key resolves a component fn from a qualified keyword)
+;; and get-method (can-expand-key? / expand).
+(ns test.integrant-compat-test
+  (:require [test :refer :all]))
+
+(def my-var 42)
+(defn my-fn [x] (* x 2))
+
+(deftest find-var-resolves-vars
+  (testing "find-var returns the interned var; var-get reads its value"
+    (is (= 42 (var-get (find-var 'test.integrant-compat-test/my-var))))
+    (is (= 20 ((var-get (find-var 'test.integrant-compat-test/my-fn)) 10))))
+  (testing "find-var returns nil for an unknown name or namespace"
+    (is (nil? (find-var 'test.integrant-compat-test/nope)))
+    (is (nil? (find-var 'no.such.namespace/x)))))
+
+(defmulti mm identity)
+(defmethod mm :a [_] :method-a)
+(defmethod mm :default [_] :fallback)
+
+(deftest get-method-lookup
+  (testing "get-method returns the method registered for a dispatch value"
+    (is (some? (get-method mm :a)))
+    (is (= :method-a ((get-method mm :a) :a))))
+  (testing "get-method falls back to the :default method"
+    (is (some? (get-method mm :absent)))
+    (is (= :fallback ((get-method mm :absent) :absent)))))
+
+(defmulti no-default identity)
+(defmethod no-default :x [_] :x-method)
+
+(deftest get-method-no-default
+  (testing "get-method returns nil when nothing matches and there is no default"
+    (is (nil? (get-method no-default :y)))
+    (is (some? (get-method no-default :x)))))


### PR DESCRIPTION
Two var/multimethod introspection fns let-go was missing:
- find-var: a namespace-qualified symbol -> the interned var (nil if the namespace or name is absent).
- get-method: (get-method multifn dispatch-val) -> the method fn that value selects (exact match, else the :default method, else nil), via a new vm.MultiFn.GetMethod. let-go multimethods dispatch on exact value + default, not the isa? hierarchy.

Motivated by weavejester/integrant (default init-key uses find-var; can-expand-key? uses get-method). Tests: test/integrant_compat_test.{go,lg}.

Resolve: #416 