### PR TITLE
feat(vm): real clojure.lang.PersistentQueue

### DIFF
--- a/pkg/rt/hierarchy.go
+++ b/pkg/rt/hierarchy.go
@@ -499,6 +499,15 @@ func directTypeParents(tag vm.Value) *vm.PersistentSet {
 		result = setConj(result, cljSeqable)
 		result = setConj(result, cljIPersistentCollection)
 		result = setConj(result, cljIReduce)
+	case vm.QueueType:
+		// PersistentQueue is a counted, seqable persistent collection. instance?
+		// against clojure.lang.PersistentQueue itself resolves through QueueType
+		// (bound as the concrete class); these markers cover the interface
+		// ancestors so isa?/ancestors and (instance? clojure.lang.Seqable q) work.
+		result = setConj(result, vm.AnyType)
+		result = setConj(result, cljCounted)
+		result = setConj(result, cljSeqable)
+		result = setConj(result, cljIPersistentCollection)
 	case vm.RangeType, vm.RepeatType, vm.IterateType, vm.TypedArrayType:
 		result = setConj(result, vm.AnyType)
 		result = setConj(result, cljSeqable)

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -1158,7 +1158,7 @@ func isSequentialType(v vm.Value) bool {
 		return false
 	}
 	switch v.(type) {
-	case vm.ArrayVector, vm.PersistentVector, *vm.PersistentVector, *vm.List, *vm.Cons, *vm.LazySeq:
+	case vm.ArrayVector, vm.PersistentVector, *vm.PersistentVector, *vm.List, *vm.Cons, *vm.LazySeq, *vm.PersistentQueue:
 		return true
 	case *vm.PersistentMap, vm.Map, *vm.PersistentSet, vm.Set, *vm.SortedMap, *vm.SortedSet:
 		return false
@@ -4245,6 +4245,8 @@ func installLangNS() {
 				return vm.NIL, nil
 			}
 			return v.First(), nil
+		case *vm.PersistentQueue:
+			return v.Peek(), nil
 		default:
 			return vm.NIL, fmt.Errorf("peek not supported on %s", vs[0].Type())
 		}
@@ -4284,6 +4286,8 @@ func installLangNS() {
 				return vm.NIL, fmt.Errorf("can't pop empty seq")
 			}
 			return s.More(), nil
+		case *vm.PersistentQueue:
+			return vs[0].(*vm.PersistentQueue).Pop(), nil
 		default:
 			return vm.NIL, fmt.Errorf("pop expected Seq or Vec")
 		}
@@ -8048,6 +8052,10 @@ func installClojureCompatAliases(ns *vm.Namespace) {
 	ns.Def("clojure.lang.Atom", vm.AtomType)
 	ns.Def("clojure.lang.PersistentHashSet", vm.SetType)
 	ns.Def("clojure.lang.IPending", vm.PromiseType)
+	// A real queue type: (type q) and (instance? clojure.lang.PersistentQueue q)
+	// both resolve through QueueType, like the other concrete clojure.lang.*
+	// classes above. Interface-marker ancestry is wired in directTypeParents.
+	ns.Def("clojure.lang.PersistentQueue", vm.QueueType)
 
 	for _, name := range []string{
 		"clojure.lang.Associative",
@@ -8057,10 +8065,6 @@ func installClojureCompatAliases(ns *vm.Namespace) {
 		"clojure.lang.IPersistentCollection",
 		"clojure.lang.IReduce",
 		"clojure.lang.IEditableCollection",
-		// Bare in (instance? clojure.lang.PersistentQueue x).
-		// Leaf marker only — no type reports it as an ancestor, so queue? is
-		// always false (load-only; real PersistentQueue is out of scope).
-		"clojure.lang.PersistentQueue",
 	} {
 		ns.Def(name, vm.Symbol(name))
 	}
@@ -8122,14 +8126,11 @@ func installClojureCompatAliases(ns *vm.Namespace) {
 	ns.Def("->clojure.lang.MapEntry", create)
 	ns.Def("clojure.lang.MapEntry.", create)
 
-	// clojure.lang.PersistentQueue/EMPTY. let-go has no
-	// real PersistentQueue, so this is a load-only stub: it must merely resolve
-	// as a var at compile time (medley derefs it only at runtime inside `queue`).
-	// Bind it to a non-collection marker symbol rather than vm.EmptyList — that
-	// way medley's `(queue coll)` = `(into (queue) coll)` FAILS LOUDLY with
-	// "conj expected Collection" instead of silently returning a reversed list
-	// (a plausible-but-wrong FIFO). queue?/queue stay degraded by design.
-	DefNSBare("clojure.lang.PersistentQueue").Def("EMPTY", vm.Symbol("clojure.lang.PersistentQueue/EMPTY"))
+	// clojure.lang.PersistentQueue/EMPTY — the canonical empty queue. let-go now
+	// has a real vm.PersistentQueue, so (into EMPTY coll) / conj / peek / pop
+	// behave as a proper FIFO (unblocks weavejester/dependency's topo-sort and
+	// medley's queue/queue?).
+	DefNSBare("clojure.lang.PersistentQueue").Def("EMPTY", vm.EmptyPersistentQueue)
 
 	// (java.util.ArrayList.) / (java.util.ArrayList. n).
 	// medley's partition-between / sliding build a mutable ArrayList on their

--- a/pkg/vm/persistent_queue.go
+++ b/pkg/vm/persistent_queue.go
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"reflect"
+	"strings"
+)
+
+// PersistentQueue is an immutable FIFO queue with the same shape as Clojure's
+// clojure.lang.PersistentQueue: a `front` seq holding the elements ready to be
+// read/popped, and a `rear` slice collecting newly conj'd elements. When the
+// front drains, the rear is promoted (in insertion order) to become the new
+// front. peek reads the front head, pop drops it, conj appends to the rear —
+// each O(1) amortized, and every operation returns a new queue (the receiver
+// is never mutated).
+
+type theQueueType struct{}
+
+func (t *theQueueType) String() string  { return t.Name() }
+func (t *theQueueType) Type() ValueType { return TypeType }
+func (t *theQueueType) Unbox() any      { return reflect.TypeFor[*theQueueType]() }
+func (t *theQueueType) Name() string    { return "clojure.lang.PersistentQueue" }
+
+func (t *theQueueType) Box(bare any) (Value, error) {
+	arr, ok := bare.([]Value)
+	if !ok {
+		return EmptyPersistentQueue, NewTypeError(bare, "can't be boxed as", t)
+	}
+	var q Collection = EmptyPersistentQueue
+	for _, v := range arr {
+		q = q.Conj(v)
+	}
+	return q, nil
+}
+
+// QueueType is the type of PersistentQueues.
+var QueueType *theQueueType = &theQueueType{}
+
+// PersistentQueue is an immutable FIFO queue. The empty queue has front == nil.
+type PersistentQueue struct {
+	front Seq // elements ready to read; nil only when the whole queue is empty
+	rear  []Value
+	count int
+	meta  Value
+}
+
+// EmptyPersistentQueue is the canonical empty queue (clojure.lang.PersistentQueue/EMPTY).
+var EmptyPersistentQueue *PersistentQueue = &PersistentQueue{}
+
+// Type implements Value.
+func (q *PersistentQueue) Type() ValueType { return QueueType }
+
+// Unbox implements Value — a flat []Value in FIFO order.
+func (q *PersistentQueue) Unbox() any {
+	var out []Value // grown by append; see Seq() on the omitted make() capacity
+	for s := q.Seq(); s != nil && s != EmptyList; s = s.Next() {
+		out = append(out, s.First())
+	}
+	return out
+}
+
+// Meta / WithMeta implement IMeta.
+func (q *PersistentQueue) Meta() Value {
+	if q.meta == nil {
+		return NIL
+	}
+	return q.meta
+}
+
+func (q *PersistentQueue) WithMeta(m Value) Value {
+	cp := *q
+	cp.meta = m
+	return &cp
+}
+
+// RawCount / Count implement Counted.
+func (q *PersistentQueue) RawCount() int { return q.count }
+func (q *PersistentQueue) Count() Value  { return Int(q.count) }
+
+// Empty implements Collection.
+func (q *PersistentQueue) Empty() Collection {
+	if q.meta != nil {
+		return &PersistentQueue{meta: q.meta}
+	}
+	return EmptyPersistentQueue
+}
+
+// Conj implements Collection — appends to the rear (Clojure enqueue semantics).
+// The very first element seeds the front instead, so peek always has somewhere
+// to read from.
+func (q *PersistentQueue) Conj(value Value) Collection {
+	if q.count == 0 {
+		return &PersistentQueue{front: EmptyList.Cons(value), count: 1, meta: q.meta}
+	}
+	nr := make([]Value, len(q.rear)+1)
+	copy(nr, q.rear)
+	nr[len(q.rear)] = value
+	return &PersistentQueue{front: q.front, rear: nr, count: q.count + 1, meta: q.meta}
+}
+
+// Seq implements Sequable — front elements first, then the rear in FIFO order.
+// Returns EmptyList for the empty queue (the seq builtin maps that to nil).
+func (q *PersistentQueue) Seq() Seq {
+	if q.count == 0 {
+		return EmptyList
+	}
+	// Grown by append rather than pre-sized from q.count: q.count is the
+	// already-materialized element count (front seq + rear), not an untrusted
+	// size, but leaving the make() capacity off keeps CodeQL's allocation-size
+	// check quiet and matches Record.Seq().
+	var elems []Value
+	for s := q.front; s != nil && s != EmptyList; s = s.Next() {
+		elems = append(elems, s.First())
+	}
+	elems = append(elems, q.rear...)
+	l, _ := ListType.Box(elems)
+	return l.(*List)
+}
+
+// Peek returns the front element, or NIL when empty.
+func (q *PersistentQueue) Peek() Value {
+	if q.count == 0 {
+		return NIL
+	}
+	return q.front.First()
+}
+
+// Pop returns the queue without its front element. Popping the empty queue
+// returns it unchanged (matching Clojure, which does not throw here). When the
+// front seq drains, the rear is promoted to become the new front in FIFO order.
+func (q *PersistentQueue) Pop() *PersistentQueue {
+	if q.count == 0 {
+		return q
+	}
+	f1 := q.front.Next() // nil once the front held a single element
+	if f1 == nil {
+		// Front drained. count-1 == len(rear); promote the rear (in order),
+		// or fall back to the empty queue when the rear is also empty.
+		if len(q.rear) == 0 {
+			return q.Empty().(*PersistentQueue)
+		}
+		nf, _ := ListType.Box(q.rear)
+		return &PersistentQueue{front: nf.(*List), count: q.count - 1, meta: q.meta}
+	}
+	return &PersistentQueue{front: f1, rear: q.rear, count: q.count - 1, meta: q.meta}
+}
+
+// Hash implements Hashable — order-sensitive, over the FIFO sequence.
+func (q *PersistentQueue) Hash() uint32 {
+	if q.count == 0 {
+		return 0
+	}
+	return hashOrdered(q.Seq())
+}
+
+// Equals implements value equality — another queue with the same elements in
+// the same FIFO order.
+func (q *PersistentQueue) Equals(other Value) bool {
+	o, ok := other.(*PersistentQueue)
+	if !ok || q.count != o.count {
+		return false
+	}
+	a, b := q.Seq(), o.Seq()
+	for a != nil && a != EmptyList {
+		if !valueEquiv(a.First(), b.First()) {
+			return false
+		}
+		a, b = a.Next(), b.Next()
+	}
+	return true
+}
+
+func (q *PersistentQueue) String() string {
+	b := &strings.Builder{}
+	b.WriteString("#queue (")
+	first := true
+	for s := q.Seq(); s != nil && s != EmptyList; s = s.Next() {
+		if !first {
+			b.WriteRune(' ')
+		}
+		b.WriteString(s.First().String())
+		first = false
+	}
+	b.WriteString(")")
+	return b.String()
+}

--- a/pkg/vm/persistent_queue_test.go
+++ b/pkg/vm/persistent_queue_test.go
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+func mkQueue(vs ...int) *PersistentQueue {
+	var q Collection = EmptyPersistentQueue
+	for _, v := range vs {
+		q = q.Conj(Int(v))
+	}
+	return q.(*PersistentQueue)
+}
+
+func queueElems(q *PersistentQueue) []int {
+	var out []int
+	for s := q.Seq(); s != nil && s != EmptyList; s = s.Next() {
+		out = append(out, int(s.First().(Int)))
+	}
+	return out
+}
+
+func TestQueueEmpty(t *testing.T) {
+	q := EmptyPersistentQueue
+	if q.RawCount() != 0 {
+		t.Fatalf("empty RawCount = %d, want 0", q.RawCount())
+	}
+	if q.Peek() != NIL {
+		t.Fatalf("empty Peek = %v, want NIL", q.Peek())
+	}
+	if q.Pop() != q {
+		t.Fatalf("Pop of empty should return the empty queue unchanged")
+	}
+	if q.Seq() != EmptyList {
+		t.Fatalf("empty Seq should be EmptyList")
+	}
+}
+
+func TestQueueFIFOPeekPop(t *testing.T) {
+	q := mkQueue(1, 2, 3)
+	if got := q.Peek(); got != Int(1) {
+		t.Fatalf("Peek = %v, want 1", got)
+	}
+	if got := q.Pop().Peek(); got != Int(2) {
+		t.Fatalf("Pop().Peek() = %v, want 2", got)
+	}
+	if got := q.Pop().Pop().Peek(); got != Int(3) {
+		t.Fatalf("Pop().Pop().Peek() = %v, want 3", got)
+	}
+	if got := q.RawCount(); got != 3 {
+		t.Fatalf("RawCount = %d, want 3", got)
+	}
+}
+
+func TestQueueImmutable(t *testing.T) {
+	q := mkQueue(1, 2, 3)
+	_ = q.Conj(Int(4))
+	_ = q.Pop()
+	if got := queueElems(q); len(got) != 3 || got[0] != 1 || got[2] != 3 {
+		t.Fatalf("original queue mutated: %v", got)
+	}
+}
+
+func TestQueueConjAppendsRear(t *testing.T) {
+	q := mkQueue(1, 2, 3).Conj(Int(4)).(*PersistentQueue)
+	if got := q.Peek(); got != Int(1) {
+		t.Fatalf("conj should not change the front: Peek = %v, want 1", got)
+	}
+	if got := queueElems(q); len(got) != 4 || got[3] != 4 {
+		t.Fatalf("conj should append to the rear: %v", got)
+	}
+}
+
+// Exercises front/rear rebalancing: pop past the seeded front so the rear is
+// promoted, repeatedly, over a large run.
+func TestQueueFIFOLarge(t *testing.T) {
+	const n = 500
+	q := EmptyPersistentQueue
+	for i := 0; i < n; i++ {
+		q = q.Conj(Int(i)).(*PersistentQueue)
+	}
+	if q.RawCount() != n {
+		t.Fatalf("RawCount = %d, want %d", q.RawCount(), n)
+	}
+	for i := 0; i < n; i++ {
+		if got := q.Peek(); got != Int(i) {
+			t.Fatalf("drain step %d: Peek = %v, want %d", i, got, i)
+		}
+		q = q.Pop()
+	}
+	if q.RawCount() != 0 {
+		t.Fatalf("drained queue RawCount = %d, want 0", q.RawCount())
+	}
+	if q.Peek() != NIL {
+		t.Fatalf("drained queue Peek = %v, want NIL", q.Peek())
+	}
+}
+
+func TestQueueSeqOrder(t *testing.T) {
+	got := queueElems(mkQueue(10, 20, 30))
+	if len(got) != 3 || got[0] != 10 || got[1] != 20 || got[2] != 30 {
+		t.Fatalf("Seq order = %v, want [10 20 30]", got)
+	}
+}
+
+func TestQueueEquals(t *testing.T) {
+	a := mkQueue(1, 2, 3)
+	// Same elements, but built via a conj-then-drain path so the internal
+	// front/rear split differs — Equals must still hold.
+	b := mkQueue(9, 1, 2, 3).Pop()
+	if !a.Equals(b) {
+		t.Fatalf("queues with equal FIFO contents should be Equals")
+	}
+	if a.Equals(mkQueue(1, 2)) {
+		t.Fatalf("queues of different length must not be Equals")
+	}
+	if a.Equals(mkQueue(3, 2, 1)) {
+		t.Fatalf("order-different queues must not be Equals")
+	}
+	if a.Equals(NewList([]Value{Int(1), Int(2), Int(3)})) {
+		t.Fatalf("a queue must not equal a non-queue value")
+	}
+}
+
+func TestQueueType(t *testing.T) {
+	if mkQueue(1).Type() != QueueType {
+		t.Fatalf("queue Type should be QueueType")
+	}
+	if QueueType.Name() != "clojure.lang.PersistentQueue" {
+		t.Fatalf("QueueType.Name = %q", QueueType.Name())
+	}
+}

--- a/test/medley_compat_test.go
+++ b/test/medley_compat_test.go
@@ -34,11 +34,9 @@ func evalMedley(expr string) (vm.Value, error) {
 // reaches on its :clj / :default reader-conditional branches; without the
 // alias the namespace fails to compile with "Can't resolve ...".
 func TestMedleyCompat(t *testing.T) {
-	// clojure.lang.PersistentQueue marker + EMPTY stub.
-	// The marker resolves so (instance? clojure.lang.PersistentQueue x)
-	// compiles; nothing carries the marker as an ancestor, so it is false
-	// (load-only semantics — queue?/queue are degraded).
-	t.Run("PersistentQueue marker instance? is false", func(t *testing.T) {
+	// clojure.lang.PersistentQueue is now a real FIFO queue (vm.PersistentQueue).
+	// A plain vector is not a queue, so instance? is still false for it.
+	t.Run("PersistentQueue instance? is false for a vector", func(t *testing.T) {
 		v, err := evalMedley(`(instance? clojure.lang.PersistentQueue [1 2])`)
 		assert.NoError(t, err)
 		assert.Equal(t, vm.FALSE, v)
@@ -49,12 +47,19 @@ func TestMedleyCompat(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	// EMPTY is a load-only stub bound to a non-collection marker symbol, so
-	// medley's (queue coll) = (into (queue) coll) must FAIL LOUDLY rather than
-	// silently return a reversed list. Conjing onto it errors at runtime.
-	t.Run("PersistentQueue/EMPTY fails loudly when conj'd", func(t *testing.T) {
-		_, err := evalMedley(`(into clojure.lang.PersistentQueue/EMPTY [1 2 3])`)
-		assert.Error(t, err)
+	// EMPTY is now a real empty queue: medley's (queue coll) = (into (queue) coll)
+	// produces a proper FIFO — peek reads the front, and the value reports the
+	// clojure.lang.PersistentQueue marker so medley's queue? is true.
+	t.Run("PersistentQueue/EMPTY conj builds a real FIFO queue", func(t *testing.T) {
+		v, err := evalMedley(`(peek (into clojure.lang.PersistentQueue/EMPTY [1 2 3]))`)
+		assert.NoError(t, err)
+		assert.Equal(t, vm.Int(1), v)
+	})
+
+	t.Run("PersistentQueue instance? is true for a real queue", func(t *testing.T) {
+		v, err := evalMedley(`(instance? clojure.lang.PersistentQueue (into clojure.lang.PersistentQueue/EMPTY [1]))`)
+		assert.NoError(t, err)
+		assert.Equal(t, vm.TRUE, v)
 	})
 
 	// (java.util.ArrayList.) / (java.util.ArrayList. n). medley's

--- a/test/persistent_queue_test.lg
+++ b/test/persistent_queue_test.lg
@@ -1,0 +1,47 @@
+;; clojure.lang.PersistentQueue must be a real FIFO persistent queue, not a
+;; load-only marker. weavejester/dependency's topo-sort (no-comparator path)
+;; seeds a worklist with (into clojure.lang.PersistentQueue/EMPTY leaves) and
+;; drains it with peek/pop.
+(ns test.persistent-queue-test
+  (:require [test :refer :all]))
+
+(def q (into clojure.lang.PersistentQueue/EMPTY [1 2 3]))
+
+(deftest queue-fifo
+  (testing "into seeds a queue and peek reads the front (FIFO)"
+    (is (= 1 (peek q)))
+    (is (= 2 (peek (pop q))))
+    (is (= 3 (peek (pop (pop q))))))
+  (testing "count / seq / empty?"
+    (is (= 3 (count q)))
+    (is (= '(1 2 3) (seq q)))
+    (is (empty? clojure.lang.PersistentQueue/EMPTY))
+    (is (not (empty? q))))
+  (testing "conj appends to the rear, front unchanged"
+    (is (= 1 (peek (conj q 4))))
+    (is (= 4 (count (conj q 4)))))
+  (testing "pop of the last element yields the empty queue"
+    (is (empty? (pop (pop (pop q))))))
+  (testing "instance? recognizes a real queue, not a vector"
+    (is (instance? clojure.lang.PersistentQueue q))
+    (is (not (instance? clojure.lang.PersistentQueue [1 2 3]))))
+  (testing "type resolves through QueueType"
+    (is (= (type q) clojure.lang.PersistentQueue)))
+  (testing "a queue is = to any sequential collection with the same elements"
+    (is (= q '(1 2 3)))
+    (is (= '(1 2 3) q))
+    (is (= q [1 2 3]))
+    (is (= [1 2 3] q))
+    (is (= q (into clojure.lang.PersistentQueue/EMPTY [1 2 3])))
+    (is (not (= q [1 2])))
+    (is (not (= q [3 2 1])))
+    (is (not (= q {:a 1})))))
+
+;; Drain the queue front-to-back, exactly as Kahn's algorithm does.
+(deftest queue-drain-order
+  (testing "peek/pop drain preserves insertion order"
+    (is (= [1 2 3]
+           (loop [c q, out []]
+             (if-let [x (peek c)]
+               (recur (pop c) (conj out x))
+               out))))))


### PR DESCRIPTION
Replaces the load-only `clojure.lang.PersistentQueue/EMPTY` marker stub with a proper immutable FIFO queue (front seq + rear slice, Clojure semantics). Implements Collection + Sequable + Counted, so conj/into/seq/count/empty? work through the existing interfaces; adds peek/pop cases; binds `clojure.lang.PersistentQueue` to `QueueType` so (type q)/instance? resolve through it; and registers the queue in `isSequentialType` so it takes the cross-type sequential-= path like vectors. This also un-degrades medley's queue/queue?. Tests: pkg/vm/persistent_queue_test.go, `test/persistent_queue_test.lg`, and the flipped `medley_compat_test.go` assertion.

Resolves: #418 