### PR TITLE
feat(gogen): math.NaN()/math.Inf() emission + go-ast read/COW import bindings

### DIFF
--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -3641,7 +3641,10 @@
         ;; carriers) with a nil :decl — skip those when collecting decls.
         decls   (filterv some? (mapv (fn [result] (:decl result)) results))
         import-nodes (mapv import-spec-node imports)]
-    (gogen/file pkg import-nodes decls)))
+    ;; gogen may emit math.NaN()/math.Inf() for non-finite float literals; those
+    ;; need the `math` import, which the caller can't know about. Let gogen wire
+    ;; it in (COW) from the assembled File.
+    (gogen/ensure-gen-imports (gogen/file pkg import-nodes decls))))
 
 (defn lower [f mode]
   (if (nil? f)

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-7ce290e1dc2e4951b53603fee0782121c1ad77710a1f7f3253ec74a31eb1b75e
+fce875dd4dce6a95ce7e136f22e5b5eb423e5e55ddb644b331bab4138d99e3fc

--- a/pkg/rt/gogen.go
+++ b/pkg/rt/gogen.go
@@ -26,6 +26,7 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -335,12 +336,36 @@ func cIntLit(v vm.Value) (vm.Value, error) {
 func cFloatLit(v vm.Value) (vm.Value, error) {
 	switch x := v.(type) {
 	case vm.Float:
-		return box(&ast.BasicLit{Kind: token.FLOAT, Value: strconv.FormatFloat(float64(x), 'g', -1, 64)}), nil
+		f := float64(x)
+		// NaN and ±Inf have NO Go literal form — strconv.FormatFloat yields the
+		// bare tokens "NaN" / "+Inf" / "-Inf", which are not valid Go and won't
+		// compile. Emit the math-package call instead; a File that contains such
+		// a call gets the "math" import wired in by ir.lower-go's ensure step
+		// (via gogen/references-pkg? + gogen/add-file-import).
+		if math.IsNaN(f) {
+			return box(mathCallExpr("NaN")), nil
+		}
+		if math.IsInf(f, 1) {
+			return box(mathCallExpr("Inf", &ast.BasicLit{Kind: token.INT, Value: "1"})), nil
+		}
+		if math.IsInf(f, -1) {
+			return box(mathCallExpr("Inf", &ast.BasicLit{Kind: token.INT, Value: "-1"})), nil
+		}
+		return box(&ast.BasicLit{Kind: token.FLOAT, Value: strconv.FormatFloat(f, 'g', -1, 64)}), nil
 	case vm.Int:
 		// Allow Int → float literal coercion for ergonomics: (float-lit 0) emits "0.0".
 		return box(&ast.BasicLit{Kind: token.FLOAT, Value: strconv.FormatFloat(float64(int64(x)), 'g', -1, 64) + ".0"}), nil
 	}
 	return vm.NIL, fmt.Errorf("gogen/float-lit: expected number, got %s", v.Type().Name())
+}
+
+// mathCallExpr builds a `math.<name>(args...)` call expression for the
+// non-finite float literals (NaN, ±Inf) that have no Go literal form.
+func mathCallExpr(name string, args ...ast.Expr) ast.Expr {
+	return &ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: ast.NewIdent("math"), Sel: ast.NewIdent(name)},
+		Args: args,
+	}
 }
 
 func cStringLit(v vm.Value) (vm.Value, error) {
@@ -1688,6 +1713,147 @@ func cFile(pkgV, importsV, declsV vm.Value) (vm.Value, error) {
 	}), nil
 }
 
+// --- go-ast read / COW bindings (for import management in lg) ---------
+//
+// gogen constructors are write-only (build nodes). These add the read + COW
+// operations lg needs to manage imports for the package calls gogen itself
+// introduces (math.NaN / math.Inf for non-finite float literals), without
+// mutating any shared node.
+
+// cReferencesPkg reports whether `node` references package `pkg` via a
+// `pkg.<name>` selector anywhere in its subtree. Read-only: walks the boxed
+// AST, mutates nothing.
+func cReferencesPkg(nodeV, pkgV vm.Value) (vm.Value, error) {
+	n, err := unboxNode(nodeV)
+	if err != nil {
+		return vm.NIL, err
+	}
+	pkg, err := asString(pkgV)
+	if err != nil {
+		return vm.NIL, err
+	}
+	if n == nil {
+		return vm.FALSE, nil
+	}
+	found := false
+	ast.Inspect(n, func(x ast.Node) bool {
+		if found {
+			return false
+		}
+		if sel, ok := x.(*ast.SelectorExpr); ok {
+			if id, ok := sel.X.(*ast.Ident); ok && id.Name == pkg {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	if found {
+		return vm.TRUE, nil
+	}
+	return vm.FALSE, nil
+}
+
+// cFileImportPaths returns the import paths (unquoted) of a *ast.File as a
+// vector of strings. Read-only.
+func cFileImportPaths(fileV vm.Value) (vm.Value, error) {
+	n, err := unboxNode(fileV)
+	if err != nil {
+		return vm.NIL, err
+	}
+	f, ok := n.(*ast.File)
+	if !ok {
+		return vm.NIL, fmt.Errorf("gogen/file-import-paths: expected *ast.File, got %T", n)
+	}
+	var out []vm.Value
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.IMPORT {
+			continue
+		}
+		for _, sp := range gd.Specs {
+			is, ok := sp.(*ast.ImportSpec)
+			if !ok || is.Path == nil {
+				continue
+			}
+			p, uerr := strconv.Unquote(is.Path.Value)
+			if uerr != nil {
+				p = is.Path.Value
+			}
+			out = append(out, vm.String(p))
+		}
+	}
+	return vm.NewArrayVector(out), nil
+}
+
+// cAddFileImport returns a NEW *ast.File with `path` added to its import block.
+// Copy-on-write: the input File and every node it shares are left unmutated —
+// only the File header and the import GenDecl are shallow-copied. Idempotent:
+// if `path` is already imported, an equivalent (structurally-copied) File is
+// returned unchanged.
+func cAddFileImport(fileV, pathV vm.Value) (vm.Value, error) {
+	n, err := unboxNode(fileV)
+	if err != nil {
+		return vm.NIL, err
+	}
+	f, ok := n.(*ast.File)
+	if !ok {
+		return vm.NIL, fmt.Errorf("gogen/add-file-import: expected *ast.File, got %T", n)
+	}
+	path, err := asString(pathV)
+	if err != nil {
+		return vm.NIL, err
+	}
+	quoted := strconv.Quote(path)
+	newDecls := make([]ast.Decl, len(f.Decls))
+	copy(newDecls, f.Decls)
+	importIdx := -1
+	for i, d := range newDecls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.IMPORT {
+			continue
+		}
+		importIdx = i
+		for _, sp := range gd.Specs {
+			if is, ok := sp.(*ast.ImportSpec); ok && is.Path != nil && is.Path.Value == quoted {
+				nf := *f
+				nf.Decls = newDecls
+				return box(&nf), nil // already imported
+			}
+		}
+		break
+	}
+	newSpec := &ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: quoted}}
+	if importIdx >= 0 {
+		old := newDecls[importIdx].(*ast.GenDecl)
+		ngd := *old
+		ngd.Specs = append(append([]ast.Spec{}, old.Specs...), newSpec)
+		newDecls[importIdx] = &ngd
+	} else {
+		newDecls = append([]ast.Decl{&ast.GenDecl{Tok: token.IMPORT, Specs: []ast.Spec{newSpec}}}, newDecls...)
+	}
+	nf := *f
+	nf.Decls = newDecls
+	return box(&nf), nil
+}
+
+// cEnsureGenImports returns a File that imports every package gogen itself may
+// have introduced but the caller could not have declared — currently only
+// "math" (for math.NaN()/math.Inf() from non-finite float literals). Thin glue
+// over the read (references-pkg?) + COW (add-file-import) bindings; native so
+// it resolves in the AOT lowering path without ir.lower-go taking a namespace
+// require on the gogen macro layer (see nooga/let-go#425: self-contain gogen).
+func cEnsureGenImports(fileV vm.Value) (vm.Value, error) {
+	ref, err := cReferencesPkg(fileV, vm.String("math"))
+	if err != nil {
+		return vm.NIL, err
+	}
+	if ref == vm.TRUE {
+		return cAddFileImport(fileV, vm.String("math"))
+	}
+	return fileV, nil
+}
+
 // --- render: the one and only output fn ------------------------------
 
 var goFset = token.NewFileSet()
@@ -1870,6 +2036,10 @@ func installGogenNS() {
 		mk(wrap3Named("multi-assign", cMultiAssign)),
 		mk(wrap3Named("var-decl", cVarDecl)),
 		mk(wrap3Named("file", cFile)),
+		mk(wrap2Named("references-pkg?", cReferencesPkg)),
+		mk(wrap1Named("file-import-paths", cFileImportPaths)),
+		mk(wrap2Named("add-file-import", cAddFileImport)),
+		mk(wrap1Named("ensure-gen-imports", cEnsureGenImports)),
 		mk(wrap3Named("func-lit", cFuncLit)),
 		mk(wrap3Named("switch-stmt", cSwitchStmt)),
 		mk(wrap3Named("type-switch-stmt", cTypeSwitchStmt)),

--- a/pkg/rt/gogen_test.go
+++ b/pkg/rt/gogen_test.go
@@ -6,6 +6,7 @@
 package rt
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -79,6 +80,78 @@ func TestFloatLit(t *testing.T) {
 	got := render(t, node)
 	if got != "3.14" {
 		t.Errorf("got %q, want %q", got, "3.14")
+	}
+}
+
+// Non-finite floats have no Go literal form, so float-lit must emit the
+// math-package call (which gogen/file auto-imports).
+func TestFloatLitNonFinite(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   float64
+		want string
+	}{
+		{"NaN", math.NaN(), "math.NaN()"},
+		{"+Inf", math.Inf(1), "math.Inf(1)"},
+		{"-Inf", math.Inf(-1), "math.Inf(-1)"},
+	} {
+		got := render(t, must(t)(cFloatLit(vm.Float(tc.in))))
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestReferencesPkg(t *testing.T) {
+	nan := must(t)(cFloatLit(vm.Float(math.NaN()))) // math.NaN()
+	if got := must(t)(cReferencesPkg(nan, vm.String("math"))); got != vm.TRUE {
+		t.Errorf("references math?: got %v, want TRUE", got)
+	}
+	if got := must(t)(cReferencesPkg(nan, vm.String("fmt"))); got != vm.FALSE {
+		t.Errorf("references fmt?: got %v, want FALSE", got)
+	}
+}
+
+// add-file-import is copy-on-write and idempotent; the input File must not be
+// mutated.
+func TestAddFileImportCOW(t *testing.T) {
+	fmtImp := must(t)(cImportSpec(vm.String("fmt")))
+	nan := must(t)(cFloatLit(vm.Float(math.NaN())))
+	fn := must(t)(cFuncDecl(vm.String("F"), vm.NIL,
+		vm.NewArrayVector([]vm.Value{must(t)(cResult(must(t)(cType(vm.String("float64")))))}),
+		vm.NewArrayVector([]vm.Value{must(t)(cReturn(vm.NewArrayVector([]vm.Value{nan})))})))
+	file := must(t)(cFile(vm.String("p"),
+		vm.NewArrayVector([]vm.Value{fmtImp}),
+		vm.NewArrayVector([]vm.Value{fn})))
+
+	pathsOf := func(f vm.Value) []string {
+		v := must(t)(cFileImportPaths(f)).(vm.ArrayVector)
+		out := make([]string, len(v))
+		for i, s := range v {
+			out[i] = string(s.(vm.String))
+		}
+		return out
+	}
+	if got := strings.Join(pathsOf(file), ","); got != "fmt" {
+		t.Fatalf("initial imports: got %q, want fmt", got)
+	}
+	added := must(t)(cAddFileImport(file, vm.String("math")))
+	if got := strings.Join(pathsOf(added), ","); got != "fmt,math" {
+		t.Errorf("after add: got %q, want fmt,math", got)
+	}
+	// COW: original unchanged.
+	if got := strings.Join(pathsOf(file), ","); got != "fmt" {
+		t.Errorf("COW violated — original mutated to %q", got)
+	}
+	// Idempotent.
+	twice := must(t)(cAddFileImport(added, vm.String("math")))
+	if got := strings.Join(pathsOf(twice), ","); got != "fmt,math" {
+		t.Errorf("idempotent add: got %q, want fmt,math", got)
+	}
+	// Rendered output compiles-shaped: has the import and the call.
+	out := render(t, added)
+	if !strings.Contains(out, `"math"`) || !strings.Contains(out, "math.NaN()") {
+		t.Errorf("rendered output missing math import or call:\n%s", out)
 	}
 }
 

--- a/test/gogen_math_import_test.lg
+++ b/test/gogen_math_import_test.lg
@@ -1,0 +1,46 @@
+;; Tests for gogen's non-finite float emission (math.NaN/math.Inf) and the
+;; go-ast read/COW import bindings that wire the `math` import in.
+(ns test.gogen-math-import-test
+  (:require
+   [gogen]
+   [test :refer :all]))
+
+(defn- float-fn [ret-lit]
+  ;; A one-decl File: func F() float64 { return <ret-lit> }
+  (gogen/file "p" []
+    [(gogen/func-decl "F" [] [(gogen/result (gogen/type "float64"))]
+       [(gogen/return-stmt [ret-lit])])]))
+
+(deftest float-lit-nonfinite-test
+  (testing "non-finite floats have no Go literal form -> math.* calls"
+    (is (= "math.NaN()"    (gogen/render (gogen/float-lit (/ 0.0 0.0)))))
+    (is (= "math.Inf(1)"   (gogen/render (gogen/float-lit (/ 1.0 0.0)))))
+    (is (= "math.Inf(-1)"  (gogen/render (gogen/float-lit (/ -1.0 0.0))))))
+  (testing "finite floats unchanged"
+    (is (= "3.14" (gogen/render (gogen/float-lit 3.14))))
+    (is (= "0.5"  (gogen/render (gogen/float-lit 0.5))))))
+
+(deftest references-pkg-test
+  (testing "references-pkg? detects a pkg.X selector, read-only"
+    (let [f (float-fn (gogen/float-lit (/ 0.0 0.0)))]
+      (is (= true  (gogen/references-pkg? f "math")))
+      (is (= false (gogen/references-pkg? f "fmt"))))))
+
+(deftest add-file-import-cow-test
+  (testing "add-file-import is copy-on-write and idempotent"
+    (let [f0 (float-fn (gogen/float-lit (/ 0.0 0.0)))
+          f1 (gogen/add-file-import f0 "math")]
+      (is (= [] (gogen/file-import-paths f0)))        ; original unmutated (COW)
+      (is (= ["math"] (gogen/file-import-paths f1)))
+      (is (= ["math"] (gogen/file-import-paths (gogen/add-file-import f1 "math")))))))
+
+(deftest ensure-gen-imports-test
+  (testing "ensure-gen-imports adds math when a non-finite literal is present"
+    (let [f (gogen/ensure-gen-imports (float-fn (gogen/float-lit (/ 0.0 0.0))))
+          out (gogen/render f)]
+      (is (= ["math"] (gogen/file-import-paths f)))
+      (is (>= (index-of out "import \"math\"") 0))
+      (is (>= (index-of out "math.NaN()") 0))))
+  (testing "ensure-gen-imports is a no-op without a non-finite literal"
+    (let [f (gogen/ensure-gen-imports (float-fn (gogen/float-lit 1.5)))]
+      (is (= [] (gogen/file-import-paths f))))))


### PR DESCRIPTION
## Stacked on #387

**This is stacked on #387** (`feat/ir-lowering-strategy`). Until #387 merges, the commit list/diff here includes #387's commits — the substantive change in *this* PR is the single top commit `feat(gogen): emit math.NaN()/math.Inf()…`. Review/merge after #387.

## What

`gogen/float-lit` rendered NaN/±Inf as the bare tokens `strconv.FormatFloat` produces (`NaN`, `+Inf`, `-Inf`) — none of which are valid Go, so any lowered fn that inlined a non-finite float constant would emit uncompilable output. This PR:

1. **Emit `math.NaN()` / `math.Inf(1)` / `math.Inf(-1)`** for non-finite floats (finite floats byte-identical).
2. **go-ast read/COW bindings** (the reusable primitives, usable from lg):
   - `(gogen/references-pkg? node pkg)` — read: does the subtree reference `pkg.X`?
   - `(gogen/file-import-paths file)` — read: the file's import paths
   - `(gogen/add-file-import file path)` — **copy-on-write**: a new File with the import added; input never mutated; idempotent
   - `(gogen/ensure-gen-imports file)` — wires in the imports gogen itself introduced (currently just `math`)
3. **`ir.lower-go/file`** runs `ensure-gen-imports` over each assembled File. It calls the **native** gogen binding rather than taking a namespace `require` on the gogen macro layer, so the AOT-lowered lowering path stays self-contained (see #425).

## Why not fold the import scan into `cFile`

An ad-hoc `ast.Inspect` buried in the file constructor is invisible and hard to test. Proper read + COW go-ast bindings make the manipulation explicit, reusable, and unit-testable from lg.

## Tests

- `pkg/rt/gogen_test.go`: NaN/Inf emission, `references-pkg?`, `add-file-import` COW + idempotence + render.
- `test/gogen_math_import_test.lg`: end-to-end through the lg bindings (build File with a NaN literal → `ensure-gen-imports` → renders `import "math"` + `math.NaN()`; COW leaves the original unchanged).
- `make check-generated` green (lowered tree compiles + dispatches natively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)