### PR TITLE
feat(ir): reach typed natives from runtime values

### DIFF
--- a/pkg/ir/lisp_crossns_directcall_test.go
+++ b/pkg/ir/lisp_crossns_directcall_test.go
@@ -61,24 +61,31 @@ func TestCrossNsLoweredDirectCallEmit(t *testing.T) {
 // leaked, unused import makes the emitted file fail to compile. Regression for
 // recording the import in lookup-direct-callable (before coercion) rather than
 // after emission succeeds.
+//
+// An UNPROVEN vm.Value arg into a scalar param no longer falls back: it takes
+// the guarded comma-ok path, which emits the static call and rightly records
+// the import (see TestCrossNsDirectCallGuardedRecordsImport). What still bails
+// whole-call is a PROVEN-mismatched scalar; here the arg is proven int
+// ((+ x 1) forces the int constraint) against a "string" param.
 func TestCrossNsDirectCallFallbackDoesNotLeakImport(t *testing.T) {
 	ensureLoader()
 	runLispExpr(t, `(do (create-ns (quote leakns)) (intern (quote leakns) (quote callee)))`)
 	runLispExpr(t, `(def lg-test-leak-imports (atom #{}))`)
 
-	fn := buildLispIR(t, `(defn lcaller [x] (leakns/callee x))`)
+	fn := buildLispIR(t, `(defn lcaller [x] (leakns/callee (+ x 1)))`)
 	optimizeLispIR(t, fn)
 	passVarCounter++
 	varName := fmt.Sprintf("*xns-leak-fn-%d*", passVarCounter)
 	rt.NS(rt.NameCoreNS).Def(varName, fn)
 
-	// Entry with a scalar "int" param: passes lookup's supported-coercion-type?
-	// gate, but coerce-arg-to-type returns nil for the unproven vm.Value arg x,
+	// Entry with a scalar "string" param: passes lookup's
+	// supported-coercion-type? gate, but coerce-arg-to-type returns nil for
+	// the proven-int arg (mismatched concrete scalar, no guard possible),
 	// forcing the trampoline fallback.
 	v := runLispExpr(t, fmt.Sprintf(`
 	  (let [reg {(ir.lower-go/registry-key (quote leakns) "callee" 1)
 	             {:go-name "Callee" :arity 1 :needs-error? false
-	              :param-specs ["int"] :result-spec "vm.Value"
+	              :param-specs ["string"] :result-spec "vm.Value"
 	              :native? false
 	              :go-pkg "github.com/nooga/let-go/pkg/rt/core_go_lowered/leakns"}}]
 	    (binding [ir.lower-go/*lowered-registry* reg
@@ -93,10 +100,54 @@ func TestCrossNsDirectCallFallbackDoesNotLeakImport(t *testing.T) {
 	// Sanity: the call really did fall back to the trampoline (otherwise the
 	// import-empty assertion below would be vacuous).
 	if !strings.Contains(rendered, "InvokeValue") && !strings.Contains(rendered, "CachedVarFn") {
-		t.Fatalf("expected a trampoline fallback for an uncoercible int param:\n--- go ---\n%s", rendered)
+		t.Fatalf("expected a trampoline fallback for an uncoercible string param:\n--- go ---\n%s", rendered)
 	}
 	// The fix: no import recorded when emission fell back.
 	if imports := string(runLispExpr(t, `(pr-str (deref lg-test-leak-imports))`).(vm.String)); imports != "#{}" {
 		t.Fatalf("fallback leaked an import: *native-imports-used* = %s, want #{}", imports)
+	}
+}
+
+// The complement of the leak test: an unproven vm.Value arg into an int param
+// takes the guarded comma-ok path — the static call IS emitted (inside the
+// guard) alongside the trampoline fallback branch, so recording the callee's
+// import is required for the file to compile.
+func TestCrossNsDirectCallGuardedRecordsImport(t *testing.T) {
+	ensureLoader()
+	runLispExpr(t, `(do (create-ns (quote guardns)) (intern (quote guardns) (quote callee)))`)
+	runLispExpr(t, `(def lg-test-guard-imports (atom #{}))`)
+
+	fn := buildLispIR(t, `(defn gcaller [x] (guardns/callee x))`)
+	optimizeLispIR(t, fn)
+	passVarCounter++
+	varName := fmt.Sprintf("*xns-guard-fn-%d*", passVarCounter)
+	rt.NS(rt.NameCoreNS).Def(varName, fn)
+
+	v := runLispExpr(t, fmt.Sprintf(`
+	  (let [reg {(ir.lower-go/registry-key (quote guardns) "callee" 1)
+	             {:go-name "Callee" :arity 1 :needs-error? false
+	              :param-specs ["int"] :result-spec "vm.Value"
+	              :native? false
+	              :go-pkg "github.com/nooga/let-go/pkg/rt/core_go_lowered/guardns"}}]
+	    (binding [ir.lower-go/*lowered-registry* reg
+	              ir.lower-go/*native-imports-used* lg-test-guard-imports]
+	      (ir.lower-go/lower %s :strict)))`, varName))
+	m, ok := v.(*vm.PersistentMap)
+	if !ok {
+		t.Fatalf("expected lower to return a map, got %T", v)
+	}
+	rendered := bindAndRenderGoDecl(t, m)
+
+	if !strings.Contains(rendered, ".(vm.Int)") {
+		t.Fatalf("expected a comma-ok vm.Int guard:\n--- go ---\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "guardns.Callee(ec, int(") {
+		t.Fatalf("expected the guarded static call guardns.Callee(ec, int(...)):\n--- go ---\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "InvokeValue") && !strings.Contains(rendered, "CachedVarFn") {
+		t.Fatalf("expected a trampoline fallback branch:\n--- go ---\n%s", rendered)
+	}
+	if imports := string(runLispExpr(t, `(pr-str (deref lg-test-guard-imports))`).(vm.String)); !strings.Contains(imports, "guardns") {
+		t.Fatalf("guarded emission must record the callee import, got %s", imports)
 	}
 }

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -1533,14 +1533,30 @@
         (some (fn [dns] (resolve-registry-entry registry dns name-str arity))
               referred-default-ns-syms))))
 
-(defn- coerce-arg-to-type
-  "Emit a Go expression that produces a value of `target-type` from
-   arg id `rid`. If typeinfer already typed rid as the matching Go
-   type, pass the value through unchanged; otherwise wrap with the
-   appropriate `<type>(arg.(vm.<Boxed>))` unbox.
+(def ^:private scalar-guard-specs
+  ;; target-spec -> [assert-type conversion] for the guarded coercion
+  ;; of an unproven vm.Value into a typed scalar param. bool uses a
+  ;; guarded vm.Boolean assert (NOT vm.IsTruthy): strictly
+  ;; conservative: a non-Boolean falls to the trampoline instead of
+  ;; silently becoming truthy.
+  {"int"     ["vm.Int"     "int"]
+   "int64"   ["vm.Int"     "int64"]
+   "float64" ["vm.Float"   "float64"]
+   "string"  ["vm.String"  "string"]
+   "bool"    ["vm.Boolean" "bool"]})
 
-   Returns nil when target-type is outside the supported set —
-   call-assign-stmts uses that to fall back to the trampoline."
+(defn- coerce-arg-to-type
+  "Coercion descriptor producing a value of `target-type` from arg id
+   `rid`:
+     {:expr e}    emit e directly (proven/boxable, as before)
+     {:guard {:boxed b :assert-spec s :conv c}}
+                  unproven vm.Value into a typed scalar: the caller
+                  must emit a comma-ok type assert on b and guard the
+                  static call, falling back to the trampoline when
+                  the runtime type does not match (preserving the
+                  bytecode path's dynamic semantics)
+     nil          whole-call bail; call-assign-stmts falls back to
+                  the trampoline as before."
   [f closed-exprs rid target-type]
   (let [src-spec (go-type-spec (ir/type-of rid f))
         bare     (value-expr f closed-exprs rid)
@@ -1548,20 +1564,22 @@
     (cond
       (nil? bare) nil
       (= target-type "vm.Value")
-      boxed
+      {:expr boxed}
       (= src-spec target-type)
       ;; typeinfer landed on the same Go type already — pass through.
-      bare
+      {:expr bare}
       ;; *T (deftype) — devirtualized constructor/method calls prove the dtype
       ;; upstream, so the pointer assert is sound.
       (and (string? target-type) (pos? (count target-type)) (= \* (nth target-type 0)))
-      (gogen/type-assert boxed (gogen/type target-type))
-      ;; A typed SCALAR param (int/int64/float64/bool/string) is only sound to
-      ;; pass when the arg is PROVEN that type — handled by the src==target
-      ;; pass-through above. An unchecked unbox-assert on an unproven vm.Value
-      ;; would change dynamic semantics (runtime panic vs the bytecode path's
-      ;; graceful handling), so fall back to the trampoline (return nil) instead
-      ;; of emitting `int(x.(vm.Int))` against an unproven value.
+      {:expr (gogen/type-assert boxed (gogen/type target-type))}
+      ;; Unproven vm.Value into a typed scalar param: guarded runtime
+      ;; coercion. The assert is only legal Go when the source expr is
+      ;; interface-typed, i.e. src-spec vm.Value; a proven-mismatched
+      ;; scalar (concrete Go type) still bails below.
+      (and (= src-spec "vm.Value") (contains? scalar-guard-specs target-type))
+      (let [[assert-spec conv] (get scalar-guard-specs target-type)]
+        {:guard {:boxed boxed :assert-spec assert-spec :conv conv}})
+      ;; Proven-mismatched scalars etc.: fall back to the trampoline.
       :else nil)))
 
 (defn- box-result-from-type
@@ -1620,19 +1638,14 @@
                                   nil)]
     [assign err-check]))
 
-(defn- emit-typed-direct-call
-  "Direct-call emit with per-arg coercion + result boxing. Branches on
-   the call entry's typed signature (param-specs + result-spec). Falls
-   back gracefully (returns nothing) when any arg can't be coerced —
-   call-assign-stmts then skips this branch and the next cond handles
-   the trampoline path."
-  [f closed-exprs nid target refs entry]
-  (let [arg-rids   (rest refs)
-        param-specs (vec (:param-specs entry))
-        result-spec (:result-spec entry)
-        coerced    (mapv (fn [rid spec] (coerce-arg-to-type f closed-exprs rid spec))
-                         arg-rids
-                         param-specs)
+(defn- typed-call-result-stmts
+  "The static-call statement sequence for one direct call, given the
+   already-coerced arg expressions: builds the call and handles the
+   four result shapes. Registers tr<nid>/te<nid> function-scoped
+   temps as a side effect (goto-CFG safety, see *typed-call-temps*),
+   so call it only when the statements WILL be emitted."
+  [f nid target entry arg-exprs]
+  (let [result-spec (:result-spec entry)
         ;; A :go-pkg means the callee lives in ANOTHER Go package — a native
         ;; module (:native?) OR a cross-ns lowered sibling — so qualify the call
         ;; `pkg.Fn` and import that package. Intra-ns lowered siblings (no
@@ -1642,57 +1655,130 @@
                          (gogen/ident (pkg-alias-from (:go-pkg entry)))
                          (:go-name entry))
                        (gogen/ident (:go-name entry)))
+        ;; A direct call to another LOWERED let-go fn (intra- OR cross-ns) passes
+        ;; ec as its first arg; native Go-module fns (:native?) are context-free.
+        call-args (if (:native? entry)
+                    arg-exprs
+                    (into [(gogen/ident "ec")] arg-exprs))
+        raw-call (gogen/call callee-ident call-args)]
+    (cond
+      ;; (vm.Value, error) — current shape. Keep the existing
+      ;; assign + err-check path.
+      (and (= result-spec "vm.Value") (:needs-error? entry))
+      (emit-call-stmts f target raw-call)
+      ;; Typed result + no error: result := <call>; target = vm.<Box>(result)
+      (and (not (:needs-error? entry))
+           (not= result-spec "vm.Value"))
+      (let [boxed (box-result-from-type raw-call result-spec)]
+        [(gogen/assign "=" target boxed)])
+      ;; Typed result + error: tr<nid>, te<nid> = <call>; if err return;
+      ;; target = vm.<Box>(tr<nid>). The intermediate result+err vars are
+      ;; FUNCTION-scoped (registered via register-typed-call-temp! and
+      ;; emitted as `var` in the prologue), assigned here with `=` — NOT an
+      ;; inline `:=`. The body is a goto-CFG, and a goto that jumps over an
+      ;; in-scope `:=` declaration is illegal Go ("goto jumps over
+      ;; declaration"); function-scope `var` + `=` is goto-safe, matching
+      ;; every other temp. Names are keyed by the node's Indexed-RPN
+      ;; position nid (positional → stable + unique across regens).
+      (and (:needs-error? entry)
+           (not= result-spec "vm.Value"))
+      (let [res-id (gogen/ident (str "tr" nid))
+            err-id (gogen/ident (str "te" nid))
+            _ (register-typed-call-temp! (str "tr" nid) result-spec)
+            _ (register-typed-call-temp! (str "te" nid) "error")
+            assign (gogen/multi-assign "=" [res-id err-id] [raw-call])
+            zero-expr (case (function-return-spec f)
+                        "bool"    (gogen/ident "false")
+                        "int"     (gogen/int-lit 0)
+                        "float64" (gogen/float-lit 0.0)
+                        "string"  (gogen/string-lit "")
+                        (gogen/ident "nil"))
+            err-check (gogen/if-stmt nil
+                                     (gogen/binary "!=" err-id (gogen/ident "nil"))
+                                     [(gogen/return-stmt [zero-expr err-id])]
+                                     nil)
+            boxed (box-result-from-type res-id result-spec)
+            box-assign (gogen/assign "=" target boxed)]
+        [assign err-check box-assign])
+      ;; vm.Value result, no error: target = <call>
+      (= result-spec "vm.Value")
+      [(gogen/assign "=" target raw-call)]
+      :else nil)))
+
+(declare trampoline-call-stmts)
+
+(defn- emit-typed-direct-call
+  "Direct-call emit with per-arg coercion + result boxing. Branches on
+   the call entry's typed signature (param-specs + result-spec).
+
+   Proven args emit the flat static call exactly as before. An
+   UNPROVEN vm.Value arg into a typed scalar param emits a GUARDED
+   call: comma-ok type asserts on the boxed args, the static call
+   when every assert holds, and the identical trampoline fallback
+   (same statements the caller would otherwise emit) when a runtime
+   type does not match, so dynamic semantics are unchanged and the
+   typed native callee becomes reachable from runtime values.
+
+   Falls back gracefully (returns nothing) when any arg can't be
+   coerced at all — call-assign-stmts then handles the trampoline."
+  [f closed-exprs nid target refs entry]
+  (let [arg-rids    (rest refs)
+        param-specs (vec (:param-specs entry))
+        descs       (mapv (fn [rid spec]
+                            (coerce-arg-to-type f closed-exprs rid spec))
+                          arg-rids
+                          param-specs)
+        tmp-name    (fn [i] (str "tg" nid "_" i))
+        ok-name     (fn [i] (str "tk" nid "_" i))
         stmts
-        (when (every? identity coerced)
-          ;; A direct call to another LOWERED let-go fn (intra- OR cross-ns) passes
-          ;; ec as its first arg; native Go-module fns (:native?) are context-free.
-          (let [call-args (if (:native? entry)
-                            coerced
-                            (into [(gogen/ident "ec")] coerced))
-                raw-call (gogen/call callee-ident call-args)]
-            (cond
-              ;; (vm.Value, error) — current shape. Keep the existing
-              ;; assign + err-check path.
-              (and (= result-spec "vm.Value") (:needs-error? entry))
-              (emit-call-stmts f target raw-call)
-              ;; Typed result + no error: result := <call>; target = vm.<Box>(result)
-              (and (not (:needs-error? entry))
-                   (not= result-spec "vm.Value"))
-              (let [boxed (box-result-from-type raw-call result-spec)]
-                [(gogen/assign "=" target boxed)])
-              ;; Typed result + error: tr<nid>, te<nid> = <call>; if err return;
-              ;; target = vm.<Box>(tr<nid>). The intermediate result+err vars are
-              ;; FUNCTION-scoped (registered via register-typed-call-temp! and
-              ;; emitted as `var` in the prologue), assigned here with `=` — NOT an
-              ;; inline `:=`. The body is a goto-CFG, and a goto that jumps over an
-              ;; in-scope `:=` declaration is illegal Go ("goto jumps over
-              ;; declaration"); function-scope `var` + `=` is goto-safe, matching
-              ;; every other temp. Names are keyed by the node's Indexed-RPN
-              ;; position nid (positional → stable + unique across regens).
-              (and (:needs-error? entry)
-                   (not= result-spec "vm.Value"))
-              (let [res-id (gogen/ident (str "tr" nid))
-                    err-id (gogen/ident (str "te" nid))
-                    _ (register-typed-call-temp! (str "tr" nid) result-spec)
-                    _ (register-typed-call-temp! (str "te" nid) "error")
-                    assign (gogen/multi-assign "=" [res-id err-id] [raw-call])
-                    zero-expr (case (function-return-spec f)
-                                "bool"    (gogen/ident "false")
-                                "int"     (gogen/int-lit 0)
-                                "float64" (gogen/float-lit 0.0)
-                                "string"  (gogen/string-lit "")
-                                (gogen/ident "nil"))
-                    err-check (gogen/if-stmt nil
-                                             (gogen/binary "!=" err-id (gogen/ident "nil"))
-                                             [(gogen/return-stmt [zero-expr err-id])]
-                                             nil)
-                    boxed (box-result-from-type res-id result-spec)
-                    box-assign (gogen/assign "=" target boxed)]
-                [assign err-check box-assign])
-              ;; vm.Value result, no error: target = <call>
-              (= result-spec "vm.Value")
-              [(gogen/assign "=" target raw-call)]
-              :else nil)))]
+        (when (every? identity descs)
+          (let [guard-idx (filterv (fn [i] (:guard (nth descs i)))
+                                   (range (count descs)))
+                arg-exprs (vec (map-indexed
+                                 (fn [i d]
+                                   (if-let [g (:guard d)]
+                                     (gogen/call (gogen/ident (:conv g))
+                                                 [(gogen/ident (tmp-name i))])
+                                     (:expr d)))
+                                 descs))]
+            (if (empty? guard-idx)
+              ;; No guards: today's flat emission, byte-identical.
+              (typed-call-result-stmts f nid target entry arg-exprs)
+              ;; Guarded: build the fallback FIRST, then the static
+              ;; branch, and only register the guard temps once both
+              ;; are known non-nil; registering earlier would leak
+              ;; unused function-scoped var decls (Go compile error).
+              (let [fallback (trampoline-call-stmts f closed-exprs nid
+                                                    target refs)]
+                (when fallback
+                  (let [then (typed-call-result-stmts f nid target
+                                                      entry arg-exprs)]
+                    (when then
+                      (doseq [i guard-idx]
+                        (let [g (:guard (nth descs i))]
+                          (register-typed-call-temp!
+                            (tmp-name i) (:assert-spec g))
+                          (register-typed-call-temp!
+                            (ok-name i) "bool")))
+                      (let [asserts
+                            (mapv (fn [i]
+                                    (let [g (:guard (nth descs i))]
+                                      (gogen/multi-assign "="
+                                        [(gogen/ident (tmp-name i))
+                                         (gogen/ident (ok-name i))]
+                                        [(gogen/type-assert
+                                           (:boxed g)
+                                           (gogen/type (:assert-spec g)))])))
+                                  guard-idx)
+                            cond-e
+                            (reduce (fn [a i]
+                                      (gogen/binary
+                                        "&&" a (gogen/ident (ok-name i))))
+                                    (gogen/ident (ok-name (first guard-idx)))
+                                    (rest guard-idx))]
+                        (conj asserts
+                              (gogen/if-stmt nil cond-e
+                                             then fallback))))))))))]
     (when stmts
       ;; Record the callee's Go import only now that emission has actually
       ;; produced statements. Doing it in lookup-direct-callable (before
@@ -2958,13 +3044,17 @@
                         (conj decls0 (gogen/var-decl "callErr" (gogen/type "error") nil))
                         decls0)
                ;; Function-scope `var` decls for typed direct-call result/error
-               ;; temps (tr<nid>/te<nid>), collected during body build. Emitting
-               ;; them at the top (not inline `:=`) keeps gotos that jump over the
-               ;; call site legal — see *typed-call-temps*.
+               ;; temps (tr<nid>/te<nid> and guard temps tg/tk<nid>_<i>),
+               ;; collected during body build. Emitting them at the top (not
+               ;; inline `:=`) keeps gotos that jump over the call site legal;
+               ;; see *typed-call-temps*. distinct: the structured attempt and
+               ;; the goto rebuild both run under one binding, so a call
+               ;; lowered in both attempts registers its temps twice, which
+               ;; would emit duplicate (redeclared) var decls.
                decls1 (reduce (fn [acc [nm go-type]]
                                 (conj acc (gogen/var-decl nm (gogen/type go-type) nil)))
                               decls1
-                              @*typed-call-temps*)
+                              (distinct @*typed-call-temps*))
                [arg-decls arg-inits] (if needs-tail-call?
                                        (arg-local-decls f)
                                        [[] []])

--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -1078,7 +1078,21 @@
                                  (conj acc (assoc (:result entry) :multi-arity? true))
                                  (:fn entry)
                                  (conj acc {:status :lowered :decl (:fn entry) :imports []})
-                                 :else acc))
+                                 :else
+                                 ;; A fallen-back arity has neither :result
+                                 ;; nor :fn; warn like the single-arity
+                                 ;; branch below instead of dropping it with
+                                 ;; no trace.
+                                 (do
+                                   (println (str "WARNING: not lowered ("
+                                                 (pr-str (:status entry))
+                                                 ") for arity of "
+                                                 (pr-str (try (second form)
+                                                              (catch _ form)))
+                                                 (if (:reason entry)
+                                                   (str ": " (:reason entry))
+                                                   "")))
+                                   acc)))
                              []
                              (:fns result))]
             (recur (rest remaining) (into out flat)))

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-171d46ca91f8ce57582731510ab32bf581eb2babb9938b783df4b88edd6a1adf
+911a69f8120b047bd9bb343450bb8225cf81fe9f52de3d0e9fda7b82c5055c39

--- a/scripts/lg-compile
+++ b/scripts/lg-compile
@@ -40,12 +40,14 @@
 (defn read-all [path]
   (read-string (str "(do " (slurp path) "\n)")))
 
-(defn single-arity-defn? [f] (boolean (some vector? (drop 2 f))))
-
 (defn lowerable? [f]
+  ;; Multi-arity defns lower too: the pipeline splits arities into
+  ;; independent per-arity units (<Name>_<arity> Go funcs, per-arity
+  ;; direct-call registry entries, and a len(args)-switch override
+  ;; adapter when every arity is uniform vm.Value).
   (and (seq? f)
        (let [h (first f)]
-         (or (and (or (= h 'defn) (= h 'defn-)) (single-arity-defn? f))
+         (or (= h 'defn) (= h 'defn-)
              (= h 'defmulti) (= h 'defmethod)))))
 
 (defn find-ns-name [forms]

--- a/test/direct_call_test.lg
+++ b/test/direct_call_test.lg
@@ -321,3 +321,36 @@
       (is (str/includes? starved "func BudgetCountdown(")
           (str "the budget_countdown entry point must survive a starved budget; got:\n"
                starved)))))
+
+;; --- guarded typed-boundary coercion ------------------------------------
+
+(deftest opaque-arg-to-typed-callee-emits-guarded-static-call
+  (testing "unproven vm.Value arg into an int-typed callee gets a comma-ok
+            guard + static call + trampoline fallback (not a whole-call bail)"
+    (let [src (compile-ns
+                ['(defn gfib [n] (if (< n 2) n (+ (gfib (- n 1)) (gfib (- n 2)))))
+                 '(defn gfib-opaque [x] (gfib x))])
+          caller (caller-body src "GfibOpaque")
+          callee (caller-body src "Gfib")]
+      (is caller "caller body extractable")
+      (is (str/includes? caller ".(vm.Int)") "comma-ok assert on the opaque arg")
+      (is (str/includes? caller "Gfib(ec, int(") "guarded static call with int conversion")
+      (is (str/includes? caller "rt.CachedVarFn(") "trampoline fallback in else branch")
+      (is callee "callee body extractable")
+      (is (not (str/includes? callee ".(vm.Int)"))
+          "proven-int self-recursive args stay flat (no guard)"))))
+
+(deftest multi-arity-defn-lowers-with-guarded-chain
+  (testing "multi-arity defn lowers per arity; the value-typed arity reaches
+            the typed sibling through the guarded static call"
+    (let [src (compile-ns
+                ['(defn mfib [n] (if (< n 2) n (+ (mfib (- n 1)) (mfib (- n 2)))))
+                 '(defn mmain ([n] (mfib n)) ([] (mmain 21)))])]
+      (is (str/includes? src "func Mmain_1(") "arity-1 helper emitted")
+      (is (str/includes? src "func Mmain_0(") "arity-0 helper emitted")
+      (let [a0 (caller-body src "Mmain_0")]
+        (is (str/includes? a0 "Mmain_1(ec, vm.Int(21))")
+            "cross-arity self-call is static"))
+      (let [a1 (caller-body src "Mmain_1")]
+        (is (str/includes? a1 "Mfib(ec, int(")
+            "guarded static call into the typed sibling")))))

--- a/test/gold-aot/typed_cross_fn.lg
+++ b/test/gold-aot/typed_cross_fn.lg
@@ -1,0 +1,12 @@
+;; Typed direct-call boundary semantics. tfib's body types its param
+;; int, so a lowered caller passing an opaque vm.Value goes through
+;; the guarded coercion: static native call when the runtime value is
+;; a vm.Int, identical trampoline fallback otherwise. Both engines
+;; must agree on all three cases: int (guard hit), keyword (guard
+;; miss, bytecode type error, caught), float (guard miss, bytecode
+;; float arithmetic).
+(defn tfib [n] (if (< n 2) n (+ (tfib (- n 1)) (tfib (- n 2)))))
+(defn tfib-opaque [x] (tfib x))
+(println (tfib-opaque 20))
+(println (try (tfib-opaque :kw) (catch e "type-error")))
+(println (tfib-opaque 2.5))


### PR DESCRIPTION
Two gaps kept lowered typed fns unreachable from values that only exist at runtime (CLI args, collection elements):

1. Guarded coercion at typed direct-call boundaries. A lowered caller passing an unproven vm.Value into a typed sibling now emits a comma-ok type assert with the static native call on match and the identical trampoline fallback on miss, instead of abandoning the static call (which landed on the bytecode callee, since typed fns are not override-registered). Proven args, e.g. int-typed self-recursion, keep the flat emission and pay no guard. Also dedupe the function-scoped temp decls in the prologue: the structured attempt and the goto rebuild both register temps for a call lowered in both passes, which emitted duplicate var decls.

2. scripts/lg-compile now passes multi-arity defns to the pipeline, which already splits them into per-arity <Name>_<arity> funcs with static cross-arity calls and a len(args)-switch override adapter. The per-arity flatten also warns when an arity falls back instead of dropping it silently.

Together these let a lowered entry chain like -main -> main_1 -> fib(n int) run natively when fed CLI input: fib(34) via that chain drops from 1.18s (all bytecode) to 0.08s.