### PR TITLE
feat(lgbgen): self-hosting lowering — Go overrides + check-selfhost target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,30 @@ perf-snapshot: lowered $(GO)
 lowered: $(GO)
 	@go run -tags bootstrap ./cmd/lgbgen --target=go >/dev/null
 
+# Self-hosting (3b + 4): re-lower the whole core with the NATIVE compiler and
+# verify the fixpoint. `lowered` (3a) bootstraps the tree from source with the
+# interpreted passes; here we build lgbgen -tags "bootstrap gogen_ir" so the
+# lowering pipeline runs on THAT tree's native passes, re-lower everything
+# (including the passes themselves), and byte-compare against the committed
+# tree. Byte-identical = the native compiler reproduces its own output, so the
+# passes are correct native code AND fast enough to self-host (bench-ratchet
+# IRCompile: native ~16% faster than bytecode). A diff means a pass changed and
+# the tree is stale relative to source — re-run `make lowered` (3a) first.
+.PHONY: check-selfhost
+check-selfhost: lowered $(GO)
+	@echo ">> 3b: build native-passes lgbgen (-tags 'bootstrap gogen_ir')"
+	@go build -tags "bootstrap gogen_ir" -o .selfhost-lgbgen ./cmd/lgbgen
+	@echo ">> 3b: re-lower the whole core with the NATIVE compiler"
+	@tmp=$$(mktemp -d); ./.selfhost-lgbgen --target=go "$$tmp" >/dev/null; \
+	echo ">> 4: fixpoint — native re-lowering vs the committed tree"; \
+	if diff -rq "$$tmp" pkg/rt/core_go_lowered >/dev/null 2>&1; then \
+		echo "OK: native self-hosting fixpoint holds (byte-identical)."; rc=0; \
+	else \
+		echo "FAIL: native re-lowering differs — a pass changed; run 'make lowered' first:"; \
+		diff -rq "$$tmp" pkg/rt/core_go_lowered 2>&1 | head; rc=1; \
+	fi; \
+	rm -rf "$$tmp" .selfhost-lgbgen; exit $$rc
+
 # Differential self-AOT execution gate: build let-go twice (bytecode + the
 # -tags gogen_ir native), run each test/gold-aot/*.lg fixture under both, and
 # diff the last output line. A new cross-engine divergence fails; the

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -512,6 +512,12 @@ func main() {
 			os.Exit(1)
 		}
 		nsChunks[ns.name] = chunk
+		// Self-hosting (3b): if a Go-lowered native override is queued for this
+		// namespace (only under -tags gogen_ir), apply it now so the lowering
+		// pipeline runs on the NATIVE passes instead of the bytecode we just
+		// compiled. Output is byte-identical (same pass logic); execution is
+		// native. A no-op without gogen_ir (the override maps are empty).
+		rt.ApplyGoOverrides(rt.LookupNS(ns.name))
 		if targetGo || targetBoth {
 			fmt.Printf("  compiled %-20s (%d bytecode + lowering to Go)\n", ns.name, len(chunk.Code())*4)
 		} else {

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-388a00451bf58540db6a099ad90069bd944e3402e9b044c3f4bf65eefdae0aee
+7ce290e1dc2e4951b53603fee0782121c1ad77710a1f7f3253ec74a31eb1b75e


### PR DESCRIPTION
Self-hosting the IR lowering. Applies the native (gogen_ir) Go overrides inside `lgbgen` so the compiler lowers its own passes natively, and adds `make check-selfhost` — a 3b native re-lower + step-4 fixpoint check that verifies the native compiler reproduces its own committed lowered output byte-identically.

Consolidates the former #435 (lgbgen self-host) + #436 (check-selfhost target) into one commit, rebased onto current main. `make check-selfhost` passes (fixpoint byte-identical); check-generated, build, and tests green.