### PR TITLE
build(make): add check-selfhost — verify the native compiler reproduces its own lowered output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,30 @@ perf-snapshot: lowered $(GO)
 lowered: $(GO)
 	@go run -tags bootstrap ./cmd/lgbgen --target=go >/dev/null
 
+# Self-hosting (3b + 4): re-lower the whole core with the NATIVE compiler and
+# verify the fixpoint. `lowered` (3a) bootstraps the tree from source with the
+# interpreted passes; here we build lgbgen -tags "bootstrap gogen_ir" so the
+# lowering pipeline runs on THAT tree's native passes, re-lower everything
+# (including the passes themselves), and byte-compare against the committed
+# tree. Byte-identical = the native compiler reproduces its own output, so the
+# passes are correct native code AND fast enough to self-host (bench-ratchet
+# IRCompile: native ~16% faster than bytecode). A diff means a pass changed and
+# the tree is stale relative to source — re-run `make lowered` (3a) first.
+.PHONY: check-selfhost
+check-selfhost: lowered $(GO)
+	@echo ">> 3b: build native-passes lgbgen (-tags 'bootstrap gogen_ir')"
+	@go build -tags "bootstrap gogen_ir" -o .selfhost-lgbgen ./cmd/lgbgen
+	@echo ">> 3b: re-lower the whole core with the NATIVE compiler"
+	@tmp=$$(mktemp -d); ./.selfhost-lgbgen --target=go "$$tmp" >/dev/null; \
+	echo ">> 4: fixpoint — native re-lowering vs the committed tree"; \
+	if diff -rq "$$tmp" pkg/rt/core_go_lowered >/dev/null 2>&1; then \
+		echo "OK: native self-hosting fixpoint holds (byte-identical)."; rc=0; \
+	else \
+		echo "FAIL: native re-lowering differs — a pass changed; run 'make lowered' first:"; \
+		diff -rq "$$tmp" pkg/rt/core_go_lowered 2>&1 | head; rc=1; \
+	fi; \
+	rm -rf "$$tmp" .selfhost-lgbgen; exit $$rc
+
 # Differential self-AOT execution gate: build let-go twice (bytecode + the
 # -tags gogen_ir native), run each test/gold-aot/*.lg fixture under both, and
 # diff the last output line. A new cross-engine divergence fails; the

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -509,6 +509,12 @@ func main() {
 			os.Exit(1)
 		}
 		nsChunks[ns.name] = chunk
+		// Self-hosting (3b): if a Go-lowered native override is queued for this
+		// namespace (only under -tags gogen_ir), apply it now so the lowering
+		// pipeline runs on the NATIVE passes instead of the bytecode we just
+		// compiled. Output is byte-identical (same pass logic); execution is
+		// native. A no-op without gogen_ir (the override maps are empty).
+		rt.ApplyGoOverrides(rt.LookupNS(ns.name))
 		if targetGo || targetBoth {
 			fmt.Printf("  compiled %-20s (%d bytecode + lowering to Go)\n", ns.name, len(chunk.Code())*4)
 		} else {

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-911a69f8120b047bd9bb343450bb8225cf81fe9f52de3d0e9fda7b82c5055c39
+7eacff533e90619c7d5be9ce3d00c5295a11703f76e3745f3e8e6d769a10471e


### PR DESCRIPTION
Adds a `make check-selfhost` target that verifies the self-hosting invariant: the compiler, built to run on its own natively-lowered passes, reproduces the committed lowered-Go tree byte-for-byte.

## What it does

1. Bootstrap the lowered-Go tree from source (`make lowered`, existing).
2. Build `lgbgen` with the `gogen_ir` tag so its lowering pipeline runs on **that tree's own native passes** (enabled by #435), then re-lower the whole core.
3. Byte-compare the re-lowering against the committed tree.

Byte-identical means the native compiler reproduces its own output — the self-hosting fixpoint holds. A difference means a pass changed and the tree is stale relative to source (run `make lowered` first). This makes the fixpoint a checkable invariant alongside `check-generated` and `check-lowered-fresh`.

## Why it matters

Running the compiler on its natively-lowered passes is measurably faster: the IR-compile benchmark runs ~16% faster under the native passes than under bytecode (18.5ms vs 22.0ms). This target proves that speedup is correctness-preserving, not just faster.

## Depends on

#435 — the fix that makes `lgbgen` apply its Go overrides so the passes actually run natively. Without it, step 2 runs interpreted and the check proves nothing.

## Test

```
$ make check-selfhost
OK: native self-hosting fixpoint holds (byte-identical).
```