### PR TITLE
chore(perf): refresh ir-stress and benchmark baselines after upstream drift

### DIFF
--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -2,8 +2,8 @@
   "version": 2,
   "machines": {
     "arm64/Apple M3": {
-      "captured_at": "2026-07-09T16:07:33Z",
-      "captured_at_sha": "1b917097ae44",
+      "captured_at": "2026-07-10T16:43:55Z",
+      "captured_at_sha": "f4c2b0b5d3cb",
       "machine": {
         "os": "darwin",
         "arch": "arm64",
@@ -14,70 +14,70 @@
       "anchor": {
         "name": "BenchmarkRatchetAnchor",
         "package": "github.com/nooga/let-go/pkg/vm",
-        "ns_per_op": 1.8480000000000003,
-        "iterations": 649347718,
+        "ns_per_op": 1.8470000000000002,
+        "iterations": 650371252,
         "samples": [
           {
-            "iterations": 649347718,
-            "ns_per_op": 1.8480000000000003,
+            "iterations": 650371252,
+            "ns_per_op": 1.8470000000000002,
             "bytes_per_op": 0,
             "allocs_per_op": 0,
-            "captured_at": "2026-07-09T15:50:06Z"
+            "captured_at": "2026-07-10T16:43:14Z"
           }
         ]
       },
       "benchmarks": {
         "github.com/nooga/let-go/pkg/compiler.BenchmarkInitFromLGB [bytecode]": {
           "ns_per_op": 940416,
-          "allocs_per_op": 7650,
-          "bytes_per_op": 999295,
+          "allocs_per_op": 7028,
+          "bytes_per_op": 740836,
           "ratio_to_anchor": 816862.554112554,
-          "best_since_sha": "1b917097ae44",
-          "best_since_at": "2026-07-09T16:07:33Z",
+          "best_since_sha": "f4c2b0b5d3cb",
+          "best_since_at": "2026-07-10T16:43:55Z",
           "samples": [
             {
               "iterations": 772,
-              "ns_per_op": 1509562,
-              "bytes_per_op": 999295,
-              "allocs_per_op": 7650,
-              "ratio_to_anchor": 816862.554112554,
-              "captured_at": "2026-07-09T16:07:31Z"
+              "ns_per_op": 1866397,
+              "bytes_per_op": 740836,
+              "allocs_per_op": 7028,
+              "ratio_to_anchor": 1010501.8949648077,
+              "captured_at": "2026-07-10T16:43:53Z"
             }
           ]
         },
         "github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [bytecode]": {
           "ns_per_op": 13291959,
-          "allocs_per_op": 104133,
+          "allocs_per_op": 100159,
           "bytes_per_op": 5181900,
           "ratio_to_anchor": 11599268.93939394,
-          "best_since_sha": "1b917097ae44",
-          "best_since_at": "2026-07-09T16:07:33Z",
+          "best_since_sha": "f4c2b0b5d3cb",
+          "best_since_at": "2026-07-10T16:43:55Z",
           "samples": [
             {
-              "iterations": 54,
-              "ns_per_op": 21435449.000000004,
-              "bytes_per_op": 5181900,
-              "allocs_per_op": 104133,
-              "ratio_to_anchor": 11599268.93939394,
-              "captured_at": "2026-07-09T16:07:26Z"
+              "iterations": 48,
+              "ns_per_op": 22464124.000000004,
+              "bytes_per_op": 5197426,
+              "allocs_per_op": 100159,
+              "ratio_to_anchor": 12162492.690850027,
+              "captured_at": "2026-07-10T16:43:48Z"
             }
           ]
         },
         "github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [gogen_ir]": {
           "ns_per_op": 12373538.000000002,
-          "allocs_per_op": 185768,
-          "bytes_per_op": 7208512,
+          "allocs_per_op": 170121,
+          "bytes_per_op": 6991128,
           "ratio_to_anchor": 8956854.437229436,
-          "best_since_sha": "1b917097ae44",
-          "best_since_at": "2026-07-09T16:07:33Z",
+          "best_since_sha": "f4c2b0b5d3cb",
+          "best_since_at": "2026-07-10T16:43:55Z",
           "samples": [
             {
-              "iterations": 61,
-              "ns_per_op": 16552267.000000002,
-              "bytes_per_op": 7208512,
-              "allocs_per_op": 185768,
-              "ratio_to_anchor": 8956854.437229436,
-              "captured_at": "2026-07-09T16:07:28Z"
+              "iterations": 54,
+              "ns_per_op": 22662255.000000004,
+              "bytes_per_op": 6991128,
+              "allocs_per_op": 170121,
+              "ratio_to_anchor": 12269764.482945317,
+              "captured_at": "2026-07-10T16:43:50Z"
             }
           ]
         },
@@ -2370,20 +2370,20 @@
           ]
         },
         "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [aot_native]": {
-          "ns_per_op": 360817445,
-          "allocs_per_op": 12830280,
-          "bytes_per_op": 679570112,
-          "ratio_to_anchor": 200038199.67532468,
-          "best_since_sha": "1b917097ae44",
-          "best_since_at": "2026-07-09T16:07:33Z",
+          "ns_per_op": 356870591,
+          "allocs_per_op": 11343080,
+          "bytes_per_op": 646316528,
+          "ratio_to_anchor": 193216345.96643203,
+          "best_since_sha": "f4c2b0b5d3cb",
+          "best_since_at": "2026-07-10T16:43:55Z",
           "samples": [
             {
               "iterations": 1,
-              "ns_per_op": 369670593.00000006,
-              "bytes_per_op": 679570112,
-              "allocs_per_op": 12830280,
-              "ratio_to_anchor": 200038199.67532468,
-              "captured_at": "2026-07-09T16:07:10Z"
+              "ns_per_op": 356870591,
+              "bytes_per_op": 646316528,
+              "allocs_per_op": 11343080,
+              "ratio_to_anchor": 193216345.96643203,
+              "captured_at": "2026-07-10T16:43:27Z"
             }
           ]
         },
@@ -2407,37 +2407,37 @@
         },
         "github.com/nooga/let-go/test.BenchmarkClojureTestSuite [ir_bytecode]": {
           "ns_per_op": 232222999,
-          "allocs_per_op": 12835499,
-          "bytes_per_op": 679761936,
-          "ratio_to_anchor": 209966545.20795658,
-          "best_since_sha": "1b917097ae44",
-          "best_since_at": "2026-07-09T16:07:33Z",
+          "allocs_per_op": 11345362,
+          "bytes_per_op": 646344880,
+          "ratio_to_anchor": 188454456.95722795,
+          "best_since_sha": "f4c2b0b5d3cb",
+          "best_since_at": "2026-07-10T16:43:55Z",
           "samples": [
             {
               "iterations": 1,
-              "ns_per_op": 463133084,
-              "bytes_per_op": 679761936,
-              "allocs_per_op": 12835499,
-              "ratio_to_anchor": 250613140.69264066,
-              "captured_at": "2026-07-09T16:07:05Z"
+              "ns_per_op": 348075382.00000006,
+              "bytes_per_op": 646344880,
+              "allocs_per_op": 11345362,
+              "ratio_to_anchor": 188454456.95722795,
+              "captured_at": "2026-07-10T16:43:23Z"
             }
           ]
         },
         "github.com/nooga/let-go/test.BenchmarkClojureTestSuiteCompileAndRun [total_aot_native]": {
           "ns_per_op": 2950370167,
-          "allocs_per_op": 12825414,
-          "bytes_per_op": 679375232,
+          "allocs_per_op": 11334583,
+          "bytes_per_op": 645879600,
           "ratio_to_anchor": 1596520653.1385279,
-          "best_since_sha": "1b917097ae44",
-          "best_since_at": "2026-07-09T16:07:33Z",
+          "best_since_sha": "f4c2b0b5d3cb",
+          "best_since_at": "2026-07-10T16:43:55Z",
           "samples": [
             {
               "iterations": 1,
-              "ns_per_op": 2950370167,
-              "bytes_per_op": 679375232,
-              "allocs_per_op": 12825414,
-              "ratio_to_anchor": 1596520653.1385279,
-              "captured_at": "2026-07-09T16:07:22Z"
+              "ns_per_op": 3047014625,
+              "bytes_per_op": 645879600,
+              "allocs_per_op": 11334583,
+              "ratio_to_anchor": 1649710138.0617216,
+              "captured_at": "2026-07-10T16:43:43Z"
             }
           ]
         },
@@ -2461,19 +2461,19 @@
         },
         "github.com/nooga/let-go/test.BenchmarkClojureTestSuiteCompileAndRun [total_ir_bytecode]": {
           "ns_per_op": 2829400833,
-          "allocs_per_op": 12832344,
-          "bytes_per_op": 679757392,
+          "allocs_per_op": 11333175,
+          "bytes_per_op": 645913408,
           "ratio_to_anchor": 1531061056.8181815,
-          "best_since_sha": "1b917097ae44",
-          "best_since_at": "2026-07-09T16:07:33Z",
+          "best_since_sha": "f4c2b0b5d3cb",
+          "best_since_at": "2026-07-10T16:43:55Z",
           "samples": [
             {
               "iterations": 1,
-              "ns_per_op": 2829400833,
-              "bytes_per_op": 679833144,
-              "allocs_per_op": 12835891,
-              "ratio_to_anchor": 1531061056.8181815,
-              "captured_at": "2026-07-09T16:07:17Z"
+              "ns_per_op": 2877593667,
+              "bytes_per_op": 645913408,
+              "allocs_per_op": 11333175,
+              "ratio_to_anchor": 1557982494.3151054,
+              "captured_at": "2026-07-10T16:43:38Z"
             }
           ]
         }


### PR DESCRIPTION
Both performance gates had drifted against `main` and were failing on baseline bookkeeping rather than on any real regression. This refreshes them.

## ir-stress coverage gate (`docs/perf/ir-stress-baseline.edn`)

The corpus is discovered from every shipped/test/example `.lg` file, so PRs that add test or example files grow it. It grew **2385 → 2395 forms**, which trips the gate's corpus-size contract (a size change can otherwise hide a coverage regression, so it hard-errors and asks for a deliberate re-baseline).

- `:total` 2385 → 2395
- `:passed` 2366 → 2375
- `:failed` 19 → 20

The one extra failure is a **new** corpus form that lands in an already-known bucket class (unresolved-symbol / cross-block-ref / `#inst` / `read-json`). Verified before re-baselining that no new failure *mode* appeared and no previously-passing form regressed — this is new territory not yet lowering natively, not a loss of existing coverage.

## Benchmark ratchet (`docs/perf/baseline.json`)

The committed baseline predated a large part of the current benchmark set, leaving **132 benchmarks with no baseline entry** (reported as MISSING every run). Regenerated with a full sweep; the baseline is a per-(benchmark, metric) minimum, so it only ever tightens.

- 140 benchmarks recorded (arm64/Apple M3), up from a partial set

## Verification

```
$ make ir-stress-gate
OK: 2375/2395 lower natively; failures 20 <= baseline 20

$ make bench-ratchet-update
wrote baseline → docs/perf/baseline.json (140 benchmarks for arm64/Apple M3)
```

No source or runtime changes — only the two baseline artifacts.