### PR TITLE
perf(rt): close timeout channels from one shared timer daemon

### DIFF
--- a/pkg/rt/async.go
+++ b/pkg/rt/async.go
@@ -37,6 +37,119 @@ type Pub struct {
 
 func init() { RegisterInstaller(installAsyncNS) }
 
+// --- Shared timeout daemon ---
+//
+// All (timeout ms) channels are closed by ONE long-lived goroutine instead of
+// a goroutine per call. A per-call goroutine is cheap on stock Go but not
+// free: each (timeout ms) paid a goroutine spawn, its stack, and a timer. On
+// runtimes with heap-allocated fixed-size goroutine stacks (TinyGo), a
+// timeout-per-frame animation loop turns that into a large allocation plus a
+// GC cycle per frame. The daemon makes timeout calls allocation-free apart
+// from the channel and a queue entry.
+//
+// The daemon runs in the root scope and exits on scope cancellation, closing
+// every pending timeout channel (same observable behavior as the old per-call
+// select on ctx.Done). timerRunning lets the next timeout call restart it in
+// the scope's next context generation after a CancelAll/Drain.
+
+type timerEntry struct {
+	deadline time.Time
+	ch       vm.Chan
+}
+
+var (
+	timerMu      sync.Mutex
+	timerQueue   []timerEntry
+	timerKick    = make(chan struct{}, 1)
+	timerRunning bool
+)
+
+// timeoutChan returns a channel that the timer daemon closes after ms.
+func timeoutChan(ms int) vm.Chan {
+	ch := make(vm.Chan)
+	if ms <= 0 {
+		close(ch)
+		return ch
+	}
+	deadline := time.Now().Add(time.Duration(ms) * time.Millisecond)
+	timerMu.Lock()
+	timerQueue = append(timerQueue, timerEntry{deadline: deadline, ch: ch})
+	start := !timerRunning
+	if start {
+		timerRunning = true
+	}
+	timerMu.Unlock()
+	if start {
+		vm.Goroutines.Go(timerDaemon)
+	} else {
+		select {
+		case timerKick <- struct{}{}:
+		default:
+		}
+	}
+	return ch
+}
+
+func timerDaemon(ctx context.Context) {
+	for {
+		timerMu.Lock()
+		now := time.Now()
+		var due []vm.Chan
+		keep := timerQueue[:0]
+		var next time.Time
+		for _, e := range timerQueue {
+			if !e.deadline.After(now) {
+				due = append(due, e.ch)
+			} else {
+				keep = append(keep, e)
+				if next.IsZero() || e.deadline.Before(next) {
+					next = e.deadline
+				}
+			}
+		}
+		timerQueue = keep
+		timerMu.Unlock()
+		for _, ch := range due {
+			close(ch)
+		}
+
+		if next.IsZero() {
+			// Idle: park until a new timeout arrives or the scope cancels.
+			select {
+			case <-timerKick:
+				continue
+			case <-ctx.Done():
+				timerDaemonStop()
+				return
+			}
+		}
+		t := time.NewTimer(time.Until(next))
+		select {
+		case <-t.C:
+		case <-timerKick: // an earlier deadline may have been queued
+		case <-ctx.Done():
+			t.Stop()
+			timerDaemonStop()
+			return
+		}
+		t.Stop()
+	}
+}
+
+// timerDaemonStop closes every pending timeout channel (scope cancellation
+// unblocks their takers, matching the old per-goroutine ctx.Done behavior)
+// and marks the daemon restartable.
+func timerDaemonStop() {
+	timerMu.Lock()
+	pending := timerQueue
+	timerQueue = nil
+	timerRunning = false
+	timerMu.Unlock()
+	for _, e := range pending {
+		close(e.ch)
+	}
+}
+
 // --- Buffer policies (core.async buffer / dropping-buffer / sliding-buffer) ---
 //
 // vm.Chan is a raw Go channel, which cannot express drop-on-full semantics
@@ -342,17 +455,7 @@ func installAsyncNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("timeout expected Int milliseconds")
 		}
-		ch := make(vm.Chan)
-		vm.Goroutines.Go(func(ctx context.Context) {
-			t := time.NewTimer(time.Duration(int(ms)) * time.Millisecond)
-			defer t.Stop()
-			select {
-			case <-t.C:
-			case <-ctx.Done():
-			}
-			close(ch)
-		})
-		return ch, nil
+		return timeoutChan(int(ms)), nil
 	})
 
 	// pipe — take from src, put on dst, close dst when src closes

--- a/pkg/rt/async.go
+++ b/pkg/rt/async.go
@@ -47,14 +47,28 @@ func init() { RegisterInstaller(installAsyncNS) }
 // GC cycle per frame. The daemon makes timeout calls allocation-free apart
 // from the channel and a queue entry.
 //
-// The daemon runs in the root scope and exits on scope cancellation, closing
-// every pending timeout channel (same observable behavior as the old per-call
-// select on ctx.Done). timerRunning lets the next timeout call restart it in
-// the scope's next context generation after a CancelAll/Drain.
+// The daemon runs in the root scope and exits on scope cancellation. Each
+// entry carries the Done channel of the scope context that was current when
+// its timeout was created, preserving the old per-call semantics: a timeout
+// closes early only when ITS OWN context generation is cancelled. A stopping
+// daemon therefore closes just the entries whose context is done and hands
+// any survivors — timeouts created after a CancelAll installed a fresh
+// generation — to a respawned daemon in that new generation.
 
 type timerEntry struct {
 	deadline time.Time
 	ch       vm.Chan
+	done     <-chan struct{} // Done of the scope context at creation time
+}
+
+// cancelled reports whether the entry's own context generation is done.
+func (e *timerEntry) cancelled() bool {
+	select {
+	case <-e.done:
+		return true
+	default:
+		return false
+	}
 }
 
 var (
@@ -71,9 +85,13 @@ func timeoutChan(ms int) vm.Chan {
 		close(ch)
 		return ch
 	}
-	deadline := time.Now().Add(time.Duration(ms) * time.Millisecond)
+	entry := timerEntry{
+		deadline: time.Now().Add(time.Duration(ms) * time.Millisecond),
+		ch:       ch,
+		done:     vm.Goroutines.Context().Done(),
+	}
 	timerMu.Lock()
-	timerQueue = append(timerQueue, timerEntry{deadline: deadline, ch: ch})
+	timerQueue = append(timerQueue, entry)
 	start := !timerRunning
 	if start {
 		timerRunning = true
@@ -98,7 +116,7 @@ func timerDaemon(ctx context.Context) {
 		keep := timerQueue[:0]
 		var next time.Time
 		for _, e := range timerQueue {
-			if !e.deadline.After(now) {
+			if !e.deadline.After(now) || e.cancelled() {
 				due = append(due, e.ch)
 			} else {
 				keep = append(keep, e)
@@ -136,17 +154,39 @@ func timerDaemon(ctx context.Context) {
 	}
 }
 
-// timerDaemonStop closes every pending timeout channel (scope cancellation
-// unblocks their takers, matching the old per-goroutine ctx.Done behavior)
-// and marks the daemon restartable.
+// timerDaemonStop runs when the daemon's own context generation is cancelled.
+// It closes the entries belonging to cancelled generations (unblocking their
+// takers, matching the old per-goroutine ctx.Done behavior) but NOT entries
+// created after a CancelAll installed a fresh generation — those keep their
+// deadlines under a respawned daemon. Without the split, a timeout created in
+// the race window between CancelAll and the old daemon noticing would be
+// closed immediately by a cancellation that predates it.
 func timerDaemonStop() {
 	timerMu.Lock()
-	pending := timerQueue
-	timerQueue = nil
-	timerRunning = false
+	var closeNow []vm.Chan
+	keep := timerQueue[:0]
+	for _, e := range timerQueue {
+		if e.cancelled() {
+			closeNow = append(closeNow, e.ch)
+		} else {
+			keep = append(keep, e)
+		}
+	}
+	timerQueue = keep
+	respawn := len(keep) > 0
+	if !respawn {
+		timerRunning = false
+	}
 	timerMu.Unlock()
-	for _, e := range pending {
-		close(e.ch)
+	for _, ch := range closeNow {
+		close(ch)
+	}
+	if respawn {
+		// Survivors belong to a newer generation; serve them from a fresh
+		// daemon spawned under the current scope context. If yet another
+		// CancelAll raced in, the new daemon's first pass closes the newly
+		// cancelled entries via the per-entry check.
+		vm.Goroutines.Go(timerDaemon)
 	}
 }
 

--- a/pkg/rt/async_test.go
+++ b/pkg/rt/async_test.go
@@ -7,6 +7,7 @@
 package rt
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -311,5 +312,37 @@ func TestGoBlockParkedInPutIsDrainable(t *testing.T) {
 	}
 	if got := vm.Goroutines.Live(); got != 0 {
 		t.Fatalf("expected 0 live after drain, got %d", got)
+	}
+}
+
+// TestTimeoutSurvivesCancelAll covers the generation race: a timeout created
+// right after CancelAll must keep its deadline, even when the previous
+// generation's daemon has not yet noticed its cancellation and still owns the
+// queue. Before the per-entry generation check, the stopping daemon closed
+// such a timeout immediately.
+func TestTimeoutSurvivesCancelAll(t *testing.T) {
+	prev := runtime.GOMAXPROCS(1) // widen the CancelAll→daemon-stop race window
+	defer runtime.GOMAXPROCS(prev)
+
+	oldGen := timeoutChan(5000) // parks the daemon on a long deadline
+	vm.Goroutines.CancelAll()
+	fresh := timeoutChan(200) // new generation, enqueued before the old daemon stops
+
+	select {
+	case <-oldGen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pre-CancelAll timeout should close promptly on cancellation")
+	}
+
+	select {
+	case <-fresh:
+		t.Fatal("post-CancelAll timeout closed early — it belongs to the fresh generation")
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	select {
+	case <-fresh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-CancelAll timeout never closed at its deadline")
 	}
 }

--- a/pkg/rt/timeout_bench_test.go
+++ b/pkg/rt/timeout_bench_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// These benchmarks quantify what the shared timer daemon buys per (timeout ms)
+// call: a channel plus a queue entry, versus the old shape's goroutine spawn,
+// goroutine stack, timer allocation, and closure per call. The old shape is
+// preserved below as the baseline so the pair stays comparable in one run:
+//
+//	go test -bench Timeout -benchmem ./pkg/rt/
+//
+// A 1ms deadline keeps the daemon's queue short while the loop runs (entries
+// drain about as fast as they are created), so the daemon numbers include its
+// steady-state rescan cost rather than an ever-growing queue.
+
+// timeoutSink defeats dead-code elimination of the returned channel.
+var timeoutSink vm.Chan
+
+// oldTimeoutChan is the pre-daemon implementation: one goroutine per call.
+func oldTimeoutChan(ms int) vm.Chan {
+	ch := make(vm.Chan)
+	vm.Goroutines.Go(func(ctx context.Context) {
+		t := time.NewTimer(time.Duration(ms) * time.Millisecond)
+		defer t.Stop()
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+		}
+		close(ch)
+	})
+	return ch
+}
+
+func benchTimeouts(b *testing.B, mk func(int) vm.Chan) {
+	b.ReportAllocs()
+	var last vm.Chan
+	for i := 0; i < b.N; i++ {
+		last = mk(1)
+	}
+	timeoutSink = last
+	b.StopTimer()
+	<-last // drain: don't leak this run's pending work into the next benchmark
+}
+
+func BenchmarkTimeoutDaemon(b *testing.B) {
+	benchTimeouts(b, timeoutChan)
+}
+
+func BenchmarkTimeoutGoroutinePerCall(b *testing.B) {
+	benchTimeouts(b, oldTimeoutChan)
+}


### PR DESCRIPTION
Every `(timeout ms)` call currently spawns its own goroutine: it holds a `time.Timer`, selects on it against scope cancellation, and closes the channel. That's a goroutine spawn, a stack, and a timer per call.

Timeout-heavy patterns pay for it. The canonical one is a frame-paced loop, `(<!! (timeout n))` per frame, which becomes a goroutine-per-frame treadmill. On stock Go that's measurable churn; on runtimes with heap-allocated fixed-size goroutine stacks (TinyGo), each spawn is a large allocation plus the GC cycle it drives, and the loop's cost is dominated by spawning rather than by anything the program does.

This PR replaces the per-call goroutine with one long-lived daemon that owns a deadline queue and closes due timeout channels. A `timeout` call now costs the channel plus a queue entry.

Semantics are unchanged:

- Timeout channels still close after their deadline.
- On scope cancellation a timeout closes early only when its own context generation was cancelled — each entry carries its creation-time context, matching the old per-call `select` on `ctx.Done()`. Timeouts created after a `CancelAll` installed a fresh generation keep their deadlines under a respawned daemon.
- The daemon starts lazily on the first `timeout` call; programs that never use `timeout` never run it.

Benchmark (darwin/arm64, Apple M2 — creation cost per `(timeout 1)` call, old shape kept in the bench file as the baseline):

```
BenchmarkTimeoutDaemon-8             3690286    338.8 ns/op    137 B/op    1 allocs/op
BenchmarkTimeoutGoroutinePerCall-8   1327947   2316 ns/op      438 B/op    6 allocs/op
```

Two implementation notes:

- The daemon rescans its queue linearly on each wake. Realistic timeout counts are small (the pathological pattern is many calls over time, not many pending at once), so a deadline heap felt like premature structure; easy to add later if a workload proves otherwise.
- `(timeout ms)` with `ms <= 0` now returns an already-closed channel synchronously. The old code spawned a goroutine whose 0-duration timer fired immediately, so the close landed asynchronously shortly after return; "closes after 0ms" is preserved, just without the detour.

The existing async suite covers close-after-ms and cancellation; the generation regression test and the benchmark pair are new. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
