### PR TITLE
fix(compiler): parse empty catch bodies with simple class names

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/nooga/let-go/pkg/rt"
 	"github.com/nooga/let-go/pkg/vm"
@@ -879,9 +880,10 @@ func tryCompiler(c *Context, form vm.Value) error {
 					// always a simple unqualified symbol, so a qualified/dotted
 					// first token can only be a class name — that disambiguates
 					// even with an empty catch body, e.g.
-					// (catch java.io.FileNotFoundException _). For a simple class
-					// name, fall back to the token count: the Clojure form needs
-					// class + binding + body (3+ tokens, first two symbols).
+					// (catch java.io.FileNotFoundException _). An uppercase simple
+					// symbol is also class-shaped, which handles empty-body forms
+					// such as (catch Throwable _). Otherwise, fall back to token
+					// count: the Clojure form needs class + binding + body.
 					restCount := 0
 					for s := rest; s != nil; s = s.Next() {
 						restCount++
@@ -890,7 +892,14 @@ func tryCompiler(c *Context, form vm.Value) error {
 						firstSym, firstIsSym := rest.First().(vm.Symbol)
 						_, secondIsSym := rest.Next().First().(vm.Symbol)
 						qualified := firstIsSym && strings.ContainsAny(string(firstSym), "./")
-						if firstIsSym && secondIsSym && (qualified || restCount >= 3) {
+						upperSimple := false
+						if firstIsSym && !qualified {
+							for _, r := range string(firstSym) {
+								upperSimple = unicode.IsUpper(r)
+								break
+							}
+						}
+						if firstIsSym && secondIsSym && (qualified || upperSimple || restCount >= 3) {
 							rest = rest.Next() // drop the leading class symbol
 						}
 					}

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -143,9 +143,13 @@
         (cond
           (and (seq? head) (= (first head) 'catch))
           (let [parts     (vec (rest head))
-                class?    (and (>= (count parts) 3)
-                               (symbol? (nth parts 0))
-                               (symbol? (nth parts 1)))
+                first-sym (nth parts 0 nil)
+                class?    (and (>= (count parts) 2)
+                               (symbol? first-sym)
+                               (symbol? (nth parts 1))
+                               (or (>= (count parts) 3)
+                                   (re-find #"[./]" (str first-sym))
+                                   (re-find #"^\p{Lu}" (str first-sym))))
                 binding   (if class? (nth parts 1) (nth parts 0))
                 cbody     (if class? (vec (drop 2 parts)) (vec (drop 1 parts)))]
             (recur (rest fs) body {:binding binding :body cbody} finally-clause))

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-1a7732da592970898ec2a9079c509e1ef12c133ff8eea57950a3de6f69cf3ca1
+89d0d114b3217aa2eec8b8ceb855210f49a18c632bf604b1d2bf6b8808a18f63

--- a/test/catch_class_test.lg
+++ b/test/catch_class_test.lg
@@ -1,5 +1,10 @@
 (ns test.catch-class-test
-  (:require [test :refer :all]))
+  (:require [ir.passes.pipeline :as pipeline]
+            [test :refer :all]))
+
+(defn- lower-status [form]
+  (binding [pipeline/*target* :go]
+    (:status (pipeline/compile-form form))))
 
 (deftest catch-bare-binding
   (testing "let-go's bare (catch e body) still works"
@@ -15,6 +20,9 @@
     (is (= "boom" (try (throw "boom") (catch Throwable e (str e)))))))
 
 (deftest catch-empty-body
+  (testing "simple class + binding with an empty body catches and returns nil"
+    (is (nil? (try (throw "boom") (catch Throwable _))))
+    (is (nil? (try (throw "boom") (catch Exception _)))))
   (testing "a qualified class + binding with an empty body catches and returns nil"
     ;; (catch java.io.FileNotFoundException _) — no body. A binding is always a
     ;; simple symbol, so the dotted first token is unambiguously the class.
@@ -31,3 +39,13 @@
         (try (throw "x") (catch Throwable e (swap! a inc)) (finally (swap! a inc)))
         (catch e nil))
       (is (= 2 @a)))))
+
+(deftest catch-empty-body-lowers-to-native-go
+  (testing "native lowering shares bytecode catch-shape parsing"
+    (is (= :lowered
+           (lower-status '(defn catch-simple []
+                            (try (throw "boom") (catch Throwable _))))))
+    (is (= :lowered
+           (lower-status '(defn catch-qualified []
+                            (try (throw "boom")
+                                 (catch java.io.FileNotFoundException _))))))))


### PR DESCRIPTION
`(catch Throwable _)` with no body parsed the class symbol as the binding and the binding as a body form, so the clause failed to compile. #413 fixed the same ambiguity for qualified class names; simple names still fell back to a three-token minimum. Treat an uppercase simple symbol as class-shaped in both the compiler and the IR builder, which mirrors the same catch parsing.

Found while loading `clojure.tools.cli`, which contains a valid typed catch clause with no body.

Merge note: independent of the other `tools.cli` compat branches. It regenerates `pkg/rt/generated.sums` (`ir/build.lg` feeds the digest), so re-run the generator after rebasing past any branch that also touches it.

Resolves: #448 