### PR TITLE
fix(rt): return Clojure-compatible regex match results

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -5381,6 +5381,26 @@ func installLangNS() {
 		return vm.String(string(s.(vm.String)) + "\n"), nil
 	})
 
+	regexSubmatchVector := func(s string, indices []int) vm.ArrayVector {
+		result := make(vm.ArrayVector, len(indices)/2)
+		for i := range result {
+			start, end := indices[2*i], indices[2*i+1]
+			if start < 0 {
+				result[i] = vm.NIL
+				continue
+			}
+			result[i] = vm.String(s[start:end])
+		}
+		return result
+	}
+
+	regexSubmatchValue := func(s string, indices []int) vm.Value {
+		if len(indices) == 2 {
+			return vm.String(s[indices[0]:indices[1]])
+		}
+		return regexSubmatchVector(s, indices)
+	}
+
 	// re-find: find first match of regex in string
 	reFind, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 2 {
@@ -5394,18 +5414,11 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("re-find expected String")
 		}
-		matches := re.FindStringSubmatch(string(s))
-		if matches == nil {
+		indices := re.FindStringSubmatchIndex(string(s))
+		if indices == nil {
 			return vm.NIL, nil
 		}
-		if len(matches) == 1 {
-			return vm.String(matches[0]), nil
-		}
-		result := make(vm.ArrayVector, len(matches))
-		for i, m := range matches {
-			result[i] = vm.String(m)
-		}
-		return result, nil
+		return regexSubmatchValue(string(s), indices), nil
 	})
 
 	// re-matches: match entire string against regex
@@ -5421,18 +5434,11 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("re-matches expected String")
 		}
-		matches := re.FindStringSubmatch(string(s))
-		if matches == nil || matches[0] != string(s) {
+		indices := re.FindStringSubmatchIndex(string(s))
+		if indices == nil || indices[0] != 0 || indices[1] != len(s) {
 			return vm.NIL, nil
 		}
-		if len(matches) == 1 {
-			return vm.String(matches[0]), nil
-		}
-		result := make(vm.ArrayVector, len(matches))
-		for i, m := range matches {
-			result[i] = vm.String(m)
-		}
-		return result, nil
+		return regexSubmatchValue(string(s), indices), nil
 	})
 
 	// re-seq: return lazy seq of all matches
@@ -5450,21 +5456,13 @@ func installLangNS() {
 		}
 		// Like Clojure (and re-find above): a groupless pattern yields
 		// the match string, capture groups yield [full g1 g2 ...].
-		all := re.FindAllStringSubmatch(string(s), -1)
+		all := re.FindAllStringSubmatchIndex(string(s), -1)
 		if all == nil {
-			return vm.EmptyList, nil
+			return vm.NIL, nil
 		}
 		vals := make([]vm.Value, len(all))
-		for i, matches := range all {
-			if len(matches) == 1 {
-				vals[i] = vm.String(matches[0])
-				continue
-			}
-			groups := make(vm.ArrayVector, len(matches))
-			for j, m := range matches {
-				groups[j] = vm.String(m)
-			}
-			vals[i] = groups
+		for i, indices := range all {
+			vals[i] = regexSubmatchValue(string(s), indices)
 		}
 		return vm.ListType.Box(vals)
 	})
@@ -6292,17 +6290,13 @@ func installLangNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("re-groups expected String")
 		}
-		all := re.FindAllStringSubmatch(string(s), -1)
+		all := re.FindAllStringSubmatchIndex(string(s), -1)
 		if all == nil {
 			return vm.NIL, nil
 		}
 		result := make([]vm.Value, len(all))
-		for i, match := range all {
-			group := make(vm.ArrayVector, len(match))
-			for j, m := range match {
-				group[j] = vm.String(m)
-			}
-			result[i] = group
+		for i, indices := range all {
+			result[i] = regexSubmatchVector(string(s), indices)
 		}
 		return vm.NewArrayVector(result), nil
 	})

--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -116,12 +116,20 @@ func (l *Regex) FindStringSubmatch(s string) []string {
 	return l.re.FindStringSubmatch(s)
 }
 
+func (l *Regex) FindStringSubmatchIndex(s string) []int {
+	return l.re.FindStringSubmatchIndex(s)
+}
+
 func (l *Regex) FindAllString(s string, n int) []string {
 	return l.re.FindAllString(s, n)
 }
 
 func (l *Regex) FindAllStringSubmatch(s string, n int) [][]string {
 	return l.re.FindAllStringSubmatch(s, n)
+}
+
+func (l *Regex) FindAllStringSubmatchIndex(s string, n int) [][]int {
+	return l.re.FindAllStringSubmatchIndex(s, n)
 }
 
 func (l *Regex) Split(s string, n int) []string {

--- a/test/builtins_test.lg
+++ b/test/builtins_test.lg
@@ -19,12 +19,21 @@
 (deftest re-find-test
   (testing "re-find finds first match"
     (is (= "123" (re-find #"\d+" "abc123def")))
-    (is (nil? (re-find #"\d+" "abcdef")))))
+    (is (nil? (re-find #"\d+" "abcdef"))))
+
+  (testing "re-find distinguishes unmatched and empty capture groups"
+    (is (= ["--verbose" "--verbose" nil]
+           (re-find #"^(--[^ =]+)(?:[ =](.*))?" "--verbose")))
+    (is (= ["b" ""] (re-find #"(a*)b" "b")))))
 
 (deftest re-matches-test
   (testing "re-matches requires full string match"
     (is (= "123" (re-matches #"\d+" "123")))
-    (is (nil? (re-matches #"\d+" "abc123")))))
+    (is (nil? (re-matches #"\d+" "abc123"))))
+
+  (testing "re-matches distinguishes unmatched and empty capture groups"
+    (is (= ["b" nil] (re-matches #"(a)?b" "b")))
+    (is (= ["b" ""] (re-matches #"(a*)b" "b")))))
 
 (deftest re-seq-test
   (testing "re-seq finds all matches"

--- a/test/core_tier3_test.lg
+++ b/test/core_tier3_test.lg
@@ -77,4 +77,7 @@
     (let [result (re-groups (re-pattern "\\d+") "123 456")]
       (is (= 2 (count result)))
       (is (= ["123"] (first result)))
-      (is (= ["456"] (second result))))))
+      (is (= ["456"] (second result)))))
+  (testing "re-groups distinguishes unmatched and empty capture groups"
+    (is (= [["b" nil]] (re-groups (re-pattern "(a)?b") "b")))
+    (is (= [["b" ""]] (re-groups (re-pattern "(a*)b") "b")))))

--- a/test/shuffle_reseq_test.lg
+++ b/test/shuffle_reseq_test.lg
@@ -23,5 +23,15 @@
            (re-seq #"(\d+)(\w)" "12W2B")))
     (is (= '(["ab" "a"]) (re-seq #"(a)b" "ab"))))
 
-  (testing "no match is empty"
-    (is (= () (re-seq #"(x)" "abc")))))
+  (testing "unmatched and empty capture groups remain distinct"
+    (is (= '(["--verbose" "--verbose" nil])
+           (re-seq #"^(--[^ =]+)(?:[ =](.*))?" "--verbose")))
+    (is (= '(["b" ""]) (re-seq #"(a*)b" "b"))))
+
+  (testing "no match is nil and falsey"
+    (is (nil? (re-seq #"(x)" "abc")))
+    (is (= :long
+           (condp re-seq "--port"
+             #"^--$" :end
+             #"^--"  :long
+             :none)))))


### PR DESCRIPTION
Three result conversions differed from Clojure and broke predicate-driven code such as `clojure.tools.cli`'s option parsing:

- `re-seq` returned an empty list when nothing matched. The empty list is truthy, so (condp `re-seq` ...) picked a wrong branch. It now returns nil, like Clojure.
- `re-find` and `re-seq` returned `""` both for an optional group that did not participate and for a group that matched zero characters. They now read Go's submatch indices and return nil for an absent group and `""` for a participating empty one.
- `re-matches` and re-groups had the same absent-vs-empty gap. They now share the index-based conversion. `re-groups` keeps its existing shape: always a vector per match, nil no-match, and its (`re-groups` regex str) all-matches signature.

Result shapes are otherwise unchanged: a groupless match is still a string and a grouped match is still `[full g1 g2 ...]`.

Merge note: independent of the other tools.cli compat branches; touches `pkg/rt/lang.go` and `pkg/vm/regex.go`, no generated artifacts.

Resolves: #455 