### PR TITLE
perf(vm): per-var root-binding gate for lock-free var deref (Phase 1)

### DIFF
--- a/pkg/vm/exec_context.go
+++ b/pkg/vm/exec_context.go
@@ -126,10 +126,14 @@ func (ec *ExecContext) orRoot() *ExecContext {
 
 // --- dynamic-var resolution (ec owns the binding state) ---------------------
 
-// deref returns v's current value in this context: the top dynamic binding if
-// any, else v's root.
 func (ec *ExecContext) deref(v *Var) Value {
 	ec = ec.orRoot()
+	if ec == RootExecContext {
+		return v.derefRoot()
+	}
+	// Child context: an isolated, per-goroutine stack — uncontended, so walk it
+	// directly. rootBindDepth tracks only ROOT bindings, so child bindings are
+	// gated by isDynamic (set at declaration or on any bind) as before.
 	if v.isDynamic.Load() {
 		if val, ok := ec.bindings.current(v); ok {
 			return val
@@ -140,11 +144,25 @@ func (ec *ExecContext) deref(v *Var) Value {
 
 func (ec *ExecContext) pushBinding(v *Var, val Value) {
 	v.isDynamic.Store(true)
-	ec.orRoot().bindings.push(v, val)
+	root := ec.orRoot()
+	if root == RootExecContext {
+		// Increment BEFORE the push: a reader that sees depth>0 then walks will
+		// either find the binding or (racing this in-progress push) fall through
+		// to Root(). It never sees depth==0 while a settled root binding exists.
+		v.rootBindDepth.Add(1)
+	}
+	root.bindings.push(v, val)
 }
 
 func (ec *ExecContext) popBinding(v *Var) {
-	ec.orRoot().bindings.pop(v)
+	root := ec.orRoot()
+	root.bindings.pop(v)
+	if root == RootExecContext {
+		// Decrement AFTER the pop: depth stays >0 while the binding is still
+		// walkable, so a concurrent reader never sees depth==0 with the binding
+		// still present.
+		v.rootBindDepth.Add(-1)
+	}
 }
 
 func (ec *ExecContext) hasBinding(v *Var) bool {

--- a/pkg/vm/var.go
+++ b/pkg/vm/var.go
@@ -29,9 +29,17 @@ type Var struct {
 	// so the dynamic flag is read on the hot deref path while being set by a
 	// concurrent bind. A plain bool here is a data race.
 	isDynamic atomic.Bool
-	isPrivate bool
-	mu        sync.Mutex // guards meta + watches
-	watches   map[Value]Fn
+	// rootBindDepth counts this var's live bindings in the ROOT (process-global)
+	// context. The deref hot path reads it — a per-var field, so distinct vars
+	// don't share a cache line. Zero means no root binding exists, so deref
+	// returns the root directly and never touches the shared binding stack.
+	// Maintained by every root-stack mutation: pushBinding/popBinding and
+	// RunWithBindings. Child-context bindings live in isolated per-goroutine
+	// stacks and never touch this.
+	rootBindDepth atomic.Int32
+	isPrivate     bool
+	mu            sync.Mutex // guards meta + watches
+	watches       map[Value]Fn
 }
 
 // valPtr boxes a Value for storage in an atomic.Pointer[Value].
@@ -74,12 +82,27 @@ func (v *Var) SetRoot(val Value) *Var {
 	return v
 }
 
+// derefRoot resolves v against the ROOT (process-global) context. It is the
+// single shared root-resolution path — Var.Deref (host/lowered callers) and
+// ExecContext.deref's root branch both call it, so the two can never diverge.
+// The rootBindDepth==0 fast path is a single per-var atomic load with no
+// shared-structure access.
+func (v *Var) derefRoot() Value {
+	if v.rootBindDepth.Load() == 0 {
+		return v.Root()
+	}
+	if val, ok := globalBindingStack.current(v); ok {
+		return val
+	}
+	return v.Root()
+}
+
 // Deref returns the current value in the root execution context: the dynamic
 // top binding if one is active, else the root. Host and lowered callers that
 // hold no ExecContext resolve here; the interpreter resolves against its
-// frame's context (which is the root context unless a child was installed).
+// frame's context via ExecContext.deref (which shares derefRoot for the root).
 func (v *Var) Deref() Value {
-	return RootExecContext.deref(v)
+	return v.derefRoot()
 }
 
 // Root returns the var's root binding directly, bypassing any current

--- a/pkg/vm/var.go
+++ b/pkg/vm/var.go
@@ -147,10 +147,33 @@ func SnapshotBindings() BindingSnapshot {
 // ec.Child() instead (see docs/design/exec-context-threading.md).
 func RunWithBindings(snap BindingSnapshot, fn func() (Value, error)) (Value, error) {
 	saved := globalBindingStack.snapshot()
-	globalBindingStack.installSnapshot(snap)
+	rootInstallSnapshot(saved, snap)
 	out, err := fn()
-	globalBindingStack.installSnapshot(saved)
+	rootInstallSnapshot(snap, saved)
 	return out, err
+}
+
+// rootInstallSnapshot swaps the ROOT binding stack from `from` to `to` and
+// keeps each affected var's rootBindDepth consistent (installSnapshot bypasses
+// push/pop). To preserve "never Root() while a settled binding exists", it
+// bumps gaining vars BEFORE the swap and drops losing vars AFTER it.
+func rootInstallSnapshot(from, to BindingSnapshot) {
+	for v, vals := range to {
+		if d := int32(len(vals) - len(from[v])); d > 0 {
+			v.rootBindDepth.Add(d)
+		}
+	}
+	globalBindingStack.installSnapshot(to)
+	for v, vals := range to {
+		if d := int32(len(vals) - len(from[v])); d < 0 {
+			v.rootBindDepth.Add(d)
+		}
+	}
+	for v, vals := range from {
+		if _, ok := to[v]; !ok {
+			v.rootBindDepth.Add(int32(-len(vals)))
+		}
+	}
 }
 
 func (v *Var) notifyWatches(oldVal, newVal Value) error {

--- a/pkg/vm/var_binding_race_test.go
+++ b/pkg/vm/var_binding_race_test.go
@@ -1,0 +1,44 @@
+package vm
+
+import "testing"
+
+func TestRootBindDepthGate(t *testing.T) {
+	v := NewVar(nil, "t", "x")
+	v.SetRoot(Int(1))
+
+	// unbound (also covers non-dynamic): reads root, gate skips the stack
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("unbound deref = %v, want 1", got)
+	}
+	if d := v.rootBindDepth.Load(); d != 0 {
+		t.Fatalf("rootBindDepth unbound = %d, want 0", d)
+	}
+
+	// bound: deref sees the binding
+	v.PushBinding(Int(2))
+	if d := v.rootBindDepth.Load(); d != 1 {
+		t.Fatalf("rootBindDepth bound = %d, want 1", d)
+	}
+	if got := v.Deref(); got != Int(2) {
+		t.Fatalf("bound deref = %v, want 2", got)
+	}
+
+	// nested shadow
+	v.PushBinding(Int(3))
+	if got := v.Deref(); got != Int(3) {
+		t.Fatalf("nested deref = %v, want 3", got)
+	}
+	v.PopBinding()
+	if got := v.Deref(); got != Int(2) {
+		t.Fatalf("after inner pop deref = %v, want 2 (restored)", got)
+	}
+
+	// fully unbound: back to root, counter zero (the PreviouslyBound case)
+	v.PopBinding()
+	if d := v.rootBindDepth.Load(); d != 0 {
+		t.Fatalf("rootBindDepth after unbind = %d, want 0", d)
+	}
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("previously-bound deref = %v, want 1 (root)", got)
+	}
+}

--- a/pkg/vm/var_binding_race_test.go
+++ b/pkg/vm/var_binding_race_test.go
@@ -42,3 +42,26 @@ func TestRootBindDepthGate(t *testing.T) {
 		t.Fatalf("previously-bound deref = %v, want 1 (root)", got)
 	}
 }
+
+func TestRunWithBindingsCounterConsistent(t *testing.T) {
+	v := NewVar(nil, "t", "y")
+	v.SetRoot(Int(10))
+	v.SetDynamic()
+
+	snap := BindingSnapshot{v: {Int(99)}}
+	_, _ = RunWithBindings(snap, func() (Value, error) {
+		if got := v.Deref(); got != Int(99) {
+			t.Errorf("inside RunWithBindings deref = %v, want 99", got)
+		}
+		if d := v.rootBindDepth.Load(); d != 1 {
+			t.Errorf("inside RunWithBindings depth = %d, want 1", d)
+		}
+		return NIL, nil
+	})
+	if got := v.Deref(); got != Int(10) {
+		t.Errorf("after RunWithBindings deref = %v, want 10 (root)", got)
+	}
+	if d := v.rootBindDepth.Load(); d != 0 {
+		t.Errorf("after RunWithBindings depth = %d, want 0", d)
+	}
+}

--- a/pkg/vm/var_binding_race_test.go
+++ b/pkg/vm/var_binding_race_test.go
@@ -1,6 +1,9 @@
 package vm
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestRootBindDepthGate(t *testing.T) {
 	v := NewVar(nil, "t", "x")
@@ -64,4 +67,85 @@ func TestRunWithBindingsCounterConsistent(t *testing.T) {
 	if d := v.rootBindDepth.Load(); d != 0 {
 		t.Errorf("after RunWithBindings depth = %d, want 0", d)
 	}
+}
+
+func TestVarDerefChildIsolation(t *testing.T) {
+	v := NewVar(nil, "t", "z")
+	v.SetRoot(Int(0))
+	v.SetDynamic()
+	v.PushBinding(Int(1)) // root binding
+	defer v.PopBinding()
+
+	child := RootExecContext.Child() // seeded from root snapshot
+	if got := child.deref(v); got != Int(1) {
+		t.Fatalf("child sees root binding = %v, want 1", got)
+	}
+	child.pushBinding(v, Int(2)) // child-local
+	if got := child.deref(v); got != Int(2) {
+		t.Fatalf("child own binding = %v, want 2", got)
+	}
+	// child binding must NOT touch the root counter or the root value
+	if d := v.rootBindDepth.Load(); d != 1 {
+		t.Fatalf("child push changed rootBindDepth to %d, want 1", d)
+	}
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("root deref after child push = %v, want 1 (unaffected)", got)
+	}
+}
+
+func TestVarDerefConcurrentBindDeref(t *testing.T) {
+	const goroutines, iters = 16, 2000
+	v := NewVar(nil, "t", "c")
+	v.SetRoot(Int(-1))
+	v.SetDynamic()
+
+	valid := map[Value]bool{Int(-1): true, Int(7): true} // root or the pushed value
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if id%2 == 0 {
+					if got := v.Deref(); !valid[got] {
+						t.Errorf("deref returned unexpected %v", got)
+						return
+					}
+				} else {
+					v.PushBinding(Int(7))
+					_ = v.Deref()
+					v.PopBinding()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	if d := v.rootBindDepth.Load(); d != 0 {
+		t.Errorf("rootBindDepth after balanced push/pop = %d, want 0", d)
+	}
+}
+
+func TestVarDerefDistinctConcurrent(t *testing.T) {
+	const goroutines, iters = 16, 2000
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			v := NewVar(nil, "t", "d") // distinct var per goroutine
+			v.SetRoot(Int(int64(id)))
+			v.SetDynamic()
+			for i := 0; i < iters; i++ {
+				v.PushBinding(Int(int64(id + 1000)))
+				if got := v.Deref(); got != Int(int64(id+1000)) {
+					t.Errorf("g%d deref = %v, want %d", id, got, id+1000)
+				}
+				v.PopBinding()
+				if got := v.Deref(); got != Int(int64(id)) {
+					t.Errorf("g%d unbound deref = %v, want %d", id, got, id)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
 }

--- a/pkg/vm/var_deref_bench_test.go
+++ b/pkg/vm/var_deref_bench_test.go
@@ -124,6 +124,19 @@ func BenchmarkVarDerefDistinctParallel(b *testing.B) {
 	})
 }
 
+// BenchmarkVarDerefChildContext measures deref against an isolated child
+// context (the per-goroutine path), which the root-context benchmarks don't
+// cover. The binding lives in the child's own stack.
+func BenchmarkVarDerefChildContext(b *testing.B) {
+	v := newRootVar()
+	v.SetDynamic()
+	ec := RootExecContext.Child()
+	ec.pushBinding(v, Int(7))
+	for i := 0; i < b.N; i++ {
+		derefSink = ec.deref(v)
+	}
+}
+
 // BenchmarkBindingPushPop measures one full binding extent (the (binding […])
 // write path). Copy-on-write makes reads lock-free at the cost of allocating a
 // fresh map per push/pop, so this is the side of the trade that gets more


### PR DESCRIPTION
**Phase 1** of recovering the `Var.Deref` fast path after the #203/#210 concurrency rework, which routed every `^:dynamic` var deref through a walk of the single shared `globalBindingStack` — regressing deref ~8× on the perf timeline (worst on the `*Parallel` variants, where all threads read the one shared head).

## Change

Add a per-var `rootBindDepth atomic.Int32` counting the var's live **root-context** bindings. Deref's root path reads only that per-var field (its own cache line, no shared-structure access) and walks the shared stack **only** when the counter is non-zero:

```go
func (v *Var) derefRoot() Value {
    if v.rootBindDepth.Load() == 0 { return v.Root() } // non-dynamic OR declared-but-unbound → no shared read
    if val, ok := globalBindingStack.current(v); ok { return val }
    return v.Root()
}
```

- `Var.Deref()` and `ExecContext.deref()`'s root branch share this one helper (can't diverge). The **child** branch is unchanged — isolated per-goroutine stacks, `isDynamic`-gated (#210 isolation preserved).
- The counter is maintained by every root-stack mutation with race-safe ordering: `pushBinding` increments **before** the push, `popBinding` pops **before** the decrement, and `RunWithBindings` bumps gaining vars before the snapshot swap and drops losing vars after — so a reader never sees `depth==0` while a settled binding is still walkable. `set!`/`setCurrent` doesn't change bound-status and correctly leaves the counter alone.

## What this fixes / doesn't

| Case | This PR |
|---|---|
| non-dynamic (fns, defs) | ✅ single per-var atomic load, contention-free |
| `^:dynamic` declared-but-unbound (`*warn-on-reflection*`, `*print-length*`, …) | ✅ `rootBindDepth==0` → skip the shared walk |
| `^:dynamic` currently root-**bound** (`Bound`/`BoundParallel`) | ⛔ still walks the shared stack — **deferred to Phase 2**, gated on measuring a real bound-parallel workload (e.g. malli) |

Bench (M3): `VarDerefPreviouslyBound` — the common declared-but-unbound read — drops from ~2.5ns (walking the shared stack) to **1.6ns serial / 0.31ns parallel**, and every `*Parallel` variant is now *faster* than its serial counterpart (contention gone). Success criterion is contention-flat + near the atomic-load floor, not restoring the pre-atomics 0.25ns.

## Tests

`-race` gate (the acceptance bar): child-context isolation, 16-goroutine concurrent bind/deref on the same var, and 16 distinct vars concurrent — all pass with zero data races. Full non-race suite green (18 packages).

**Note (not this PR):** `go test ./pkg/vm/ -race` also surfaces a **pre-existing** data race in `TestArrayVectorSeqChunkedFirstRace` (`vector.go:268`) — confirmed identical on `main`; this branch doesn't touch `vector.go`. Worth its own fix.

Spec/plan: `docs/superpowers/specs/2026-07-12-var-deref-fast-path-design.md`.



---
**Part of #464** (Epic: Runtime performance & concurrency) — var-deref regression recovery, Phase 1.