### PR TITLE
fix(rt): expose key-pending? on plan9

### DIFF
--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -35,6 +35,9 @@ func installTermNS() {
 	stubTrue, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		return vm.TRUE, nil
 	})
+	stubFalse, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		return vm.FALSE, nil
+	})
 	stubNil, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		return vm.NIL, nil
 	})
@@ -42,6 +45,7 @@ func installTermNS() {
 	ns.Def("raw-mode!", stubTrue)
 	ns.Def("restore-mode!", stubTrue)
 	ns.Def("read-key", stubNil)
+	ns.Def("key-pending?", stubFalse)
 
 	sizeFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		return vm.NewPersistentVector([]vm.Value{vm.MakeInt(80), vm.MakeInt(24)}), nil

--- a/test/term_test.lg
+++ b/test/term_test.lg
@@ -10,6 +10,7 @@
     (is (not (nil? term/write)))
     (is (not (nil? term/write-at)))
     (is (not (nil? term/read-key)))
+    (is (not (nil? term/key-pending?)))
     (is (not (nil? term/raw-mode!)))
     (is (not (nil? term/restore-mode!)))
     (is (not (nil? term/hide-cursor)))


### PR DESCRIPTION
## What changed

- define `term/key-pending?` in the Plan 9 terminal namespace
- return `false`, consistent with Plan 9's existing stubbed `term/read-key`
- include `key-pending?` in the terminal namespace surface test

## Why

Plan 9 builds create the `term` namespace but did not register `key-pending?`. Code using `(term/key-pending?)` therefore failed during compilation with `Can't resolve term/key-pending? in this context`, even though the operation is present on native and WASM targets.

This restores a consistent namespace surface without claiming unsupported Plan 9 input polling behavior.

## Validation

- `go test -count=1 -run 'TestRunner/term_test.lg' ./test`
- `GOOS=plan9 GOARCH=amd64 go test -c -o /tmp/let-go-plan9-term.test ./test`
- `GOOS=js GOARCH=wasm go build ./...`
- `GOOS=linux GOARCH=amd64 go build ./...`
- `gofmt -d pkg/rt/term_plan9.go`
- `git diff --check`
