### PR TITLE
feat(rt): real Plan 9 terminal input (raw mode, read-key, key-pending?)

### DIFF
--- a/pkg/rt/keysource_queued.go
+++ b/pkg/rt/keysource_queued.go
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"io"
+	"sync"
+)
+
+// queuedKeySource is a KeySource for hosts without a non-blocking input peek: a
+// background goroutine blocks on an io.Reader and appends to a shared queue,
+// ReadKey tokenizes one key per call off it (via scanKey), and KeyPending peeks
+// it. This is the shape Plan 9 needs — it has no poll(2)/FIONREAD, so a
+// non-blocking key-pending? can only be answered from a buffer a concurrent
+// reader fills, where native (term.go) reads stdin synchronously inside ReadKey.
+// It is platform-neutral, so it is also available to embedders whose input is a
+// plain blocking reader (a pipe, a socket) — see NewQueuedKeySource.
+//
+// State lives on the instance, not a package global like native's keyBuf: the
+// goroutine consumes the reader, so it must start only when THIS source is the
+// one being read. If an embedder rebinds *keys* via api.WithKeySource, this
+// source's ReadKey/KeyPending are never called and the reader never starts — no
+// bytes stolen from the source that replaced it.
+type queuedKeySource struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	r       io.Reader
+	buf     []byte // read but not yet tokenized out
+	eof     bool
+	started bool
+}
+
+// NewQueuedKeySource returns a KeySource that reads keys from r via a background
+// goroutine and a buffered queue, so KeyPending is non-blocking on platforms
+// that lack a poll/FIONREAD peek. The reader goroutine starts lazily on the
+// first ReadKey/KeyPending, so binding this at *keys* without ever consulting it
+// (e.g. when api.WithKeySource overrides it) reads nothing.
+func NewQueuedKeySource(r io.Reader) KeySource {
+	s := &queuedKeySource{r: r}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// queuedReadChunkSize matches native's readChunkSize: a blocking Read returns as
+// soon as any data is available, so a larger buffer adds no latency to a single
+// keystroke — it just collects held-key bursts in fewer reads.
+const queuedReadChunkSize = 256
+
+// start launches the background reader once. Called with s.mu held.
+func (s *queuedKeySource) start() {
+	if s.started {
+		return
+	}
+	s.started = true
+	go s.readLoop()
+}
+
+// readLoop blocks on r.Read WITHOUT holding the lock, then locks only to append
+// the chunk and wake a waiter. Runs until EOF or a read error, which it records
+// as eof so a parked ReadKey unblocks with the nil contract.
+func (s *queuedKeySource) readLoop() {
+	chunk := make([]byte, queuedReadChunkSize)
+	for {
+		n, err := s.r.Read(chunk)
+		s.mu.Lock()
+		if n > 0 {
+			s.buf = append(s.buf, chunk[:n]...)
+		}
+		if err != nil || n == 0 {
+			s.eof = true
+			s.cond.Broadcast()
+			s.mu.Unlock()
+			return
+		}
+		s.cond.Broadcast()
+		s.mu.Unlock()
+	}
+}
+
+// ReadKey blocks until a whole key token is available (or EOF), tokenizing one
+// key per call off the shared buffer via scanKey. "" signals end-of-input (the
+// read-key nil contract). Blocking here matches native (which blocks in poll);
+// callers stay responsive by gating on KeyPending first.
+func (s *queuedKeySource) ReadKey() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.start()
+	for len(s.buf) == 0 && !s.eof {
+		s.cond.Wait()
+	}
+	if len(s.buf) == 0 {
+		return "", nil // EOF
+	}
+	for {
+		status, n := scanKey(s.buf)
+		if status == keyNeedMore && n > 1 && !s.eof {
+			// A multi-byte token (CSI/SS3/UTF-8) split across reader chunks —
+			// short reads are normal over a network transport like 9P/drawterm.
+			// Wait for one more append, then re-scan to stitch it, rather than
+			// emitting a broken partial that would desync every following key.
+			// Bounded: each wait adds bytes (progress) or hits eof (then emit
+			// best-effort below). A lone ESC (scanKey → keyNeedMore, 1) is
+			// deliberately NOT waited on — it is the Escape key, emitted now
+			// rather than parked until the next keypress.
+			before := len(s.buf)
+			for len(s.buf) == before && !s.eof {
+				s.cond.Wait()
+			}
+			continue
+		}
+		tok := string(s.buf[:n])
+		s.buf = s.buf[n:]
+		if len(s.buf) == 0 {
+			s.buf = nil // release the backing array once drained
+		}
+		return tok, nil
+	}
+}
+
+// KeyPending reports whether a key is buffered and ready, without consuming it.
+// Non-blocking and eof-blind (false once the queue drains at end-of-input),
+// mirroring native's FIONREAD-based rawPending so a per-tick input poll doesn't
+// busy-drain end-of-input forever.
+func (s *queuedKeySource) KeyPending() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.start()
+	return len(s.buf) > 0
+}

--- a/pkg/rt/keysource_queued.go
+++ b/pkg/rt/keysource_queued.go
@@ -8,6 +8,7 @@ package rt
 import (
 	"io"
 	"sync"
+	"time"
 )
 
 // queuedKeySource is a KeySource for hosts without a non-blocking input peek: a
@@ -26,12 +27,24 @@ import (
 // bytes stolen from the source that replaced it.
 type queuedKeySource struct {
 	mu      sync.Mutex
-	cond    *sync.Cond
 	r       io.Reader
-	buf     []byte // read but not yet tokenized out
-	eof     bool
-	started bool
+	buf     []byte        // read but not yet tokenized out
+	err     error         // sticky reader error; nil for a clean EOF
+	done    bool          // reader finished (EOF or error) — no more bytes coming
+	started bool          // reader goroutine launched
+	notify  chan struct{} // buffered(1) wakeup; reader signals on append/done
+	grace   time.Duration // inter-byte wait for stitching a split escape sequence
 }
+
+// escGrace bounds how long ReadKey waits for the rest of an incomplete escape
+// (or UTF-8) sequence before emitting what it has. It's the classic terminal
+// "ESC delay": long enough to stitch a sequence split across reads on a slow
+// transport (drawterm/9P), short enough that a bare Escape key still registers
+// promptly. Only an incomplete front token pays it — a complete key returns with
+// zero added latency. Without it, distinguishing a bare ESC from the start of a
+// split arrow is impossible on a host with no FIONREAD peek (a lone ESC would
+// either be emitted too eagerly, breaking split arrows, or waited on forever).
+const escGrace = 40 * time.Millisecond
 
 // NewQueuedKeySource returns a KeySource that reads keys from r via a background
 // goroutine and a buffered queue, so KeyPending is non-blocking on platforms
@@ -39,9 +52,7 @@ type queuedKeySource struct {
 // first ReadKey/KeyPending, so binding this at *keys* without ever consulting it
 // (e.g. when api.WithKeySource overrides it) reads nothing.
 func NewQueuedKeySource(r io.Reader) KeySource {
-	s := &queuedKeySource{r: r}
-	s.cond = sync.NewCond(&s.mu)
-	return s
+	return &queuedKeySource{r: r, notify: make(chan struct{}, 1), grace: escGrace}
 }
 
 // queuedReadChunkSize matches native's readChunkSize: a blocking Read returns as
@@ -58,9 +69,21 @@ func (s *queuedKeySource) start() {
 	go s.readLoop()
 }
 
+// signal wakes a waiting ReadKey without blocking; the buffered channel
+// coalesces bursts, and ReadKey re-checks the buffer under the lock after each
+// wake, so a dropped (already-pending) signal is never a missed update.
+func (s *queuedKeySource) signal() {
+	select {
+	case s.notify <- struct{}{}:
+	default:
+	}
+}
+
 // readLoop blocks on r.Read WITHOUT holding the lock, then locks only to append
-// the chunk and wake a waiter. Runs until EOF or a read error, which it records
-// as eof so a parked ReadKey unblocks with the nil contract.
+// the chunk and wake a waiter. On a read error it retains the error (draining
+// any bytes that came with it) and stops; io.EOF is a clean end, recorded as a
+// nil error so ReadKey returns the "" contract. A (0, nil) read is not EOF (the
+// io.Reader contract) — it loops and reads again.
 func (s *queuedKeySource) readLoop() {
 	chunk := make([]byte, queuedReadChunkSize)
 	for {
@@ -69,55 +92,95 @@ func (s *queuedKeySource) readLoop() {
 		if n > 0 {
 			s.buf = append(s.buf, chunk[:n]...)
 		}
-		if err != nil || n == 0 {
-			s.eof = true
-			s.cond.Broadcast()
+		if err != nil {
+			if err != io.EOF {
+				s.err = err
+			}
+			s.done = true
 			s.mu.Unlock()
+			s.signal()
 			return
 		}
-		s.cond.Broadcast()
 		s.mu.Unlock()
+		if n > 0 {
+			s.signal()
+		}
 	}
 }
 
-// ReadKey blocks until a whole key token is available (or EOF), tokenizing one
-// key per call off the shared buffer via scanKey. "" signals end-of-input (the
-// read-key nil contract). Blocking here matches native (which blocks in poll);
-// callers stay responsive by gating on KeyPending first.
+// ReadKey blocks until a whole key token is available (or the reader ends),
+// tokenizing one key per call off the shared buffer via scanKey. It returns ""
+// with a nil error at a clean EOF (the read-key nil contract), or "" with the
+// retained error if the reader failed. Blocking here matches native (which
+// blocks in poll); callers stay responsive by gating on KeyPending first.
 func (s *queuedKeySource) ReadKey() (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.start()
-	for len(s.buf) == 0 && !s.eof {
-		s.cond.Wait()
+
+	for len(s.buf) == 0 && !s.done {
+		s.waitLocked(0) // no deadline: block until data or reader end
 	}
 	if len(s.buf) == 0 {
-		return "", nil // EOF
+		return "", s.err // clean EOF (err nil) or a real reader failure
 	}
+
+	var deadline time.Time // set on the first incomplete front token
 	for {
 		status, n := scanKey(s.buf)
-		if status == keyNeedMore && n > 1 && !s.eof {
-			// A multi-byte token (CSI/SS3/UTF-8) split across reader chunks —
-			// short reads are normal over a network transport like 9P/drawterm.
-			// Wait for one more append, then re-scan to stitch it, rather than
-			// emitting a broken partial that would desync every following key.
-			// Bounded: each wait adds bytes (progress) or hits eof (then emit
-			// best-effort below). A lone ESC (scanKey → keyNeedMore, 1) is
-			// deliberately NOT waited on — it is the Escape key, emitted now
-			// rather than parked until the next keypress.
-			before := len(s.buf)
-			for len(s.buf) == before && !s.eof {
-				s.cond.Wait()
-			}
-			continue
+		if status == keyReady || s.done {
+			// Complete token, or the reader ended so no completion is coming —
+			// emit best-effort (a lone ESC at EOF is the Escape key; a truncated
+			// sequence surfaces rather than hangs).
+			return s.take(n), nil
 		}
-		tok := string(s.buf[:n])
-		s.buf = s.buf[n:]
-		if len(s.buf) == 0 {
-			s.buf = nil // release the backing array once drained
+		// keyNeedMore and the reader is still live: a front token split across
+		// reads. Wait for more bytes up to the grace period, then re-scan; if the
+		// grace expires with no completion, emit what we have. This is what makes
+		// a bare ESC vs. a split arrow decidable without a FIONREAD peek. The
+		// grace is inter-byte — each byte that arrives resets it — so a sequence
+		// dribbling in over a slow transport keeps stitching, while a truly bare
+		// ESC (nothing more within one grace window) emits as the Escape key.
+		if deadline.IsZero() {
+			deadline = time.Now().Add(s.grace)
 		}
-		return tok, nil
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return s.take(n), nil
+		}
+		before := len(s.buf)
+		s.waitLocked(remaining)
+		if len(s.buf) > before {
+			deadline = time.Time{} // new bytes — restart the inter-byte window
+		}
 	}
+}
+
+// take slices the front n bytes off the buffer as a token, releasing the backing
+// array once drained. Called with s.mu held.
+func (s *queuedKeySource) take(n int) string {
+	tok := string(s.buf[:n])
+	s.buf = s.buf[n:]
+	if len(s.buf) == 0 {
+		s.buf = nil
+	}
+	return tok
+}
+
+// waitLocked releases the lock, waits for a reader wake (or the timeout, if
+// nonzero), and re-acquires it — the condition-variable wait, done over a
+// channel so it can be time-bounded. Called with s.mu held; returns holding it.
+func (s *queuedKeySource) waitLocked(timeout time.Duration) {
+	s.mu.Unlock()
+	if timeout > 0 {
+		select {
+		case <-s.notify:
+		case <-time.After(timeout):
+		}
+	} else {
+		<-s.notify
+	}
+	s.mu.Lock()
 }
 
 // KeyPending reports whether a key is buffered and ready, without consuming it.

--- a/pkg/rt/keysource_queued.go
+++ b/pkg/rt/keysource_queued.go
@@ -7,6 +7,8 @@ package rt
 
 import (
 	"io"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -36,15 +38,33 @@ type queuedKeySource struct {
 	grace   time.Duration // inter-byte wait for stitching a split escape sequence
 }
 
-// escGrace bounds how long ReadKey waits for the rest of an incomplete escape
-// (or UTF-8) sequence before emitting what it has. It's the classic terminal
-// "ESC delay": long enough to stitch a sequence split across reads on a slow
-// transport (drawterm/9P), short enough that a bare Escape key still registers
-// promptly. Only an incomplete front token pays it — a complete key returns with
-// zero added latency. Without it, distinguishing a bare ESC from the start of a
-// split arrow is impossible on a host with no FIONREAD peek (a lone ESC would
-// either be emitted too eagerly, breaking split arrows, or waited on forever).
+// escGrace is the default bound on how long ReadKey waits for the rest of an
+// incomplete escape (or UTF-8) sequence before emitting what it has. It's the
+// classic terminal "ESC delay": long enough to stitch a sequence split across
+// reads on a slow transport (drawterm/9P), short enough that a bare Escape key
+// still registers promptly. Only an incomplete front token pays it — a complete
+// key returns with zero added latency. Without it, distinguishing a bare ESC
+// from the start of a split arrow is impossible on a host with no FIONREAD peek
+// (a lone ESC would either be emitted too eagerly, breaking split arrows, or
+// waited on forever).
 const escGrace = 40 * time.Millisecond
+
+// escGraceEnv overrides escGrace, in milliseconds, for slow/high-latency
+// transports — drawterm over a WAN link, where the 40ms default can lapse
+// mid-sequence and split an arrow into a stray ESC + [A. Read once per source at
+// construction.
+const escGraceEnv = "LETGO_ESC_GRACE_MS"
+
+// resolveGrace returns the inter-byte escape grace, honoring escGraceEnv when it
+// holds a positive integer and falling back to escGrace otherwise.
+func resolveGrace() time.Duration {
+	if v := os.Getenv(escGraceEnv); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return escGrace
+}
 
 // NewQueuedKeySource returns a KeySource that reads keys from r via a background
 // goroutine and a buffered queue, so KeyPending is non-blocking on platforms
@@ -52,7 +72,7 @@ const escGrace = 40 * time.Millisecond
 // first ReadKey/KeyPending, so binding this at *keys* without ever consulting it
 // (e.g. when api.WithKeySource overrides it) reads nothing.
 func NewQueuedKeySource(r io.Reader) KeySource {
-	return &queuedKeySource{r: r, notify: make(chan struct{}, 1), grace: escGrace}
+	return &queuedKeySource{r: r, notify: make(chan struct{}, 1), grace: resolveGrace()}
 }
 
 // queuedReadChunkSize matches native's readChunkSize: a blocking Read returns as

--- a/pkg/rt/keysource_queued.go
+++ b/pkg/rt/keysource_queued.go
@@ -80,7 +80,10 @@ func NewQueuedKeySource(r io.Reader) KeySource {
 // keystroke — it just collects held-key bursts in fewer reads.
 const queuedReadChunkSize = 256
 
-// start launches the background reader once. Called with s.mu held.
+// start launches the reader goroutine once. The caller must hold s.mu: start
+// flips s.started, so the guard against a double launch relies on the lock. The
+// goroutine it spawns (readLoop) then does its own finer-grained locking and
+// does not hold s.mu while blocked on Read.
 func (s *queuedKeySource) start() {
 	if s.started {
 		return
@@ -139,7 +142,7 @@ func (s *queuedKeySource) ReadKey() (string, error) {
 	s.start()
 
 	for len(s.buf) == 0 && !s.done {
-		s.waitLocked(0) // no deadline: block until data or reader end
+		s.condWait(0) // no deadline: block until data or reader end
 	}
 	if len(s.buf) == 0 {
 		return "", s.err // clean EOF (err nil) or a real reader failure
@@ -169,7 +172,7 @@ func (s *queuedKeySource) ReadKey() (string, error) {
 			return s.take(n), nil
 		}
 		before := len(s.buf)
-		s.waitLocked(remaining)
+		s.condWait(remaining)
 		if len(s.buf) > before {
 			deadline = time.Time{} // new bytes — restart the inter-byte window
 		}
@@ -187,10 +190,12 @@ func (s *queuedKeySource) take(n int) string {
 	return tok
 }
 
-// waitLocked releases the lock, waits for a reader wake (or the timeout, if
-// nonzero), and re-acquires it — the condition-variable wait, done over a
-// channel so it can be time-bounded. Called with s.mu held; returns holding it.
-func (s *queuedKeySource) waitLocked(timeout time.Duration) {
+// condWait releases s.mu, waits for a reader wake (or the timeout, if nonzero),
+// then re-acquires it — a condition-variable wait done over a channel so it can
+// be time-bounded. Named for the sync.Cond.Wait pattern: the lock is dropped for
+// the duration of the wait, not held across it. Call with s.mu held; returns
+// holding it.
+func (s *queuedKeySource) condWait(timeout time.Duration) {
 	s.mu.Unlock()
 	if timeout > 0 {
 		select {

--- a/pkg/rt/keysource_queued_test.go
+++ b/pkg/rt/keysource_queued_test.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Matt Parrett
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"io"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// chunkReader hands out one queued chunk per Read (splitting a chunk across
+// Reads only if the caller's buffer is smaller), blocks when the queue is empty,
+// and returns io.EOF once the channel is closed. It lets a test control exactly
+// how input bytes are split across reads — the thing the queued source has to
+// stitch back together.
+type chunkReader struct {
+	ch  chan []byte
+	rem []byte
+}
+
+func (c *chunkReader) Read(p []byte) (int, error) {
+	if len(c.rem) == 0 {
+		b, ok := <-c.ch
+		if !ok {
+			return 0, io.EOF
+		}
+		c.rem = b
+	}
+	n := copy(p, c.rem)
+	c.rem = c.rem[n:]
+	return n, nil
+}
+
+// feed returns a queued source over the given chunks, delivered in order then
+// EOF. All chunks are queued up front, so ReadKey sees end-of-input after the
+// last one.
+func feed(chunks ...[]byte) KeySource {
+	ch := make(chan []byte, len(chunks))
+	for _, c := range chunks {
+		ch <- c
+	}
+	close(ch)
+	return NewQueuedKeySource(&chunkReader{ch: ch})
+}
+
+// readAll drains keys until the EOF nil contract ("") and returns the tokens.
+// Guarded by a deadline so a stuck ReadKey fails loudly instead of hanging CI.
+func readAll(t *testing.T, ks KeySource) []string {
+	t.Helper()
+	var got []string
+	done := make(chan []string, 1)
+	go func() {
+		var out []string
+		for {
+			k, err := ks.ReadKey()
+			if err != nil {
+				t.Errorf("ReadKey error: %v", err)
+				break
+			}
+			if k == "" {
+				break
+			}
+			out = append(out, k)
+		}
+		done <- out
+	}()
+	select {
+	case got = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readAll timed out — ReadKey blocked")
+	}
+	return got
+}
+
+func TestQueuedKeySourceTokenizes(t *testing.T) {
+	cases := []struct {
+		name   string
+		chunks [][]byte
+		want   []string
+	}{
+		{"held-key burst", [][]byte{[]byte("llll")}, []string{"l", "l", "l", "l"}},
+		{"arrow one chunk", [][]byte{[]byte("\x1b[A")}, []string{"\x1b[A"}},
+		{"lone esc", [][]byte{[]byte("\x1b")}, []string{"\x1b"}},
+		{"ss3 f1", [][]byte{[]byte("\x1bOP")}, []string{"\x1bOP"}},
+		{"mixed keys and csi", [][]byte{[]byte("l\x1b[Bx")}, []string{"l", "\x1b[B", "x"}},
+		// A CSI arrow split across two reads must come back as one token.
+		{"split arrow", [][]byte{[]byte("\x1b["), []byte("A")}, []string{"\x1b[A"}},
+		// A multi-byte rune split across reads must never be torn.
+		{"split utf8", [][]byte{{0xe2}, {0x8c, 0x98}}, []string{"⌘"}},
+		// A truncated CSI at EOF is emitted best-effort rather than lost.
+		{"truncated csi at eof", [][]byte{[]byte("\x1b[")}, []string{"\x1b["}},
+		{"empty then eof", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readAll(t, feed(tc.chunks...))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("tokens = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQueuedKeySourceStitchesWhileBlocked drives the wait-for-more path
+// deterministically: the partial CSI arrives while ReadKey is already parked, so
+// ReadKey must wait for the completing byte and stitch, not emit "\x1b[".
+func TestQueuedKeySourceStitchesWhileBlocked(t *testing.T) {
+	ch := make(chan []byte) // unbuffered: each send blocks until the reader takes it
+	ks := NewQueuedKeySource(&chunkReader{ch: ch})
+
+	res := make(chan string, 1)
+	go func() {
+		k, _ := ks.ReadKey()
+		res <- k
+	}()
+
+	ch <- []byte("\x1b[") // reader appends; ReadKey wakes, sees keyNeedMore, waits
+	ch <- []byte("A")     // completes the sequence; ReadKey stitches and returns
+
+	select {
+	case got := <-res:
+		if got != "\x1b[A" {
+			t.Errorf("stitched token = %q, want %q", got, "\x1b[A")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadKey did not return after the sequence completed")
+	}
+	close(ch)
+}
+
+// TestQueuedKeySourceKeyPending verifies the non-blocking, eof-blind peek:
+// false before input, true once a byte is buffered, false again once drained at
+// end-of-input (so a poll loop doesn't busy-spin on EOF).
+func TestQueuedKeySourceKeyPending(t *testing.T) {
+	ch := make(chan []byte, 1)
+	ks := NewQueuedKeySource(&chunkReader{ch: ch})
+
+	// Starts the reader; nothing queued yet → not pending.
+	if ks.KeyPending() {
+		t.Fatal("KeyPending true before any input")
+	}
+
+	ch <- []byte("x")
+	if !eventually(func() bool { return ks.KeyPending() }) {
+		t.Fatal("KeyPending never became true after input")
+	}
+
+	if k, _ := ks.ReadKey(); k != "x" {
+		t.Fatalf("ReadKey = %q, want %q", k, "x")
+	}
+	if ks.KeyPending() {
+		t.Fatal("KeyPending true after the only key was consumed")
+	}
+
+	// EOF must not read as pending (else xsofy's input poll busy-drains it).
+	close(ch)
+	if eventually(func() bool { return ks.KeyPending() }) {
+		t.Fatal("KeyPending true at EOF")
+	}
+}
+
+func eventually(cond func() bool) bool {
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return cond()
+}

--- a/pkg/rt/keysource_queued_test.go
+++ b/pkg/rt/keysource_queued_test.go
@@ -6,6 +6,7 @@
 package rt
 
 import (
+	"errors"
 	"io"
 	"reflect"
 	"testing"
@@ -35,6 +36,15 @@ func (c *chunkReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+// testGrace is a short inter-byte grace so timing-dependent cases resolve fast.
+const testGrace = 15 * time.Millisecond
+
+// newSource builds a queued source over r with the test grace. Constructs the
+// unexported type directly (same package) so tests can shorten the grace.
+func newSource(r io.Reader) *queuedKeySource {
+	return &queuedKeySource{r: r, notify: make(chan struct{}, 1), grace: testGrace}
+}
+
 // feed returns a queued source over the given chunks, delivered in order then
 // EOF. All chunks are queued up front, so ReadKey sees end-of-input after the
 // last one.
@@ -44,7 +54,7 @@ func feed(chunks ...[]byte) KeySource {
 		ch <- c
 	}
 	close(ch)
-	return NewQueuedKeySource(&chunkReader{ch: ch})
+	return newSource(&chunkReader{ch: ch})
 }
 
 // readAll drains keys until the EOF nil contract ("") and returns the tokens.
@@ -105,31 +115,101 @@ func TestQueuedKeySourceTokenizes(t *testing.T) {
 	}
 }
 
-// TestQueuedKeySourceStitchesWhileBlocked drives the wait-for-more path
-// deterministically: the partial CSI arrives while ReadKey is already parked, so
-// ReadKey must wait for the completing byte and stitch, not emit "\x1b[".
-func TestQueuedKeySourceStitchesWhileBlocked(t *testing.T) {
-	ch := make(chan []byte) // unbuffered: each send blocks until the reader takes it
-	ks := NewQueuedKeySource(&chunkReader{ch: ch})
+// TestQueuedKeySourceStitchesAcrossReads drives the wait-for-more path
+// deterministically: an arrow arrives byte-by-byte over an open channel — the
+// worst case the review called out (ESC, then [, then A as separate reads).
+// ReadKey must stitch it into one token, not emit ESC early and split the rest.
+func TestQueuedKeySourceStitchesAcrossReads(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		chunks []string
+		want   string
+	}{
+		{"esc bracket A separately", []string{"\x1b", "[", "A"}, "\x1b[A"},
+		{"esc then bracket-A", []string{"\x1b", "[A"}, "\x1b[A"},
+		{"esc-bracket then A", []string{"\x1b[", "A"}, "\x1b[A"},
+		{"utf8 byte by byte", []string{"\xe2", "\x8c", "\x98"}, "⌘"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan []byte) // unbuffered: each send blocks until read
+			ks := newSource(&chunkReader{ch: ch})
+			res := make(chan string, 1)
+			go func() {
+				k, _ := ks.ReadKey()
+				res <- k
+			}()
+			for _, c := range tc.chunks {
+				ch <- []byte(c) // each byte arrives within the inter-byte grace
+			}
+			select {
+			case got := <-res:
+				if got != tc.want {
+					t.Errorf("stitched token = %q, want %q", got, tc.want)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("ReadKey did not return after the sequence completed")
+			}
+			close(ch)
+		})
+	}
+}
+
+// TestQueuedKeySourceBareEscEmitsAfterGrace: a lone ESC with no completing byte
+// (channel stays open, so no EOF short-circuit) must resolve to the Escape key
+// once the inter-byte grace expires — not hang, and not split.
+func TestQueuedKeySourceBareEscEmitsAfterGrace(t *testing.T) {
+	ch := make(chan []byte, 1)
+	ks := newSource(&chunkReader{ch: ch})
+	ch <- []byte("\x1b") // no close — reader blocks after this, done stays false
 
 	res := make(chan string, 1)
 	go func() {
 		k, _ := ks.ReadKey()
 		res <- k
 	}()
-
-	ch <- []byte("\x1b[") // reader appends; ReadKey wakes, sees keyNeedMore, waits
-	ch <- []byte("A")     // completes the sequence; ReadKey stitches and returns
-
 	select {
 	case got := <-res:
-		if got != "\x1b[A" {
-			t.Errorf("stitched token = %q, want %q", got, "\x1b[A")
+		if got != "\x1b" {
+			t.Errorf("bare ESC = %q, want %q", got, "\x1b")
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("ReadKey did not return after the sequence completed")
+		t.Fatal("bare ESC never resolved — likely parked waiting for more bytes")
 	}
 	close(ch)
+}
+
+// TestQueuedKeySourceReaderErrorPropagates: a non-EOF reader error must surface
+// through ReadKey's error return after buffered bytes drain, not be swallowed as
+// a clean EOF.
+func TestQueuedKeySourceReaderErrorPropagates(t *testing.T) {
+	wantErr := errors.New("console read failed")
+	ks := newSource(&errAfterReader{data: []byte("ab"), err: wantErr})
+
+	// The bytes that arrived before the error still tokenize.
+	for _, want := range []string{"a", "b"} {
+		if k, err := ks.ReadKey(); k != want || err != nil {
+			t.Fatalf("ReadKey = (%q, %v), want (%q, nil)", k, err, want)
+		}
+	}
+	// Then the retained error surfaces.
+	if k, err := ks.ReadKey(); k != "" || err != wantErr {
+		t.Fatalf("ReadKey at error = (%q, %v), want (\"\", %v)", k, err, wantErr)
+	}
+}
+
+// errAfterReader yields data once, then returns err on the next read.
+type errAfterReader struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if !r.done {
+		r.done = true
+		return copy(p, r.data), nil
+	}
+	return 0, r.err
 }
 
 // TestQueuedKeySourceKeyPending verifies the non-blocking, eof-blind peek:

--- a/pkg/rt/keysource_queued_test.go
+++ b/pkg/rt/keysource_queued_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -252,4 +253,19 @@ func eventually(cond func() bool) bool {
 		time.Sleep(time.Millisecond)
 	}
 	return cond()
+}
+
+// TestQueuedKeySourceGraceEnvOverride: NewQueuedKeySource honors
+// LETGO_ESC_GRACE_MS when it holds a positive integer, and falls back to the
+// default for empty/invalid values. Reads the unexported grace directly (same
+// package) since it isn't otherwise observable.
+func TestQueuedKeySourceGraceEnvOverride(t *testing.T) {
+	t.Setenv("LETGO_ESC_GRACE_MS", "120")
+	if g := NewQueuedKeySource(strings.NewReader("")).(*queuedKeySource).grace; g != 120*time.Millisecond {
+		t.Fatalf("grace = %v, want 120ms", g)
+	}
+	t.Setenv("LETGO_ESC_GRACE_MS", "nonsense")
+	if g := NewQueuedKeySource(strings.NewReader("")).(*queuedKeySource).grace; g != escGrace {
+		t.Fatalf("invalid override: grace = %v, want default %v", g, escGrace)
+	}
 }

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -8,6 +8,7 @@
 package rt
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -311,27 +312,32 @@ func installTermNS() {
 	ns.Def("char-width", charWidth)
 
 	// flush — sync the active *out* binding, mirroring native term.go (#308).
+	//
 	// Plan 9 has no fsync on a console/pipe: Sync there fails with "bad arg in
-	// system call", and flushing such an fd is a no-op. Swallow that for a
-	// file-backed *out* (on Plan 9 that's the console/pipe). A non-file-backed
-	// embedder writer's Sync goes through Flush() and still surfaces its own
-	// errors. Native swallows the specific errnos (ENOTTY/EBADF/EINVAL); Plan 9
-	// errors are strings, not errno constants, so we can't errno-match and
-	// swallow all file-backed sync errors instead.
+	// system call" (EINVAL), and flushing such an fd is a no-op. xsofy calls
+	// flush every frame, so for the default console/pipe stdout (the hot path)
+	// we skip the syscall entirely — an early no-op — rather than issuing a
+	// failing Fwstat per frame. Whether stdout is a real (syncable) file is
+	// decided once here. A regular-file or buffered-writer *out* still gets a
+	// real Sync with its errors surfaced; only the EINVAL a console-backed
+	// *out* would raise is swallowed.
+	stdoutSyncable := false
+	if fi, e := os.Stdout.Stat(); e == nil {
+		stdoutSyncable = fi.Mode().IsRegular()
+	}
 	flushFn := vm.NewCtxNativeFn("flush", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
-		var (
-			err        error
-			fileBacked bool
-		)
-		if h := resolveIOHandleVar(ec, "*out*"); h != nil {
+		h := resolveIOHandleVar(ec, "*out*")
+		if (h == nil || h.File() == os.Stdout) && !stdoutSyncable {
+			return vm.NIL, nil // console/pipe stdout: no fsync, no syscall
+		}
+		var err error
+		if h != nil {
 			err = h.Sync()
-			fileBacked = h.File() != nil
 		} else {
 			err = os.Stdout.Sync()
-			fileBacked = true
 		}
-		if fileBacked {
-			err = nil
+		if errors.Is(err, syscall.EINVAL) {
+			err = nil // a non-stdout console-backed *out* — fsync is a no-op
 		}
 		return vm.NIL, err
 	})

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -310,12 +310,30 @@ func installTermNS() {
 	})
 	ns.Def("char-width", charWidth)
 
-	// flush — sync the active *out* binding (see term.go for rationale).
+	// flush — sync the active *out* binding, mirroring native term.go (#308).
+	// Plan 9 has no fsync on a console/pipe: Sync there fails with "bad arg in
+	// system call", and flushing such an fd is a no-op. Swallow that for a
+	// file-backed *out* (on Plan 9 that's the console/pipe). A non-file-backed
+	// embedder writer's Sync goes through Flush() and still surfaces its own
+	// errors. Native swallows the specific errnos (ENOTTY/EBADF/EINVAL); Plan 9
+	// errors are strings, not errno constants, so we can't errno-match and
+	// swallow all file-backed sync errors instead.
 	flushFn := vm.NewCtxNativeFn("flush", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var (
+			err        error
+			fileBacked bool
+		)
 		if h := resolveIOHandleVar(ec, "*out*"); h != nil {
-			return vm.NIL, h.Sync()
+			err = h.Sync()
+			fileBacked = h.File() != nil
+		} else {
+			err = os.Stdout.Sync()
+			fileBacked = true
 		}
-		return vm.NIL, os.Stdout.Sync()
+		if fileBacked {
+			err = nil
+		}
+		return vm.NIL, err
 	})
 	ns.Def("flush", flushFn)
 

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -10,15 +10,40 @@ package rt
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/nooga/let-go/pkg/vm"
 )
 
-// Plan 9 has no termios/ioctl. raw-mode/size/pty are stubbed; the ANSI output
-// functions route through *out* (WriteToOut) like native (rio won't render
-// escapes, but they're harmless). If you need real terminal control on plan9,
-// wire in /dev/cons here.
+// Plan 9 terminal support. Input is real: raw-mode! holds /dev/consctl open with
+// "rawon" (Plan 9 has no termios; consctl controls the console), and read-key /
+// key-pending? read through a queuedKeySource (keysource_queued.go) — a
+// background goroutine feeding a byte queue, because Plan 9 lacks the Unix
+// poll(2)/FIONREAD non-blocking peek. The ANSI output functions route through
+// *out* (WriteToOut) like native. size reads $COLS/$LINES (fallback 80x24); real
+// window geometry (/dev/wctl pixels) is a deferred follow-up. open-pty/set-size
+// stay unsupported. mouse decoding is native-only.
+
+// consctl holds /dev/consctl open while the terminal is in raw mode. Plan 9
+// reverts to cooked mode as soon as this fd closes, so raw-mode! keeps it open
+// and restore-mode! writes "rawoff" then closes it. Guarded by consctlMu.
+var (
+	consctl   *os.File
+	consctlMu sync.Mutex
+)
+
+// envInt reads an integer environment variable, returning def when it is unset
+// or unparseable.
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
 
 func init() { RegisterInstaller(installTermNS) }
 
@@ -32,23 +57,97 @@ func installTermNS() {
 	ns := vm.NewNamespace("term")
 	ns.Refer(CoreNS, "", true)
 
-	stubTrue, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		return vm.TRUE, nil
-	})
-	stubFalse, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		return vm.FALSE, nil
-	})
 	stubNil, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		return vm.NIL, nil
 	})
 
-	ns.Def("raw-mode!", stubTrue)
-	ns.Def("restore-mode!", stubTrue)
-	ns.Def("read-key", stubNil)
-	ns.Def("key-pending?", stubFalse)
+	// Bind the plan9 key source (background stdin reader + queue) at the *keys*
+	// root — the input dual of the os.Stdout *out* default in iort.go. read-key
+	// and key-pending? consult the bound source, so api.WithKeySource / (binding
+	// [*keys* …]) transparently overrides it for tests and embedders.
+	CoreNS.Lookup("*keys*").(*vm.Var).SetRoot(vm.NewBoxed(NewQueuedKeySource(os.Stdin)))
 
+	// raw-mode! — enter raw mode by opening /dev/consctl and writing "rawon",
+	// holding the fd (Plan 9 reverts to cooked mode when it closes). Only the
+	// 0-arg global form is supported; xsofy never passes a handle. Returns nil
+	// (not an error) when there's no console — mirrors native's not-a-TTY path.
+	rawMode, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 0 {
+			return vm.NIL, fmt.Errorf("raw-mode!: per-handle raw mode not supported on plan9")
+		}
+		consctlMu.Lock()
+		defer consctlMu.Unlock()
+		if consctl != nil {
+			return vm.TRUE, nil // already raw
+		}
+		f, err := os.OpenFile("/dev/consctl", os.O_WRONLY, 0)
+		if err != nil {
+			return vm.NIL, nil // no console (e.g. piped stdin)
+		}
+		if _, err := f.WriteString("rawon"); err != nil {
+			f.Close()
+			return vm.NIL, nil
+		}
+		consctl = f
+		return vm.TRUE, nil
+	})
+	ns.Def("raw-mode!", rawMode)
+
+	// restore-mode! — write "rawoff" and close /dev/consctl, reverting to cooked
+	// mode. Idempotent: a no-op (nil) when raw mode was never entered.
+	restoreMode, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		consctlMu.Lock()
+		defer consctlMu.Unlock()
+		if consctl == nil {
+			return vm.NIL, nil
+		}
+		_, _ = consctl.WriteString("rawoff")
+		err := consctl.Close()
+		consctl = nil
+		if err != nil {
+			return vm.NIL, fmt.Errorf("restore-mode!: %w", err)
+		}
+		return vm.TRUE, nil
+	})
+	ns.Def("restore-mode!", restoreMode)
+
+	// read-key — read one keypress through the *keys* source. Returns single
+	// chars, or escape sequences like "\x1b[A" for arrows; "" is the
+	// end-of-input nil contract. Ctx-aware so api.WithKeySource is honored.
+	// Mouse-report decoding is native-only — plan9 has no mouse path.
+	readKey := vm.NewCtxNativeFn("read-key", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		s, err := boundKeySource(ec).ReadKey()
+		if err != nil {
+			return vm.NIL, err
+		}
+		if s == "" {
+			return vm.NIL, nil
+		}
+		return vm.String(s), nil
+	})
+	ns.Def("read-key", readKey)
+
+	// key-pending? — true if a key is buffered and ready, without consuming it.
+	// Plan 9 has no poll/FIONREAD, so the bound source answers from its
+	// background-reader queue. Non-blocking; eof-blind so the
+	// (when (key-pending?) (read-key)) idiom doesn't busy-spin at end-of-input.
+	keyPendingFn := vm.NewCtxNativeFn("key-pending?", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		if boundKeySource(ec).KeyPending() {
+			return vm.TRUE, nil
+		}
+		return vm.FALSE, nil
+	})
+	ns.Def("key-pending?", keyPendingFn)
+
+	// size — [cols rows] from $COLS/$LINES, falling back to 80x24. Real Plan 9
+	// window geometry lives in /dev/wctl (pixels) and is rarely surfaced as env
+	// vars under rio/drawterm, so this usually returns the fallback — safe,
+	// since callers diff term/size per tick and simply see "no resize".
 	sizeFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
-		return vm.NewPersistentVector([]vm.Value{vm.MakeInt(80), vm.MakeInt(24)}), nil
+		return vm.NewPersistentVector([]vm.Value{
+			vm.MakeInt(envInt("COLS", 80)),
+			vm.MakeInt(envInt("LINES", 24)),
+		}), nil
 	})
 	ns.Def("size", sizeFn)
 

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -334,17 +334,26 @@ func installTermNS() {
 
 	// flush — sync the active *out* binding, mirroring native term.go (#308).
 	//
-	// Plan 9 has no fsync on a console/pipe: Sync there fails with "bad arg in
-	// system call" (EINVAL), and flushing such an fd is a no-op. xsofy calls
-	// flush every frame, so for the default console/pipe stdout (the hot path)
-	// we skip the syscall entirely — an early no-op — rather than issuing a
-	// failing Fwstat per frame. Whether stdout is a real (syncable) file is
-	// decided once here. A regular-file or buffered-writer *out* still gets a
-	// real Sync with its errors surfaced; only the EINVAL a console-backed
-	// *out* would raise is swallowed.
+	// Plan 9 has no fsync on a console/pipe/device: Sync there fails — the local
+	// console reports EINVAL ("bad arg in system call"), while /dev/stdout over
+	// drawterm reports EPERM ("permission denied") — and flushing such an fd is a
+	// no-op either way. xsofy calls flush every frame, so for a console/pipe/
+	// device stdout (the hot path) we skip the syscall entirely — an early no-op
+	// — rather than issue a failing Fwstat per frame.
+	//
+	// os.Stdout.Stat().IsRegular() can't make this call on Plan 9: a console
+	// Stats as "regular" through Go's FileMode (Plan 9 has no device-type bits),
+	// so IsRegular misclassifies the console as a syncable file and the flush
+	// then really Syncs it and errors. Classify by the fd's namespace path
+	// instead — a real file is syncable; the console (/dev/cons, /dev/stdout) and
+	// any #-prefixed device/pipe are not. A genuine regular-file or
+	// buffered-writer *out* still gets a real Sync with its errors surfaced; the
+	// EINVAL/EPERM a console-backed *out* raises (e.g. a rebound handle that slips
+	// past the fast path) is swallowed below.
 	stdoutSyncable := false
-	if fi, e := os.Stdout.Stat(); e == nil {
-		stdoutSyncable = fi.Mode().IsRegular()
+	if p, e := syscall.Fd2path(int(os.Stdout.Fd())); e == nil {
+		stdoutSyncable = !strings.HasPrefix(p, "#") &&
+			p != "/dev/cons" && p != "/dev/stdout"
 	}
 	flushFn := vm.NewCtxNativeFn("flush", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		h := resolveIOHandleVar(ec, "*out*")
@@ -357,8 +366,8 @@ func installTermNS() {
 		} else {
 			err = os.Stdout.Sync()
 		}
-		if errors.Is(err, syscall.EINVAL) {
-			err = nil // a non-stdout console-backed *out* — fsync is a no-op
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.EPERM) {
+			err = nil // console/device-backed *out* — fsync is a meaningless no-op
 		}
 		return vm.NIL, err
 	})

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"syscall"
 	"unicode/utf8"
 
 	"github.com/nooga/let-go/pkg/vm"
@@ -45,6 +46,17 @@ func envInt(name string, def int) int {
 	return def
 }
 
+// stdinIsConsole reports whether fd 0 is the window's console (/dev/cons). Plan
+// 9 keeps /dev/cons and /dev/consctl present in the namespace even when stdin is
+// redirected, so opening consctl always succeeds — checking the actual path of
+// fd 0 is how we tell a real interactive console from `lg <somepipe`, and it
+// keeps raw-mode! from flipping a console we aren't reading. It's the plan9
+// analogue of native's "is stdin a TTY" gate.
+func stdinIsConsole() bool {
+	p, err := syscall.Fd2path(0)
+	return err == nil && p == "/dev/cons"
+}
+
 func init() { RegisterInstaller(installTermNS) }
 
 func installTermNS() {
@@ -70,10 +82,14 @@ func installTermNS() {
 	// raw-mode! — enter raw mode by opening /dev/consctl and writing "rawon",
 	// holding the fd (Plan 9 reverts to cooked mode when it closes). Only the
 	// 0-arg global form is supported; xsofy never passes a handle. Returns nil
-	// (not an error) when there's no console — mirrors native's not-a-TTY path.
+	// (not an error) when stdin isn't the console — mirrors native's not-a-TTY
+	// path, and avoids raw-moding a console we aren't reading (piped stdin).
 	rawMode, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 0 {
 			return vm.NIL, fmt.Errorf("raw-mode!: per-handle raw mode not supported on plan9")
+		}
+		if !stdinIsConsole() {
+			return vm.NIL, nil // stdin redirected — consctl would flip the wrong console
 		}
 		consctlMu.Lock()
 		defer consctlMu.Unlock()
@@ -82,7 +98,7 @@ func installTermNS() {
 		}
 		f, err := os.OpenFile("/dev/consctl", os.O_WRONLY, 0)
 		if err != nil {
-			return vm.NIL, nil // no console (e.g. piped stdin)
+			return vm.NIL, nil // no console control available
 		}
 		if _, err := f.WriteString("rawon"); err != nil {
 			f.Close()
@@ -153,7 +169,12 @@ func installTermNS() {
 
 	ns.Def("set-size", stubNil)
 
+	// tty? — true when fd 0 is the window console (/dev/cons), the same gate
+	// raw-mode! uses. The native arity takes a handle; plan9 answers for stdin.
 	ttyPred, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if stdinIsConsole() {
+			return vm.TRUE, nil
+		}
 		return vm.FALSE, nil
 	})
 	ns.Def("tty?", ttyPred)

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"unicode/utf8"
@@ -36,13 +37,21 @@ var (
 	consctlMu sync.Mutex
 )
 
-// envInt reads an integer environment variable, returning def when it is unset
-// or unparseable.
-func envInt(name string, def int) int {
-	if v := os.Getenv(name); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
+// readEnvInt reads /env/<name> as a live file and parses it as an int, returning
+// def when the file is missing or unparseable. Plan 9's environment is a
+// filesystem, so reading the file each call picks up updates that os.Getenv's
+// startup snapshot misses: alacritty9 (and drawterm hosts) rewrite /env/COLS and
+// /env/LINES on every window resize, so the live read is what lets term/size
+// track the real terminal size instead of a stale startup value.
+func readEnvInt(name string, def int) int {
+	b, err := os.ReadFile("/env/" + name)
+	if err != nil {
+		return def
+	}
+	// /env values can carry a trailing NUL (Plan 9 stores them NUL-terminated)
+	// and/or a newline; trim before parsing.
+	if n, err := strconv.Atoi(strings.TrimRight(string(b), "\x00\n\r\t ")); err == nil {
+		return n
 	}
 	return def
 }
@@ -156,14 +165,17 @@ func installTermNS() {
 	})
 	ns.Def("key-pending?", keyPendingFn)
 
-	// size — [cols rows] from $COLS/$LINES, falling back to 80x24. Real Plan 9
-	// window geometry lives in /dev/wctl (pixels) and is rarely surfaced as env
-	// vars under rio/drawterm, so this usually returns the fallback — safe,
-	// since callers diff term/size per tick and simply see "no resize".
+	// size — [cols rows] read live from /env/COLS and /env/LINES (80x24 fallback).
+	// alacritty9 and drawterm hosts publish the terminal size there and rewrite
+	// it on every resize; reading the files each call (not os.Getenv, which
+	// snapshots at process start) makes term/size track the current window, so
+	// callers that diff size per tick actually see resizes. A bare rio console
+	// leaves the vars unset and gets the 80x24 fallback. (Real per-window pixel
+	// geometry via /dev/wctl is a separate, larger follow-up.)
 	sizeFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		return vm.NewPersistentVector([]vm.Value{
-			vm.MakeInt(envInt("COLS", 80)),
-			vm.MakeInt(envInt("LINES", 24)),
+			vm.MakeInt(readEnvInt("COLS", 80)),
+			vm.MakeInt(readEnvInt("LINES", 24)),
 		}), nil
 	})
 	ns.Def("size", sizeFn)

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -64,7 +64,16 @@ func readEnvInt(name string, def int) int {
 // analogue of native's "is stdin a TTY" gate.
 func stdinIsConsole() bool {
 	p, err := syscall.Fd2path(0)
-	return err == nil && p == "/dev/cons"
+	if err != nil {
+		return false
+	}
+	// The cons device is /dev/cons in a normal namespace, but it can surface
+	// under another path: 9front reports the raw device path #c/cons when /dev
+	// isn't bound over the cons device, and a console reached through a different
+	// mount carries that mount's prefix (…/dev/cons). Match those forms rather
+	// than one hard-coded string, while still rejecting the pipe (#|/data) and
+	// redirected-file stdins this gate exists to catch.
+	return p == "#c/cons" || strings.HasSuffix(p, "/dev/cons")
 }
 
 func init() { RegisterInstaller(installTermNS) }


### PR DESCRIPTION
Stacked on #460. That PR made the Plan 9 build compile again by registering `term/key-pending?`, but as a `false` stub. Because xsofy's input loop only calls `read-key` once `key-pending?` reports a key is ready, an always-`false` `key-pending?` means the game animates but never reads input. This PR replaces the input stubs with a working path, so xsofy takes keystrokes and is playable on ANSI-capable Plan 9 terminals.

## The problem specific to Plan 9

The native and WASM key paths both rely on a non-blocking "is a byte ready?" check — `FIONREAD` on native, the SharedArrayBuffer fill level in the browser. Plan 9 has no `poll(2)`/`FIONREAD` equivalent for the console, so there is no way to answer `key-pending?` by peeking the OS directly.

The fix is to keep the bytes on our side of that boundary. A background goroutine does the blocking read and appends to a buffer; `key-pending?` then answers from the buffer (non-blocking), and `read-key` tokenizes off it.

## What's here

A new `KeySource` implementation, `NewQueuedKeySource(io.Reader)` (`pkg/rt/keysource_queued.go`):

- a reader goroutine blocks on the `io.Reader` and appends chunks to a shared queue under a mutex; it never holds the lock across the blocking read
- `ReadKey` blocks until a whole key token is available, tokenizing one key per call off the queue via the existing `scanKey`
- `KeyPending` returns whether bytes are buffered — non-blocking, and false at end-of-input, matching native's `FIONREAD`-based behavior so a per-tick poll loop doesn't busy-spin once input is exhausted

It's platform-neutral and exported: Plan 9 needs it, but any embedder whose input is a plain blocking reader (a pipe, a socket) can bind it via `api.WithKeySource`. State lives on the instance rather than a package global, so the reader goroutine starts only when this source is consulted — an `api.WithKeySource` override reads nothing.

The Plan 9 wiring (`pkg/rt/term_plan9.go`):

- `read-key`/`key-pending?` route through the bound `*keys*` source, so `api.WithKeySource` and `(binding [*keys* …])` still override them
- `raw-mode!`/`restore-mode!` open `/dev/consctl` and write `rawon`/`rawoff`. Plan 9 reverts to cooked mode when the consctl fd closes, so the fd is held open until `restore-mode!`. Raw mode is gated on `fd 0` being the console (`Fd2path`), so a piped stdin returns nil rather than raw-moding a console it isn't reading — mirroring native's not-a-TTY path
- `size` reads `/env/COLS` and `/env/LINES` as live files (80x24 fallback), so it tracks alacritty9/drawterm resizes rather than a value cached at startup
- `flush` is a no-op on the console/pipe: Plan 9 has no `fsync` there (sync returns "bad arg in system call"), so a naive sync crashed on exit — the Plan 9 twin of #308

## Multi-byte keys can split across reads

`read-key` hands out one key per call, and a single key can be multiple bytes (an arrow is `ESC [ A`). With a chunked background reader, a multi-byte sequence can straddle two reads — a short read mid-sequence is normal when the console is a network transport (drawterm/9P). If `read-key` emitted the partial bytes immediately, it would hand out a broken `ESC [` and desync every following key.

So on an incomplete front token, `read-key` waits up to a short inter-byte grace — reset by each byte that arrives — and re-scans, stitching a sequence that dribbles in across reads. A genuinely bare `ESC` (nothing more within one grace window) resolves to the Escape key; a complete key pays no latency. This is the classic terminal ESC delay: with no `FIONREAD` peek, a bare `ESC` and the head of a split arrow are indistinguishable synchronously — emit eagerly and arrows break, wait unconditionally and `ESC` hangs.

## Validation

- `go test -race` over the queued source: held-key bursts, single-chunk arrows, an SS3 key, an `ESC`/`[`/`A` arrow and a UTF-8 rune each split byte-by-byte across reads, a bare `ESC` resolving after the grace, a truncated sequence, a non-EOF reader error surfacing after its bytes, and the `key-pending?` transitions (false → true → false-at-EOF).
- Cross-compiles: `GOOS=plan9`, `GOOS=js/wasm`, `GOOS=linux` build; `go vet` clean on native and plan9; the Plan 9 test binary compiles.

**Tested on real Plan 9 (9front amd64 under QEMU, including agent9).** The bare-console smoke accepts keystrokes, enters and exits raw mode, resolves a bare Escape through the grace window, and restores the terminal on quit. The full xsofy game then runs under **alacritty9** — title screen, movement, inventory, combat, potions, and a clean quit, which exercises the `flush` shutdown path (that clean exit is what the flush fix buys — before it, quitting crashed on `sync /dev/stdout`). `term/size` tracks live window resizes there (measured 84×27 → 98×28 on a manual resize). A second pass on real hardware is still welcome — especially the ANSI arrow path and rendering throughput under alacritty9/drawterm. Thanks @dharmatech / @Alino (nooga/xsofy#141).

**Smoke test (qemu):**
<img width="480" height="345" alt="image" src="https://github.com/user-attachments/assets/e769dccd-c75c-4beb-9ca3-3b39b8076c39" />


## Out of scope

- **Output throughput.** The slowness reported in nooga/xsofy#141 is most likely the renderer's per-cell write amplification, not input; batching terminal output is a separate change.
- Mouse reports and per-handle raw mode stay native-only.
- Real per-window pixel geometry via `/dev/wctl` is a follow-up; the `/env`-based `size` above covers terminals that publish `$COLS`/`$LINES` (alacritty9, drawterm), with the 80x24 fallback where they're unset.

Refs nooga/xsofy#141.
