### PR TITLE
perf(vm): per-var root binding chains — O(1) bound deref (Phase 2, stacks on #459)

### DIFF
--- a/pkg/vm/exec_context.go
+++ b/pkg/vm/exec_context.go
@@ -49,12 +49,15 @@ func NewExecContext() *ExecContext {
 // A nil receiver seeds from the root context.
 func (ec *ExecContext) Child() *ExecContext {
 	src := ec
-	if src == nil {
-		src = RootExecContext
-	}
 	c := NewExecContext()
-	c.bindings.installSnapshot(src.bindings.snapshot())
-	c.scope = src.scope
+	if src == nil || src == RootExecContext {
+		c.bindings.installSnapshot(rootSnapshot())
+	} else {
+		c.bindings.installSnapshot(src.bindings.snapshot())
+	}
+	if src != nil {
+		c.scope = src.scope
+	}
 	return c
 }
 
@@ -98,11 +101,10 @@ func OpenChildEC(ec *ExecContext) *Scope {
 // suitable for passing to NewExecContextFrom to isolate a child context.
 // A nil receiver uses the root context.
 func (ec *ExecContext) BindingSnapshot() BindingSnapshot {
-	src := ec
-	if src == nil {
-		src = RootExecContext
+	if ec == nil || ec == RootExecContext {
+		return rootSnapshot()
 	}
-	return src.bindings.snapshot()
+	return ec.bindings.snapshot()
 }
 
 // NewExecContextFrom returns a fresh context whose binding stack is seeded from
@@ -126,10 +128,14 @@ func (ec *ExecContext) orRoot() *ExecContext {
 
 // --- dynamic-var resolution (ec owns the binding state) ---------------------
 
-// deref returns v's current value in this context: the top dynamic binding if
-// any, else v's root.
 func (ec *ExecContext) deref(v *Var) Value {
 	ec = ec.orRoot()
+	if ec == RootExecContext {
+		return v.derefRoot()
+	}
+	// Child context: an isolated, per-goroutine stack — uncontended, so walk it
+	// directly. Child bindings are gated by isDynamic (set at declaration or on
+	// any bind) as before.
 	if v.isDynamic.Load() {
 		if val, ok := ec.bindings.current(v); ok {
 			return val
@@ -140,22 +146,40 @@ func (ec *ExecContext) deref(v *Var) Value {
 
 func (ec *ExecContext) pushBinding(v *Var, val Value) {
 	v.isDynamic.Store(true)
-	ec.orRoot().bindings.push(v, val)
+	root := ec.orRoot()
+	if root == RootExecContext {
+		rootPush(v, val)
+		return
+	}
+	root.bindings.push(v, val)
 }
 
 func (ec *ExecContext) popBinding(v *Var) {
-	ec.orRoot().bindings.pop(v)
+	root := ec.orRoot()
+	if root == RootExecContext {
+		rootPop(v)
+		return
+	}
+	root.bindings.pop(v)
 }
 
 func (ec *ExecContext) hasBinding(v *Var) bool {
-	return ec.orRoot().bindings.hasBinding(v)
+	root := ec.orRoot()
+	if root == RootExecContext {
+		return rootHasBinding(v)
+	}
+	return root.bindings.hasBinding(v)
 }
 
 // setBinding mutates v's top dynamic binding in this context (Clojure's
 // thread-local set!), returning false if v has no active binding here. Callers
 // fall back to mutating the root for the no-binding case.
 func (ec *ExecContext) setBinding(v *Var, val Value) bool {
-	return ec.orRoot().bindings.setCurrent(v, val)
+	root := ec.orRoot()
+	if root == RootExecContext {
+		return rootSetCurrent(v, val)
+	}
+	return root.bindings.setCurrent(v, val)
 }
 
 // Exported entry points for runtime builtins (pkg/rt) that resolve dynamic

--- a/pkg/vm/root_bindings.go
+++ b/pkg/vm/root_bindings.go
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "sync"
+
+// rootBindFrame is one immutable link in a var's ROOT-context binding chain.
+// Frames are never mutated after publication, so readers load the head
+// atomically and read val without locking. Nesting (shadowed bindings) lives in
+// next; the head is always the current binding.
+type rootBindFrame struct {
+	val  Value
+	next *rootBindFrame
+}
+
+// rootRegistry is the set of vars that currently have a live root binding. It
+// exists so snapshot() can enumerate live root bindings without a shared chain
+// to walk. Written ONLY on bind/unbind transitions (first bind adds, last
+// unbind removes) and read ONLY by snapshot — the deref hot path never touches
+// it. A single mutex is enough: writes are rare (binding establishment, not
+// reads) and concurrent ROOT binding is itself unusual (thread-local binding
+// uses child contexts, which never touch this registry).
+var (
+	rootRegistryMu sync.Mutex
+	rootRegistry   = map[*Var]struct{}{}
+)
+
+func registryAdd(v *Var) {
+	rootRegistryMu.Lock()
+	rootRegistry[v] = struct{}{}
+	rootRegistryMu.Unlock()
+}
+
+func registryRemove(v *Var) {
+	rootRegistryMu.Lock()
+	delete(rootRegistry, v)
+	rootRegistryMu.Unlock()
+}
+
+// rootPush makes val v's current root binding. O(1). Serialized on v.mu with
+// pop/setCurrent. Registers v on its first live binding. Note: v.mu is released
+// BEFORE touching the registry so we never nest v.mu inside rootRegistryMu
+// (rootInstall nests the other way).
+func rootPush(v *Var, val Value) {
+	v.mu.Lock()
+	old := v.rootBind.Load()
+	v.rootBind.Store(&rootBindFrame{val: val, next: old})
+	v.mu.Unlock()
+	if old == nil {
+		registryAdd(v)
+	}
+}
+
+// rootPop removes v's current root binding, restoring the shadowed one. O(1).
+// Deregisters v when its last binding is popped.
+func rootPop(v *Var) {
+	v.mu.Lock()
+	cur := v.rootBind.Load()
+	var next *rootBindFrame
+	if cur != nil {
+		next = cur.next
+	}
+	v.rootBind.Store(next)
+	v.mu.Unlock()
+	if cur != nil && next == nil {
+		registryRemove(v)
+	}
+}
+
+// rootDerefHead returns (value, true) if v has a live root binding, else
+// (_, false). O(1), lock-free — the hot deref path.
+func rootDerefHead(v *Var) (Value, bool) {
+	if f := v.rootBind.Load(); f != nil {
+		return f.val, true
+	}
+	return nil, false
+}
+
+// rootHasBinding reports whether v has a live root binding.
+func rootHasBinding(v *Var) bool { return v.rootBind.Load() != nil }
+
+// rootSetCurrent replaces v's current root binding value in place (Clojure
+// set!), returning false if v has none. Rebuilds the head frame so frames stay
+// immutable for lock-free readers.
+func rootSetCurrent(v *Var, val Value) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	cur := v.rootBind.Load()
+	if cur == nil {
+		return false
+	}
+	v.rootBind.Store(&rootBindFrame{val: val, next: cur.next})
+	return true
+}
+
+// rootSnapshot captures all live root bindings as a BindingSnapshot
+// (map[*Var][]Value, top = last). Reads the registry under lock, then each
+// member's chain. A binding racing establishment/teardown may be included or
+// omitted — snapshotting concurrently with binding is inherently racy, and each
+// captured chain is internally consistent (atomic head load).
+func rootSnapshot() BindingSnapshot {
+	rootRegistryMu.Lock()
+	vars := make([]*Var, 0, len(rootRegistry))
+	for v := range rootRegistry {
+		vars = append(vars, v)
+	}
+	rootRegistryMu.Unlock()
+
+	out := BindingSnapshot{}
+	for _, v := range vars {
+		var vals []Value // head→tail = innermost→outermost
+		for f := v.rootBind.Load(); f != nil; f = f.next {
+			vals = append(vals, f.val)
+		}
+		if len(vals) == 0 {
+			continue // raced an unbind
+		}
+		for i, j := 0, len(vals)-1; i < j; i, j = i+1, j-1 { // reverse → top-last
+			vals[i], vals[j] = vals[j], vals[i]
+		}
+		out[v] = vals
+	}
+	return out
+}
+
+// rootInstall replaces the entire root binding state with target: sets each
+// var's chain from target[v] (top-last) and fixes registry membership. Used by
+// RunWithBindings' whole-state swap. Holds rootRegistryMu across the swap so
+// membership stays consistent; takes each v.mu inside it (the one allowed
+// nesting direction — see rootPush).
+func rootInstall(target BindingSnapshot) {
+	rootRegistryMu.Lock()
+	defer rootRegistryMu.Unlock()
+
+	// Clear vars currently bound but absent from target.
+	for v := range rootRegistry {
+		if _, ok := target[v]; !ok {
+			v.mu.Lock()
+			v.rootBind.Store(nil)
+			v.mu.Unlock()
+			delete(rootRegistry, v)
+		}
+	}
+	// Set each target var's chain (bottom-to-top so the last value is head).
+	for v, vals := range target {
+		var head *rootBindFrame
+		for _, val := range vals {
+			head = &rootBindFrame{val: val, next: head}
+		}
+		v.mu.Lock()
+		v.rootBind.Store(head)
+		v.mu.Unlock()
+		if head != nil {
+			rootRegistry[v] = struct{}{}
+		} else {
+			delete(rootRegistry, v)
+		}
+	}
+}

--- a/pkg/vm/root_bindings_test.go
+++ b/pkg/vm/root_bindings_test.go
@@ -1,0 +1,182 @@
+package vm
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRootBindingsHelpers(t *testing.T) {
+	v := NewVar(nil, "t", "x")
+	v.SetRoot(Int(1))
+
+	if _, ok := rootDerefHead(v); ok {
+		t.Fatal("unbound: rootDerefHead ok=true, want false")
+	}
+	if rootHasBinding(v) {
+		t.Fatal("unbound: rootHasBinding true")
+	}
+
+	rootPush(v, Int(2))
+	if val, ok := rootDerefHead(v); !ok || val != Int(2) {
+		t.Fatalf("bound head = %v,%v want 2,true", val, ok)
+	}
+	rootPush(v, Int(3)) // nested shadow
+	if val, _ := rootDerefHead(v); val != Int(3) {
+		t.Fatalf("nested head = %v want 3", val)
+	}
+	if !rootSetCurrent(v, Int(30)) {
+		t.Fatal("setCurrent on bound returned false")
+	}
+	if val, _ := rootDerefHead(v); val != Int(30) {
+		t.Fatalf("after set! head = %v want 30", val)
+	}
+	rootPop(v)
+	if val, _ := rootDerefHead(v); val != Int(2) {
+		t.Fatalf("after pop head = %v want 2 (restored)", val)
+	}
+
+	// snapshot captures live bindings top-last
+	snap := rootSnapshot()
+	if got := snap[v]; len(got) != 1 || got[0] != Int(2) {
+		t.Fatalf("snapshot[v] = %v want [2]", got)
+	}
+
+	rootPop(v)
+	if rootHasBinding(v) {
+		t.Fatal("after full unbind: still bound")
+	}
+	if _, ok := rootSnapshot()[v]; ok {
+		t.Fatal("after full unbind: still in snapshot/registry")
+	}
+	if rootSetCurrent(v, Int(9)) {
+		t.Fatal("setCurrent on unbound returned true")
+	}
+}
+
+func TestRootInstallReplacesState(t *testing.T) {
+	a := NewVar(nil, "t", "a")
+	a.SetRoot(Int(0))
+	b := NewVar(nil, "t", "b")
+	b.SetRoot(Int(0))
+	rootPush(a, Int(1)) // a bound before install
+
+	rootInstall(BindingSnapshot{b: {Int(7), Int(8)}}) // install: b bound (2 deep), a cleared
+	if rootHasBinding(a) {
+		t.Fatal("install: a should be cleared")
+	}
+	if val, _ := rootDerefHead(b); val != Int(8) {
+		t.Fatalf("install: b head = %v want 8 (top)", val)
+	}
+	if _, ok := rootSnapshot()[a]; ok {
+		t.Fatal("install: a still in registry")
+	}
+	if got := rootSnapshot()[b]; len(got) != 2 {
+		t.Fatalf("install: b depth = %d want 2", len(got))
+	}
+	rootInstall(BindingSnapshot{}) // clear all
+	if rootHasBinding(b) {
+		t.Fatal("clear: b still bound")
+	}
+}
+
+func TestRootPathWiredEndToEnd(t *testing.T) {
+	v := NewVar(nil, "t", "e")
+	v.SetRoot(Int(1))
+	v.SetDynamic()
+
+	if v.Deref() != Int(1) {
+		t.Fatal("unbound deref != root")
+	}
+	v.PushBinding(Int(2))
+	if v.Deref() != Int(2) {
+		t.Fatal("bound deref != 2")
+	}
+	// child seeded from root must inherit the root binding
+	child := RootExecContext.Child()
+	if child.deref(v) != Int(2) {
+		t.Fatalf("child deref = %v want 2 (inherited)", child.deref(v))
+	}
+	// child's own binding does not leak to root
+	child.pushBinding(v, Int(3))
+	if v.Deref() != Int(2) {
+		t.Fatal("root deref changed by child binding")
+	}
+	if child.deref(v) != Int(3) {
+		t.Fatal("child deref != own binding")
+	}
+	v.PopBinding()
+	if v.Deref() != Int(1) {
+		t.Fatal("after unbind deref != root")
+	}
+	// RunWithBindings brackets a root value
+	_, _ = RunWithBindings(BindingSnapshot{v: {Int(42)}}, func() (Value, error) {
+		if v.Deref() != Int(42) {
+			t.Error("inside RunWithBindings deref != 42")
+		}
+		return NIL, nil
+	})
+	if v.Deref() != Int(1) {
+		t.Fatal("after RunWithBindings deref != root")
+	}
+}
+
+func TestRootBindingsConcurrent(t *testing.T) {
+	const goroutines, iters = 16, 2000
+	v := NewVar(nil, "t", "c")
+	v.SetRoot(Int(-1))
+	v.SetDynamic()
+	valid := map[Value]bool{Int(-1): true, Int(7): true}
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if id%3 == 0 {
+					if got := v.Deref(); !valid[got] {
+						t.Errorf("deref returned %v", got)
+						return
+					}
+				} else if id%3 == 1 {
+					v.PushBinding(Int(7))
+					v.PopBinding()
+				} else {
+					_ = SnapshotBindings() // registry read racing binds
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	if rootHasBinding(v) {
+		t.Errorf("after balanced push/pop, still bound")
+	}
+	if _, ok := SnapshotBindings()[v]; ok {
+		t.Errorf("after balanced push/pop, still in registry")
+	}
+}
+
+func TestRootBindingsDistinctConcurrent(t *testing.T) {
+	const goroutines, iters = 16, 2000
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			v := NewVar(nil, "t", "d")
+			v.SetRoot(Int(int64(id)))
+			v.SetDynamic()
+			for i := 0; i < iters; i++ {
+				v.PushBinding(Int(int64(id + 1000)))
+				if v.Deref() != Int(int64(id+1000)) {
+					t.Errorf("g%d bound deref wrong", id)
+				}
+				v.PopBinding()
+				if v.Deref() != Int(int64(id)) {
+					t.Errorf("g%d unbound deref wrong", id)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/pkg/vm/var.go
+++ b/pkg/vm/var.go
@@ -45,6 +45,10 @@ type Var struct {
 	// so the dynamic flag is read on the hot deref path while being set by a
 	// concurrent bind. A plain bool here is a data race.
 	isDynamic atomic.Bool
+	// rootBind is this var's ROOT-context binding chain (Phase 2). Head = current
+	// binding; nil = unbound. Per-var, so deref reads the head in O(1) with no
+	// shared-structure access. Nesting lives in next; readers touch only the head.
+	rootBind  atomic.Pointer[rootBindFrame]
 	isPrivate bool
 	mu        sync.Mutex // guards meta + watches
 	watches   map[Value]Fn
@@ -156,12 +160,22 @@ func sameRootIdentity(a, b Value) bool {
 	return a == b
 }
 
+// derefRoot resolves v against the ROOT (process-global) context. It is the
+// single shared root-resolution path — Var.Deref (host/lowered callers) and
+// ExecContext.deref's root branch both call it, so the two can never diverge.
+func (v *Var) derefRoot() Value {
+	if val, ok := rootDerefHead(v); ok {
+		return val
+	}
+	return v.Root()
+}
+
 // Deref returns the current value in the root execution context: the dynamic
 // top binding if one is active, else the root. Host and lowered callers that
 // hold no ExecContext resolve here; the interpreter resolves against its
-// frame's context (which is the root context unless a child was installed).
+// frame's context via ExecContext.deref (which shares derefRoot for the root).
 func (v *Var) Deref() Value {
-	return RootExecContext.deref(v)
+	return v.derefRoot()
 }
 
 // Root returns the var's root binding directly, bypassing any current
@@ -196,7 +210,7 @@ func (v *Var) PopBinding() {
 // SnapshotBindings captures the root context's dynamic bindings — the
 // explicit-propagation primitive a goroutine spawn hands to its child.
 func SnapshotBindings() BindingSnapshot {
-	return globalBindingStack.snapshot()
+	return rootSnapshot()
 }
 
 // RunWithBindings runs fn with snap installed as the root context's dynamic
@@ -205,10 +219,10 @@ func SnapshotBindings() BindingSnapshot {
 // child ExecContext; true per-goroutine isolation comes from running fn under
 // ec.Child() instead (see docs/design/exec-context-threading.md).
 func RunWithBindings(snap BindingSnapshot, fn func() (Value, error)) (Value, error) {
-	saved := globalBindingStack.snapshot()
-	globalBindingStack.installSnapshot(snap)
+	saved := rootSnapshot()
+	rootInstall(snap)
 	out, err := fn()
-	globalBindingStack.installSnapshot(saved)
+	rootInstall(saved)
 	return out, err
 }
 

--- a/pkg/vm/var_binding_race_test.go
+++ b/pkg/vm/var_binding_race_test.go
@@ -1,0 +1,151 @@
+package vm
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRootBindDepthGate(t *testing.T) {
+	v := NewVar(nil, "t", "x")
+	v.SetRoot(Int(1))
+
+	// unbound (also covers non-dynamic): reads root, gate skips the stack
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("unbound deref = %v, want 1", got)
+	}
+	if rootHasBinding(v) {
+		t.Fatalf("unbound: rootHasBinding true, want false")
+	}
+
+	// bound: deref sees the binding
+	v.PushBinding(Int(2))
+	if !rootHasBinding(v) {
+		t.Fatalf("bound: rootHasBinding false, want true")
+	}
+	if got := v.Deref(); got != Int(2) {
+		t.Fatalf("bound deref = %v, want 2", got)
+	}
+
+	// nested shadow
+	v.PushBinding(Int(3))
+	if got := v.Deref(); got != Int(3) {
+		t.Fatalf("nested deref = %v, want 3", got)
+	}
+	v.PopBinding()
+	if got := v.Deref(); got != Int(2) {
+		t.Fatalf("after inner pop deref = %v, want 2 (restored)", got)
+	}
+
+	// fully unbound: back to root, counter zero (the PreviouslyBound case)
+	v.PopBinding()
+	if rootHasBinding(v) {
+		t.Fatalf("after unbind: rootHasBinding true, want false")
+	}
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("previously-bound deref = %v, want 1 (root)", got)
+	}
+}
+
+func TestRunWithBindingsCounterConsistent(t *testing.T) {
+	v := NewVar(nil, "t", "y")
+	v.SetRoot(Int(10))
+	v.SetDynamic()
+
+	snap := BindingSnapshot{v: {Int(99)}}
+	_, _ = RunWithBindings(snap, func() (Value, error) {
+		if got := v.Deref(); got != Int(99) {
+			t.Errorf("inside RunWithBindings deref = %v, want 99", got)
+		}
+		if !rootHasBinding(v) {
+			t.Errorf("inside RunWithBindings: rootHasBinding false, want true")
+		}
+		return NIL, nil
+	})
+	if got := v.Deref(); got != Int(10) {
+		t.Errorf("after RunWithBindings deref = %v, want 10 (root)", got)
+	}
+	if rootHasBinding(v) {
+		t.Errorf("after RunWithBindings: rootHasBinding true, want false")
+	}
+}
+
+func TestVarDerefChildIsolation(t *testing.T) {
+	v := NewVar(nil, "t", "z")
+	v.SetRoot(Int(0))
+	v.SetDynamic()
+	v.PushBinding(Int(1)) // root binding
+	defer v.PopBinding()
+
+	child := RootExecContext.Child() // seeded from root snapshot
+	if got := child.deref(v); got != Int(1) {
+		t.Fatalf("child sees root binding = %v, want 1", got)
+	}
+	child.pushBinding(v, Int(2)) // child-local
+	if got := child.deref(v); got != Int(2) {
+		t.Fatalf("child own binding = %v, want 2", got)
+	}
+	// child binding must NOT touch the root binding state or the root value
+	if !rootHasBinding(v) {
+		t.Fatalf("child push lost root binding, want true")
+	}
+	if got := v.Deref(); got != Int(1) {
+		t.Fatalf("root deref after child push = %v, want 1 (unaffected)", got)
+	}
+}
+
+func TestVarDerefConcurrentBindDeref(t *testing.T) {
+	const goroutines, iters = 16, 2000
+	v := NewVar(nil, "t", "c")
+	v.SetRoot(Int(-1))
+	v.SetDynamic()
+
+	valid := map[Value]bool{Int(-1): true, Int(7): true} // root or the pushed value
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if id%2 == 0 {
+					if got := v.Deref(); !valid[got] {
+						t.Errorf("deref returned unexpected %v", got)
+						return
+					}
+				} else {
+					v.PushBinding(Int(7))
+					_ = v.Deref()
+					v.PopBinding()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	if rootHasBinding(v) {
+		t.Errorf("after balanced push/pop: rootHasBinding true, want false")
+	}
+}
+
+func TestVarDerefDistinctConcurrent(t *testing.T) {
+	const goroutines, iters = 16, 2000
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			v := NewVar(nil, "t", "d") // distinct var per goroutine
+			v.SetRoot(Int(int64(id)))
+			v.SetDynamic()
+			for i := 0; i < iters; i++ {
+				v.PushBinding(Int(int64(id + 1000)))
+				if got := v.Deref(); got != Int(int64(id+1000)) {
+					t.Errorf("g%d deref = %v, want %d", id, got, id+1000)
+				}
+				v.PopBinding()
+				if got := v.Deref(); got != Int(int64(id)) {
+					t.Errorf("g%d unbound deref = %v, want %d", id, got, id)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/pkg/vm/var_deref_bench_test.go
+++ b/pkg/vm/var_deref_bench_test.go
@@ -124,6 +124,19 @@ func BenchmarkVarDerefDistinctParallel(b *testing.B) {
 	})
 }
 
+// BenchmarkVarDerefChildContext measures deref against an isolated child
+// context (the per-goroutine path), which the root-context benchmarks don't
+// cover. The binding lives in the child's own stack.
+func BenchmarkVarDerefChildContext(b *testing.B) {
+	v := newRootVar()
+	v.SetDynamic()
+	ec := RootExecContext.Child()
+	ec.pushBinding(v, Int(7))
+	for i := 0; i < b.N; i++ {
+		derefSink = ec.deref(v)
+	}
+}
+
 // BenchmarkBindingPushPop measures one full binding extent (the (binding […])
 // write path). Copy-on-write makes reads lock-free at the cost of allocating a
 // fresh map per push/pop, so this is the side of the trade that gets more
@@ -154,6 +167,33 @@ func bindDepth(b *testing.B, depth int) (vars []*Var, miss *Var) {
 	miss = newRootVar()
 	miss.SetDynamic() // declared dynamic, never bound → deref walks the whole stack and misses
 	return vars, miss
+}
+
+// BenchmarkVarDerefBoundDepth: deref a bound var while N OTHER dynamic vars are
+// also bound. Phase 1 was O(N) (shared-chain walk); Phase 2 must be flat.
+func BenchmarkVarDerefBoundDepth(b *testing.B) {
+	for _, n := range []int{0, 1, 4, 16, 64} {
+		b.Run(fmt.Sprintf("others=%d", n), func(b *testing.B) {
+			target := newRootVar()
+			target.SetDynamic()
+			target.PushBinding(Int(7))
+			others := make([]*Var, n)
+			for i := range others {
+				others[i] = newRootVar()
+				others[i].SetDynamic()
+				others[i].PushBinding(Int(int64(i)))
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				derefSink = target.Deref()
+			}
+			b.StopTimer()
+			target.PopBinding()
+			for _, o := range others {
+				o.PopBinding()
+			}
+		})
+	}
 }
 
 // BenchmarkVarDerefDepth measures deref cost as a function of how many unrelated


### PR DESCRIPTION
**Phase 2**, stacked on #459. Replaces the shared-binding-stack walk for bound dynamic vars with **per-var binding chains + a membership registry**, making root-var deref **O(1)** regardless of how many other vars are bound.

## The problem Phase 1 left

Phase 1 fixed the *unbound* dynamic case. A genuinely *bound* dynamic var still resolved via `globalBindingStack.current(v)`, which walks the shared chain **from the head until it finds `v`** — so bound-var deref was **O(number of dynamic vars bound after it)**. Deref of `*a*` in `(binding [*a* *b* *c*] …)` walked past `*c*` and `*b*`. Measured (M3):

| others bound | Phase 1 | **Phase 2** |
|---|---|---|
| 0 | 1.10 ns | **0.55 ns** |
| 4 | 3.08 ns | **0.58 ns** |
| 16 | 7.54 ns | **0.58 ns** |
| 64 | **46.9 ns** | **0.58 ns** |

This is a **serial** cost — it hits single-threaded code, which is most Clojure code — whenever several dynamics are bound (nested `binding`, config-heavy frameworks). Deref of a bound var shouldn't depend on *other* vars' bindings; now it doesn't.

## Change

Root bindings move onto each `Var` as its own immutable-frame chain behind an atomic head (`rootBind`):

```go
func (v *Var) derefRoot() Value {
    if val, ok := rootDerefHead(v); ok { return val } // this var's own head — O(1), per-var cache line
    return v.Root()
}
```

- **O(1), contention-free:** the chain is per-var, so the head *is* the current binding — no walk, no shared read. `rootBindDepth` (Phase 1) is retired; the head pointer subsumes it.
- **Registry** (`map[*Var]struct{}` under one mutex) lets `Child()`/`RunWithBindings` enumerate live root bindings. Written **only** on first-bind/last-unbind transitions; **deref never touches it**.
- **Single source of truth, no cache:** per-var chain authoritative for values, registry for membership — updated together, nothing to keep coherent.
- **Lock ordering** is acyclic: push/pop take `v.mu`, release, then `rootRegistryMu` (un-nested); `rootInstall` nests `rootRegistryMu`→`v.mu`; never both held in push/pop.
- **Child contexts unchanged** — isolated per-goroutine stacks, seeded via `rootSnapshot()` at spawn. #210 isolation preserved.

## Tests

`-race` gate: 16-goroutine concurrent bind/deref/**snapshot** on the same var (registry read-while-write), distinct vars, child isolation, `RunWithBindings` bracketing, full-unbind→registry-empty. Zero data races. Full non-race suite green.

`BenchmarkVarDerefBoundDepth` proves flat-in-N (the O(1) payoff); `BoundParallel` 0.14 ns (contention gone).

**Note (not this PR):** `go test ./pkg/vm/ -race` surfaces a **pre-existing** `TestArrayVectorSeqChunkedFirstRace` race (`vector.go:268`), confirmed on main; unrelated.

Spec/plan under `docs/superpowers/`. Shows the combined diff with #459 until that merges.



---
**Part of #464** (Epic: Runtime performance & concurrency) — var-deref regression recovery, Phase 2 (stacks on #459).