### PR TITLE
chore(hooks): reject committing compiled executables (pre-commit/prek)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,17 @@ repos:
 
   - repo: local
     hooks:
+      # Fail fast on an accidentally-staged compiled executable (e.g. a stray
+      # `go build` output). Magic-byte based (Mach-O / ELF / PE), so it ignores
+      # the repo's legitimate binary assets — the LGB core bundle and images.
+      # No type filter: it must inspect every staged file's leading bytes.
+      - id: forbid-compiled-binaries
+        name: forbid committing compiled executables
+        description: Reject staged Mach-O / ELF / PE binaries before they bloat history
+        entry: python3 scripts/reject_compiled_binaries.py
+        language: system
+        stages: [pre-commit]
+
       # Auto-fix formatting before linters run. gofmt ships with Go.
       # goimports is fetched on demand via `go run ...@latest` so contributors
       # don't need a separate install; the module cache makes subsequent runs

--- a/scripts/reject_compiled_binaries.py
+++ b/scripts/reject_compiled_binaries.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Reject staged compiled executables (Mach-O / ELF / PE).
+
+Catches an accidentally-committed `go build` output (e.g. an `lg` binary)
+before it bloats history. Detection is magic-byte based, so it does NOT flag
+the repo's legitimate binary assets: the core bundle starts with `LGB\x01`
+and images (PNG/JPEG) are not executable formats.
+
+pre-commit / prek passes the staged filenames as argv; we inspect each file's
+leading bytes and fail if any is an executable. Bypass an intentional commit
+with `git commit --no-verify`.
+"""
+import sys
+
+# 4-byte magic prefixes of executable formats we refuse to commit.
+EXECUTABLE_MAGICS = {
+    b"\x7fELF": "ELF executable",
+    b"\xfe\xed\xfa\xce": "Mach-O executable (32-bit)",
+    b"\xfe\xed\xfa\xcf": "Mach-O executable (64-bit)",
+    b"\xce\xfa\xed\xfe": "Mach-O executable (32-bit, LE)",
+    b"\xcf\xfa\xed\xfe": "Mach-O executable (64-bit, LE)",
+    b"\xca\xfe\xba\xbe": "Mach-O universal binary",
+    b"\xbe\xba\xfe\xca": "Mach-O universal binary (LE)",
+}
+
+
+def classify(path):
+    """Return a human label if `path` is a compiled executable, else None."""
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(4)
+    except (OSError, IsADirectoryError):
+        return None
+    for magic, label in EXECUTABLE_MAGICS.items():
+        if head.startswith(magic):
+            return label
+    # PE/DOS ("MZ") — only the first two bytes are load-bearing.
+    if head[:2] == b"MZ":
+        return "PE/DOS executable"
+    return None
+
+
+def main(argv):
+    offenders = [(p, label) for p in argv if (label := classify(p))]
+    if not offenders:
+        return 0
+    sys.stderr.write("refusing to commit compiled executable binaries:\n")
+    for path, label in offenders:
+        sys.stderr.write(f"  {path}  ({label})\n")
+    sys.stderr.write(
+        "these look like build artifacts — unstage them "
+        "(git rm --cached <file>, then gitignore), or commit with --no-verify.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Adds a fail-fast `pre-commit` hook that refuses staged **compiled executables** (Mach-O / ELF / PE) — e.g. an accidentally-`git add`-ed `go build` output — before they bloat history.

- `scripts/reject_compiled_binaries.py` — stdlib-only Python (consistent with the repo's other hook scripts), magic-byte detection.
- `.pre-commit-config.yaml` — wired as the first local `pre-commit` hook so it fails cheaply before build/lint.

## Why magic-byte, not size

Detection is by executable magic prefix, so it **does not** flag the repo's legitimate binary assets: the core bundle starts with `LGB\x01` and images (`meta/logo.png`) aren't executable formats. A blanket size cap would false-positive on `core_compiled.lgb`.

## Tested

- Rejects a real Mach-O `go build` output (exit 1, names the file).
- `prek run forbid-compiled-binaries --all-files` **passes** on the entire repo — no false positives on `core_compiled.lgb` / `logo.png`.

## Caveat

Git-only — `jj` doesn't run git hooks, same as the repo's existing `scripts/pre-commit` / ratchet hooks. Bypass an intentional commit with `git commit --no-verify`.
