### PR TITLE
Build let-go as a WASI (`GOOS=wasip1`) module

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -95,6 +95,27 @@ jobs:
           LETGO_RUN_LOWERING_DETERMINISM: "1"
         run: go test -v -timeout 600s ./test/e2e/ -run 'TestLoweringDeterminism|TestDeftypeSkeletonNativeLowering'
 
+  # Cross-build guard for the wasip1 (WASI) target. The REPL and interactive
+  # terminal are build-tagged off wasip1 (routed to lg_repl_stub.go); without
+  # this gate, a change that pulls chzyer/readline or x/sys/unix terminal code
+  # back into the wasip1 link would break the module and only surface
+  # downstream. Keeps the "let-go builds as a GOOS=wasip1 module" guarantee
+  # honest. Build-only: the committed bytecode bundle is enough to link, no
+  # regeneration or wasm runtime needed.
+  wasip1-build:
+    name: wasip1-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build for GOOS=wasip1
+        run: GOOS=wasip1 GOARCH=wasm go build -v -o /tmp/lg-wasip1.wasm .
+
   # Differential gold check against a LIVE Clojure. The everyday `build` job is
   # clojure-free (it compares let-go to the committed test/gold/*.out goldens);
   # this job re-derives those goldens from real Clojure and fails if they drift.

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,8 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | Version requirements, range matching (`let-go.semver`) | `guide/semver.md` |
 | `io/resource`, `-resource-paths` / `-source-paths` resolution | `guide/resources-and-source-paths.md` |
 | Embedding let-go in a Go program | `guide/embedding-in-go.md` |
+| Running as a WASI (`GOOS=wasip1`) module | `guide/wasi.md` |
+| let-go under TinyGo (status: not currently supported) | `guide/tinygo.md` |
 | nREPL server + editor setup | `guide/nrepl.md` |
 | Clojure compatibility: namespace table + differences | `guide/clojure-compatibility.md` |
 | Running, compiling, WASM, project mgmt (lgx) | `guide/usage.md` |

--- a/docs/guide/tinygo.md
+++ b/docs/guide/tinygo.md
@@ -1,0 +1,21 @@
+---
+status: active
+last-verified: 2026-07-13
+human-verified:
+---
+
+# let-go under TinyGo
+
+**Status: not currently supported.** This note records what's known, surfaced
+while adding the standard-Go wasip1 target (which shares `GOARCH=wasm`).
+
+TinyGo's `-target=wasi` is also `GOOS=wasip1`, so the wasip1 build gating applies
+to it too — but let-go does not build and run under TinyGo as-is:
+
+- **Traps at initialization.** With stock TinyGo 0.41.1 the module builds, but
+  traps before executing any code: `unimplemented: (reflect.Type).Method()`.
+  let-go's runtime boxes Go values through `reflect`, which TinyGo does not fully
+  implement, so namespace installation fails at startup.
+
+Until that's resolved, use the standard-Go build — see
+[Running let-go as a WASI module](wasi.md).

--- a/docs/guide/wasi.md
+++ b/docs/guide/wasi.md
@@ -42,12 +42,9 @@ $ wasmtime lg.wasm -e '(bit-shift-left 1 62)'
 
 ## TinyGo
 
-This guide covers the standard Go toolchain, which is what builds let-go as a
-wasip1 module. TinyGo's `-target=wasi` is also `GOOS=wasip1`, but it does not
-build let-go as-is: stock TinyGo 0.41.1 traps at initialization with
-`unimplemented: (reflect.Type).Method()` before running any code, because the
-runtime's reflect-based boxing isn't available there. So the build here is the
-standard-Go one.
+This guide is the standard-Go build. TinyGo's `-target=wasi` is also `GOOS=wasip1`
+but doesn't build let-go as-is today — see [let-go under TinyGo](tinygo.md) for
+the known blocker.
 
 ## Capabilities
 

--- a/docs/guide/wasi.md
+++ b/docs/guide/wasi.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-07-12
+last-verified: 2026-07-13
 human-verified:
 ---
 
@@ -41,28 +41,28 @@ $ wasmtime lg.wasm -e '(bit-shift-left 1 62)'
 4611686018427387904
 ```
 
-## Toolchain: size vs. fidelity
+## TinyGo
 
-The same 3-tag gating also lets TinyGo (`-target=wasi`, itself `GOOS=wasip1`)
-build the module, and TinyGo produces a much smaller artifact — at the cost of
-numeric fidelity, since its wasm `int` is 32-bit. let-go traps on overflow
-rather than wrapping, so the break is loud, not silently corrupting.
+This guide covers the standard Go toolchain. TinyGo's `-target=wasi` is also
+`GOOS=wasip1`, so the gating here applies, but building let-go under TinyGo needs
+additional reflect shims (boxing and method dispatch) that are not part of this
+build — without them, stock TinyGo 0.41.1 traps at initialization with
+`unimplemented: (reflect.Type).Method()` before running any code. TinyGo support
+is tracked separately.
 
-| Toolchain | Module size | 64-bit `int` |
-|---|---|---|
-| standard Go | ~24 MB | faithful (10^18, 2^62 exact) |
-| TinyGo `-target=wasi` | ~9 MB | 32-bit; `(* 1e9 1e9)` overflows |
-
-Pick the standard-Go build when numeric correctness matters (the general case
-for a Clojure dialect); reach for TinyGo only where you can accept 32-bit ints
-in exchange for the smaller module.
+When that enablement is in place, TinyGo trades the ~24 MB standard-Go module
+for a much smaller one (~9 MB), but its wasm `int` is 32-bit, so 64-bit
+arithmetic overflows (let-go traps on overflow rather than wrapping — loud, not
+silently corrupting). Use the standard-Go build when numeric correctness matters,
+which is the general case for a Clojure dialect.
 
 ## Limits
 
 wasip1 is compute + stdio only. Specifically:
 
 - **No `term` namespace.** The interactive terminal is excluded, so there is no
-  `term` ns under wasip1. Fine for headless eval and embedding; a TUI-over-wasi
+  `term` ns under wasip1; requiring it reports `unable to load namespace term`
+  rather than failing hard. Fine for headless eval and embedding; a TUI-over-wasi
   would need a headless `term` stub (future work).
 - **No sockets, no threads.** The wasip1 preview is single-threaded with no
   network. Compute and stdio only.

--- a/docs/guide/wasi.md
+++ b/docs/guide/wasi.md
@@ -1,0 +1,72 @@
+---
+status: active
+last-verified: 2026-07-12
+human-verified:
+---
+
+# Running let-go as a WASI (`GOOS=wasip1`) module
+
+let-go builds to a standalone WASI module with the standard Go toolchain — no
+TinyGo, no build tags beyond the target. The result runs under any wasip1 host
+(wasmtime, wazero, …) as a headless compute + stdio runtime, with full 64-bit
+integer fidelity.
+
+## Build
+
+```
+GOOS=wasip1 GOARCH=wasm go build -o lg.wasm .
+```
+
+The interactive REPL and terminal code are gated off wasip1 (they depend on
+`chzyer/readline` and `x/sys/unix` poll/ioctl, which have no wasip1 backing), so
+the wasip1 build routes to the non-interactive entry point automatically. The
+`wasip1-build` CI job builds this target on every PR so it can't silently
+regress.
+
+## Run
+
+Any wasip1 host works. Under wasmtime:
+
+```
+$ wasmtime lg.wasm -e '(println (str "wasi says " (* 6 7)))'
+wasi says 42
+```
+
+Integer arithmetic is 64-bit, matching the native build:
+
+```
+$ wasmtime lg.wasm -e '(* 1000000000 1000000000)'
+1000000000000000000
+$ wasmtime lg.wasm -e '(bit-shift-left 1 62)'
+4611686018427387904
+```
+
+## Toolchain: size vs. fidelity
+
+The same 3-tag gating also lets TinyGo (`-target=wasi`, itself `GOOS=wasip1`)
+build the module, and TinyGo produces a much smaller artifact — at the cost of
+numeric fidelity, since its wasm `int` is 32-bit. let-go traps on overflow
+rather than wrapping, so the break is loud, not silently corrupting.
+
+| Toolchain | Module size | 64-bit `int` |
+|---|---|---|
+| standard Go | ~24 MB | faithful (10^18, 2^62 exact) |
+| TinyGo `-target=wasi` | ~9 MB | 32-bit; `(* 1e9 1e9)` overflows |
+
+Pick the standard-Go build when numeric correctness matters (the general case
+for a Clojure dialect); reach for TinyGo only where you can accept 32-bit ints
+in exchange for the smaller module.
+
+## Limits
+
+wasip1 is compute + stdio only. Specifically:
+
+- **No `term` namespace.** The interactive terminal is excluded, so there is no
+  `term` ns under wasip1. Fine for headless eval and embedding; a TUI-over-wasi
+  would need a headless `term` stub (future work).
+- **No sockets, no threads.** The wasip1 preview is single-threaded with no
+  network. Compute and stdio only.
+
+For loading the module from a Go host rather than a CLI runtime, see
+[embedding in Go](embedding-in-go.md); for the I/O seams the host binds, see
+[decoupling runtime I/O from the host](../design/runtime-io-host-decoupling.md).

--- a/docs/guide/wasi.md
+++ b/docs/guide/wasi.md
@@ -8,8 +8,7 @@ human-verified:
 
 let-go builds to a standalone WASI module with the standard Go toolchain — no
 TinyGo, no build tags beyond the target. The result runs under any wasip1 host
-(wasmtime, wazero, …) as a headless compute + stdio runtime, with full 64-bit
-integer fidelity.
+(wasmtime, wazero, …) as a headless runtime with full 64-bit integer fidelity.
 
 ## Build
 
@@ -43,29 +42,27 @@ $ wasmtime lg.wasm -e '(bit-shift-left 1 62)'
 
 ## TinyGo
 
-This guide covers the standard Go toolchain. TinyGo's `-target=wasi` is also
-`GOOS=wasip1`, so the gating here applies, but building let-go under TinyGo needs
-additional reflect shims (boxing and method dispatch) that are not part of this
-build — without them, stock TinyGo 0.41.1 traps at initialization with
-`unimplemented: (reflect.Type).Method()` before running any code. TinyGo support
-is tracked separately.
+This guide covers the standard Go toolchain, which is what builds let-go as a
+wasip1 module. TinyGo's `-target=wasi` is also `GOOS=wasip1`, but it does not
+build let-go as-is: stock TinyGo 0.41.1 traps at initialization with
+`unimplemented: (reflect.Type).Method()` before running any code, because the
+runtime's reflect-based boxing isn't available there. So the build here is the
+standard-Go one.
 
-When that enablement is in place, TinyGo trades the ~24 MB standard-Go module
-for a much smaller one (~9 MB), but its wasm `int` is 32-bit, so 64-bit
-arithmetic overflows (let-go traps on overflow rather than wrapping — loud, not
-silently corrupting). Use the standard-Go build when numeric correctness matters,
-which is the general case for a Clojure dialect.
+## Capabilities
 
-## Limits
-
-wasip1 is compute + stdio only. Specifically:
+The module has no ambient authority; a wasip1 host grants what it needs.
 
 - **No `term` namespace.** The interactive terminal is excluded, so there is no
   `term` ns under wasip1; requiring it reports `unable to load namespace term`
-  rather than failing hard. Fine for headless eval and embedding; a TUI-over-wasi
-  would need a headless `term` stub (future work).
+  rather than failing hard. A TUI-over-wasi would need a headless `term` stub
+  (future work).
+- **Filesystem is host-controlled.** Nothing is reachable by default, but the
+  host can preopen directories — e.g. `wasmtime --dir=/tmp lg.wasm …` — and
+  `slurp` and other file operations then see them. This is the WASI capability
+  model: opt-in, host-granted, no ambient filesystem.
 - **No sockets, no threads.** The wasip1 preview is single-threaded with no
-  network. Compute and stdio only.
+  network.
 
 For loading the module from a Go host rather than a CLI runtime, see
 [embedding in Go](embedding-in-go.md); for the I/O seams the host binds, see

--- a/lg_repl.go
+++ b/lg_repl.go
@@ -1,4 +1,4 @@
-//go:build !plan9 && !js
+//go:build !plan9 && !js && !wasip1
 
 /*
  * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>

--- a/lg_repl_stub.go
+++ b/lg_repl_stub.go
@@ -1,4 +1,4 @@
-//go:build plan9 || js
+//go:build plan9 || js || wasip1
 
 /*
  * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>

--- a/pkg/bytecode/lgb_integration_test.go
+++ b/pkg/bytecode/lgb_integration_test.go
@@ -269,3 +269,33 @@ func TestLGBParity(t *testing.T) {
 		(prn #inst "2024-01-01T00:00:00.123456789Z")
 	`)
 }
+
+// TestRequireUnregisteredTermReportsUnavailable guards the wasip1 regression
+// from nooga/let-go#466: gating pkg/rt/term.go off wasip1 leaves no
+// installTermNS, so `term` is never registered. loadEmbedded's term special
+// case must report it unavailable via a non-registering lookup; the previous
+// rt.NS("term") re-registered a placeholder and re-entered the loader,
+// recursing until the wasm stack was exhausted. Simulated here by removing the
+// natively-installed term ns and requiring it — expect a clean error, not a
+// stack overflow.
+func TestRequireUnregisteredTermReportsUnavailable(t *testing.T) {
+	consts := vm.NewConsts()
+	ctx := compiler.NewCompiler(consts, rt.NS("user"))
+	rt.SetNSLoader(resolver.NewNSResolver(ctx, []string{"."}))
+	ctx.SetSource("<test>")
+
+	// Drop the natively-installed term ns to mimic a platform without an
+	// installTermNS (e.g. wasip1), then restore it so other tests are unaffected.
+	saved := rt.LookupNS("term")
+	rt.RemoveNS("term")
+	defer func() {
+		if saved != nil {
+			rt.RegisterNS(saved)
+		}
+	}()
+
+	_, _, err := ctx.CompileMultiple(strings.NewReader("(require 'term)"))
+	if err == nil {
+		t.Fatal("requiring an unregistered term ns should error, got nil (regressed to the recursive loader path?)")
+	}
+}

--- a/pkg/bytecode/lgb_integration_test.go
+++ b/pkg/bytecode/lgb_integration_test.go
@@ -269,33 +269,3 @@ func TestLGBParity(t *testing.T) {
 		(prn #inst "2024-01-01T00:00:00.123456789Z")
 	`)
 }
-
-// TestRequireUnregisteredTermReportsUnavailable guards the wasip1 regression
-// from nooga/let-go#466: gating pkg/rt/term.go off wasip1 leaves no
-// installTermNS, so `term` is never registered. loadEmbedded's term special
-// case must report it unavailable via a non-registering lookup; the previous
-// rt.NS("term") re-registered a placeholder and re-entered the loader,
-// recursing until the wasm stack was exhausted. Simulated here by removing the
-// natively-installed term ns and requiring it — expect a clean error, not a
-// stack overflow.
-func TestRequireUnregisteredTermReportsUnavailable(t *testing.T) {
-	consts := vm.NewConsts()
-	ctx := compiler.NewCompiler(consts, rt.NS("user"))
-	rt.SetNSLoader(resolver.NewNSResolver(ctx, []string{"."}))
-	ctx.SetSource("<test>")
-
-	// Drop the natively-installed term ns to mimic a platform without an
-	// installTermNS (e.g. wasip1), then restore it so other tests are unaffected.
-	saved := rt.LookupNS("term")
-	rt.RemoveNS("term")
-	defer func() {
-		if saved != nil {
-			rt.RegisterNS(saved)
-		}
-	}()
-
-	_, _, err := ctx.CompileMultiple(strings.NewReader("(require 'term)"))
-	if err == nil {
-		t.Fatal("requiring an unregistered term ns should error, got nil (regressed to the recursive loader path?)")
-	}
-}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -241,8 +241,14 @@ func (r *NSResolver) loadEmbedded(name string) *vm.Namespace {
 	}
 
 	if name == "term" {
-		// term is a pure Go namespace, already registered in init()
-		return rt.NS("term")
+		// term is a pure-Go namespace installed at init() on platforms that
+		// have an installTermNS (see pkg/rt/term*.go). When it isn't installed —
+		// e.g. wasip1, where the interactive terminal is build-tagged out —
+		// there is nothing to load: return the registered ns if present, else
+		// nil so the require reports term unavailable. Must be a non-registering
+		// lookup; rt.NS would re-register a placeholder and re-enter the loader
+		// (infinite recursion → "call stack exhausted").
+		return rt.LookupNS("term")
 	}
 	src, ok := rt.EmbeddedSource(name)
 	if !ok || src == "" {

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -3,7 +3,12 @@ package resolver
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
 )
 
 func TestParseSearchPaths(t *testing.T) {
@@ -58,5 +63,35 @@ func TestForceSourceNS(t *testing.T) {
 		if got := forceSourceNS(c.name); got != c.want {
 			t.Errorf("forceSourceNS(%q) with LG_FORCE_SOURCE_NS=%q = %v, want %v", c.name, c.env, got, c.want)
 		}
+	}
+}
+
+// TestRequireUnregisteredTermReportsUnavailable guards the wasip1 regression
+// from nooga/let-go#466: gating pkg/rt/term.go off wasip1 leaves no
+// installTermNS, so `term` is never registered. loadEmbedded's term special
+// case must report it unavailable via a non-registering lookup; the previous
+// rt.NS("term") re-registered a placeholder and re-entered the loader,
+// recursing until the wasm stack was exhausted. Simulated here by removing the
+// natively-installed term ns and requiring it — expect a clean error, not a
+// stack overflow.
+func TestRequireUnregisteredTermReportsUnavailable(t *testing.T) {
+	consts := vm.NewConsts()
+	ctx := compiler.NewCompiler(consts, rt.NS("user"))
+	rt.SetNSLoader(NewNSResolver(ctx, []string{"."}))
+	ctx.SetSource("<test>")
+
+	// Drop the natively-installed term ns to mimic a platform without an
+	// installTermNS (e.g. wasip1), then restore it so other tests are unaffected.
+	saved := rt.LookupNS("term")
+	rt.RemoveNS("term")
+	defer func() {
+		if saved != nil {
+			rt.RegisterNS(saved)
+		}
+	}()
+
+	_, _, err := ctx.CompileMultiple(strings.NewReader("(require 'term)"))
+	if err == nil {
+		t.Fatal("requiring an unregistered term ns should error, got nil (regressed to the recursive loader path?)")
 	}
 }

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -1,4 +1,4 @@
-//go:build !js && !plan9
+//go:build !js && !plan9 && !wasip1
 
 /*
  * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>


### PR DESCRIPTION
# Build let-go as a WASI (`GOOS=wasip1`) module

let-go already targets `GOOS=js` for the browser. Extending that to `wasip1` turns it into a standalone WASI module any wasm host can load: wasmtime from a CLI, or wazero from a Go program embedding let-go as a sandboxed, capability-gated compute runtime. That embedding shape is the payoff: a Clojure dialect you can drop into a Go host, with the host controlling what it can touch.

Like the existing browser build, this uses `GOARCH=wasm`. That's a 32-bit-memory target, but standard Go keeps `int` 64-bit on it, so arithmetic matches the native runtime — `10^18` and `2^62` exact (verified below).

## The change

Three build-tag flips, extending the existing `js` platform gates to also cover `wasip1`:

```
lg_repl.go       !plan9 && !js          → !plan9 && !js && !wasip1
lg_repl_stub.go  plan9 || js            → plan9 || js || wasip1
pkg/rt/term.go   !js && !plan9          → !js && !plan9 && !wasip1
```

The REPL (`lg_repl.go`) and interactive terminal (`pkg/rt/term.go`) pull in `chzyer/readline` and `x/sys/unix` poll/ioctl, which have no wasip1 backing. The gates stopped at `!js`, so a `GOOS=wasip1` build dragged them in and failed to link. Routing wasip1 to the existing `lg_repl_stub.go` fixes it; the stub seam was already there for `js`/`plan9`, so no new stub was needed, and nothing in the default entry point force-links a terminal namespace.

Also in the PR:

- **Fix:** requiring an unavailable native namespace under wasip1 now reports it cleanly instead of recursing. Gating out `term.go` leaves no `term` installer, and `loadEmbedded`'s `term` special case called `rt.NS("term")`, which re-registered a placeholder and re-entered the loader until the wasm stack was exhausted (`(require 'term)` → `call stack exhausted`). It now uses a non-registering lookup and returns `unable to load namespace term`. Guarded by a resolver regression test.
- **CI:** a `wasip1-build` job that cross-builds the target on every PR, so a change that pulls readline or unix terminal code back into the wasip1 link fails the PR instead of surfacing downstream.
- **Docs:** `docs/guide/wasi.md` (build, run, and the host-controlled capability model), plus a short `docs/guide/tinygo.md` noting that TinyGo isn't currently supported and the blocker it hits — surfaced while adding this target.

## Validation

Standard Go `GOOS=wasip1 GOARCH=wasm go build`, run under wasmtime:

| check | result |
|---|---|
| build | clean, 24 MB `.wasm` |
| `-e '(println (str "wasi says " (* 6 7)))'` | `wasi says 42` — stdio works |
| `-e '(* 1000000000 1000000000)'` | `1000000000000000000` (10^18) — 64-bit exact |
| `-e '(bit-shift-left 1 62)'` | `4611686018427387904` (2^62) — full width |

Scope: this is the standard-Go target. TinyGo's `-target=wasi` is also `GOOS=wasip1`, but it doesn't build let-go as-is — TinyGo 0.41.1 traps at init on `reflect.Type.Method()` — so it's out of scope here.

## Notes for review

- **Capabilities.** The module has no ambient authority. No `term` namespace (the interactive terminal is gated out; requiring it reports `unable to load namespace term` rather than recursing), no sockets, no threads. Filesystem access is host-controlled: nothing by default, but a wasip1 host can preopen directories (e.g. wasmtime `--dir`), which `slurp` and friends then see. Fine for headless eval and embedding; a TUI-over-wasi would need a headless `term` stub (future work).
- **Independent of the runtime-only build (#424).** These compose but don't couple: different files (platform gates in `pkg/rt`/repl vs. compiler linkage in `eval.go`), different risk (mechanical vs. design), different guarantees (capability vs. trust surface). Layering runtime-only on top gives the "no `eval`, run untrusted precompiled bytecode under a wasm sandbox" shape, but that's a separate change.
- **Follow-up, not here: the wazero embedding demo.** wasmtime already proves it runs as wasip1; the embedding pitch is the same module loaded from a Go host via wazero, fed a form, capturing output. Happy to add it as a follow-up example if that's useful.
