### PR TITLE
chore(ir-stress): exclude scripts/lginterop.lg from corpus — stale gogen/parse-stmts

### DIFF
--- a/scripts/ir-stress-corpus.edn
+++ b/scripts/ir-stress-corpus.edn
@@ -1,8 +1,9 @@
 {:doc
  "IR-stress lower-go corpus: every repo .lg the AOT lowering should handle. Failures against :stress are real lowering gaps - forward/mutual-ref resolution, unsupported arg patterns, gogen emission, lowering-cost timeouts. Widest net: core via go:embed all:core plus tests, examples, scripts; external deps are themselves lowered .lg so they stay IN. Consumer: make ir-stress runs lower-go on :stress minus :exclude. Regenerate the file list via scripts/ir-stress.lg."
- ;; Nothing excluded: every listed file must read and lower.
+ ;; Every non-excluded file must read and lower. Excludes carry a rationale.
  :exclude
- {}
+ {"scripts/lginterop.lg"
+  "stale build-wrapper-body references undefined gogen/parse-stmts (#293); the smart-wrapper path is superseded by the annotation-driven registrar (#411)"}
  :stress
  ["examples/async.lg"
   "examples/concurrent-primes.lg"


### PR DESCRIPTION
## Summary
`scripts/lginterop.lg`'s `build-wrapper-body` calls `gogen/parse-stmts`, which is not defined anywhere in `pkg/rt/gogen/gogen.lg` (gogen builds AST from s-expression forms; it has no Go-source statement parser). The smart-wrapper path is therefore dead-on-arrival today and only pollutes the ir-stress corpus failure set.

Per the options in #293, this excludes the file from the corpus with a rationale in `:exclude` (the map is consumed via `keys` in `scripts/ir-stress.lg:116`, so the rationale string rides along as the value). The wrapper model itself is being superseded by the annotation-driven registrar (#411), so repairing `build-wrapper-body` against the s-expression gogen API would be effort spent on a path already slated for replacement.

Fixes #293

## Test plan
- [x] corpus EDN still parses; `scripts/lginterop.lg` remains listed in `:stress` and is now subtracted via `:exclude`
- [x] `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)