### PR TITLE
fix(ir): accept defn attr-map position in AOT lowering

### DIFF
--- a/pkg/ir/lisp_build_defn_test.go
+++ b/pkg/ir/lisp_build_defn_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// TestBuildFnDefnAttrMap covers the defn header grammar
+// (defn name docstring? attr-map? [params] body) in the IR builder (#289):
+// the attr-map position ({:added "1.0"} etc.) is var metadata the lowering
+// must skip, not an arg pattern. Before the fix, build-fn treated the map as
+// the arglist and threw "unsupported destructuring pattern: :added".
+func TestBuildFnDefnAttrMap(t *testing.T) {
+	ensureLoader()
+
+	cases := []struct {
+		label string
+		src   string
+	}{
+		{"doc+attr single-arity", `(defn meta-doc-fn "defn doc" {:added "1.0"} [x] x)`},
+		{"attr only single-arity", `(defn attr-fn {:added "1.0"} [x] x)`},
+		{"doc+attr multi-arity", `(defn meta-doc-multi "doc" {:added "2.0"} ([x] x) ([x y] y))`},
+		{"attr only multi-arity", `(defn attr-multi {:added "2.0"} ([x] x) ([x y] y))`},
+		{"doc only (regression guard)", `(defn doc-fn "doc" [x] x)`},
+		{"bare (regression guard)", `(defn bare-fn [x] x)`},
+	}
+	for _, tc := range cases {
+		f := buildLispIR(t, tc.src)
+		if f == vm.NIL {
+			t.Errorf("%s: build-fn returned nil for %s", tc.label, tc.src)
+		}
+	}
+}

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -1408,28 +1408,24 @@
 ;; --- entry point ---------------------------------------------------------
 
 (defn parse-defn-args-body [form]
-  (let [x2 (nth form 2 nil)
-        x3 (nth form 3 nil)
-        x4 (nth form 4 nil)]
-    (cond
-      (string? x2)
-      (if (map? x3)
-        [x4 (drop 5 form)]
-        [x3 (drop 4 form)])
-      (map? x2)
-      [x3 (drop 4 form)]
-      :else
-      [x2 (drop 3 form)])))
+  "Split a defn form past its header — (defn name docstring? attr-map?
+   arglist-or-first-clause rest...) — into [args-vec body-forms]. The
+   attr-map position ({:added \"1.0\"} etc.) is metadata the bytecode
+   compiler attaches to the var; lowering skips it. Mirrors the header
+   walk in core.lg's defn/defmacro macros — keep the three in step."
+  (let [forms (drop 2 form)
+        forms (if (string? (first forms)) (next forms) forms)
+        forms (if (map? (first forms)) (next forms) forms)]
+    [(first forms) (rest forms)]))
 
 (defn build-fn [defn-form]
   "Build an IR Function from a (defn name [args] body...) or
    multi-arity (defn name ([args] body...) ([args2] body2...)) form.
-   Handles optional docstring. Returns a boxed *ir.Function."
+   Handles optional docstring and attr-map. Returns a boxed *ir.Function."
   (let [name-sym   (nth defn-form 1)
-        maybe-doc  (nth defn-form 2)
-        has-doc?   (string? maybe-doc)
-        args-vec   (if has-doc? (nth defn-form 3) maybe-doc)
-        body-forms (drop (if has-doc? 4 3) defn-form)
+        parsed     (parse-defn-args-body defn-form)
+        args-vec   (nth parsed 0)
+        body-forms (nth parsed 1)
         multi?     (list? args-vec)]
     (if-not multi?
       ;; Single-arity path. Expand destructured args before building.

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-d93da4d0a0a4dc0c844fa6ea99ac3fa80775883970122dec3bad971d1cd745b4
+5862800bcf49fc20886faf75febd245511105d241cd653f83b8af8d6fae15896


### PR DESCRIPTION
## Summary
Clojure's defn grammar is `(defn name docstring? attr-map? [params*] body)`. The IR builder's `build-fn` did its own header parse that only understood the optional docstring, so a defn using the attr-map position — `(defn meta-doc-fn "defn doc" {:added "1.0"} [x] x)` — treated `{:added "1.0"}` as the arglist and failed to lower with `unsupported destructuring pattern: :added` (surfaced by the ir-stress corpus on `test/metadata_test.lg`).

The fix wires in `parse-defn-args-body`, which already implemented the full grammar but had **zero callers**. The attr-map is var metadata the bytecode compiler attaches; lowering skips it, as the issue specifies. Covers all four header shapes (doc+attr / attr-only × single / multi-arity).

Fixes #289

## Test plan
- [x] new `TestBuildFnDefnAttrMap` (pkg/ir): doc+attr, attr-only, multi-arity variants + doc-only/bare regression guards
- [x] runtime repro gone: `(ir.build/build-fn '(defn meta-doc-fn "defn doc" {:added "1.0"} [x] x))` builds
- [x] `make generate` + `make check-generated` (build.lg is a core source)
- [x] pre-push gate: `go test ./...`, Clojure compat suite (both backends), ir-stress coverage ratchet — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)