### PR TITLE
fix(compiler): evaluate top-level (do ...) subform-by-subform like Clojure

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -112,13 +112,23 @@ func (c *Context) CompileMultiple(reader io.Reader) (*vm.CodeChunk, vm.Value, er
 	chunk := vm.NewCodeChunk(c.consts)
 	var result vm.Value = vm.NIL
 	compiledForms := 0
-	for {
-		o, err := r.Read()
-		if err != nil {
-			if isErrorEOF(err) {
-				break
+	var evalTopForm func(o vm.Value) error
+	evalTopForm = func(o vm.Value) error {
+		// Clojure's Compiler.eval special-cases a top-level (do ...): each
+		// subform is compiled AND evaluated in turn, so an earlier subform's
+		// compile-time effect (a require loading a namespace, an in-ns, an
+		// intern) is visible when a later subform compiles. This is what
+		// makes (do (require 'x) (x/f)) work at the REPL (#195). An empty
+		// (do) falls through to compileForm and evaluates to nil.
+		if lst, ok := o.(*vm.List); ok && lst.Next() != nil {
+			if first, isSym := lst.First().(vm.Symbol); isSym && first == "do" {
+				for s := lst.Next(); s != nil; s = s.Next() {
+					if err := evalTopForm(s.First()); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
-			return nil, result, err
 		}
 		if compiledForms > 0 {
 			chunk.Append(vm.OP_POP)
@@ -126,10 +136,10 @@ func (c *Context) CompileMultiple(reader io.Reader) (*vm.CodeChunk, vm.Value, er
 		formchunk := vm.NewCodeChunk(c.consts)
 		c.chunk = formchunk
 		c.resetSP()
-		err = c.compileForm(o)
+		err := c.compileForm(o)
 		c.chunk.SetMaxStack(c.spMax)
 		if err != nil {
-			return nil, result, err
+			return err
 		}
 		chunk.AppendChunk(formchunk)
 
@@ -143,9 +153,22 @@ func (c *Context) CompileMultiple(reader io.Reader) (*vm.CodeChunk, vm.Value, er
 		result, err = f.RunProtected()
 		vm.ReleaseFrame(f)
 		if err != nil {
-			return nil, result, err
+			return err
 		}
 		compiledForms++
+		return nil
+	}
+	for {
+		o, err := r.Read()
+		if err != nil {
+			if isErrorEOF(err) {
+				break
+			}
+			return nil, result, err
+		}
+		if err := evalTopForm(o); err != nil {
+			return nil, result, err
+		}
 	}
 
 	c.chunk = chunk

--- a/test/top_level_do_test.lg
+++ b/test/top_level_do_test.lg
@@ -1,0 +1,17 @@
+;; #195: a top-level (do ...) is evaluated subform-by-subform (Clojure's
+;; Compiler.eval special case), so an earlier subform's compile-time effect —
+;; here (require 'topdo-helper) loading a namespace from disk — is visible
+;; when a later subform compiles. These asserts must stay TOP-LEVEL forms:
+;; inside a fn body (or any non-top-level position) a do is a single compiled
+;; unit, in let-go and Clojure alike.
+(do (require 'topdo-helper)
+    (assert (= :hi (topdo-helper/hello))))
+
+;; Nested top-level do splices recursively.
+(do (do (require 'topdo-helper))
+    (assert (= :hi (topdo-helper/hello))))
+
+;; Value semantics are unchanged.
+(assert (= 3 (do 1 2 3)))
+(assert (nil? (do)))
+(do (assert true) (assert (= 1 1)))

--- a/test/topdo_helper.lg
+++ b/test/topdo_helper.lg
@@ -1,0 +1,7 @@
+;; Helper namespace for top_level_do_test.lg (#195): loaded from disk via
+;; require so the requiring file exercises compile-after-require resolution.
+;; (Embedded clojure.* namespaces resolve at compile time without require and
+;; would mask the bug.)
+(ns topdo-helper)
+
+(defn hello [] :hi)


### PR DESCRIPTION
## Summary
Clojure's `Compiler.eval` special-cases a top-level `(do ...)`: each subform is compiled **and evaluated** in turn, so an earlier subform's compile-time effect (a `require` loading a namespace, an `in-ns`, an `intern`) is visible when a later subform compiles. let-go compiled a top-level `do` as one unit, so the common REPL idiom broke:

```clojure
(do (require 'a) (a/hello))   ; before: Can't resolve a/hello in this context
                              ; after:  :hi
```

`CompileMultiple` already compiles+runs each *separate* top-level form sequentially; this change splices a top-level `(do ...)` into that same sequence, recursively (nested top-level `do`s splice too). Non-top-level `do` is untouched — `(println (do (require 'a) (a/hello)))` still fails, exactly as it does in Clojure. Empty `(do)` falls through to the normal path and evaluates to nil; value semantics (`(do 1 2 3)` → 3) are unchanged.

Note: like Clojure, the check is on the literal form. Clojure also macroexpands before the check (a macro expanding to a top-level `do` gets spliced); that extension is left for a follow-up if wanted — it requires hoisting the compiler's inline macro-invocation out of `compileForm`.

Fixes #195

## Test plan
- [x] new `test/top_level_do_test.lg` + `test/topdo_helper.lg` (disk-loaded ns, so embedded-clojure.* masking doesn't hide the bug): require-then-use in one top-level do, nested do splice, value/nil semantics
- [x] `make generate` → bundle byte-identical (compiler change does not perturb codegen); `make check-generated` OK
- [x] pre-push gate: `go test ./...`, Clojure compat suite (both backends), ir-stress ratchet — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)