### PR TITLE
feat(ir): legalize cross-block refs and run lambda-lifted fns natively in gogen_ir

### DIFF
--- a/pkg/ir/lisp_constfold_test.go
+++ b/pkg/ir/lisp_constfold_test.go
@@ -50,7 +50,7 @@ func ensureLoader() {
 			"ir.passes.mutability", "ir.passes.cse",
 			"ir.passes.typeinfer", "ir.passes.infer-arg-types",
 			"ir.passes.licm", "ir.passes.lambda-lift", "ir.passes.inline", "ir.passes.fusion",
-			"ir.passes.liveness", "ir.passes.blockarg", "ir.passes.cleanup", "ir.passes.pipeline", "ir.dump", "ir.dominance", "ir.lower-go"} {
+			"ir.passes.liveness", "ir.passes.blockarg", "ir.passes.cleanup", "ir.passes.legalize", "ir.passes.pipeline", "ir.dump", "ir.dominance", "ir.lower-go"} {
 			if res.Load(ns) == nil {
 				panic("namespace failed to load: " + ns)
 			}

--- a/pkg/ir/lisp_lambda_lift_main_test.go
+++ b/pkg/ir/lisp_lambda_lift_main_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// Part 3 of the lambda-lift native-safety work: the MAIN fn of a lambda-lift
+// multi-fn-template must carry its full lowering result through the flatten,
+// exactly like its lifted siblings (Part 2). Otherwise the main is stripped to
+// a bare decl — no :fn-name/:override-eligible? — so it is (a) never registered
+// as a native override, and (b) invisible to the direct-call registry, forcing
+// every intra-ns caller through the rt.CachedVarFn bytecode trampoline even
+// though a native decl for it sits in the same package (self-trampolining).
+func TestLambdaLiftMainIsRegisteredAndDirectCallable(t *testing.T) {
+	ensureLoader()
+
+	// Define the fns in their namespace first (interns liftmain/cx so use-cx's
+	// (cx x) resolves during build), then lower — mirroring how the bootstrap
+	// lowers a fully-loaded namespace.
+	v := runLispExpr(t, `
+      (ns liftmain)
+      (defn cx [p] (identity (fn* [q] q)))
+      (defn use-cx [x] (cx x))
+      (ns user)
+      (ir.passes.pipeline/lower-ns-to-go "liftmain" (quote liftmain)
+        [(quote (defn cx [p] (identity (fn* [q] q))))
+         (quote (defn use-cx [x] (cx x)))])`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go source string, got %T", v)
+	}
+	src := string(s)
+
+	// Sanity: main + sibling decls exist, sibling is registered (Parts 1+2).
+	if !strings.Contains(src, "func Cx(") || !strings.Contains(src, "func Cx__lifted0(") {
+		t.Fatalf("expected both main and sibling decls:\n%s", src)
+	}
+	if !regexp.MustCompile(`"cx__lifted0":\s*__gogen_wrap`).MatchString(src) {
+		t.Fatalf("sibling cx__lifted0 not registered (Part 2 regressed?):\n%s", src)
+	}
+
+	// Part 3a: the main itself is registered as a native override.
+	if !regexp.MustCompile(`"cx":\s*__gogen_wrap`).MatchString(src) {
+		t.Fatalf("main cx is NOT registered in the override init map:\n%s", src)
+	}
+
+	// Part 3b: an intra-ns caller direct-calls the native main — no trampoline.
+	if !regexp.MustCompile(`=\s*Cx\(ec,`).MatchString(src) {
+		t.Fatalf("use-cx does not direct-call Cx natively:\n%s", src)
+	}
+	if strings.Contains(src, `"liftmain", "cx")`) {
+		t.Fatalf("use-cx still trampolines to cx via var lookup:\n%s", src)
+	}
+}

--- a/pkg/ir/lisp_lambda_lift_ns_test.go
+++ b/pkg/ir/lisp_lambda_lift_ns_test.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// compileFormToGoInNs is compileFormToGo but with *ns* bound to a non-core
+// namespace via compile-form's caller-ns arg. This exposes ns-sensitivity in
+// lowering: a lambda-lifted sibling lives in the SAME ns as its outer fn, so a
+// reference to it must resolve against that ns — not the hardcoded "core"
+// default that load-var-deref-expr applies to bare (unqualified) symbols.
+func compileFormToGoInNs(t *testing.T, nsName, src string) string {
+	t.Helper()
+	passVarCounter++
+	formName := fmt.Sprintf("*compile-form-ns-%d*", passVarCounter)
+
+	coreNS := rt.NS(rt.NameCoreNS)
+
+	consts := vm.NewConsts()
+	c := compiler.NewCompiler(consts, coreNS)
+	c.SetSource("compile-form-to-go-ns-parse")
+	_, parsed, err := c.CompileMultiple(strings.NewReader(fmt.Sprintf(`(quote %s)`, src)))
+	if err != nil {
+		t.Fatalf("parse form: %v", err)
+	}
+	coreNS.Def(formName, parsed)
+
+	consts = vm.NewConsts()
+	c = compiler.NewCompiler(consts, coreNS)
+	c.SetSource("compile-form-to-go-ns")
+	compileExpr := fmt.Sprintf(`(do (create-ns (quote %s))
+                                    (binding [ir.passes.pipeline/*target* :go]
+                                      (ir.passes.pipeline/compile-form %s (the-ns (quote %s)))))`,
+		nsName, formName, nsName)
+	_, result, err := c.CompileMultiple(strings.NewReader(compileExpr))
+	if err != nil {
+		t.Fatalf("compile-form with *target* :go in ns %s: %v", nsName, err)
+	}
+
+	declVarName := fmt.Sprintf("*compile-result-ns-%d*", passVarCounter)
+	coreNS.Def(declVarName, result)
+
+	renderExpr := fmt.Sprintf(`
+(let [decls (if (= :multi-fn-template (:kind %s))
+              (mapv (fn* [entry] (:fn entry)) (:fns %s))
+              (if (= :lowered (:status %s))
+                [(:decl %s)]
+                []))]
+  (apply str (mapv (fn* [d] (gogen/render d)) decls)))`, declVarName, declVarName, declVarName, declVarName)
+
+	consts = vm.NewConsts()
+	c = compiler.NewCompiler(consts, coreNS)
+	c.SetSource("render-decls-ns")
+	_, rendered, err := c.CompileMultiple(strings.NewReader(renderExpr))
+	if err != nil {
+		t.Fatalf("render decls: %v", err)
+	}
+	if s, ok := rendered.(vm.String); ok {
+		return string(s)
+	}
+	t.Fatalf("expected gogen/render to return string, got %T", rendered)
+	return ""
+}
+
+// A lambda-lifted sibling is interned into the SAME namespace as the outer fn.
+// When the outer fn references it as a value (here, passed to identity), the
+// reference lowers to rt.LookupVar(<ns>, "<name>__lifted0"). The ns MUST be the
+// outer fn's ns, not the "core" default. Before the fix, load-var-deref-expr
+// saw a bare (unqualified) symbol and emitted LookupVar("core", ...), which
+// dangles at runtime in any non-core ns (the observed AnalyzeNsForms nil-deref).
+func TestLambdaLiftSiblingRefUsesOuterNs(t *testing.T) {
+	ensureLoader()
+	out := compileFormToGoInNs(t, "lifttest.pkg", `(defn cx [p] (identity (fn* [q] q)))`)
+
+	if !strings.Contains(out, `"cx__lifted0"`) {
+		t.Fatalf("expected a var reference to the lifted sibling cx__lifted0:\n%s", out)
+	}
+	if strings.Contains(out, `LookupVar("core", "cx__lifted0")`) {
+		t.Fatalf("lifted sibling ref wrongly defaulted to \"core\" ns:\n%s", out)
+	}
+	if !strings.Contains(out, `LookupVar("lifttest.pkg", "cx__lifted0")`) {
+		t.Fatalf("expected LookupVar(\"lifttest.pkg\", \"cx__lifted0\"), got:\n%s", out)
+	}
+}

--- a/pkg/ir/lisp_lambda_lift_register_test.go
+++ b/pkg/ir/lisp_lambda_lift_register_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// A lambda-lifted sibling is emitted as a native Go func in the SAME package as
+// its outer fn, and referenced from the outer fn's native body via
+// rt.LookupVar(<ns>, "<name>__lifted0"). For that lookup to resolve at runtime
+// (rather than nil-deref), the sibling's var must be interned — i.e. it must
+// appear in the package init()'s rt.RegisterGoOverrides map. Before the fix, the
+// go-target lambda-lift path stripped each sibling's result to {:fn decl},
+// dropping :fn-name/:override-eligible?, so override-entries never registered it.
+func TestLambdaLiftSiblingIsRegisteredNatively(t *testing.T) {
+	ensureLoader()
+
+	v := runLispExpr(t, `(do (create-ns (quote liftreg))
+      (ir.passes.pipeline/lower-ns-to-go "liftreg" (quote liftreg)
+        [(quote (defn cx [p] (identity (fn* [q] q))))]))`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go source string, got %T", v)
+	}
+	src := string(s)
+
+	// Sanity: the sibling decl and the var reference both exist (Part 1).
+	if !strings.Contains(src, "func Cx__lifted0(") {
+		t.Fatalf("expected the lifted sibling decl `func Cx__lifted0(`:\n%s", src)
+	}
+	if !strings.Contains(src, `LookupVar("liftreg", "cx__lifted0")`) {
+		t.Fatalf("expected the outer body to reference LookupVar(\"liftreg\", \"cx__lifted0\"):\n%s", src)
+	}
+
+	// Part 2: the sibling's var must be registered in the init() override map so
+	// the LookupVar above resolves at runtime. The map key is the bare var name.
+	if !strings.Contains(src, "RegisterGoOverrides") {
+		t.Fatalf("expected an init() with rt.RegisterGoOverrides:\n%s", src)
+	}
+	registered := regexp.MustCompile(`"cx__lifted0":\s*__gogen_wrap`)
+	if !registered.MatchString(src) {
+		t.Fatalf("lifted sibling cx__lifted0 is NOT registered in the override init map:\n%s", src)
+	}
+}
+
+// A lifted sibling whose body typeinfer would prove TYPED (here: int? -> bool)
+// must STILL end up registered. Siblings are only ever invoked boxed through
+// their var (higher-order use), so they are lowered with the uniform vm.Value
+// ABI — a typed signature would fail override-uniform-value?, silently skip
+// registration, and leave the main's rt.LookupVar dangling (the Part-3 parity
+// break: 674 nil-derefs from typeinfer's numeric-op-type__lifted0).
+func TestLambdaLiftTypedSiblingStillRegisters(t *testing.T) {
+	ensureLoader()
+
+	v := runLispExpr(t, `(do (create-ns (quote liftt))
+      (ir.passes.pipeline/lower-ns-to-go "liftt" (quote liftt)
+        [(quote (defn cx [p] (some (fn* [q] (or (= q :int) (= q :float))) p)))]))`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go source string, got %T", v)
+	}
+	src := string(s)
+
+	// The invariant: EVERY emitted LookupVar of a lifted sibling has a matching
+	// registration. Either the sibling registers (preferred) or the whole form
+	// fell back to bytecode (no native decls at all) — never a dangling ref.
+	if strings.Contains(src, `"cx__lifted0")`) {
+		if !regexp.MustCompile(`"cx__lifted0":\s*__gogen_wrap`).MatchString(src) {
+			t.Fatalf("main references cx__lifted0 but the sibling is NOT registered (dangling LookupVar):\n%s", src)
+		}
+		// And the sibling must present the uniform boxed ABI.
+		if regexp.MustCompile(`func Cx__lifted0\([^)]*\) \(?bool`).MatchString(src) {
+			t.Fatalf("lifted sibling lowered with a typed (bool) ABI — must be uniform vm.Value:\n%s", src)
+		}
+	}
+}

--- a/pkg/ir/lisp_legalize_test.go
+++ b/pkg/ir/lisp_legalize_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// A hand-built 2-block Function carrying a cross-block ref:
+//
+//	block0: v0 = load-arg 0        (cheap-load, exempt)
+//	        v1 = (+ v0 v0)         (non-cheap, defined in block0)
+//	        branch -> block1
+//	block1: v2 = (+ v1 v1)         (refs v1 ACROSS blocks — illegal SSA)
+//	        return v2
+//
+// This is the minimal shape ir.validate/check-no-cross-block-refs! rejects,
+// and the shape a real build (e.g. try-assign-stmts) trips on. Constructed
+// directly so the fixture does not depend on build.lg's threading behaviour.
+const xblockFixture = `
+  (let [f  (ir/new-fn "xblock" 1 false)
+        v0 (ir/add-inst f 0 :load-arg [] 0)
+        v1 (ir/add-inst f 0 :add [v0 v0] nil)
+        b1 (ir/add-block f)]
+    (ir/add-pred! f b1 0)
+    (ir/add-terminator! f 0 :branch [] (ir/new-branch-target b1 []))
+    (let [v2 (ir/add-inst f b1 :add [v1 v1] nil)]
+      (ir/add-terminator! f b1 :return [v2] nil))
+    f)`
+
+// Guard: the fixture is genuinely invalid SSA (a cross-block ref), so the
+// GREEN test below is not vacuous.
+func TestLegalizeFixtureIsGenuinelyCrossBlock(t *testing.T) {
+	ensureLoader()
+	got := string(runLispExpr(t, `
+      (do (require 'ir.data) (require 'ir.validate)
+        (let [f `+xblockFixture+`]
+          (try (ir.validate/validate-fn! f "probe") "UNEXPECTEDLY-VALID"
+               (catch e (str e)))))`).(vm.String))
+	if !strings.Contains(got, "cross-block ref") {
+		t.Fatalf("fixture should carry a cross-block ref; validate said: %s", got)
+	}
+}
+
+// RED→GREEN driver: the legalize pass must thread the cross-block value into a
+// fresh block-arg so the function validates, and block1 must gain exactly one
+// param (the threaded arg) — proving the value was threaded, not deleted.
+func TestLegalizeThreadsCrossBlockRefIntoBlockArg(t *testing.T) {
+	ensureLoader()
+	got := string(runLispExpr(t, `
+      (do (require 'ir.data) (require 'ir.validate)
+        (let [f `+xblockFixture+`]
+          (ir.passes.legalize/legalize-fn! f)
+          (try (ir.validate/validate-fn! f "legalize-test")
+               (pr-str [:validated (count (ir/block-params 1 f))])
+               (catch e (str "STILL-INVALID: " e)))))`).(vm.String))
+	if got != `[:validated 1]` {
+		t.Fatalf("legalize should thread the cross-block ref into a block1 block-arg; got %s", got)
+	}
+}

--- a/pkg/rt/core/ir/passes/lambda_lift.lg
+++ b/pkg/rt/core/ir/passes/lambda_lift.lg
@@ -56,11 +56,17 @@
 (defn- rewrite-site! [f cand sibling-name]
   "Capture-free: the fn-template :const becomes a :load-var of the sibling.
    Keeping the same nid means all consumers (the name*/applier Call args)
-   keep referencing it with no further rewrite."
+   keep referencing it with no further rewrite.
+
+   The sibling var is interned into the SAME namespace as the outer fn (the
+   *ns* bound by the compile pipeline). Qualify the :load-var symbol with that
+   ns so lowering resolves rt.LookupVar(<ns>, name) against the real home ns —
+   NOT the \"core\" default that load-var-deref-expr applies to bare symbols,
+   which dangles at runtime for any non-core ns."
   (let [nid (:template-const cand)]
     (ir/replace-op! f nid :load-var)
     (ir/set-refs!   f nid [])
-    (ir/set-aux!    f nid (symbol sibling-name))))
+    (ir/set-aux!    f nid (symbol (str (ns-name *ns*)) sibling-name))))
 
 (defn lambda-lift [f]
   "Hoist inner fn literals to top-level siblings. Returns {:main f :lifted [...]}.
@@ -69,7 +75,16 @@
     (if (empty? cands)
       {:main f :lifted []}
       (let [outer (str (ir/fn-name f))
-            free  (filter (fn [c] (empty? (:captures c))) cands)
+            ;; Lift only capture-free NON-VARIADIC inners. A lifted sibling
+            ;; lives behind an interned var (the main body LookupVars it), and
+            ;; the override registration that interns it cannot adapt a
+            ;; variadic signature (override-uniform-value? excludes variadic).
+            ;; A variadic inner stays an inline fn-template — lower-fn-lit
+            ;; emits it as a plain Go func-lit, the pre-lambda-lift path.
+            free  (filter (fn [c] (and (empty? (:captures c))
+                                       (let [inner (:inner c)]
+                                         (and inner (not (ir/fn-variadic? inner))))))
+                          cands)
             lifted (vec (map-indexed
                           (fn [i c]
                             (let [g (lift-sibling f outer i c)]

--- a/pkg/rt/core/ir/passes/legalize.lg
+++ b/pkg/rt/core/ir/passes/legalize.lg
@@ -1,0 +1,166 @@
+;; Copyright (c) 2026 Norman Nunley, Jr
+;; SPDX-License-Identifier: MIT
+;;
+;; ir.passes.legalize — repair cross-block direct references by threading
+;; the referenced value through fresh block-args (SSA legalization).
+;;
+;; build.lg's construction-time threading (build-if/build-loop/build-args)
+;; prevents cross-block refs for the shapes it knows, but a few complex
+;; shapes (notably the :try lowering in `try-assign-stmts`) still emit an
+;; Inst whose ref points at a value defined in another block. The validator
+;; (ir.validate/check-no-cross-block-refs!) rejects that, which today forces
+;; the whole fn to fall back off the native-lowering path onto a bytecode
+;; trampoline. This pass legalizes such refs on demand — ONLY the refs the
+;; validator would reject — so no unused "passenger" block-args are ever
+;; introduced (the failure mode that sank the GVN pass this was salvaged
+;; from: cross-block GVN, commit "feat(ir): cross-block GVN via
+;; value-threading"; the value-numbering half is dropped, the threading
+;; primitive kept).
+;;
+;; Runs after build, before validate. Correct when the def-block dominates
+;; the use-block (true for any value legitimately computed-before-used on
+;; every path — i.e. any ref a correct build could have emitted).
+
+(ns ir.passes.legalize)
+
+;; --- detection: non-throwing enumeration of illegal cross-block refs ----
+;; Mirrors ir.validate/check-no-cross-block-refs! EXACTLY (same exemptions)
+;; but collects instead of throwing on the first hit.
+
+(defn- cross-block-refs [f]
+  "Seq of {:inst nid :ref v :use-block ub} for every Inst.refs entry that
+   points at a non-cheap, non-block-arg value defined in another block."
+  (let [insts (:insts @f)]
+    (reduce
+      (fn [acc [i ins]]
+        (let [op (nth ins 0)]
+          (if (= op :invalid)
+            acc
+            (let [use-block (nth ins 3)]
+              (reduce
+                (fn [a r]
+                  (let [referent  (nth insts r)
+                        ref-op    (nth referent 0)
+                        def-block (nth referent 3)]
+                    (if (and (not= def-block use-block)
+                             (not= :block-arg ref-op)
+                             ;; :load-var is cheap but mutable — must be threaded.
+                             (not (and (ir/op-cheap-load? ref-op)
+                                       (not= ref-op :load-var))))
+                      (conj a {:inst i :ref r :use-block use-block})
+                      a)))
+                acc
+                (nth ins 1))))))
+      []
+      (map-indexed vector insts))))
+
+;; --- threading primitive (salvaged from the stranded GVN pass) ----------
+
+(defn- compute-needs [f v use-block]
+  "BFS backwards from use-block toward v's def-block: the set of blocks
+   that need a fresh param to carry v. The :branch-if symmetric-args
+   invariant (tt.args == ft.args) requires BOTH successors of any visited
+   branch-if pred to be in the set, so they are added too."
+  (let [def-block (ir/block-of v f)]
+    (loop [needs    #{use-block}
+           frontier [use-block]]
+      (if (empty? frontier)
+        needs
+        (let [t          (peek frontier)
+              rest-front (pop frontier)
+              preds      (ir/block-preds t f)
+              add-preds  (remove (fn [p] (or (= p def-block) (contains? needs p))) preds)
+              add-siblings
+              (->> preds
+                   (mapcat (fn [p]
+                             (let [term (ir/block-term p f)]
+                               (if (or (nil? term) (not= :branch-if (ir/op term f)))
+                                 []
+                                 (let [aux    (ir/aux term f)
+                                       tt-bid (ir/branch-target-target (ir/cond-target-true aux))
+                                       ft-bid (ir/branch-target-target (ir/cond-target-false aux))]
+                                   [tt-bid ft-bid])))))
+                   (remove (fn [b] (or (= b def-block) (contains? needs b))))
+                   distinct
+                   vec)
+              additions (vec (distinct (concat add-preds add-siblings)))]
+          (recur (into needs additions)
+                 (vec (concat rest-front additions))))))))
+
+(defn- extend-pred-all-args! [f pred-bid value]
+  "Append `value` to every BranchTarget.args on pred's terminator. :branch
+   has one target; :branch-if has tt+ft (append to both — preserves the
+   symmetric invariant)."
+  (let [term (ir/block-term pred-bid f)]
+    (when-not (nil? term)
+      (let [op  (ir/op term f)
+            aux (ir/aux term f)]
+        (cond
+          (= op :branch)
+          (let [new-args (conj (vec (ir/branch-target-args aux)) value)
+                new-bt   (ir/new-branch-target (ir/branch-target-target aux) new-args)]
+            (ir/set-aux! f term new-bt))
+          (= op :branch-if)
+          (let [tt      (ir/cond-target-true aux)
+                ft      (ir/cond-target-false aux)
+                tt-args (conj (vec (ir/branch-target-args tt)) value)
+                ft-args (conj (vec (ir/branch-target-args ft)) value)
+                new-tt  (ir/new-branch-target (ir/branch-target-target tt) tt-args)
+                new-ft  (ir/new-branch-target (ir/branch-target-target ft) ft-args)]
+            (ir/set-aux! f term (ir/new-cond-target new-tt new-ft))))))))
+
+(defn- thread-value-to [f v use-block]
+  "Make v accessible in use-block by allocating fresh BlockArgs on every
+   block of the def→use frontier and extending every pred's
+   BranchTarget.args. Returns the InstId usable in use-block."
+  (if (= use-block (ir/block-of v f))
+    v
+    (let [def-block (ir/block-of v f)
+          needs     (compute-needs f v use-block)
+          ;; Phase 1: one fresh :block-arg per block in needs.
+          new-args  (reduce (fn [acc b]
+                              (let [pos (count (ir/block-params b f))
+                                    nid (ir/add-block-arg-front! f b pos)]
+                                (ir/add-block-param! f b nid)
+                                (assoc acc b nid)))
+                            {}
+                            needs)
+          ;; Phase 2: extend each distinct pred once (branch-if updates both
+          ;; targets in one call). Each pred passes v if it is the def-block,
+          ;; else its own fresh block-arg.
+          all-preds (->> needs
+                         (mapcat (fn [b] (ir/block-preds b f)))
+                         distinct
+                         vec)]
+      (doseq [pred-bid all-preds]
+        (let [value (if (= pred-bid def-block)
+                      v
+                      (get new-args pred-bid))]
+          (when-not (nil? value)
+            (extend-pred-all-args! f pred-bid value))))
+      (get new-args use-block))))
+
+;; --- driver -------------------------------------------------------------
+
+(defn legalize-fn! [f]
+  "Rewrite every illegal cross-block ref to reference a freshly-threaded
+   block-arg in the using block. Returns f. Idempotent: a fn with no
+   cross-block refs is unchanged. Loops so that any ref exposed while
+   threading is caught (converges in one round for dominating values)."
+  (loop [guard 0]
+    (let [bad (cross-block-refs f)]
+      (if (empty? bad)
+        f
+        (do
+          (when (> guard 1000)
+            (throw "legalize-fn!: did not converge (non-dominating cross-block ref?)"))
+          ;; Thread once per (value, use-block); reuse the block-arg for every
+          ;; inst in that block that references the value.
+          (doseq [[[v use-block] entries]
+                  (group-by (fn [e] [(:ref e) (:use-block e)]) bad)]
+            (let [new-id (thread-value-to f v use-block)]
+              (doseq [e entries]
+                (let [nid  (:inst e)
+                      refs (vec (map (fn [r] (if (= r v) new-id r)) (ir/refs nid f)))]
+                  (ir/set-refs! f nid refs)))))
+          (recur (inc guard)))))))

--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -32,6 +32,7 @@
    [ir.passes.infer-arg-types :refer [infer-arg-types]]
    [ir.passes.inline]
    [ir.passes.lambda-lift]
+   [ir.passes.legalize :refer [legalize-fn!]]
    [ir.passes.licm :refer [licm]]
    [ir.passes.typeinfer :refer [typeinfer]]
    [ir.validate :refer [validate-fn!]]))
@@ -92,7 +93,32 @@
 (defn- optimize-fn-tail [f]
   (run-pass-list f default-pass-list))
 
+;; default-pass-list minus the typeinfra epochs. Used for lambda-lifted
+;; siblings: a sibling is only ever invoked BOXED through its interned var
+;; (higher-order use — the main body passes it to some/map/…), so a typed
+;; signature buys nothing at the boundary — and it actively breaks the
+;; registration invariant: a typed sibling fails override-uniform-value?, is
+;; silently skipped by override-entries, and the main's
+;; rt.LookupVar(<ns>, "<name>__liftedN") nil-derefs at runtime (the sibling
+;; var has NO bytecode fallback — lambda-lift runs only on the :go path).
+;; Skipping type inference keeps every inst :unknown → the whole body lowers
+;; through the boxed vm.Value path → uniform ABI by construction.
+(def uniform-pass-list
+  (vec (filter (fn [entry] (not= run-typeinfra-epoch (nth entry 0)))
+               default-pass-list)))
+
+(defn- optimize-fn-uniform [f]
+  (legalize-fn! f)
+  (validate-fn! f "build")
+  (run-pass-list f uniform-pass-list))
+
 (defn optimize-fn [f]
+  ;; Repair any cross-block direct refs build.lg emitted for shapes its
+  ;; construction-time threading missed (e.g. the :try lowering) BEFORE the
+  ;; build-validation gate — otherwise a legal-semantics fn is rejected and
+  ;; forced onto a bytecode trampoline. On-demand: a fn with no cross-block
+  ;; refs is untouched. See ir.passes.legalize.
+  (legalize-fn! f)
   (validate-fn! f "build")
   (when (and ir.passes.inline/*enable-inline*
              (seq ir.passes.inline/*inline-registry*))
@@ -616,14 +642,43 @@
           (if go-target?
             ;; Wire lambda-lift: thread lifted siblings through compile pipeline
             (let [{:keys [main lifted]} (ir.passes.lambda-lift/lambda-lift built)
-                  lower1 (fn [g] (let [r ((lowerings :go) (optimize-fn g))]
-                                   (if (= :lowered (:status r)) {:fn (:decl r)} r)))]
+                  ;; Every member of the lambda-lift template — the main AND its
+                  ;; lifted siblings — carries its FULL result (:fn-name,
+                  ;; :override-eligible?, :needs-error?, :go-name, :arity) so the
+                  ;; flatten registers each as a native override in the package
+                  ;; init() and each is visible to the direct-call registry.
+                  ;; Siblings MUST register: the main body's
+                  ;; rt.LookupVar(<ns>, "<name>__liftedN") nil-derefs at runtime
+                  ;; against an unregistered var. The main registering makes it
+                  ;; direct-callable like any single-arity lowered fn — without
+                  ;; it, intra-ns callers trampoline through rt.CachedVarFn to
+                  ;; bytecode even though the native decl sits in the same
+                  ;; package (self-trampolining). The :lifted? marker keeps each
+                  ;; a single-arity entry — these are NOT multi-arity arms.
+                  entryize (fn [r] (if (= :lowered (:status r))
+                                     {:fn (:decl r) :result r :lifted? true}
+                                     r))]
               (if (empty? lifted)
                 ;; No lifted siblings: return single-decl result unchanged
                 ((lowerings :go) (optimize-fn main))
-                ;; Has lifted siblings: return multi-fn-template for flatten path
-                {:kind :multi-fn-template
-                 :fns (into [(lower1 main)] (mapv lower1 lifted))}))
+                ;; Has lifted siblings: lower the main normally and each sibling
+                ;; through the uniform-ABI pipeline (optimize-fn-uniform), then
+                ;; GUARD: every sibling must have lowered AND be registrable
+                ;; (:override-eligible?). If any is not — variadic, or a typed
+                ;; signature that slipped through (e.g. an intrinsically-typed
+                ;; const return) — the WHOLE form falls back to bytecode: a
+                ;; native main whose body LookupVars an unregistered sibling is
+                ;; a guaranteed runtime nil-deref, never a valid emission.
+                (let [main-r (entryize ((lowerings :go) (optimize-fn main)))
+                      sib-rs (mapv (fn [g] ((lowerings :go) (optimize-fn-uniform g)))
+                                   lifted)]
+                  (if (every? (fn [r] (and (= :lowered (:status r))
+                                           (:override-eligible? r)))
+                              sib-rs)
+                    {:kind :multi-fn-template
+                     :fns (into [main-r] (mapv entryize sib-rs))}
+                    {:status :fallback :decl nil
+                     :reason "lambda-lift: sibling not override-eligible"}))))
             ;; Bytecode path: no lambda-lift. When inlining is enabled,
             ;; fold-over-rest combinator calls are OUTLINED to unrolled
             ;; fixed-arity siblings (never spliced — the AOT splice creates
@@ -1092,6 +1147,12 @@
           ;; (defensive) fall back to the decl-only shape.
           (let [flat (reduce (fn [acc entry]
                                (cond
+                                 ;; Lambda-lifted sibling: a single-arity native
+                                 ;; fn. Carry its full result so override-entries
+                                 ;; registers its var, but do NOT tag :multi-arity?
+                                 ;; (it is not a multi-arity arm).
+                                 (:lifted? entry)
+                                 (conj acc (:result entry))
                                  (:result entry)
                                  (conj acc (assoc (:result entry) :multi-arity? true))
                                  (:fn entry)

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-5862800bcf49fc20886faf75febd245511105d241cd653f83b8af8d6fae15896
+d218b5b7078b792b0082b15da898f5ce22a18c16a9fbe1e961adc1eba1b18cd1

--- a/pkg/wasmhost/zz_gogen_ir_wire_test.go
+++ b/pkg/wasmhost/zz_gogen_ir_wire_test.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/nooga/let-go/pkg/rt/core_go_lowered/ir/passes/infer_arg_types"
 	_ "github.com/nooga/let-go/pkg/rt/core_go_lowered/ir/passes/inline"
 	_ "github.com/nooga/let-go/pkg/rt/core_go_lowered/ir/passes/lambda_lift"
+	_ "github.com/nooga/let-go/pkg/rt/core_go_lowered/ir/passes/legalize"
 	_ "github.com/nooga/let-go/pkg/rt/core_go_lowered/ir/passes/licm"
 	_ "github.com/nooga/let-go/pkg/rt/core_go_lowered/ir/passes/liveness"
 	_ "github.com/nooga/let-go/pkg/rt/core_go_lowered/ir/passes/mutability"


### PR DESCRIPTION
Two coupled changes that let lambda-lift templates execute natively instead of self-trampolining through `rt.CachedVarFn` back to bytecode.

## 1. `ir.passes.legalize` — cross-block ref repair

`build.lg` emits cross-block direct refs for shapes its construction-time threading misses (e.g. the `:try` lowering), which the build validator rejects — forcing legal-semantics fns onto the bytecode trampoline. The new pass threads those values through block args (respecting the `:branch-if` symmetric-args invariant) before validation, on demand: fns with no cross-block refs are untouched.

## 2. Lambda-lift native activation

- **Correct ns on sibling refs**: `rewrite-site!` now qualifies the lifted-sibling `:load-var` with the current ns — bare symbols default to `"core"` in lower-go, which dangles for any other ns, and lifted vars have **no bytecode fallback** (lambda-lift runs only on the `:go` path).
- **Registration**: siblings and the main carry their full lowering result through the multi-fn-template flatten, so each registers as a native override and enters the direct-call registry. Intra-ns callers now emit direct Go calls to the main — **73 fns across the lowered tree go native** (e.g. `AnalyzeNsForms` callers call it directly instead of trampolining).
- **Uniform-ABI siblings**: siblings lower through a typeinfer-free pass list, giving a uniform `vm.Value` ABI by construction. They are only ever invoked boxed through their interned var, and a typed signature (e.g. a `bool`-returning predicate) would silently fail override registration and leave the main body dereferencing an uninterned var — a guaranteed runtime nil-deref.
- **Guard**: if any sibling still is not registrable, the whole form falls back to bytecode; a native main with a dangling sibling `LookupVar` is never emitted.
- **Variadic inners are not lifted**: overrides cannot adapt variadic signatures, so variadic capture-free inners stay inline fn-templates lowered as plain Go func-lits (the pre-lift path).

## Invariant

Every `rt.LookupVar(ns, "<name>__liftedN")` in the generated tree has a matching `"<name>__liftedN": __gogen_wrap` registration in that package's init — verified tree-wide (134 references, 0 dangling).

## Verification

- `make parity-full` green: jank suite + ir-stress lower-go + ir-stress ir-compile, untagged vs `-tags gogen_ir` all parity-identical (738/738, matching failure buckets)
- `pkg/ir` (367) and `pkg/rt` (196) suites pass under both tags
- New tests: `lisp_legalize_test.go`, `lisp_lambda_lift_ns_test.go`, `lisp_lambda_lift_register_test.go` (incl. typed-sibling case), `lisp_lambda_lift_main_test.go`

Note: `TestUnrollBytecodePipelineAll` fails under `gogen_ir` **pre-existing** (A/B-verified at clean main with identical op counts) — native core-fn dispatch deflates the VM-op ratio the test asserts; not introduced here.