### PR TITLE
bench: YamlStar real-corpus parse benchmark + ITER-0035 gate (#352)

### DIFF
--- a/test/benches/README.md
+++ b/test/benches/README.md
@@ -31,6 +31,32 @@ The IR-on number depends on the loop/recur lowering fix in this branch
 (see the parent commit); before it, `pegbench-ir.lg` crashed. The remaining
 VM→JVM gap is the lowered-Go target (tracked separately).
 
+## ysbench — YamlStar parse benchmark (ITER-0035 gate)
+
+The real-corpus counterpart to pegbench: times `(yamlstar.parser/parse
+"foo: 42")` against yamlstar's actual grammar (212 `def`-closure rules).
+Needs a [yamlstar](https://github.com/yaml/yamlstar) checkout; skips
+cleanly without one.
+
+| file | what | run |
+|------|------|-----|
+| `ysbench.lg` | one mode (`interp` or `ir`), prints ms-per-call | `LG_SOURCE_PATHS=$HOME/development/yamlstar/core/src ./lg test/benches/ysbench.lg ir` |
+| `ysbench.sh` | EPIC-013 acceptance gate: runs both modes, requires `ir` ≥1.10× faster (`LG_YSBENCH_MIN_SPEEDUP`) | `./test/benches/ysbench.sh` |
+
+### Recorded numbers (2026-07-13, Apple Silicon)
+
+| mode | ms/call |
+|------|--------:|
+| interpreted VM bytecode | 36.4 |
+| `*ir-compile*` + `ir.passes.inline` enabled | 34.1 |
+
+Speedup 1.07× — the gate currently **fails**. The inline/specialize passes
+(EPIC-013 ITER-0031..0034) don't reach this corpus yet: the runtime inline
+registry seeds only from same-namespace `defn` siblings, while yamlstar's
+grammar rules are top-level `def` closures calling combinators from another
+namespace (`prelude`). The parse stays dispatch-bound in the combinator
+tree walk. Issue #352 stays open on making this gate pass.
+
 ## repro/ — loop-lowering miscompile fixtures
 
 Minimal reproductions of the four `ir.lower` / one `ir.build` defects fixed

--- a/test/benches/ysbench.lg
+++ b/test/benches/ysbench.lg
@@ -1,0 +1,38 @@
+;; YamlStar parse benchmark — EPIC-013 / ITER-0035 (issue #352).
+;; Times (yamlstar.parser/parse "foo: 42") against the real yamlstar
+;; grammar (212 def-closure rules), the corpus pegbench.lg only mirrors
+;; synthetically. Interpreted baseline recorded at ~36 ms/call.
+;;
+;; Needs the yamlstar sources on the load path:
+;;   LG_SOURCE_PATHS=$HOME/development/yamlstar/core/src ./lg test/benches/ysbench.lg [mode]
+;; mode: "interp" (default) = plain VM bytecode
+;;       "ir"               = *ir-compile* + ir.passes.inline enabled
+;; Run both and compare with ysbench.sh (the ITER-0035 gate).
+
+(def mode (or (first *command-line-args*) "interp"))
+
+(require 'ir.passes.pipeline)
+(when (= mode "ir")
+  (set! *ir-compile* true)
+  (alter-var-root #'ir.passes.inline/*enable-inline* (constantly true)))
+
+(def t-load-start (System/nanoTime))
+(require 'yamlstar.parser)
+(def t-load-end (System/nanoTime))
+
+(def input "foo: 42")
+(def warmup 3)
+(def reps 20)
+
+(def t-cold-start (System/nanoTime))
+(yamlstar.parser/parse input)
+(def t-cold-end (System/nanoTime))
+
+(dotimes [_ warmup] (yamlstar.parser/parse input))
+(let [t0 (System/nanoTime)]
+  (dotimes [_ reps] (yamlstar.parser/parse input))
+  (let [ms (/ (- (System/nanoTime) t0) 1000000.0 reps)]
+    (println "mode:" mode)
+    (println "load-ms:" (/ (- t-load-end t-load-start) 1000000.0))
+    (println "cold-ms:" (/ (- t-cold-end t-cold-start) 1000000.0))
+    (println "ms-per-call:" ms)))

--- a/test/benches/ysbench.sh
+++ b/test/benches/ysbench.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# ITER-0035 acceptance gate (issue #352): the IR-optimized (inline-enabled)
+# yamlstar parse must be measurably faster than the interpreted baseline.
+# Runs ysbench.lg in both modes and compares ms-per-call.
+#
+#   LG_YAMLSTAR_SRC        yamlstar core/src checkout (default ~/development/yamlstar/core/src)
+#   LG_YSBENCH_MIN_SPEEDUP required interp/ir ratio (default 1.10 = 10% faster)
+#
+# Exits 0 on pass, 1 on fail, 0 with a skip notice when yamlstar is absent.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+YS_SRC="${LG_YAMLSTAR_SRC:-$HOME/development/yamlstar/core/src}"
+if [ ! -d "$YS_SRC/yamlstar" ]; then
+  echo "skip: yamlstar sources not found at $YS_SRC (set LG_YAMLSTAR_SRC)" >&2
+  exit 0
+fi
+
+[ -x ./lg ] || go build -o lg .
+
+run() {
+  LG_SOURCE_PATHS="$YS_SRC" ./lg test/benches/ysbench.lg "$1" \
+    | tee /dev/stderr | awk '/^ms-per-call:/{print $2}'
+}
+
+interp=$(run interp)
+ir=$(run ir)
+speedup=$(awk -v a="$interp" -v b="$ir" 'BEGIN{printf "%.2f", a/b}')
+min="${LG_YSBENCH_MIN_SPEEDUP:-1.10}"
+
+echo "interp: ${interp} ms/call   ir+inline: ${ir} ms/call   speedup: ${speedup}x (required: ${min}x)"
+if awk -v s="$speedup" -v m="$min" 'BEGIN{exit !(s+0 >= m+0)}'; then
+  echo "PASS: ITER-0035 criterion met"
+else
+  echo "FAIL: ITER-0035 criterion not met"
+  exit 1
+fi


### PR DESCRIPTION
Part of #352 (EPIC-013) — the last open iteration, ITER-0035.

Adds `test/benches/ysbench.{lg,sh}`: times `(yamlstar.parser/parse "foo: 42")` against the real 212-rule yamlstar grammar in two modes — interpreted VM bytecode vs `*ir-compile*` with `ir.passes.inline` enabled — and asserts the epic's closing criterion (optimized parse ≥1.10× faster than the interpreted baseline). Skips cleanly when no yamlstar checkout is present; knobs: `LG_YAMLSTAR_SRC`, `LG_YSBENCH_MIN_SPEEDUP`.

One call-out: the gate currently **fails** — recorded numbers (Apple Silicon, 2026-07-13): interp 36.4 ms/call (matching the epic's 36 ms baseline), ir+inline 34.1 ms/call, speedup 1.07×. The ITER-0031..0034 passes don't reach this corpus yet: the runtime inline registry seeds only from same-namespace `defn` siblings, while yamlstar's grammar rules are top-level `def` closures invoking combinators from another namespace (`prelude`), so the parse stays dispatch-bound in the combinator tree walk. This PR is the measurement instrument the epic's acceptance is judged by; #352 stays open on making it pass.