### PR TITLE
feat(rt): BootCore() — compiler-free clojure.core load for AOT/embedded binaries

### DIFF
--- a/pkg/rt/bootcore.go
+++ b/pkg/rt/bootcore.go
@@ -1,0 +1,103 @@
+//go:build !bootstrap
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"fmt"
+
+	"github.com/nooga/let-go/pkg/bytecode"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// BootCore decodes and runs the embedded precompiled clojure.core bundle
+// (CoreCompiledLGB) so a program that links only pkg/rt + pkg/vm — with no
+// compiler — can resolve and invoke the full clojure.core surface plus the lg
+// baseline namespaces. It returns a fresh ExecContext ready to Invoke.
+//
+// The motivating case is an AOT-lowered binary (scripts/lg-compile output): its
+// generated funcs call core via ec.Invoke(rt.CachedVarFn(..., "clojure.core",
+// name), ...), which needs those vars bound. Programs that touch only NATIVE
+// core fns (str, +, vector, …) already work from a bare vm.NewExecContext(),
+// because installers register those at package init; BootCore is what
+// additionally binds the .lg-DEFINED core (and let-go.core / let-go.types).
+//
+// Call once at startup. This mirrors the runtime half of pkg/compiler/eval.go's
+// loadPrecompiledBundle without linking the compiler; a future refactor should
+// unify the two behind this function so there is a single core-load path.
+func BootCore() (*vm.ExecContext, error) {
+	if len(CoreCompiledLGB) == 0 {
+		return nil, fmt.Errorf("BootCore: embedded core is empty (built -tags bootstrap?)")
+	}
+
+	// Namespaces present before decode are native-backed (installers ran at
+	// package init); a bundle chunk for one of them is a hybrid ns whose chunk
+	// must run eagerly (below), since qualified refs bypass the on-demand loader.
+	preexisting := map[string]bool{}
+	for name := range AllNSes() {
+		preexisting[name] = true
+	}
+
+	// DefNSBare gives a var a home ns without triggering a loader; DefStub avoids
+	// warn-on-shadow while the chunk Defs the real value later.
+	resolve := func(nsName, name string) *vm.Var {
+		n := DefNSBare(nsName)
+		if v := n.LookupLocal(vm.Symbol(name)); v != nil {
+			return v
+		}
+		return n.DefStub(name)
+	}
+
+	unit, err := bytecode.DecodeToExecUnitBytes(CoreCompiledLGB, resolve)
+	if err != nil {
+		return nil, fmt.Errorf("BootCore: decode core: %w", err)
+	}
+
+	// Replay core's def/defn/defmacro definitions.
+	if err := runChunk(unit.MainChunk); err != nil {
+		return nil, fmt.Errorf("BootCore: run core chunk: %w", err)
+	}
+
+	// The lg baseline namespaces (let-go.core, …) are auto-refer'd everywhere but
+	// never explicitly required, so nothing else runs them — do it eagerly, after
+	// core (whose defs they depend on).
+	baseline := map[string]bool{}
+	for _, name := range LgBaselineNSNames() {
+		baseline[name] = true
+		if unit.NSChunks != nil {
+			if err := runChunk(unit.NSChunks[name]); err != nil {
+				return nil, fmt.Errorf("BootCore: run baseline %s: %w", name, err)
+			}
+		}
+	}
+
+	// Hybrid namespaces (native fns + bundled lg source, e.g. async) are reachable
+	// via qualified symbols without a require, so their chunks must run eagerly
+	// too or the lg-defined vars stay nil stubs.
+	if unit.NSChunks != nil {
+		for name, ch := range unit.NSChunks {
+			if name == "core" || baseline[name] || !preexisting[name] {
+				continue
+			}
+			if err := runChunk(ch); err != nil {
+				return nil, fmt.Errorf("BootCore: run hybrid %s: %w", name, err)
+			}
+		}
+	}
+
+	return vm.NewExecContext(), nil
+}
+
+func runChunk(ch *vm.CodeChunk) error {
+	if ch == nil {
+		return nil
+	}
+	f := vm.NewFrame(ch, nil)
+	_, err := f.RunProtected()
+	vm.ReleaseFrame(f)
+	return err
+}

--- a/pkg/rt/bootcore.go
+++ b/pkg/rt/bootcore.go
@@ -1,10 +1,12 @@
-//go:build !bootstrap
-
 /*
  * Copyright (c) 2026 let-go contributors
  * SPDX-License-Identifier: MIT
  */
 
+// This file carries no bootstrap build constraint on purpose: BootCore must
+// exist in every build so a downstream caller compiles, and under -tags
+// bootstrap the embedded core (CoreCompiledLGB) is empty, making the len==0
+// guard return the documented error instead of an undefined-symbol failure.
 package rt
 
 import (
@@ -33,6 +35,14 @@ func BootCore() (*vm.ExecContext, error) {
 	if len(CoreCompiledLGB) == 0 {
 		return nil, fmt.Errorf("BootCore: embedded core is empty (built -tags bootstrap?)")
 	}
+
+	// Each eager chunk below runs its (ns …) form. runChunk frames carry no
+	// ExecContext, so in-ns falls through to CurrentNS.SetRoot — mutating the
+	// global *ns* root. Left unrestored, the returned context would deref a
+	// *ns* pointing at whichever chunk ran last; restore the pre-boot root so
+	// lowered code sees a stable namespace.
+	savedNS := CurrentNS.Deref()
+	defer CurrentNS.SetRoot(savedNS)
 
 	// Namespaces present before decode are native-backed (installers ran at
 	// package init); a bundle chunk for one of them is a hybrid ns whose chunk
@@ -77,13 +87,14 @@ func BootCore() (*vm.ExecContext, error) {
 
 	// Hybrid namespaces (native fns + bundled lg source, e.g. async) are reachable
 	// via qualified symbols without a require, so their chunks must run eagerly
-	// too or the lg-defined vars stay nil stubs.
+	// too or the lg-defined vars stay nil stubs. Iterate NSOrder (chunk/dependency
+	// order), not the NSChunks map, so execution order is deterministic.
 	if unit.NSChunks != nil {
-		for name, ch := range unit.NSChunks {
+		for _, name := range unit.NSOrder {
 			if name == "core" || baseline[name] || !preexisting[name] {
 				continue
 			}
-			if err := runChunk(ch); err != nil {
+			if err := runChunk(unit.NSChunks[name]); err != nil {
 				return nil, fmt.Errorf("BootCore: run hybrid %s: %w", name, err)
 			}
 		}

--- a/pkg/rt/bootcore_test.go
+++ b/pkg/rt/bootcore_test.go
@@ -1,9 +1,9 @@
+//go:build !bootstrap
+
 /*
  * Copyright (c) 2026 let-go contributors
  * SPDX-License-Identifier: MIT
  */
-
-//go:build !bootstrap
 
 package rt
 

--- a/pkg/rt/bootcore_test.go
+++ b/pkg/rt/bootcore_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+//go:build !bootstrap
+
+package rt
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// BootCore must bind the .lg-DEFINED core surface, not just the native
+// installers. `frequencies` is defined in clojure.core's .lg source, so it is
+// bound only after the embedded core chunk runs — on a fresh ExecContext it is
+// a nil stub, which is exactly the AOT-binary nil-panic BootCore exists to fix.
+func TestBootCoreBindsLgDefinedCore(t *testing.T) {
+	ec, err := BootCore()
+	if err != nil {
+		t.Fatalf("BootCore: %v", err)
+	}
+	if ec == nil {
+		t.Fatal("BootCore returned a nil ExecContext")
+	}
+
+	v := LookupCoreVar("frequencies")
+	if v == nil || !v.IsBound() {
+		t.Fatal("clojure.core/frequencies unbound after BootCore")
+	}
+
+	// It actually runs: (frequencies ()) => {} with no error.
+	if _, err := v.Invoke([]vm.Value{vm.EmptyList}); err != nil {
+		t.Fatalf("invoke frequencies after BootCore: %v", err)
+	}
+}

--- a/pkg/rt/bootcore_test.go
+++ b/pkg/rt/bootcore_test.go
@@ -36,3 +36,18 @@ func TestBootCoreBindsLgDefinedCore(t *testing.T) {
 		t.Fatalf("invoke frequencies after BootCore: %v", err)
 	}
 }
+
+// The eager chunk loops mutate the global *ns* root (in-ns with no ExecContext
+// falls through to CurrentNS.SetRoot). Without a restore, the returned context
+// would deref *ns* pointing at whichever hybrid chunk iterated last — a value
+// that used to vary with map order between runs. BootCore must leave *ns* at
+// its pre-boot root.
+func TestBootCoreRestoresCurrentNS(t *testing.T) {
+	before := CurrentNS.Deref()
+	if _, err := BootCore(); err != nil {
+		t.Fatalf("BootCore: %v", err)
+	}
+	if after := CurrentNS.Deref(); after != before {
+		t.Fatalf("*ns* not restored: before=%v after=%v", before, after)
+	}
+}


### PR DESCRIPTION
## Why

`scripts/lg-compile` lowers a set of `.lg` namespaces to native Go packages that import only `pkg/rt` and `pkg/vm`. By design there's no compiler: an AOT-lowered binary shouldn't carry the reader and compiler.

Such a binary can only reach part of `clojure.core`. The native core fns (`str`, `+`, `vector`, …) are registered by installers at package init, so a lowered call to one resolves from a bare `vm.NewExecContext()`. The `.lg`-defined core fns (`frequencies`, `partition`, …) bind only when the embedded core bundle runs, which nothing triggers unless the compiler's eval path runs. Until then they're unbound nil stubs, and the generated call — `ec.Invoke(rt.CachedVarFn(&v, "clojure.core", "frequencies"), …)` — nil-panics.

There's no public "load core, hand me an `ExecContext`" entry point. `lg`'s own boot runs through `compiler.Context`, which the AOT binary deliberately doesn't link. So a lowered binary that touches `.lg`-defined core has no way to load it short of reproducing the core boot by hand.

## What it does

`rt.BootCore() (*vm.ExecContext, error)` decodes and runs the embedded precompiled core (`CoreCompiledLGB`) and returns a ready `ExecContext`:

- runs core's main chunk (replays every `def`/`defn`/`defmacro`),
- runs the lg baseline namespaces (`let-go.core`, …), which are auto-refer'd everywhere but never explicitly required, so nothing else runs them,
- runs the chunks of hybrid namespaces (native fns plus bundled lg source, e.g. `async`), whose lg-defined vars are reachable via qualified symbols without a `require`.

It links only `pkg/rt`, `pkg/vm`, and `pkg/bytecode`, so an AOT binary can call it and then invoke the full `clojure.core` surface. Callers that touch only native core still pass `nil` or a fresh `vm.NewExecContext()`; `BootCore` is what additionally binds the `.lg`-defined core.

## Notes for reviewers

`BootCore` currently parallels the runtime half of `pkg/compiler/eval.go`'s `loadPrecompiledBundle`: same decode, same eager chunk-runs, minus the compiler-side lazy-loader wiring. I kept it separate to keep the change small; the follow-up is to have `loadPrecompiledBundle` call `BootCore` so there's one core-load path (noted in the doc comment and below).

The hybrid-namespace eager-run mirrors `loadPrecompiledBundle`: a namespace that exists before decode is native-backed, and a bundle chunk for one of those is a hybrid whose chunk must run eagerly, since qualified resolution finds the already-registered ns and its decoded stubs without ever triggering a loader.

## Testing

- New `TestBootCoreBindsLgDefinedCore` (`pkg/rt`): after `BootCore`, `clojure.core/frequencies` is bound and `(frequencies ())` runs without error, the case a fresh `ExecContext` leaves as a nil stub.
- End to end against an AOT-lowered binary: `(count (frequencies (range 5)))` nil-panics on a fresh `ExecContext` and returns `5` after `rt.BootCore()`.
- `go test ./pkg/rt/` green; `gofmt` and `go vet` clean; builds under `GOOS=linux`, `js/wasm`, and `plan9`.

## Follow-up

Unify `loadPrecompiledBundle` onto `BootCore` so the compiler path and the compiler-free path share one core-load implementation. Kept out of this PR to stay focused on the new entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
