### PR TITLE
feat(lgbgen): compress the embedded core bundle (default off)

### DIFF
--- a/cmd/lgbgen/atomic_write_test.go
+++ b/cmd/lgbgen/atomic_write_test.go
@@ -1,0 +1,83 @@
+//go:build bootstrap
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomicallyPreservesDestinationOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "core_compiled.lgb")
+	if err := os.WriteFile(path, []byte("original"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := errors.New("encode failed")
+	_, err := writeFileAtomically(path, func(w io.Writer) error {
+		if _, err := io.WriteString(w, "partial"); err != nil {
+			return err
+		}
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("writeFileAtomically() error = %v, want %v", err, wantErr)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("destination = %q after failed write, want original", got)
+	}
+	assertNoAtomicTemps(t, dir)
+}
+
+func TestWriteFileAtomicallyReplacesDestination(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "core_compiled.lgb")
+	if err := os.WriteFile(path, []byte("old"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	size, err := writeFileAtomically(path, func(w io.Writer) error {
+		_, err := io.WriteString(w, "replacement")
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != int64(len("replacement")) {
+		t.Fatalf("size = %d, want %d", size, len("replacement"))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "replacement" {
+		t.Fatalf("destination = %q, want replacement", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0o640 {
+		t.Fatalf("destination mode = %o, want 640", gotMode)
+	}
+	assertNoAtomicTemps(t, dir)
+}
+
+func assertNoAtomicTemps(t *testing.T, dir string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, ".core_compiled.lgb.tmp-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files left behind: %v", matches)
+	}
+}

--- a/cmd/lgbgen/atomic_write_test.go
+++ b/cmd/lgbgen/atomic_write_test.go
@@ -81,3 +81,34 @@ func assertNoAtomicTemps(t *testing.T, dir string) {
 		t.Fatalf("temporary files left behind: %v", matches)
 	}
 }
+
+// The size lgbgen prints must come from the file it names. Reading it off the
+// temporary file gives the same number today but stops being checkable the
+// moment the two can differ, so pin the destination as the source.
+func TestWriteFileAtomicallyReportsDestinationSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "core_compiled.lgb")
+	content := []byte("bundle bytes, more than the original")
+	if err := os.WriteFile(path, []byte("short"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	size, err := writeFileAtomically(path, func(w io.Writer) error {
+		_, err := w.Write(content)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != int64(len(content)) {
+		t.Errorf("reported size = %d, want %d", size, len(content))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != info.Size() {
+		t.Errorf("reported size = %d, destination on disk = %d", size, info.Size())
+	}
+	assertNoAtomicTemps(t, dir)
+}

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -611,6 +611,13 @@ func writeBundle(outPath string, consts *vm.Consts, nsChunks map[string]*vm.Code
 // writeFileAtomically writes path through a same-directory temporary file and
 // replaces path only after the contents are synced and closed successfully.
 // Any failure leaves an existing destination untouched.
+//
+// The directory is synced after the rename as well. Syncing the file persists
+// its contents; it does not persist the directory entry that names it, so a
+// crash between the two can leave the rename lost even though the data
+// survived. That is durability rather than atomicity — the destination is
+// never torn either way — but it is cheap here, and this tool writes the
+// artifact the whole build then trusts.
 func writeFileAtomically(path string, write func(io.Writer) error) (int64, error) {
 	mode := fs.FileMode(0o644)
 	if info, err := os.Stat(path); err == nil {
@@ -637,10 +644,6 @@ func writeFileAtomically(path string, write func(io.Writer) error) (int64, error
 	if err := tmp.Sync(); err != nil {
 		return closeOnError(fmt.Errorf("sync temporary file: %w", err))
 	}
-	info, err := tmp.Stat()
-	if err != nil {
-		return closeOnError(fmt.Errorf("stat temporary file: %w", err))
-	}
 	if err := tmp.Chmod(mode); err != nil {
 		return closeOnError(fmt.Errorf("set temporary file mode: %w", err))
 	}
@@ -650,7 +653,33 @@ func writeFileAtomically(path string, write func(io.Writer) error) (int64, error
 	if err := os.Rename(tmpName, path); err != nil {
 		return 0, fmt.Errorf("replace destination: %w", err)
 	}
+	if err := syncDir(dir); err != nil {
+		return 0, fmt.Errorf("sync destination directory: %w", err)
+	}
+
+	// Report the destination's own size rather than the temporary file's. The
+	// bytes are the same; reading it off the file the caller is told about is
+	// what makes the number checkable.
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("stat destination: %w", err)
+	}
 	return info.Size(), nil
+}
+
+// syncDir flushes a directory entry to disk. lgbgen is a bootstrap-tagged
+// build tool that runs on developer machines and Linux CI, so the POSIX
+// behaviour is the only one in play.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	if err := d.Sync(); err != nil {
+		_ = d.Close()
+		return err
+	}
+	return d.Close()
 }
 
 // refreshManifest records the content digest of all .lg + lgbgen sources

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -15,6 +15,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/signal"
@@ -388,6 +389,13 @@ func main() {
 	fs.StringVar(&cpuProfilePath, "cpuprofile", "", "write Go CPU profile for the lgbgen process")
 	fs.StringVar(&memProfilePath, "memprofile", "", "write Go allocation profile (allocs) for the lgbgen process")
 	fs.StringVar(&codeDir, "code-dir", "", "base dir for generated gogen_ir wireup files (default: repo root)")
+	// --compress DEFLATE-compresses the bundle body. Default OFF for the
+	// committed core: it trims the binary but adds work and allocations to every
+	// process start (the core is decoded on every boot), and that tradeoff is a
+	// policy call for the maintainer, not a silent default. Decode inflates it
+	// transparently either way (see the FlagCompressed path in pkg/bytecode).
+	compress := false
+	fs.BoolVar(&compress, "compress", false, "DEFLATE-compress the .lgb bundle body (smaller binary, slower boot)")
 	fs.Parse(os.Args[1:])
 
 	switch target {
@@ -568,44 +576,81 @@ func main() {
 		return
 	}
 	if targetBoth {
-		writeBundle(outPath, consts, nsChunks, bundleOrder)
+		writeBundle(outPath, consts, nsChunks, bundleOrder, compress)
 		compileIRForLowering()
 		runGoTarget(goOutDir, codeDir)
 		return
 	}
 
 	// Bytecode mode: write .lgb bundle (ir.* excluded).
-	writeBundle(outPath, consts, nsChunks, bundleOrder)
+	writeBundle(outPath, consts, nsChunks, bundleOrder, compress)
 }
 
 // writeBundle encodes the compiled namespace chunks into the .lgb bundle at
-// outPath and closes the file before returning (so callers may proceed to the
-// Go-lowering target against the same in-memory state).
-func writeBundle(outPath string, consts *vm.Consts, nsChunks map[string]*vm.CodeChunk, nsOrder []string) {
-	f, err := os.Create(outPath)
+// outPath atomically before returning (so callers may proceed to the Go-lowering
+// target against the same in-memory state). Encoding happens in a temporary
+// file in the destination directory; the previous bundle remains intact unless
+// encoding, flushing, and closing all succeed.
+func writeBundle(outPath string, consts *vm.Consts, nsChunks map[string]*vm.CodeChunk, nsOrder []string, compress bool) {
+	// The core bundle is decoded on every process start, so the decode path
+	// inflates it transparently; compressing here trims the embedded bytes from
+	// every binary (see the FlagCompressed decode path in pkg/bytecode).
+	size, err := writeFileAtomically(outPath, func(w io.Writer) error {
+		return bytecode.EncodeBundleOrderedCompressed(w, consts, nsChunks, nsOrder, compress)
+	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "create %s: %v\n", outPath, err)
+		fmt.Fprintf(os.Stderr, "write %s: %v\n", outPath, err)
 		os.Exit(1)
 	}
 
-	if err := bytecode.EncodeBundleOrdered(f, consts, nsChunks, nsOrder); err != nil {
-		f.Close()
-		fmt.Fprintf(os.Stderr, "encode failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Stat is best-effort: success here is just for the byte-count in the
-	// success line. If it fails, we still wrote the bundle, so report what we
-	// know without dereferencing a nil FileInfo.
-	if fi, err := f.Stat(); err == nil {
-		fmt.Printf("wrote %s (%d bytes, %d consts, %d namespaces)\n",
-			outPath, fi.Size(), len(consts.Values()), len(nsChunks))
-	} else {
-		fmt.Printf("wrote %s (%d consts, %d namespaces; stat failed: %v)\n",
-			outPath, len(consts.Values()), len(nsChunks), err)
-	}
-	f.Close()
+	fmt.Printf("wrote %s (%d bytes, %d consts, %d namespaces)\n",
+		outPath, size, len(consts.Values()), len(nsChunks))
 	refreshManifest()
+}
+
+// writeFileAtomically writes path through a same-directory temporary file and
+// replaces path only after the contents are synced and closed successfully.
+// Any failure leaves an existing destination untouched.
+func writeFileAtomically(path string, write func(io.Writer) error) (int64, error) {
+	mode := fs.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return 0, fmt.Errorf("stat destination: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return 0, fmt.Errorf("create temporary file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	closeOnError := func(err error) (int64, error) {
+		_ = tmp.Close()
+		return 0, err
+	}
+	if err := write(tmp); err != nil {
+		return closeOnError(fmt.Errorf("encode temporary file: %w", err))
+	}
+	if err := tmp.Sync(); err != nil {
+		return closeOnError(fmt.Errorf("sync temporary file: %w", err))
+	}
+	info, err := tmp.Stat()
+	if err != nil {
+		return closeOnError(fmt.Errorf("stat temporary file: %w", err))
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return closeOnError(fmt.Errorf("set temporary file mode: %w", err))
+	}
+	if err := tmp.Close(); err != nil {
+		return 0, fmt.Errorf("close temporary file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return 0, fmt.Errorf("replace destination: %w", err)
+	}
+	return info.Size(), nil
 }
 
 // refreshManifest records the content digest of all .lg + lgbgen sources

--- a/pkg/bytecode/bench_test.go
+++ b/pkg/bytecode/bench_test.go
@@ -28,6 +28,78 @@ func BenchmarkDecodeCore(b *testing.B) {
 	}
 }
 
+// BenchmarkDecodeCoreCompressed decodes a DEFLATE-compressed copy of the core
+// bundle, so the delta against BenchmarkDecodeCore is the boot-time cost of
+// shipping the embedded core compressed (it is decoded on every process start).
+func BenchmarkDecodeCoreCompressed(b *testing.B) {
+	b.ReportAllocs()
+	corePath := filepath.Join("..", "rt", "core_compiled.lgb")
+	if _, err := os.Stat(corePath); os.IsNotExist(err) {
+		b.Skip("core_compiled.lgb not found at expected path")
+	}
+	data, err := os.ReadFile(corePath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	// Re-encode the committed (uncompressed) core with FlagCompressed so the
+	// comparison is the same content through the compressed path.
+	m, err := Decode(bytes.NewReader(data))
+	if err != nil {
+		b.Fatal(err)
+	}
+	m.Flags |= FlagCompressed
+	var comp bytes.Buffer
+	if err := Encode(&comp, m); err != nil {
+		b.Fatal(err)
+	}
+	compressed := comp.Bytes()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Decode(bytes.NewReader(compressed)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeCore(b *testing.B) {
+	benchmarkEncodeCore(b, false)
+}
+
+func BenchmarkEncodeCoreCompressed(b *testing.B) {
+	benchmarkEncodeCore(b, true)
+}
+
+func benchmarkEncodeCore(b *testing.B, compressed bool) {
+	b.Helper()
+	b.ReportAllocs()
+	corePath := filepath.Join("..", "rt", "core_compiled.lgb")
+	data, err := os.ReadFile(corePath)
+	if os.IsNotExist(err) {
+		b.Skip("core_compiled.lgb not found at expected path")
+	}
+	if err != nil {
+		b.Fatal(err)
+	}
+	m, err := Decode(bytes.NewReader(data))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if compressed {
+		m.Flags |= FlagCompressed
+	}
+
+	b.SetBytes(int64(len(data)))
+	var out bytes.Buffer
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out.Reset()
+		if err := Encode(&out, m); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(out.Len()), "bytes/output")
+}
+
 func BenchmarkDecodeModuleSmall(b *testing.B) {
 	b.ReportAllocs()
 	mb := NewModuleBuilder()

--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -8,7 +8,7 @@ pkg/rt/core/ir/data/generated.lg scripts/generate.lg generator cdc22a756403d0720
 pkg/rt/core/ir/data/generated.lg pkg/ir/ir_data.lg input 56b726cad1508d7c355612d6db39f9c7eb95ce6f5ae7f27fcdeb75345ae51a3e
 pkg/rt/core/ir/data/generated.lg pkg/rt/core/ir/data/generated.lg output 4d0b04f91c56ec50e752bdc522c2ede7690d6de8d8474eae88b64ed53b243774
 pkg/rt/core_compiled.lgb cmd/lgbgen/generate.go generator a6092b5c1b0f9cc88994b85943c727242a916fcc734d16d1d52c8c77e26a3cab
-pkg/rt/core_compiled.lgb cmd/lgbgen/main.go generator a9688661651d4358b20a02dc5c14b15305ecc57c7db0a9d33bcb88d902ceef22
+pkg/rt/core_compiled.lgb cmd/lgbgen/main.go generator fbfa8d57541cb104dbbc8658400576562f29fae12a041b845452f7daa4189aec
 pkg/rt/core_compiled.lgb cmd/lgbgen/main_stub.go generator 44a9bb8e9e54a3cd8511467049f0683892e93a0fe3e3a0cc8fdd0fc53984e298
 pkg/rt/core_compiled.lgb pkg/bytecode/capabilities.go generator 6ed836f4d0943b5d3ecdab26ac21630096775ccd4f67361164d7095a4be56436
 pkg/rt/core_compiled.lgb pkg/bytecode/decode_stats.go generator 3ac32f41e23fc72aab9eb5e5a51db7800e158fc1e3064b0780b1a389289d2fd2
@@ -322,7 +322,7 @@ pkg/rt/core_compiled.lgb pkg/rt/core/walk.lg input 9866ba54606595988cc2efa4de139
 pkg/rt/core_compiled.lgb pkg/rt/core/zip.lg input c0b0d5795a5b6ebe32f8b58ed86bd39575a2f2a38fef30402137c8e978171396
 pkg/rt/core_compiled.lgb pkg/rt/core_compiled.lgb output f2f0a70dcc9b11671e27190888237c5247feba3e3bdadff88d95ac3dd0caa64f
 pkg/rt/core_go_lowered/ cmd/lgbgen/generate.go generator a6092b5c1b0f9cc88994b85943c727242a916fcc734d16d1d52c8c77e26a3cab
-pkg/rt/core_go_lowered/ cmd/lgbgen/main.go generator a9688661651d4358b20a02dc5c14b15305ecc57c7db0a9d33bcb88d902ceef22
+pkg/rt/core_go_lowered/ cmd/lgbgen/main.go generator fbfa8d57541cb104dbbc8658400576562f29fae12a041b845452f7daa4189aec
 pkg/rt/core_go_lowered/ cmd/lgbgen/main_stub.go generator 44a9bb8e9e54a3cd8511467049f0683892e93a0fe3e3a0cc8fdd0fc53984e298
 pkg/rt/core_go_lowered/ pkg/bytecode/capabilities.go generator 6ed836f4d0943b5d3ecdab26ac21630096775ccd4f67361164d7095a4be56436
 pkg/rt/core_go_lowered/ pkg/bytecode/decode_stats.go generator 3ac32f41e23fc72aab9eb5e5a51db7800e158fc1e3064b0780b1a389289d2fd2

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-e8d702cf86adf3396bae29e2bff611b38272b460ec1e4720cc93a50222f46bad
+bcc983c96d53a5f9c3f4e514cacf86a696e16dad27b7234a49ea2bd48acf4804


### PR DESCRIPTION
Stacked on #501 (base branch `feat/lgb-compression`).

## What it does

Adds `lgbgen --compress` for emitting a compressed embedded-core bundle. The flag is **off by default**: the committed core remains uncompressed unless the maintainer explicitly chooses the size/startup tradeoff under #503.

The bundle is written atomically through a same-directory temporary file. Encoding, sync, chmod, and close must all succeed before rename, so a failed generation leaves the existing checked-in `core_compiled.lgb` intact.

## Fresh measurements

Measured on an Apple M2 after rebasing onto the reviewed #501 format:

| | uncompressed | compressed | delta |
|---|---:|---:|---:|
| core `.lgb` | 297,359 B | 89,776 B | -207,583 B (3.31x) |
| `lg` binary | 13,844,450 B | 13,629,794 B | -214,656 B |
| decode core | 2.23 ms | 3.40 ms | +1.17 ms, +91,824 B/op, +303 allocs |
| warm process boot | 7.9 ± 0.8 ms | 9.8 ± 1.1 ms | about +1.9 ms |

Compression primarily benefits larger bundles; for smaller programs, the framing/codec overhead can consume or exceed the byte savings. The committed core is large enough to show a clear size win, but the startup regression makes default-on a policy decision rather than a mechanical one.

Encode cost for the core rose from about 1.35 ms to 24.37 ms and from 344,159 B/op to 2,220,688 B/op. That cost is paid during generation, not process startup.

## Validation

- Atomic-write tests cover preserving an existing destination after an encode failure, successful replacement, mode preservation, and temporary-file cleanup.
- Decode and encode benchmarks are checked in under `pkg/bytecode`.
- `go test ./...` passes locally.

## Policy

Keep compression opt-in for now. The default-on decision remains under #503, including the stripping nuance and any target-specific defaults.
