### PR TITLE
test(ir): build-stable op baseline for the fold-unroll pipeline tests

### DIFF
--- a/pkg/ir/lisp_fold_bytecode_pipeline_test.go
+++ b/pkg/ir/lisp_fold_bytecode_pipeline_test.go
@@ -99,14 +99,11 @@ func TestUnrollBytecodePipelineFires(t *testing.T) {
 		t.Logf("parity OK x=%d: %v", x, loopRes)
 	}
 
-	// Op profile: the unrolled caller must execute well under half the ops
-	// of the loop caller on a full scan (measured reference is ~3.1x fewer).
-	opsLoop := profiledOps(t, nsName, "(call-loop 2)")
-	opsUnroll := profiledOps(t, nsName, "(call-unroll 2)")
-	t.Logf("full-scan ops: loop=%d unroll=%d ratio=%.2fx", opsLoop, opsUnroll, float64(opsLoop)/float64(opsUnroll))
-	if opsUnroll*2 >= opsLoop {
-		t.Fatalf("unroll did NOT fire through the pipeline: ops(unroll)=%d vs ops(loop)=%d (want < 0.5x)", opsUnroll, opsLoop)
-	}
+	// Hand-unrolled nested-if baseline, compiled with the flags off: the
+	// build-stable yardstick for the specialization's op profile.
+	runInNs(t, nsName,
+		"(defn call-hand [x] (if (rt0 x) true (if (rf0 x) true (if (rf1 x) true (if (rf2 x) true (if (rf3 x) true (if (rf4 x) true (if (rf5 x) true (if (rf6 x) true false)))))))))")
+	assertUnrolled(t, nsName, "loopc$any$8", 8, "(call-loop 2)", "(call-unroll 2)", "(call-hand 2)")
 }
 
 // TestUnrollBytecodePipelineAll: same proof for the :all-shaped combinator.
@@ -116,8 +113,11 @@ func TestUnrollBytecodePipelineAll(t *testing.T) {
 	nsName := "bcunrollall"
 
 	// Rules all true for x!=0; rule 0 false for x=99 exercises early exit.
+	// The filler prefix must differ from the special rule's name — a shared
+	// "at" prefix would make defRules emit its own at0 and clobber the
+	// early-exit rule.
 	runInNs(t, nsName, "(defn at0 [x] (not= x 99))")
-	args := " at0" + defRules(t, nsName, "at", "(not= x 0)", N-1)
+	args := " at0" + defRules(t, nsName, "af", "(not= x 0)", N-1)
 
 	runInNs(t, nsName, loopAllSrc)
 	runInNs(t, nsName, fmt.Sprintf("(defn call-loop [x] (allc x%s))", args))
@@ -135,11 +135,42 @@ func TestUnrollBytecodePipelineAll(t *testing.T) {
 		}
 	}
 
-	opsLoop := profiledOps(t, nsName, "(call-loop 1)")
-	opsUnroll := profiledOps(t, nsName, "(call-unroll 1)")
-	t.Logf("full-scan ops: loop=%d unroll=%d ratio=%.2fx", opsLoop, opsUnroll, float64(opsLoop)/float64(opsUnroll))
-	if opsUnroll*2 >= opsLoop {
-		t.Fatalf("all-shape unroll did NOT fire: ops(unroll)=%d vs ops(loop)=%d", opsUnroll, opsLoop)
+	runInNs(t, nsName,
+		"(defn call-hand [x] (if (at0 x) (if (af0 x) (if (af1 x) (if (af2 x) (if (af3 x) (if (af4 x) (if (af5 x) (if (af6 x) true false) false) false) false) false) false) false) false))")
+	assertUnrolled(t, nsName, "allc$all$8", 8, "(call-loop 1)", "(call-unroll 1)", "(call-hand 1)")
+}
+
+// assertUnrolled verifies the outlined specialization fired and that its op
+// profile is in hand-written territory. The former assertion compared the
+// unrolled caller against the loop combinator at a fixed 2x ratio, but the
+// loop baseline's VM-op cost is build-dependent: under -tags gogen_ir the
+// per-element seq walk (empty?/first/rest) dispatches to native Go and
+// executes zero VM ops, shrinking the baseline — and it keeps shrinking as
+// more core fns go native. The unrolled path's cost IS build-stable (it
+// executes only user bytecode and native builtins on both builds), so assert
+// (a) the callee var was rewritten to the interned specialization, (b) the
+// unrolled caller strictly beats the loop build, and (c) it stays within an
+// additive budget of a hand-unrolled nested-if baseline compiled with the
+// flags off. The budget models what outlining adds over hand-written code —
+// one extra fixed-arity call hop carrying the n+1 flat operands (measured
+// ~37 ops at n=8) — so it is 6*(n+1); a specialization that kept any
+// per-element seq walk would blow past it (the walk alone costs ~10 ops per
+// element).
+func assertUnrolled(t *testing.T, nsName, specName string, n int, loopProg, unrollProg, handProg string) {
+	t.Helper()
+	if v := runInNs(t, nsName, fmt.Sprintf("(some? (resolve (quote %s)))", specName)); v != vm.TRUE {
+		t.Fatalf("specialization %s was not interned — unroll did not fire", specName)
+	}
+	opsLoop := profiledOps(t, nsName, loopProg)
+	opsUnroll := profiledOps(t, nsName, unrollProg)
+	opsHand := profiledOps(t, nsName, handProg)
+	budget := opsHand + uint64(6*(n+1))
+	t.Logf("full-scan ops: loop=%d unroll=%d hand=%d budget=%d", opsLoop, opsUnroll, opsHand, budget)
+	if opsUnroll >= opsLoop {
+		t.Fatalf("unrolled caller is no cheaper than the loop: ops(unroll)=%d vs ops(loop)=%d", opsUnroll, opsLoop)
+	}
+	if opsUnroll > budget {
+		t.Fatalf("unrolled caller not in hand-written territory: ops(unroll)=%d > ops(hand)=%d + outlining budget %d", opsUnroll, opsHand, 6*(n+1))
 	}
 }
 


### PR DESCRIPTION
`TestUnrollBytecodePipelineAll` fails on clean `main` under `-tags gogen_ir` once the lowered tree is generated and wired (`make generate` then `go test -tags gogen_ir ./pkg/ir/`): ops loop=212, unroll=113, ratio 1.88x vs the required 2x. CI never sees it because the gogen wire test file only exists after `make generate`. Surfaced while re-validating #438's gates; it reproduces identically without that branch.

## Root cause — a build-dependent baseline, not a codegen regression

The unrolled specialization's op profile is **byte-identical across builds** (113 ops both ways; the pipeline's IR dumps are identical at every stage). What shifts is the *loop combinator baseline* the test divides by: under `gogen_ir` the per-element seq walk (`empty?`/`first`/`rest`) dispatches to native Go and executes zero VM ops, shrinking ops(loop) 257 → 212 (`All`) and 235 → 190 (`Fires`). The fixed 2x ratio decays with every trampoline drained — `Fires` was at 2.04x under gogen_ir, one native prim away from failing too.

## Fix — assert build-stable properties instead

- **Mechanism:** the specialization var (`allc$all$8` / `loopc$any$8`) must actually be interned.
- **Sanity:** the unrolled caller strictly beats the loop build.
- **Quality:** the unrolled caller stays within an additive outlining budget — `6*(n+1)` ops, the measured cost of the one extra fixed-arity call hop (~37 ops at n=8) — of a **hand-unrolled nested-if baseline**, whose profile is identical on both builds (56/78 ops). A specialization that kept any per-element seq walk would blow the budget (~10 ops/element).

Also fixes a latent setup bug in `All`: the filler rules shared the `at` prefix with the special early-exit rule, so `defRules` emitted its own `at0` and clobbered it — the x=99 "early exit" parity case never exercised early exit.

## Verification

Both variants now log identical unroll/hand numbers under both tags and pass: default `loop=257 unroll=114 hand=78 budget=132`, gogen_ir `loop=212 unroll=114 hand=78 budget=132` (`All`); `loop=235/190 unroll=93 hand=56 budget=110` (`Fires`). Full `go test ./...` (1288 tests / 61 pkgs), `go test -tags gogen_ir ./pkg/ir/` (362), and lint are green. Test-only change — no generated artifacts touched.