### PR TITLE
perf(ci): interleaved repeat A/B as an informational shadow check

### DIFF
--- a/.github/workflows/perf-pr-repeat.yml
+++ b/.github/workflows/perf-pr-repeat.yml
@@ -1,0 +1,140 @@
+name: Perf PR (repeat A/B)
+
+# INFORMATIONAL shadow check — a variance-reduced same-runner A/B. A single-shot
+# base-vs-head A/B on shared CI runners is too heavy-tailed to gate on (~1 in 4
+# runs blows a memory-bound cluster to 25-40% while the register-only anchor
+# stays flat; nooga/let-go#445). This runs N INTERLEAVED base/head snapshots
+# across two pre-built worktrees and reports the per-family median-of-N delta and
+# whether any family WOULD gate at each candidate budget. Interleaving (ABBA)
+# also cancels slow time-separation drift.
+#
+# It never fails the PR on a perf verdict — the job's exit code reflects only
+# harness integrity (a flaky / non-comparable measurement). The point of this
+# phase is to collect the false-positive and provenance data needed to calibrate
+# a real gate before enforcing one, per the review on #445. Runs alongside the
+# single-shot perf-pr.yml (separate `perf-repeat` label) so the two can be
+# compared during the shadow phase.
+
+# Opt-in via the `perf-repeat` label (same-repo PRs run the workflow from the PR
+# branch, so this need not live on the default branch). workflow_dispatch is kept
+# for the eventual upstream form, where it will sit on main.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'pkg/**'
+      - 'cmd/**'
+      - 'scripts/ab_repeat.py'
+      - '.github/workflows/perf-pr-repeat.yml'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to benchmark'
+        required: true
+      n:
+        description: 'repeat count (interleaved cycles)'
+        default: '7'
+      budgets:
+        description: 'candidate budgets % to report would-gate for (comma-separated)'
+        default: '6,8,10'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-pr-repeat-${{ github.event.pull_request.number || github.event.inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'perf-repeat')
+    runs-on: ubuntu-latest
+    # N=7 × pr-fast (count 3 × 500ms) is 14 snapshots plus two `make lowered`
+    # builds. Measured ~49 min on a quiet EPYC 9V74 draw; the cap leaves headroom
+    # for a noisier runner, where the memory-bound families (and so the whole
+    # suite) run slower. Right-size from observed runtime during the shadow phase.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Resolve base and head
+        id: refs
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_FROM_EVENT: ${{ github.event.pull_request.number }}
+          PR_FROM_INPUT: ${{ github.event.inputs.pr }}
+          BASE_FROM_EVENT: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            PR="$PR_FROM_INPUT"
+            [[ "$PR" =~ ^[0-9]+$ ]] || { echo "pr must be numeric" >&2; exit 1; }
+            base_ref="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .base.ref)"
+          else
+            PR="$PR_FROM_EVENT"
+            base_ref="$BASE_FROM_EVENT"
+          fi
+          git fetch --no-tags origin "$base_ref" "refs/pull/${PR}/head:pr-head"
+          head_sha="$(git rev-parse pr-head)"
+          base_sha="$(git merge-base "origin/${base_ref}" pr-head)"
+          echo "base=${base_sha}" >> "$GITHUB_OUTPUT"
+          echo "head=${head_sha}" >> "$GITHUB_OUTPUT"
+          echo "Base (merge-base): ${base_sha}"
+          echo "Head:              ${head_sha}"
+
+      - name: Build base and head worktrees
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+          HEAD: ${{ steps.refs.outputs.head }}
+        run: |
+          set -euo pipefail
+          git worktree add --force ../wt-base "$BASE"
+          git worktree add --force ../wt-head "$HEAD"
+          # lowered (gogen_ir) tree must exist in each worktree before bench.
+          ( cd ../wt-base && git submodule update --init --recursive && make lowered )
+          ( cd ../wt-head && git submodule update --init --recursive && make lowered )
+
+      - name: Interleaved repeat A/B
+        env:
+          N: ${{ github.event.inputs.n || '7' }}
+          BUDGETS: ${{ github.event.inputs.budgets || '6,8,10' }}
+        run: |
+          set -euo pipefail
+          # The driver exits nonzero only on an integrity failure (a family seen
+          # on some cycles but not all N — the halves aren't comparable). That is
+          # a real problem worth a red job; it is NOT a perf gate. Capture the
+          # code so the summary still posts and the artifacts still upload.
+          rc=0
+          python3 scripts/ab_repeat.py \
+            --base ../wt-base --head ../wt-head \
+            --n "$N" --budgets "$BUDGETS" --confirm-k 2 \
+            --out "${RUNNER_TEMP}/ab-out" | tee "${RUNNER_TEMP}/ab-report.txt" || rc=$?
+          {
+            echo '## Repeat A/B (variance-reduced) — informational shadow check'
+            echo
+            echo '```'
+            cat "${RUNNER_TEMP}/ab-report.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"
+
+      # Retain the full evidence trail (every base/head snapshot with raw samples,
+      # cycle order, provenance, aggregate) so the shadow-phase false-positive and
+      # power analysis can run offline. always() so an integrity failure above
+      # still preserves the data that explains it.
+      - name: Upload snapshots and aggregate
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-pr-repeat
+          path: ${{ runner.temp }}/ab-out/
+          if-no-files-found: warn

--- a/scripts/ab_repeat.py
+++ b/scripts/ab_repeat.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Interleaved repeated A/B for perf-pr variance reduction — informational.
+
+Runs N interleaved base/head benchmark snapshots across two pre-built worktrees
+and reports the per-family delta distribution. It NEVER fails the job: the exit
+code reflects harness integrity (see below), not a perf verdict. The point of
+this phase is to collect the data needed to calibrate a gate, not to be one.
+
+Why repeat + interleave: a single-shot base-vs-head A/B on shared CI runners is
+too heavy-tailed to gate on — ~1 in 4 runs blows a memory-bound cluster to
+25-40% while the register-only anchor stays flat (nooga/let-go#445). Repetition
+lets the per-family MEDIAN absorb up to floor((N-1)/2) contaminated cycles;
+interleaving cancels slow time-separation drift.
+
+Each side is snapshotted with `bench-ratchet -profile <p> ... snapshot`, which
+emits ratio_to_anchor per benchmark; delta = head_ratio / base_ratio - 1.
+
+Reported per run (a same-code no-op PR should show zero would-gates):
+  - median-of-N delta per family, and whether ANY family would gate at each
+    candidate budget — the decision unit is the whole workflow, so we report
+    "would any family gate", one Bernoulli sample toward P(any-gate | no-op).
+  - confirm K-of-N as a secondary statistic (dominated within one job, since
+    contaminated cycles cluster — kept only for corroboration).
+
+Integrity (drives the exit code, so a broken measurement can't read as clean):
+  - MISSING / NEW families: present on every cycle of one side but never the
+    other. A rename/add/remove between base and head — reported, not silently
+    dropped (the old `set(base) & set(head)` hid these).
+  - FLAKY families: present on some cycles of a side but not all, i.e. not
+    exactly N observations. That means the two halves aren't comparable, which
+    invalidates the deltas — exit nonzero.
+"""
+import argparse, json, os, statistics, subprocess, sys
+
+
+def snapshot(worktree, profile, out, timeout):
+    """Run one bench-ratchet snapshot in a worktree.
+
+    Returns (ratios, samples, meta):
+      ratios  {family: ratio_to_anchor}
+      samples {family: [ratio_to_anchor, ...]}   raw per-sample distribution
+      meta    {anchor_ns, cpu_model, go_version, num_cpu, arch, sha}
+    """
+    subprocess.run(
+        ["go", "run", "./cmd/bench-ratchet", "-profile", profile,
+         "-timeout", timeout, "-baseline", out, "snapshot"],
+        cwd=worktree, check=True,
+    )
+    with open(out) as f:
+        d = json.load(f)
+    (_, m), = d["machines"].items()
+    ratios = {k: e["ratio_to_anchor"] for k, e in m["benchmarks"].items()}
+    samples = {k: [s.get("ratio_to_anchor") for s in e.get("samples", [])]
+               for k, e in m["benchmarks"].items()}
+    mach = m.get("machine", {})
+    meta = {
+        "anchor_ns": m["anchor"]["ns_per_op"],
+        "cpu_model": mach.get("cpu_model", "?"),
+        "go_version": mach.get("go_version", "?"),
+        "num_cpu": mach.get("num_cpu", 0),
+        "arch": mach.get("arch", "?"),
+        "sha": m.get("captured_at_sha", "?"),
+    }
+    return ratios, samples, meta
+
+
+def short(fam):
+    return fam.replace("github.com/nooga/let-go/pkg/vm.Benchmark", "")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True, help="pre-built base worktree")
+    ap.add_argument("--head", required=True, help="pre-built head worktree")
+    ap.add_argument("--n", type=int, default=7, help="interleaved cycle count")
+    ap.add_argument("--profile", default="pr-fast")
+    ap.add_argument("--budgets", default="6,8,10",
+                    help="comma-separated candidate budgets %% to report would-gate for")
+    ap.add_argument("--confirm-k", type=int, default=2,
+                    help="cycles that must exceed the primary budget (secondary stat)")
+    ap.add_argument("--timeout", default="15m")
+    ap.add_argument("--out", default="ab-out")
+    args = ap.parse_args()
+    os.makedirs(args.out, exist_ok=True)
+    budgets = [float(b) for b in args.budgets.split(",")]
+    primary = budgets[-1]  # confirm-K reported at the widest (most lenient) budget
+
+    # Per-side, per-family: list of ratios, one entry per cycle it appeared in.
+    base_seen, head_seen = {}, {}
+    base_samples, head_samples = {}, {}
+    anchors = []          # (base_ns, head_ns) per cycle
+    order = []            # measurement order per cycle: "BH" or "HB"
+    machines = {"base": None, "head": None}
+
+    for i in range(1, args.n + 1):
+        print(f"::group::cycle {i}/{args.n}", flush=True)
+        # Counterbalance (ABBA): odd cycles base-first, even head-first. Base and
+        # head are identical code on a no-op PR, so a fixed base-then-head order
+        # lets first-vs-second-position drift (warmup, cache, thermal) look like a
+        # consistent head regression — a systematic bias the median cannot remove.
+        # Alternating cancels it. (Surfaced porting to paserati: a fixed order
+        # produced a 1-in-N false positive on a no-op PR.)
+        base_first = (i % 2 == 1)
+        order.append("BH" if base_first else "HB")
+
+        def do_base():
+            r, s, meta = snapshot(args.base, args.profile,
+                                  f"{args.out}/base_{i}.json", args.timeout)
+            machines["base"] = machines["base"] or meta
+            for fam, v in r.items():
+                base_seen.setdefault(fam, []).append(v)
+                base_samples.setdefault(fam, []).append(s.get(fam))
+            return meta["anchor_ns"]
+
+        def do_head():
+            r, s, meta = snapshot(args.head, args.profile,
+                                  f"{args.out}/head_{i}.json", args.timeout)
+            machines["head"] = machines["head"] or meta
+            for fam, v in r.items():
+                head_seen.setdefault(fam, []).append(v)
+                head_samples.setdefault(fam, []).append(s.get(fam))
+            return meta["anchor_ns"]
+
+        if base_first:
+            ba = do_base()
+            ha = do_head()
+        else:
+            ha = do_head()
+            ba = do_base()
+        anchors.append((ba, ha))
+        print("::endgroup::", flush=True)
+
+    # --- Integrity: categorize families before computing any delta. ------------
+    # A family is comparable only if it appears on EXACTLY N base and N head
+    # cycles. Anything else is surfaced, not silently intersected away.
+    base_fams, head_fams = set(base_seen), set(head_seen)
+    comparable, missing, new, flaky = [], [], [], []
+    for fam in sorted(base_fams | head_fams):
+        nb, nh = len(base_seen.get(fam, [])), len(head_seen.get(fam, []))
+        if nb == args.n and nh == args.n:
+            comparable.append(fam)
+        elif nb == args.n and nh == 0:
+            missing.append(fam)      # dropped/renamed in head
+        elif nb == 0 and nh == args.n:
+            new.append(fam)          # added/renamed in head
+        else:
+            flaky.append((fam, nb, nh))  # inconsistent presence — harness noise
+
+    rows = []
+    for fam in comparable:
+        ds = [(head_seen[fam][k] / base_seen[fam][k] - 1.0) * 100
+              for k in range(args.n) if base_seen[fam][k]]
+        med = statistics.median(ds)
+        rows.append({
+            "fam": short(fam),
+            "n": len(ds),
+            "median": med,
+            "worst": max(ds, key=abs),
+            "deltas": ds,
+            "exceed_primary": sum(1 for d in ds if d > primary),
+            "base_samples": base_samples.get(fam),
+            "head_samples": head_samples.get(fam),
+        })
+    rows.sort(key=lambda r: r["median"], reverse=True)
+
+    # would-gate at each budget: does ANY comparable family's median exceed it?
+    would_gate = {}
+    for bud in budgets:
+        hits = [r["fam"] for r in rows if r["median"] > bud]
+        would_gate[bud] = hits
+    confirm_hits = [r["fam"] for r in rows
+                    if r["exceed_primary"] >= args.confirm_k]
+
+    aggregate = {
+        "provenance": {
+            "n": args.n, "profile": args.profile, "budgets": budgets,
+            "confirm_k": args.confirm_k,
+            "samples_per_snapshot": len(next(iter(base_samples.values()), []) or []),
+            "cycle_order": order,
+            "anchors": anchors,
+            "machine_base": machines["base"],
+            "machine_head": machines["head"],
+        },
+        "integrity": {
+            "comparable": len(comparable),
+            "missing": [short(f) for f in missing],
+            "new": [short(f) for f in new],
+            "flaky": [[short(f), nb, nh] for f, nb, nh in flaky],
+        },
+        "would_gate": {str(b): hits for b, hits in would_gate.items()},
+        "confirm_hits": confirm_hits,
+        "rows": rows,
+    }
+    with open(f"{args.out}/aggregate.json", "w") as f:
+        json.dump(aggregate, f, indent=2)
+
+    # --- Human report (job summary). ------------------------------------------
+    mb = machines["base"] or {}
+    print(f"\n=== interleaved repeat A/B — N={args.n}, profile={args.profile} "
+          f"(INFORMATIONAL, never gates) ===")
+    print(f"runner: {mb.get('cpu_model','?')}  "
+          f"{mb.get('num_cpu','?')} CPU  {mb.get('go_version','?')}")
+    print(f"base {(machines['base'] or {}).get('sha','?')[:12]}  "
+          f"head {(machines['head'] or {}).get('sha','?')[:12]}  "
+          f"order {' '.join(order)}")
+    print("anchor stability per cycle (base/head ns/op, "
+          "should stay flat — it measures compute, not memory):")
+    for i, (ba, ha) in enumerate(anchors, 1):
+        drift = (ha / ba - 1) * 100 if ba else float("nan")
+        print(f"  cycle {i}: base {ba:.3f}  head {ha:.3f}  Δ{drift:+.1f}%")
+
+    if missing or new:
+        print(f"\nfamily-set change vs base:  "
+              f"MISSING={[short(f) for f in missing] or '-'}  "
+              f"NEW={[short(f) for f in new] or '-'}")
+    if flaky:
+        print(f"\n!! FLAKY families (not exactly N obs — measurement suspect): "
+              f"{[(short(f), nb, nh) for f, nb, nh in flaky]}")
+
+    print(f"\n{'family':40} {'median%':>8} {'worst%':>7} {'>prim':>5}")
+    print("-" * 64)
+    for r in rows[:12]:
+        print(f"{r['fam']:40} {r['median']:+8.2f} {r['worst']:+7.2f} "
+              f"{r['exceed_primary']:5d}")
+    if len(rows) > 12:
+        print(f"... {len(rows) - 12} more (full table in aggregate.json)")
+
+    print("\nwould-gate (any comparable family's median > budget):")
+    for bud in budgets:
+        hits = would_gate[bud]
+        print(f"  budget {bud:4.0f}%:  {'GATE' if hits else 'clean':5}  "
+              f"{hits or ''}")
+    print(f"confirm K={args.confirm_k}/{args.n} @ {primary:.0f}% (secondary): "
+          f"{confirm_hits or 'clean'}")
+
+    # On a no-op PR any would-gate is a FALSE POSITIVE; each budget's boolean is
+    # one Bernoulli sample toward P(any-gate | no-op), aggregated across runs.
+    print("\n(no-op PR: every would-gate above is a false positive; "
+          "each is one sample toward P(any-gate).)")
+
+    # Exit code = integrity only, never a perf verdict. Flaky presence means the
+    # halves aren't comparable, so the run's deltas are not trustworthy.
+    if flaky:
+        print("\nFAIL: flaky family presence — deltas not trustworthy.",
+              file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ab_repeat.py
+++ b/scripts/ab_repeat.py
@@ -33,22 +33,32 @@ Integrity (drives the exit code, so a broken measurement can't read as clean):
 import argparse, json, os, statistics, subprocess, sys
 
 
-def snapshot(worktree, profile, out, timeout):
+def snapshot(worktree, profile, out, timeout, label):
     """Run one bench-ratchet snapshot in a worktree.
+
+    label is a human tag ("base cycle 3/7") so a failed `go run` or an
+    unexpected bench-ratchet JSON shape surfaces as one triage line instead
+    of a raw traceback. The failure still exits nonzero — a missing sample is
+    a harness-integrity failure, not a perf verdict — just legibly.
 
     Returns (ratios, samples, meta):
       ratios  {family: ratio_to_anchor}
       samples {family: [ratio_to_anchor, ...]}   raw per-sample distribution
       meta    {anchor_ns, cpu_model, go_version, num_cpu, arch, sha}
     """
-    subprocess.run(
-        ["go", "run", "./cmd/bench-ratchet", "-profile", profile,
-         "-timeout", timeout, "-baseline", out, "snapshot"],
-        cwd=worktree, check=True,
-    )
-    with open(out) as f:
-        d = json.load(f)
-    (_, m), = d["machines"].items()
+    try:
+        subprocess.run(
+            ["go", "run", "./cmd/bench-ratchet", "-profile", profile,
+             "-timeout", timeout, "-baseline", out, "snapshot"],
+            cwd=worktree, check=True,
+        )
+        with open(out) as f:
+            d = json.load(f)
+        (_, m), = d["machines"].items()
+    except (subprocess.CalledProcessError, OSError,
+            json.JSONDecodeError, KeyError, ValueError) as e:
+        print(f"::error::{label} failed: {type(e).__name__}: {e}", flush=True)
+        raise
     ratios = {k: e["ratio_to_anchor"] for k, e in m["benchmarks"].items()}
     samples = {k: [s.get("ratio_to_anchor") for s in e.get("samples", [])]
                for k, e in m["benchmarks"].items()}
@@ -105,7 +115,8 @@ def main():
 
         def do_base():
             r, s, meta = snapshot(args.base, args.profile,
-                                  f"{args.out}/base_{i}.json", args.timeout)
+                                  f"{args.out}/base_{i}.json", args.timeout,
+                                  f"base cycle {i}/{args.n}")
             machines["base"] = machines["base"] or meta
             for fam, v in r.items():
                 base_seen.setdefault(fam, []).append(v)
@@ -114,7 +125,8 @@ def main():
 
         def do_head():
             r, s, meta = snapshot(args.head, args.profile,
-                                  f"{args.out}/head_{i}.json", args.timeout)
+                                  f"{args.out}/head_{i}.json", args.timeout,
+                                  f"head cycle {i}/{args.n}")
             machines["head"] = machines["head"] or meta
             for fam, v in r.items():
                 head_seen.setdefault(fam, []).append(v)


### PR DESCRIPTION
Implements step 1 from #445, in the shape the review there settled on: land the median-of-N as a shadow check first, not a gate. It also closes out the memory-aware second anchor (step 2) as a dead end.

## Why

The single-shot `perf-pr.yml` A/B is too heavy-tailed to gate on. On a no-op PR (base and head byte-identical in every benchmark, so every delta is pure noise) roughly 1 run in 4 blows a cluster of memory-bound micros to 25-40% while the register-only anchor stays flat. To never false-fire on a genuine no-op you'd need a budget above 40%, which can't catch a real 30% regression. A bigger budget can't fix a variance problem; more samples can.

The per-family median of N interleaved base/head snapshots absorbs up to ⌊(N-1)/2⌋ contaminated cycles. That turns the ungateable 40% floor into a would-gate in single digits.

## What it adds

- `scripts/ab_repeat.py` runs N interleaved base/head snapshots across two pre-built worktrees (each via `bench-ratchet -profile pr-fast ... snapshot`), then reports the per-family median delta and whether any family would gate at each candidate budget.
- `.github/workflows/perf-pr-repeat.yml` is opt-in via a `perf-repeat` label, N=7 default. It runs alongside the existing single-shot `perf-pr.yml` (untouched) so the two can be compared during the shadow phase.

## Informational, not a gate

The issue's step 1 said "turn on the gate." The review that followed, after a cross-check against the sibling Paserati workflow, narrowed that: accept the diagnosis, proceed with median-of-N, but shadow it before enforcing it. The specificity is studied; the power isn't, and the workflow-level false-positive rate hasn't been validated held-out at N=7. So this check never fails a PR on a perf verdict. Its exit code reflects only harness integrity (below). Enabling a required check is a follow-up, once the shadow data meets an explicit target.

## Non-obvious choices

- ABBA counterbalancing (odd cycles base-first, even head-first). A fixed base-then-head order lets first-vs-second-position drift (warmup, cache, thermal) masquerade as a consistent head regression, a systematic bias the median can't remove. Alternating cancels it. This came out of porting the same idea to Paserati, where a fixed order produced a 1-in-N false positive on a no-op PR.
- Exit code reflects integrity, never a perf verdict. Families are categorized rather than intersected: `comparable` (exactly N base and N head observations), `MISSING`/`NEW` (present on every cycle of one side only, i.e. a renamed or dropped benchmark, reported instead of silently vanishing), and `FLAKY` (present on some cycles but not all N). Flaky presence means the two halves aren't comparable, so the deltas can't be trusted, and that fails the job. A perf delta never does.
- The decision unit is the whole workflow. The check reports "would any family gate" at 6/8/10%, one Bernoulli sample toward `P(any-gate | no-op)`, rather than a per-family rate. A per-family rate undercounts the failure a maintainer sees, since any one of ~53 families crossing budget fails the check.
- Full evidence trail. Every base/head snapshot (with raw samples), cycle order, per-cycle anchor, CPU model, Go version, and SHAs are kept in the aggregate and uploaded, so the shadow-phase false-positive and power analysis can run offline.

## The memory-aware second anchor (issue step 2) is dropped

I prototyped it and it doesn't hold up, for a structural reason. `go test -bench` runs benchmarks sequentially, so the anchor and each family are measured seconds apart. Noisy-neighbor contention is non-stationary at that timescale, so dividing by the anchor injects its volatility rather than cancelling the family's. On one contended run, normalization made the worst family's |median| worse (4.09% to 13.23%). A working version would need concurrent measurement of anchor and family, a much larger harness change. Median-of-N alone is the fix.

## No-op validation

Labeling this PR runs a same-code A/B (it touches only `scripts/` and the workflow, no `pkg/**` or `cmd/**`), so every would-gate is a false positive. One no-op run on a fork (N=7, AMD EPYC 9V74, go1.26.4, ~49 min):

| budget | would-gate |
|---|---|
| 6% | 1 (`VectorConj/PersistentVector/10`, median +6.67%) |
| 8% | 0 |
| 10% | 0 |

Integrity: 53 comparable families, 0 missing, 0 new, 0 flaky. Anchor drift ≤0.33% per cycle (a quiet draw). This matches #445: N=7 holds at 8%, and the lone 6% straggler is `VectorConj`, one of the memory-bound families the issue flagged for exclusion or a wider budget.

The median doing its job on this run: `VectorConj/ArrayVector/100` had a worst cycle of +58.53%, a single contaminated snapshot that would hard-gate a single-shot A/B, which the median of 7 absorbed to +5.33%, under the 8% budget. One run is one sample, not the held-out validation a gate needs, but the mechanism behaves as designed on real CI.

## Next (not in this PR)

Per the review's path: collect gate-level false-positive and power data in shadow mode (P(any-gate | no-op) across runner draws, plus detection rate for injected 10/15/30% regressions), then enable a required check only after those numbers meet a target. Right-size N and the timeout from observed runtime.

