### PR TITLE
chore: gitignore .gomodcache and drop the committed toolchain lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,6 @@ openspec/changes/*
 lg451
 lg458
 lgmain
+
+# Local Go module cache (GOMODCACHE pointed into the repo — never commit)
+.gomodcache/


### PR DESCRIPTION
A GOMODCACHE pointed into the repo once leaked a Go toolchain download lock file (`.gomodcache/cache/download/golang.org/toolchain/@v/v0.0.1-go1.26.0.darwin-arm64.lock`) into version control, so the directory re-materializes in every fresh checkout/workspace. Ignores `.gomodcache/` and removes the stray file. No build impact — nothing reads it.