### PR TITLE
feat(rt): unify core-boot onto LoadCoreBundle (#506)

### DIFF
--- a/pkg/compiler/eval.go
+++ b/pkg/compiler/eval.go
@@ -130,129 +130,46 @@ func evalInit() {
 }
 
 func loadPrecompiledBundle() error {
-	// Namespaces that exist BEFORE decode are native-backed (installers run
-	// at package init). If the bundle also carries a chunk for one of them
-	// — a HYBRID namespace like async (native fns + lg-source macros) —
-	// lazy loading is broken for it: qualified symbol resolution finds the
-	// already-registered ns and its decoded nil stubs without ever
-	// triggering the loader. Those chunks must run eagerly (below).
-	preexisting := map[string]bool{}
-	for name := range rt.AllNSes() {
-		preexisting[name] = true
-	}
-
-	resolve := func(nsName, name string) *vm.Var {
-		// Use DefNSBare to create minimal namespaces without triggering
-		// the loader. This ensures vars have a home namespace but the
-		// actual loading (executing precompiled chunks) happens on demand.
-		n := rt.DefNSBare(nsName)
-		// Use LookupLocal to check only the namespace's own registry,
-		// not refers. This matches how the compiler creates vars via
-		// LookupOrAdd (which also skips refers).
-		v := n.LookupLocal(vm.Symbol(name))
-		if v == nil {
-			// Use DefStub to avoid spurious warn-on-shadow warnings during
-			// bundle decoding (the chunk will properly Def the value later).
-			if decodeTagStats {
-				bytecode.NoteDecodeVarRefMiss(true)
-			}
-			return n.DefStub(name)
-		}
-		if decodeTagStats {
-			bytecode.NoteDecodeVarRefHit()
-		}
-		return v
-	}
-	t0 := time.Now()
+	// The decode + replay of core, the lg baseline namespaces, and the eager
+	// hybrid pass all live in the compiler-free spine rt.LoadCoreBundle (#506),
+	// shared with rt.LoadCore and rt.BootCore. EagerHybrids is true here for the
+	// same reason it is in BootCore: api.NewContext returns straight to user
+	// code, so hybrid vars reachable via qualified symbols (which bypass the
+	// on-demand loader) must be bound before then. The spine also folds in the
+	// *ns* save/restore and NSOrder-deterministic hybrid order that used to be
+	// BootCore-only.
+	//
+	// Decode diagnostics (LG_DECODE_TAG_STATS, #356) still work: the var-ref
+	// hit/miss counting now lives in rt.LGBVarResolver (self-gating), so the
+	// enable/reset/print wrapper here drives it across the shared decode, and
+	// the OnPhase hook restores the decode-bundle / run-core-chunk bootMarks.
 	if decodeTagStats {
 		bytecode.ResetDecodeStats()
 		bytecode.SetDecodeStatsEnabled(true)
 		defer bytecode.SetDecodeStatsEnabled(false)
 	}
-	// Bytes entry: the embedded core is already a []byte, so decode keeps it
-	// resident and defers per-chunk source-map materialization off the hot path.
-	unit, err := bytecode.DecodeToExecUnitBytes(rt.CoreCompiledLGB, resolve)
+	unit, err := rt.LoadCoreBundle(rt.CoreLoadOptions{
+		EagerHybrids: true,
+		OnPhase:      func(phase string, since time.Time) { bootMark(phase, since) },
+	})
 	if err != nil {
 		return err
 	}
-	bootMark("decode-bundle", t0)
 	if decodeTagStats {
 		fmt.Fprint(os.Stderr, bytecode.SnapshotDecodeStats().Summary())
 	}
 
-	// Use the decoded const pool as the global pool
+	// Compiler-side leftovers the runtime spine deliberately omits: the decoded
+	// const pool becomes the global pool for further compilation, and the chunk
+	// map is what the resolver+compiler NSLoader replays a namespace from.
 	consts = unit.Consts
+	precompiledNS = unit.NSChunks
 
-	// Execute core's main chunk to replay all def/defn/defmacro definitions
-	t1 := time.Now()
-	f := vm.NewFrame(unit.MainChunk, nil)
-	_, err = f.RunProtected()
-	vm.ReleaseFrame(f)
-	if err != nil {
-		return err
-	}
-	bootMark("run-core-chunk", t1)
-
-	// Store remaining namespace chunks for on-demand loading by the resolver.
-	// Mark non-core namespaces as needing load so LookupOrRegisterNS triggers
-	// the loader even though the namespace already exists in the registry.
-	if unit.NSChunks != nil {
-		precompiledNS = unit.NSChunks
-		// The lg baseline namespaces (let-go.core, let-go.types) hold lg-specific
-		// extras and are auto-refer'd into every namespace (RegisterNS) but never
-		// explicitly required. On-demand loading only fires through
-		// LookupOrRegisterNS (qualified refs / require), which refer-resolution
-		// bypasses — so their .lg chunks would never run and the .lg-defined vars
-		// would stay unbound stubs. Run them eagerly right after core, whose
-		// definitions they depend on. (purify-clojure-core ②)
-		baselineNS := map[string]bool{}
-		for _, name := range rt.LgBaselineNSNames() {
-			baselineNS[name] = true
-			if ch := precompiledNS[name]; ch != nil {
-				lf := vm.NewFrame(ch, nil)
-				_, lerr := lf.RunProtected()
-				vm.ReleaseFrame(lf)
-				if lerr != nil {
-					return lerr
-				}
-			}
-		}
-		for name := range precompiledNS {
-			if name != "core" && !baselineNS[name] {
-				rt.MarkNSNeedsLoad(name)
-			}
-		}
-		// Eagerly execute chunks of hybrid namespaces (native + bundled lg
-		// source): their vars are reachable via qualified symbols without a
-		// (require ...), so lazy loading would leave the bundle-defined
-		// vars as nil stubs. The loader isn't configured yet at this point
-		// (api.NewContext sets it later), so run the chunk directly, the
-		// same way the core main chunk runs above. Note: a hybrid chunk
-		// that :requires another lazy bundled ns would load it too early
-		// here — fine for today's hybrids (async: macros over core only).
-		for name, ch := range precompiledNS {
-			if name == "core" || !preexisting[name] || ch == nil {
-				continue
-			}
-			f := vm.NewFrame(ch, nil)
-			_, err := f.RunProtected()
-			vm.ReleaseFrame(f)
-			if err != nil {
-				return err
-			}
-			rt.ClearNSNeedsLoad(name)
-			// The chunk's bootstrap defs overwrite any generated native
-			// adapters registered at init — restore them, same as the
-			// on-demand loader path does after a lazy load.
-			rt.ReapplyGeneratedPrimitives(name)
-		}
-	}
-
-	// Source-only namespaces (precompiled bundle deliberately skips them
+	// Source-only namespaces (the precompiled bundle deliberately skips them
 	// because their precompiled stubs would intern nil into dependent
-	// namespaces — see cmd/lgbgen/main.go). Their vars may already exist
-	// as stubs in the registry from bundle decoding's VarRef pass; mark
-	// them NeedsLoad so (require 'name) re-loads from source.
+	// namespaces — see cmd/lgbgen/main.go). Their vars may already exist as
+	// stubs from bundle decoding's VarRef pass; mark them NeedsLoad so
+	// (require 'name) re-loads from source.
 	for _, name := range []string{"ir.data"} {
 		rt.MarkNSNeedsLoad(name)
 	}

--- a/pkg/rt/boot.go
+++ b/pkg/rt/boot.go
@@ -17,49 +17,26 @@ import (
 // LoadCore, consumed by the bytecode-only NSLoader.
 var precompiledCoreNS map[string]*vm.CodeChunk
 
-// LoadCore boots the runtime from the embedded core .lgb: decode it, replay the
-// core main chunk (which defines all of core), then register the remaining
-// namespace chunks for on-demand loading. It imports only bytecode + vm and
-// touches no compiler code, so it can boot a build where pkg/compiler is not
-// linked (see cmd/lg-runtime). It mirrors the boot fast-path in
-// pkg/compiler/eval.go (loadPrecompiledBundle), minus the compiler-side pieces
-// (the global const pool for further compilation, and postCoreInit's eval
-// builtins) that a runtime-only build deliberately omits.
+// LoadCore boots the runtime from the embedded core .lgb: decode it, replay
+// core + the lg baseline namespaces, then register the remaining namespace
+// chunks for on-demand loading via bytecodeNSLoader. It touches no compiler
+// code, so it can boot a build where pkg/compiler is not linked (see
+// cmd/lg-runtime).
+//
+// Hybrid namespaces (native fns + a bundled lg chunk, e.g. async) are left for
+// the on-demand loader — EagerHybrids is false — safe today because async's
+// bundled content is macro-only and macros are fully expanded before a .lgb
+// exists. LoadCore's whole reason for existing over BootCore is that it
+// installs a namespace loader (UseBytecodeNSLoader), so it doesn't need the
+// eager pass; a future hybrid bundling runtime fns would flip this to true.
 func LoadCore() error {
-	unit, err := DecodeExecUnit(CoreCompiledLGB)
+	unit, err := LoadCoreBundle(CoreLoadOptions{EagerHybrids: false})
 	if err != nil {
-		return fmt.Errorf("decode core bundle: %w", err)
+		return err
 	}
-	if err := runChunk(unit.MainChunk); err != nil {
-		return fmt.Errorf("replay core: %w", err)
-	}
-	if unit.NSChunks != nil {
-		precompiledCoreNS = unit.NSChunks
-		// The lg baseline namespaces (let-go.core, let-go.types) are auto-refer'd
-		// into every namespace but never explicitly required, so on-demand
-		// loading never fires for them. Replay them eagerly — right after core,
-		// whose definitions they depend on — or their .lg-defined vars stay nil
-		// stubs. Mirrors loadPrecompiledBundle in pkg/compiler/eval.go.
-		baseline := map[string]bool{}
-		for _, name := range LgBaselineNSNames() {
-			baseline[name] = true
-			if c := precompiledCoreNS[name]; c != nil {
-				if err := runChunk(c); err != nil {
-					return fmt.Errorf("replay %s: %w", name, err)
-				}
-			}
-		}
-		for name := range precompiledCoreNS {
-			if name != NameCoreNS && !baseline[name] {
-				MarkNSNeedsLoad(name)
-			}
-		}
-	}
-	// Unlike loadPrecompiledBundle, hybrid namespaces (native fns + a bundled
-	// lg chunk, e.g. async) are NOT replayed eagerly here. Safe today because
-	// async's bundled content is macro-only and macros are fully expanded
-	// before a .lgb exists; a future hybrid that bundles runtime fns would
-	// need the eager replay too.
+	// Retain the chunk map so bytecodeNSLoader can replay a namespace on
+	// (require ...).
+	precompiledCoreNS = unit.NSChunks
 	return nil
 }
 

--- a/pkg/rt/bootcore.go
+++ b/pkg/rt/bootcore.go
@@ -1,0 +1,103 @@
+//go:build !bootstrap
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"fmt"
+
+	"github.com/nooga/let-go/pkg/bytecode"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// BootCore decodes and runs the embedded precompiled clojure.core bundle
+// (CoreCompiledLGB) so a program that links only pkg/rt + pkg/vm — with no
+// compiler — can resolve and invoke the full clojure.core surface plus the lg
+// baseline namespaces. It returns a fresh ExecContext ready to Invoke.
+//
+// The motivating case is an AOT-lowered binary (scripts/lg-compile output): its
+// generated funcs call core via ec.Invoke(rt.CachedVarFn(..., "clojure.core",
+// name), ...), which needs those vars bound. Programs that touch only NATIVE
+// core fns (str, +, vector, …) already work from a bare vm.NewExecContext(),
+// because installers register those at package init; BootCore is what
+// additionally binds the .lg-DEFINED core (and let-go.core / let-go.types).
+//
+// Call once at startup. This mirrors the runtime half of pkg/compiler/eval.go's
+// loadPrecompiledBundle without linking the compiler; a future refactor should
+// unify the two behind this function so there is a single core-load path.
+func BootCore() (*vm.ExecContext, error) {
+	if len(CoreCompiledLGB) == 0 {
+		return nil, fmt.Errorf("BootCore: embedded core is empty (built -tags bootstrap?)")
+	}
+
+	// Namespaces present before decode are native-backed (installers ran at
+	// package init); a bundle chunk for one of them is a hybrid ns whose chunk
+	// must run eagerly (below), since qualified refs bypass the on-demand loader.
+	preexisting := map[string]bool{}
+	for name := range AllNSes() {
+		preexisting[name] = true
+	}
+
+	// DefNSBare gives a var a home ns without triggering a loader; DefStub avoids
+	// warn-on-shadow while the chunk Defs the real value later.
+	resolve := func(nsName, name string) *vm.Var {
+		n := DefNSBare(nsName)
+		if v := n.LookupLocal(vm.Symbol(name)); v != nil {
+			return v
+		}
+		return n.DefStub(name)
+	}
+
+	unit, err := bytecode.DecodeToExecUnitBytes(CoreCompiledLGB, resolve)
+	if err != nil {
+		return nil, fmt.Errorf("BootCore: decode core: %w", err)
+	}
+
+	// Replay core's def/defn/defmacro definitions.
+	if err := runChunk(unit.MainChunk); err != nil {
+		return nil, fmt.Errorf("BootCore: run core chunk: %w", err)
+	}
+
+	// The lg baseline namespaces (let-go.core, …) are auto-refer'd everywhere but
+	// never explicitly required, so nothing else runs them — do it eagerly, after
+	// core (whose defs they depend on).
+	baseline := map[string]bool{}
+	for _, name := range LgBaselineNSNames() {
+		baseline[name] = true
+		if unit.NSChunks != nil {
+			if err := runChunk(unit.NSChunks[name]); err != nil {
+				return nil, fmt.Errorf("BootCore: run baseline %s: %w", name, err)
+			}
+		}
+	}
+
+	// Hybrid namespaces (native fns + bundled lg source, e.g. async) are reachable
+	// via qualified symbols without a require, so their chunks must run eagerly
+	// too or the lg-defined vars stay nil stubs.
+	if unit.NSChunks != nil {
+		for name, ch := range unit.NSChunks {
+			if name == "core" || baseline[name] || !preexisting[name] {
+				continue
+			}
+			if err := runChunk(ch); err != nil {
+				return nil, fmt.Errorf("BootCore: run hybrid %s: %w", name, err)
+			}
+		}
+	}
+
+	return vm.NewExecContext(), nil
+}
+
+func runChunk(ch *vm.CodeChunk) error {
+	if ch == nil {
+		return nil
+	}
+	f := vm.NewFrame(ch, nil)
+	_, err := f.RunProtected()
+	vm.ReleaseFrame(f)
+	return err
+}

--- a/pkg/rt/bootcore.go
+++ b/pkg/rt/bootcore.go
@@ -1,10 +1,12 @@
-//go:build !bootstrap
-
 /*
  * Copyright (c) 2026 let-go contributors
  * SPDX-License-Identifier: MIT
  */
 
+// This file carries no bootstrap build constraint on purpose: BootCore must
+// exist in every build so a downstream caller compiles, and under -tags
+// bootstrap the embedded core (CoreCompiledLGB) is empty, making the len==0
+// guard return the documented error instead of an undefined-symbol failure.
 package rt
 
 import (
@@ -33,6 +35,14 @@ func BootCore() (*vm.ExecContext, error) {
 	if len(CoreCompiledLGB) == 0 {
 		return nil, fmt.Errorf("BootCore: embedded core is empty (built -tags bootstrap?)")
 	}
+
+	// Each eager chunk below runs its (ns …) form. runChunk frames carry no
+	// ExecContext, so in-ns falls through to CurrentNS.SetRoot — mutating the
+	// global *ns* root. Left unrestored, the returned context would deref a
+	// *ns* pointing at whichever chunk ran last; restore the pre-boot root so
+	// lowered code sees a stable namespace.
+	savedNS := CurrentNS.Deref()
+	defer CurrentNS.SetRoot(savedNS)
 
 	// Namespaces present before decode are native-backed (installers ran at
 	// package init); a bundle chunk for one of them is a hybrid ns whose chunk
@@ -77,13 +87,14 @@ func BootCore() (*vm.ExecContext, error) {
 
 	// Hybrid namespaces (native fns + bundled lg source, e.g. async) are reachable
 	// via qualified symbols without a require, so their chunks must run eagerly
-	// too or the lg-defined vars stay nil stubs.
+	// too or the lg-defined vars stay nil stubs. Iterate NSOrder (chunk/dependency
+	// order), not the NSChunks map, so execution order is deterministic.
 	if unit.NSChunks != nil {
-		for name, ch := range unit.NSChunks {
+		for _, name := range unit.NSOrder {
 			if name == "core" || baseline[name] || !preexisting[name] {
 				continue
 			}
-			if err := runChunk(ch); err != nil {
+			if err := runChunk(unit.NSChunks[name]); err != nil {
 				return nil, fmt.Errorf("BootCore: run hybrid %s: %w", name, err)
 			}
 		}

--- a/pkg/rt/bootcore.go
+++ b/pkg/rt/bootcore.go
@@ -5,21 +5,20 @@
 
 // This file carries no bootstrap build constraint on purpose: BootCore must
 // exist in every build so a downstream caller compiles, and under -tags
-// bootstrap the embedded core (CoreCompiledLGB) is empty, making the len==0
-// guard return the documented error instead of an undefined-symbol failure.
+// bootstrap the embedded core (CoreCompiledLGB) is empty, making LoadCoreBundle
+// return the documented error instead of an undefined-symbol failure.
 package rt
 
 import (
 	"fmt"
 
-	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/vm"
 )
 
-// BootCore decodes and runs the embedded precompiled clojure.core bundle
-// (CoreCompiledLGB) so a program that links only pkg/rt + pkg/vm — with no
-// compiler — can resolve and invoke the full clojure.core surface plus the lg
-// baseline namespaces. It returns a fresh ExecContext ready to Invoke.
+// BootCore decodes and runs the embedded precompiled clojure.core bundle so a
+// program that links only pkg/rt + pkg/vm — with no compiler — can resolve and
+// invoke the full clojure.core surface plus the lg baseline and hybrid
+// namespaces. It returns a fresh ExecContext ready to Invoke.
 //
 // The motivating case is an AOT-lowered binary (scripts/lg-compile output): its
 // generated funcs call core via ec.Invoke(rt.CachedVarFn(..., "clojure.core",
@@ -28,87 +27,13 @@ import (
 // because installers register those at package init; BootCore is what
 // additionally binds the .lg-DEFINED core (and let-go.core / let-go.types).
 //
-// Call once at startup. This mirrors the runtime half of pkg/compiler/eval.go's
-// loadPrecompiledBundle without linking the compiler; a future refactor should
-// unify the two behind this function so there is a single core-load path.
+// Call once at startup. It shares the compiler-free boot spine with LoadCore
+// and compiler.loadPrecompiledBundle via LoadCoreBundle; the eager hybrid
+// replay is what BootCore needs over LoadCore, since it returns straight to the
+// caller with no namespace loader installed.
 func BootCore() (*vm.ExecContext, error) {
-	if len(CoreCompiledLGB) == 0 {
-		return nil, fmt.Errorf("BootCore: embedded core is empty (built -tags bootstrap?)")
+	if _, err := LoadCoreBundle(CoreLoadOptions{EagerHybrids: true}); err != nil {
+		return nil, fmt.Errorf("BootCore: %w", err)
 	}
-
-	// Each eager chunk below runs its (ns …) form. runChunk frames carry no
-	// ExecContext, so in-ns falls through to CurrentNS.SetRoot — mutating the
-	// global *ns* root. Left unrestored, the returned context would deref a
-	// *ns* pointing at whichever chunk ran last; restore the pre-boot root so
-	// lowered code sees a stable namespace.
-	savedNS := CurrentNS.Deref()
-	defer CurrentNS.SetRoot(savedNS)
-
-	// Namespaces present before decode are native-backed (installers ran at
-	// package init); a bundle chunk for one of them is a hybrid ns whose chunk
-	// must run eagerly (below), since qualified refs bypass the on-demand loader.
-	preexisting := map[string]bool{}
-	for name := range AllNSes() {
-		preexisting[name] = true
-	}
-
-	// DefNSBare gives a var a home ns without triggering a loader; DefStub avoids
-	// warn-on-shadow while the chunk Defs the real value later.
-	resolve := func(nsName, name string) *vm.Var {
-		n := DefNSBare(nsName)
-		if v := n.LookupLocal(vm.Symbol(name)); v != nil {
-			return v
-		}
-		return n.DefStub(name)
-	}
-
-	unit, err := bytecode.DecodeToExecUnitBytes(CoreCompiledLGB, resolve)
-	if err != nil {
-		return nil, fmt.Errorf("BootCore: decode core: %w", err)
-	}
-
-	// Replay core's def/defn/defmacro definitions.
-	if err := runChunk(unit.MainChunk); err != nil {
-		return nil, fmt.Errorf("BootCore: run core chunk: %w", err)
-	}
-
-	// The lg baseline namespaces (let-go.core, …) are auto-refer'd everywhere but
-	// never explicitly required, so nothing else runs them — do it eagerly, after
-	// core (whose defs they depend on).
-	baseline := map[string]bool{}
-	for _, name := range LgBaselineNSNames() {
-		baseline[name] = true
-		if unit.NSChunks != nil {
-			if err := runChunk(unit.NSChunks[name]); err != nil {
-				return nil, fmt.Errorf("BootCore: run baseline %s: %w", name, err)
-			}
-		}
-	}
-
-	// Hybrid namespaces (native fns + bundled lg source, e.g. async) are reachable
-	// via qualified symbols without a require, so their chunks must run eagerly
-	// too or the lg-defined vars stay nil stubs. Iterate NSOrder (chunk/dependency
-	// order), not the NSChunks map, so execution order is deterministic.
-	if unit.NSChunks != nil {
-		for _, name := range unit.NSOrder {
-			if name == "core" || baseline[name] || !preexisting[name] {
-				continue
-			}
-			if err := runChunk(unit.NSChunks[name]); err != nil {
-				return nil, fmt.Errorf("BootCore: run hybrid %s: %w", name, err)
-			}
-		}
-	}
-
 	return vm.NewExecContext(), nil
-}
-
-func runChunk(ch *vm.CodeChunk) error {
-	if ch == nil {
-		return nil
-	}
-	f := vm.NewFrame(ch, nil)
-	_, err := f.RunProtected()
-	vm.ReleaseFrame(f)
-	return err
 }

--- a/pkg/rt/bootcore_test.go
+++ b/pkg/rt/bootcore_test.go
@@ -1,9 +1,9 @@
+//go:build !bootstrap
+
 /*
  * Copyright (c) 2026 let-go contributors
  * SPDX-License-Identifier: MIT
  */
-
-//go:build !bootstrap
 
 package rt
 

--- a/pkg/rt/bootcore_test.go
+++ b/pkg/rt/bootcore_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+//go:build !bootstrap
+
+package rt
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// BootCore must bind the .lg-DEFINED core surface, not just the native
+// installers. `frequencies` is defined in clojure.core's .lg source, so it is
+// bound only after the embedded core chunk runs — on a fresh ExecContext it is
+// a nil stub, which is exactly the AOT-binary nil-panic BootCore exists to fix.
+func TestBootCoreBindsLgDefinedCore(t *testing.T) {
+	ec, err := BootCore()
+	if err != nil {
+		t.Fatalf("BootCore: %v", err)
+	}
+	if ec == nil {
+		t.Fatal("BootCore returned a nil ExecContext")
+	}
+
+	v := LookupCoreVar("frequencies")
+	if v == nil || !v.IsBound() {
+		t.Fatal("clojure.core/frequencies unbound after BootCore")
+	}
+
+	// It actually runs: (frequencies ()) => {} with no error.
+	if _, err := v.Invoke([]vm.Value{vm.EmptyList}); err != nil {
+		t.Fatalf("invoke frequencies after BootCore: %v", err)
+	}
+}

--- a/pkg/rt/bootcore_test.go
+++ b/pkg/rt/bootcore_test.go
@@ -36,3 +36,18 @@ func TestBootCoreBindsLgDefinedCore(t *testing.T) {
 		t.Fatalf("invoke frequencies after BootCore: %v", err)
 	}
 }
+
+// The eager chunk loops mutate the global *ns* root (in-ns with no ExecContext
+// falls through to CurrentNS.SetRoot). Without a restore, the returned context
+// would deref *ns* pointing at whichever hybrid chunk iterated last — a value
+// that used to vary with map order between runs. BootCore must leave *ns* at
+// its pre-boot root.
+func TestBootCoreRestoresCurrentNS(t *testing.T) {
+	before := CurrentNS.Deref()
+	if _, err := BootCore(); err != nil {
+		t.Fatalf("BootCore: %v", err)
+	}
+	if after := CurrentNS.Deref(); after != before {
+		t.Fatalf("*ns* not restored: before=%v after=%v", before, after)
+	}
+}

--- a/pkg/rt/coreload.go
+++ b/pkg/rt/coreload.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nooga/let-go/pkg/bytecode"
+)
+
+// CoreLoadOptions tunes the shared core-boot spine (LoadCoreBundle).
+//
+// It intentionally exposes a SINGLE behavioral axis (EagerHybrids). If a future
+// caller wants a third replay behavior, that's the signal this shared spine is
+// turning into the wrong abstraction — split it rather than growing more flags.
+type CoreLoadOptions struct {
+	// EagerHybrids replays HYBRID namespace chunks (native fns + bundled lg
+	// source, e.g. async) immediately after core+baseline instead of leaving
+	// them to the on-demand loader. Their vars are reachable via qualified
+	// symbols WITHOUT a (require ...), which bypasses the loader, so a caller
+	// that returns straight to user code (the compiler boot path,
+	// BootCore) must run them eagerly or those vars stay nil stubs. A caller
+	// that installs a namespace loader and only reaches hybrids through it
+	// (LoadCore + bytecodeNSLoader) can leave this false.
+	EagerHybrids bool
+
+	// OnPhase, if set, is called after each boot phase with the phase name and
+	// the time it started, so a caller can record fine-grained boot timing
+	// (the compiler path's bootMark). Phases: "decode-bundle", "run-core-chunk".
+	// nil disables timing.
+	OnPhase func(phase string, since time.Time)
+}
+
+// LoadCoreBundle is the single compiler-free core-boot path: decode the
+// embedded clojure.core bundle (CoreCompiledLGB) and replay it onto the live
+// registry — core's main chunk (all of core's def/defn/defmacro), then the lg
+// baseline namespaces (let-go.core, let-go.types) which are auto-refer'd
+// everywhere but never explicitly required, then optionally the hybrid
+// namespace chunks. Non-core/non-baseline namespaces are marked NeedsLoad so a
+// configured loader picks them up on (require ...). Returns the decoded unit so
+// a caller can read its const pool or chunk map.
+//
+// It folds together what were three parallel implementations (#506):
+// compiler.loadPrecompiledBundle, rt.LoadCore, and rt.BootCore. Two invariants
+// that used to live in only some of them are now unconditional here:
+//
+//   - *ns* is saved before the replay and restored after. Each chunk runs its
+//     (ns …) form under a frame with no ExecContext, so in-ns falls through to
+//     CurrentNS.SetRoot and mutates the global root; unrestored, a caller that
+//     returns straight to user code (BootCore) would deref a *ns* left pointing
+//     at whichever chunk ran last. loadPrecompiledBundle only got away without
+//     this because api.NewContext re-establishes *ns* before user code.
+//   - the eager hybrid loop iterates unit.NSOrder (dependency order), not the
+//     NSChunks map, so replay order is deterministic, and calls
+//     ReapplyGeneratedPrimitives after each chunk — the chunk's bootstrap defs
+//     overwrite the native adapters #438 Def'd at init, so without the reapply
+//     a bundle that eager-re-Defs one would strand its callers on the
+//     trampoline and lose the direct-call fast path.
+func LoadCoreBundle(opts CoreLoadOptions) (*bytecode.ExecUnit, error) {
+	if len(CoreCompiledLGB) == 0 {
+		return nil, fmt.Errorf("LoadCoreBundle: embedded core is empty (built -tags bootstrap?)")
+	}
+
+	// Restore the pre-boot *ns* root: the eager (ns …) forms below mutate it.
+	savedNS := CurrentNS.Deref()
+	defer CurrentNS.SetRoot(savedNS)
+
+	// Namespaces present before decode are native-backed (installers ran at
+	// package init). A bundle chunk for one of them is a HYBRID namespace whose
+	// chunk must run eagerly (qualified refs bypass the on-demand loader).
+	preexisting := map[string]bool{}
+	for name := range AllNSes() {
+		preexisting[name] = true
+	}
+
+	tDecode := time.Now()
+	unit, err := bytecode.DecodeToExecUnitBytes(CoreCompiledLGB, LGBVarResolver)
+	if err != nil {
+		return nil, fmt.Errorf("decode core bundle: %w", err)
+	}
+	if opts.OnPhase != nil {
+		opts.OnPhase("decode-bundle", tDecode)
+	}
+
+	// Replay core's def/defn/defmacro definitions.
+	tCore := time.Now()
+	if err := runChunk(unit.MainChunk); err != nil {
+		return nil, fmt.Errorf("run core chunk: %w", err)
+	}
+	if opts.OnPhase != nil {
+		opts.OnPhase("run-core-chunk", tCore)
+	}
+
+	if unit.NSChunks == nil {
+		return unit, nil
+	}
+
+	// lg baseline namespaces depend on core's defs — run eagerly, right after.
+	// A Go-only baseline (let-go.types, predicates Def'd in Go) has no chunk;
+	// rt.runChunk does not nil-guard, so skip those here.
+	baseline := map[string]bool{}
+	for _, name := range LgBaselineNSNames() {
+		baseline[name] = true
+		if ch := unit.NSChunks[name]; ch != nil {
+			if err := runChunk(ch); err != nil {
+				return nil, fmt.Errorf("run baseline %s: %w", name, err)
+			}
+		}
+	}
+
+	// Everything else loads on demand.
+	for name := range unit.NSChunks {
+		if name != NameCoreNS && !baseline[name] {
+			MarkNSNeedsLoad(name)
+		}
+	}
+
+	if opts.EagerHybrids {
+		for _, name := range unit.NSOrder {
+			if name == NameCoreNS || baseline[name] || !preexisting[name] {
+				continue
+			}
+			ch := unit.NSChunks[name]
+			if ch == nil {
+				continue
+			}
+			if err := runChunk(ch); err != nil {
+				return nil, fmt.Errorf("run hybrid %s: %w", name, err)
+			}
+			ClearNSNeedsLoad(name)
+			ReapplyGeneratedPrimitives(name)
+		}
+	}
+
+	return unit, nil
+}

--- a/pkg/rt/coreload_test.go
+++ b/pkg/rt/coreload_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// TestReapplyGeneratedPrimitivesRestoresClobberedRoot guards the #438
+// coordination the unified eager-hybrid pass relies on (#506). When a hybrid
+// namespace's bundle chunk re-Defs a generated native-primitive var with its
+// bootstrap closure, ReapplyGeneratedPrimitives must restore the recorded
+// adapter as the var's root — otherwise the root stays deviated and lowered
+// direct-call sites are stranded on the var-dispatch trampoline (the native
+// fast path never re-engages). LoadCoreBundle calls this after every eager
+// hybrid chunk; the on-demand loader calls it after a lazy load.
+//
+// The mechanism is exercised directly against a synthetic namespace on purpose:
+// no real namespace is both an eager hybrid AND a carrier of generated
+// primitives today (the only eager hybrid, async, has none; clojure.string has
+// one but loads lazily), so a bundle-driven assertion would pass even with the
+// reapply removed. This keeps the guard meaningful the moment a generated-
+// primitive-bearing hybrid is added.
+func TestReapplyGeneratedPrimitivesRestoresClobberedRoot(t *testing.T) {
+	const nsName = "test.reapplyhybrid"
+	ns := DefNSBare(nsName)
+
+	// Stand-ins for the native adapter and the bootstrap closure a hybrid chunk
+	// would Def over it. Distinct comparable Values suffice: the guard compares
+	// roots by identity (vm.sameRootIdentity) and Deref equality is exact here.
+	adapter := vm.String("native-adapter")
+	bootstrap := vm.String("bootstrap-closure")
+
+	// Bind + guard + record the adapter exactly as RegisterGeneratedPrimitives.
+	defGeneratedPrimitive(ns, nsName, "prim", adapter)
+	v := ns.LookupLocal(vm.Symbol("prim"))
+	if v == nil {
+		t.Fatal("prim var not defined")
+	}
+	if got := v.Deref(); got != adapter {
+		t.Fatalf("adapter not bound as root: got %v, want %v", got, adapter)
+	}
+
+	// A hybrid chunk's (def prim …) overwrites the adapter root in place.
+	setPrimitiveRoot(ns, "prim", bootstrap)
+	if got := v.Deref(); got != bootstrap {
+		t.Fatalf("clobber did not take: got %v, want %v", got, bootstrap)
+	}
+
+	// The eager-hybrid pass (and the on-demand loader) restore it.
+	ReapplyGeneratedPrimitives(nsName)
+	if got := v.Deref(); got != adapter {
+		t.Fatalf("reapply did not restore adapter: got %v, want %v", got, adapter)
+	}
+}

--- a/pkg/rt/run.go
+++ b/pkg/rt/run.go
@@ -24,11 +24,19 @@ import (
 // the var's home namespace is materialized bare (no loader trigger) and the
 // name is interned as a stub if not yet defined. The single resolver behind
 // every .lgb decode site.
+//
+// It records var-ref hit/miss decode stats (LG_DECODE_TAG_STATS). The Note
+// calls self-gate on bytecode.decodeStatsEnabled, so they're a no-op unless a
+// caller has enabled stats around the decode; folding them in here — rather
+// than a decode-site-specific resolver — makes the counter available at every
+// canonical decode site, not just core boot where it started (#356).
 func LGBVarResolver(nsName, name string) *vm.Var {
 	n := DefNSBare(nsName)
 	if v := n.LookupLocal(vm.Symbol(name)); v != nil {
+		bytecode.NoteDecodeVarRefHit()
 		return v
 	}
+	bytecode.NoteDecodeVarRefMiss(true)
 	return n.DefStub(name)
 }
 


### PR DESCRIPTION
Supersedes #499. Closes #506.

## Why

`BootCore` (#499), `rt.LoadCore` (#424), and `compiler.loadPrecompiledBundle` were three parallel implementations of the same compiler-free core boot: decode the embedded core `.lgb`, replay the core main chunk, eager-run the lg baseline namespaces, mark the rest for on-demand load, and — for two of the three — eager-run the hybrid namespace chunks.

Three copies of one invariant is not a stylistic problem here; it is a correctness one. The invariant changed twice recently, and each change landed in a different subset of the copies:

- `loadPrecompiledBundle` reapplies generated primitives (#438) but never restored `*ns*`.
- `BootCore` restored `*ns*` and iterated `NSOrder` (#499) but never reapplied generated primitives.
- `LoadCore` did neither.

So the three paths sat at three different states of correctness. That is exactly what #506 set out to fix: namespace preservation and deterministic execution order are boot invariants that should not live in parallel implementations.

There was also a latent build break. `BootCore` carried its own `runChunk`, which collides with the `runChunk` #424 added in `pkg/rt/run.go`. Merging #499 onto current `main` is textually clean — `bootcore.go` is a new file — but does not compile: two `runChunk` in package `rt`. This PR is cut from current `main`, so that is gone; the old #499 branch was 17 commits behind and predated #424.

## What

One shared spine, `rt.LoadCoreBundle`, parametrized by a single behavioral axis, `CoreLoadOptions.EagerHybrids`. Both boot invariants now live there unconditionally:

- `*ns*` is saved before the replay and restored after, so a caller that returns straight to user code (`BootCore`) can't observe a `*ns*` left pointing at the last chunk that ran.
- the eager hybrid loop iterates `unit.NSOrder` for deterministic order and calls `ReapplyGeneratedPrimitives` after each chunk: the #438 coordination `BootCore` was missing, now unavoidable since #438 merged first.

The three callers keep only what is theirs: `LoadCore` retains the chunk map for its bytecode loader; `loadPrecompiledBundle` retains the const pool, the compiler `NSLoader`'s chunk map, and the `ir.data` source-only mark; `BootCore` is now a thin wrapper that runs the spine with eager hybrids and returns a fresh `ExecContext`.

The single boolean is deliberate. The alternative, each caller running its own hybrid loop, re-fragments the reapply/`NSOrder` invariant — the thing this unifies. If a fourth behavior ever appears, that's the signal to split the spine rather than grow more flags, and there's a comment on the options type saying so.

## What isn't obvious

**Decode diagnostics are preserved, and broadened.** The `LG_DECODE_TAG_STATS` var-ref hit/miss counting used to live in `loadPrecompiledBundle`'s inline resolver. It now lives in the canonical `rt.LGBVarResolver`. The `Note` calls self-gate on `decodeStatsEnabled`, so this is a no-op unless stats are on, and it now covers every `.lgb` decode site instead of only core boot. The fine-grained `decode-bundle` / `run-core-chunk` bootMarks are restored through an optional `OnPhase` hook on `CoreLoadOptions` (the runtime spine can't call the compiler's `bootMark` directly). `LG_DECODE_TAG_STATS` and `LG_BOOT_TIMING` output is unchanged on a real `lg` run.

**The reapply test runs against a synthetic namespace on purpose.** No real namespace today is both an eager hybrid and a generated-primitive carrier — the only eager hybrid, `async`, has no generated primitives, and `clojure.string` has one but loads lazily (its reapply fires through the on-demand loader, not the eager loop). A bundle-driven assertion would therefore pass even with the reapply deleted. `TestReapplyGeneratedPrimitivesRestoresClobberedRoot` exercises the mechanism directly so the guard stays meaningful the moment a generated-primitive-bearing hybrid is added. It has a verified negative control: remove the reapply and it fails with the adapter left clobbered.

## Validation

- `go build` / `go vet` / `gofmt` clean
- full `go test ./...` green, including `test/e2e`
- `-race` on `pkg/rt`
- `-tags bootstrap` build (the guard path returns the documented error, not an undefined symbol)
- `linux` / `wasm` / `plan9` cross-compiles
- `check-generated`: bundle + lowered tree in lockstep
