### PR TITLE
ci: run the race detector over pkg/vm and pkg/rt

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -95,6 +95,25 @@ jobs:
           LETGO_RUN_LOWERING_DETERMINISM: "1"
         run: go test -v -timeout 600s ./test/e2e/ -run 'TestLoweringDeterminism|TestDeftypeSkeletonNativeLowering'
 
+  # Race-detector pass over the packages that hold cross-goroutine state:
+  # the VM's shared runtime structures and the rt layer. Motivated by #464 —
+  # the #463 ArrayVectorSeq.ChunkedFirst data race shipped because no CI job
+  # ran the race detector. A separate job so the race-runtime multiplier
+  # (~5-20x) stays out of the primary test gate; -short skips the long
+  # e2e/determinism harnesses. The scoped run completes in well under a
+  # minute of wall clock locally.
+  race:
+    name: race
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Race-detector tests (pkg/vm, pkg/rt)
+        run: go test -race -short -count=1 -timeout 300s ./pkg/vm/... ./pkg/rt/...
+
   # Cross-build guard for the wasip1 (WASI) target. The REPL and interactive
   # terminal are build-tagged off wasip1 (routed to lg_repl_stub.go); without
   # this gate, a change that pulls chzyer/readline or x/sys/unix terminal code


### PR DESCRIPTION
## Why

No CI job runs `go test -race` — I checked every workflow, the Makefile, and the hook configs; the race detector appears nowhere in the repo's automation. #464 names the consequence: the `ArrayVectorSeq.ChunkedFirst` data race (#463, a scratch-field write on a goroutine-shared seq node) shipped undetected. With the binding-stack rework (#459/#462) and parallel lowering both touching shared VM state, this bug class has more surface than usual right now.

## What

One new `race` job in go.yml: `go test -race -short -count=1 -timeout 300s ./pkg/vm/... ./pkg/rt/...`

Scoping choices, made explicit:

- **pkg/vm + pkg/rt only:** that's where cross-goroutine state lives (VM runtime structures, binding stacks, the rt layer's channels and timers). The compiler and tooling packages are single-goroutine at test time; widening later is a one-line change.
- **`-short`:** skips the long e2e/determinism harnesses, matching the main test job's convention.
- **Separate job rather than a flag on the existing test job:** the race runtime multiplier (2-20x per the Go docs) stays out of the primary gate. The scoped run passes in ~20s wall clock locally (~99s CPU), so the added CI cost is one small parallel job.

## Follow-up (not in this PR)

A `testing/synctest`-based deterministic regression test for the #463 shape would complement this: the detector catches the class probabilistically under load, synctest makes the specific regression repeatable. I can take that as a second PR under #464 if useful.

Refs #464.
