### PR TITLE
fix(rt): request-method arrives as a keyword, Ring-style

### DIFF
--- a/pkg/rt/http.go
+++ b/pkg/rt/http.go
@@ -46,15 +46,11 @@ type Handler struct {
 	fn vm.Fn
 }
 
-func methodToLG(scheme string) vm.Keyword {
-	return map[string]vm.Keyword{
-		"GET":     vm.Keyword("get"),
-		"POST":    vm.Keyword("post"),
-		"PUT":     vm.Keyword("put"),
-		"DELETE":  vm.Keyword("delete"),
-		"HEAD":    vm.Keyword("head"),
-		"OPTIONS": vm.Keyword("options"),
-	}[scheme]
+// methodToLG maps an HTTP method to a lowercase keyword, Ring-style
+// (:get, :post, …). Extension methods (PATCH, etc.) pass through lowercased
+// rather than falling back to an empty keyword.
+func methodToLG(method string) vm.Keyword {
+	return vm.Keyword(strings.ToLower(method))
 }
 
 func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
@@ -88,7 +84,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, request *http.Request) {
 	}
 
 	req := httpRequestMapping.StructToRecord(HTTPRequest{
-		RequestMethod: string(methodToLG(request.Method)),
+		RequestMethod: methodToLG(request.Method),
 		Scheme:        scheme,
 		URI:           url.RequestURI(),
 		Path:          url.Path,

--- a/pkg/rt/http_test.go
+++ b/pkg/rt/http_test.go
@@ -34,6 +34,29 @@ func TestHandlerResponseHeadersUseRawStrings(t *testing.T) {
 	}
 }
 
+func TestHandlerRequestMethodIsKeyword(t *testing.T) {
+	var gotMethod vm.Value
+	handlerFnValue, err := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		req := vs[0].(vm.Lookup)
+		gotMethod = req.ValueAt(vm.Keyword("request-method"))
+		return vm.NewPersistentMap([]vm.Value{vm.Keyword("body"), vm.String("ok")}), nil
+	})
+	if err != nil {
+		t.Fatalf("wrap handler: %v", err)
+	}
+	handlerFn := handlerFnValue.(vm.Fn)
+
+	// PATCH is not in the old static map — it used to arrive as an empty
+	// keyword; now it passes through lowercased, Ring-style.
+	req := httptest.NewRequest(http.MethodPatch, "http://example.test/", nil)
+	rec := httptest.NewRecorder()
+	(&Handler{fn: handlerFn}).ServeHTTP(rec, req)
+
+	if got, want := gotMethod, vm.Keyword("patch"); got != want {
+		t.Fatalf("expected :request-method to be keyword %q, got %#v", want, got)
+	}
+}
+
 func TestHandlerResponseHeadersUseRawStringKeys(t *testing.T) {
 	handlerFnValue, err := vm.NativeFnType.Wrap(func(_ []vm.Value) (vm.Value, error) {
 		return vm.NewPersistentMap([]vm.Value{

--- a/pkg/rt/types.go
+++ b/pkg/rt/types.go
@@ -21,7 +21,7 @@ type ShellResult struct {
 
 // HTTPRequest is the struct behind ring-style HTTP request maps.
 type HTTPRequest struct {
-	RequestMethod string   `letgo:"request-method"`
+	RequestMethod vm.Value `letgo:"request-method"`
 	Scheme        string   `letgo:"scheme"`
 	URI           string   `letgo:"uri"`
 	Path          string   `letgo:"path"`


### PR DESCRIPTION
## What

The HTTP request map exposed `:request-method` as a string (`"get"`) instead of the keyword `:get`. `methodToLG` built a keyword and then threw the keyword-ness away, because the `HTTPRequest` struct field was typed `string` (`pkg/rt/types.go`). Ring convention — and routers built on it, like ruuter — expect the keyword, so every handler had to keywordize before routing:

```clojure
(r/route routes (update req :request-method keyword))
```

There was also a second bug next to it: `methodToLG` only mapped GET/POST/PUT/DELETE/HEAD/OPTIONS. Any other method (`PATCH`, `CONNECT`, `TRACE`, extension methods) hit the map's zero value and arrived as an **empty** keyword, so those routes silently never matched and no error was raised.

## Fix

- Type the field as `vm.Value` holding a keyword, like `:headers` already does.
- Replace the static method map with `strings.ToLower(method)`, which is the Ring convention (`:get`, `:post`, …) and passes extension methods through for free instead of dropping them.

Three-line change plus a test. With it, the workaround above becomes `(r/route routes req)`, and a `PATCH` request arrives as `:patch`.

## Compatibility

This is a shape change to the request map: `:request-method` goes from a string to a keyword. Handler code that string-compared it (`(= "get" (:request-method req))`) must switch to keyword comparison. The keyword is the Ring-correct value, and nothing in let-go's own tree depended on the old string shape.

## Test

`TestHandlerRequestMethodIsKeyword` drives `Handler.ServeHTTP` with a capturing handler and asserts `:request-method` is `:patch` for a PATCH request — covering both the keyword shape and the extension-method path that used to come through empty. `go test ./pkg/rt -race` passes; builds are clean on linux, js/wasm, wasip1/wasm, and plan9.

## Motivation

Surfaced by the lgx HTTP server example, where the `update` keywordize dance is the one wart the otherwise-clean Ring demo has to carry. Filed alongside the `net` socket discussion in #523, though this fix stands on its own.
