### PR TITLE
feat(ir): accept numeric param hints (^double/^long) in AOT lowering (#357)

### DIFF
--- a/pkg/ir/lisp_lower_go_test.go
+++ b/pkg/ir/lisp_lower_go_test.go
@@ -9,6 +9,8 @@ package ir_test
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -291,6 +293,56 @@ func TestLowerNsMultiArityDoubleHintLowersToFloat64Params(t *testing.T) {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("multi-arity ^double hint missing %q:\n--- rendered Go ---\n%s", want, rendered)
 		}
+	}
+}
+
+// captureLetGoOut runs fn with let-go's *out* rebound to a pipe and returns what
+// it wrote. let-go's println (the lowering's WARNING emitter) resolves *out*
+// dynamically via WriteToOut, and its root IOHandle captured os.Stdout at init —
+// so swapping os.Stdout doesn't intercept it; rebinding the *out* var does.
+func captureLetGoOut(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	ns := rt.NS(rt.NameCoreNS)
+	ns.Def("*out*", vm.NewBoxed(rt.NewIOHandle(w)))
+	defer ns.Def("*out*", vm.NewBoxed(rt.NewIOHandle(os.Stdout)))
+	fn()
+	w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// #530 review: a recognized but non-numeric hint (^String, a class) has no native
+// param type. It must not crash and must not mis-route to a numeric param — it
+// stays vm.Value (boxed); and build-fn must WARN rather than drop the hint
+// silently (the actual subject of the review).
+func TestLowerGoNonNumericHintStaysBoxed(t *testing.T) {
+	ensureLoader()
+
+	var fn vm.Value
+	out := captureLetGoOut(t, func() {
+		fn = buildLispIR(t, `(defn takes-str [^String s] s)`)
+	})
+	if !strings.Contains(out, "ignoring unsupported param type hint ^String") {
+		t.Fatalf("expected a warning for the non-numeric ^String hint; stdout:\n%s", out)
+	}
+
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered status for a ^String-hinted param, got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "arg0 vm.Value") {
+		t.Fatalf("expected non-numeric ^String hint to leave the param boxed (vm.Value), got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "arg0 float64") || strings.Contains(rendered, "arg0 int") {
+		t.Fatalf("non-numeric hint must not mis-route to a native numeric param, got:\n%s", rendered)
 	}
 }
 

--- a/pkg/ir/lisp_lower_go_test.go
+++ b/pkg/ir/lisp_lower_go_test.go
@@ -267,6 +267,32 @@ func TestLowerGoDoubleHintLowersToFloat64Param(t *testing.T) {
 	}
 }
 
+// #530 review: the authoritative-hint guard (assert-hint-agrees-with-inference!)
+// must stay inert when op-based inference AGREES with a numeric hint or is silent.
+// A ^double param used in arithmetic infers :int through the backward pass, which
+// is numeric and so no contradiction — the param keeps its float64 hint and lowers
+// natively, no throw. (The guard fires only on a concrete NON-numeric inferred
+// type, which the current numeric-only inference can't produce; this is the
+// negative case proving it doesn't over-fire on the motivating escape-style code.)
+func TestLowerGoNumericHintGuardInertWhenInferenceAgrees(t *testing.T) {
+	ensureLoader()
+
+	// `cx` is ^double but used in `< cx 4.0` and `+ cx 1.0`, which the backward
+	// pass constrains to :int — numeric, so the guard leaves the hint alone.
+	fn := buildLispIR(t, `(defn step [^double cx] (if (< cx 4.0) (+ cx 1.0) cx))`)
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered status (guard must not fire on a numeric-agreeing hint), got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "arg0 float64") {
+		t.Fatalf("expected the ^double hint to survive inference and lower to float64, got:\n%s", rendered)
+	}
+}
+
 // #357: multi-arity hint routing. The AOT :go path rebuilds each arity as a
 // single-arity defn through build-fn (pipeline lower-ns-to-go), so ^double hints
 // flow to every arity — each lowers to its own native float64-param func

--- a/pkg/ir/lisp_lower_go_test.go
+++ b/pkg/ir/lisp_lower_go_test.go
@@ -346,6 +346,50 @@ func TestLowerGoNonNumericHintStaysBoxed(t *testing.T) {
 	}
 }
 
+// #357: a ^long hint lowers to a native int param (the :int branch of the
+// hint→arg-type map, the peer of the ^double/:float case above).
+func TestLowerGoLongHintLowersToIntParam(t *testing.T) {
+	ensureLoader()
+
+	fn := buildLispIR(t, `(defn addl [^long a] (+ a 1))`)
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered status for a ^long-hinted param, got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "arg0 int") {
+		t.Fatalf("expected ^long param to lower to a native int param, got:\n%s", rendered)
+	}
+}
+
+// #530 review follow-up: a non-Named tag shape (^{:tag [long]}) has no name, so
+// tag->arg-type's guard must let it warn-and-box rather than throw on (name t).
+func TestLowerGoNonNamedHintWarnsAndBoxes(t *testing.T) {
+	ensureLoader()
+
+	var fn vm.Value
+	out := captureLetGoOut(t, func() {
+		fn = buildLispIR(t, `(defn tv [^{:tag [long]} x] x)`)
+	})
+	if !strings.Contains(out, "ignoring unsupported param type hint") {
+		t.Fatalf("expected a warning for a non-Named tag shape; stdout:\n%s", out)
+	}
+
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered (not a throw) for a non-Named tag, got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "arg0 vm.Value") {
+		t.Fatalf("expected non-Named tag to leave the param boxed, got:\n%s", rendered)
+	}
+}
+
 // Regression for PR #235 review (robustness): a genuinely ambiguous :number
 // result — e.g. (+ x x) where x is only known to be {int,float} — has no native
 // Go type, so go-type-spec must give it a lowering target (vm.Value) instead of

--- a/pkg/ir/lisp_lower_go_test.go
+++ b/pkg/ir/lisp_lower_go_test.go
@@ -240,6 +240,60 @@ func TestLowerGoStrictMixedIntFloatEqUsesEqValueNotNativeEq(t *testing.T) {
 	}
 }
 
+// #357: a ^double param hint routes to :arg-types so the param lowers to a
+// native float64 — without any explicit seedArgTypes. Before this, the AOT
+// arg-pattern matcher threw "unsupported arg pattern" on a :tag-annotated param,
+// and op-based backward inference typed a float-used param :int (float64 + int,
+// which doesn't compile — and truncates coordinates if it did).
+func TestLowerGoDoubleHintLowersToFloat64Param(t *testing.T) {
+	ensureLoader()
+
+	fn := buildLispIR(t, `(defn addf [^double a] (+ a 1.5))`)
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered status for a ^double-hinted param, got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "arg0 float64") {
+		t.Fatalf("expected ^double param to lower to a native float64 param, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "vm.Value") {
+		t.Fatalf("expected no boxing for a ^double-hinted param, got:\n%s", rendered)
+	}
+}
+
+// #357: multi-arity hint routing. The AOT :go path rebuilds each arity as a
+// single-arity defn through build-fn (pipeline lower-ns-to-go), so ^double hints
+// flow to every arity — each lowers to its own native float64-param func
+// (Scale_1 / Scale_2). Drives the ns-lowering seam, not build-fn directly:
+// build-fn's own multi-arity path produces the :multi-fn-template CLOSURE, a
+// different (boxed) representation the AOT path doesn't use.
+func TestLowerNsMultiArityDoubleHintLowersToFloat64Params(t *testing.T) {
+	ensureLoader()
+
+	v := runLispExpr(t, `(ir.passes.pipeline/lower-ns-to-go "scalepkg" (quote core)
+	  (quote [(defn scale
+	            ([^double a] (* a 2.0))
+	            ([^double a ^double b] (+ (* a 2.0) b)))]))`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go string, got %T: %v", v, v)
+	}
+	rendered := string(s)
+
+	for _, want := range []string{
+		"Scale_1(ec *vm.ExecContext, arg0 float64)",
+		"Scale_2(ec *vm.ExecContext, arg0 float64, arg1 float64)",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("multi-arity ^double hint missing %q:\n--- rendered Go ---\n%s", want, rendered)
+		}
+	}
+}
+
 // Regression for PR #235 review (robustness): a genuinely ambiguous :number
 // result — e.g. (+ x x) where x is only known to be {int,float} — has no native
 // Go type, so go-type-spec must give it a lowering target (vm.Value) instead of

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -1273,9 +1273,34 @@
           (nil? n)    (recur (drop 2 b) out)
           :else       (recur (drop 2 b) (conj out n v)))))))
 
+;; A type-hinted param — `^double a` — reaches here reified as the form
+;; (with-meta a {:tag (quote double)}). Bind the symbol and carry the tag out to
+;; :arg-types so the param lowers to a native Go type (#357). Clojure's model:
+;; the hint is a declaration, callers coerce at the boundary (coerce-arg-to-type).
+(defn- hinted-arg? [x]
+  (and (seq? x) (= 'with-meta (first x)) (symbol? (second x))))
+
+(defn- hinted-sym [x] (second x))
+
+(defn- hinted-tag [x]
+  (let [m (nth x 2 nil)
+        m (if (and (seq? m) (= 'quote (first m))) (second m) m)
+        t (when (map? m) (get m :tag))]
+    (if (and (seq? t) (= 'quote (first t))) (second t) t)))
+
+;; Numeric hint -> lattice type. double/float -> :float, long/int -> :int.
+;; Class hints (e.g. ^Foo) fall through to nil (no native numeric type).
+(defn- tag->arg-type [t]
+  (let [n (when t (name t))]
+    (cond
+      (contains? #{"double" "float"} n) :float
+      (contains? #{"long" "int"} n)     :int
+      :else                              nil)))
+
 (defn- expand-fn-args [args-vec body-forms]
   "Detect & rest and destructuring patterns in args-vec.
-   Returns nil if nothing to expand, or {:flat-args [...] :body (...) :variadic? bool}."
+   Returns nil if nothing to expand, or
+   {:flat-args [...] :body (...) :variadic? bool :arg-tags [tag-or-nil ...]}."
   (let [amp-pos   (loop [i 0 remaining args-vec]
                     (if (empty? remaining)
                       -1
@@ -1287,12 +1312,21 @@
         rest-sym   (when variadic? (nth args-vec (inc amp-pos) nil))
         has-destructure? (some (fn [x] (not (symbol? x))) fixed-args)]
     (when (or variadic? has-destructure?)
-      (let [result (loop [remaining fixed-args flat-args [] let-binds []]
+      (let [result (loop [remaining fixed-args flat-args [] let-binds [] arg-tags []]
                      (if (empty? remaining)
-                       {:flat-args flat-args :let-binds let-binds}
+                       {:flat-args flat-args :let-binds let-binds :arg-tags arg-tags}
                        (let [x (first remaining)]
-                         (if (symbol? x)
-                           (recur (rest remaining) (conj flat-args x) let-binds)
+                         (cond
+                           (symbol? x)
+                           (recur (rest remaining) (conj flat-args x) let-binds (conj arg-tags nil))
+
+                           (hinted-arg? x)
+                           (recur (rest remaining)
+                                  (conj flat-args (hinted-sym x))
+                                  let-binds
+                                  (conj arg-tags (hinted-tag x)))
+
+                           :else
                            (let [gs (gensym "p__")
                                  binds (cond
                                          (vector? x) (expand-vector-pattern gs x)
@@ -1300,16 +1334,21 @@
                                          :else (throw (str "unsupported arg pattern: " (pr-str x))))]
                              (recur (rest remaining)
                                     (conj flat-args gs)
-                                    (into let-binds binds)))))))
+                                    (into let-binds binds)
+                                    (conj arg-tags nil)))))))
             final-flat-args (if variadic?
                               (conj (:flat-args result) rest-sym)
                               (:flat-args result))
+            final-arg-tags  (if variadic?
+                              (conj (:arg-tags result) nil)
+                              (:arg-tags result))
             body (if (seq (:let-binds result))
                    (list (apply list 'let* (vec (:let-binds result)) body-forms))
                    body-forms)]
         {:flat-args final-flat-args
          :body body
-         :variadic? variadic?}))))
+         :variadic? variadic?
+         :arg-tags final-arg-tags}))))
 
 (defn- return-hinted-arity-vector? [form]
   (and (seq? form)
@@ -1469,6 +1508,14 @@
             (ir/add-terminator! f final-blk :return
                                 [last-val]
                                 nil)))
+        ;; Route numeric param hints (^double/^long) into :arg-types so the param
+        ;; lowers to a native Go type instead of vm.Value (#357). infer-arg-types
+        ;; leaves an explicitly-typed param alone, so the hint is authoritative.
+        (when-let [tags (and expanded (:arg-tags expanded))]
+          (when (some some? tags)
+            (swap! f assoc :arg-types
+                   (mapv (fn [t] (or (tag->arg-type t) :unknown))
+                         (take arity tags)))))
         f)
       ;; Multi-arity path: preserve each arity as a nested template
       ;; with a shared capture layout. The outer function (arity 0)

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -1289,9 +1289,14 @@
     (if (and (seq? t) (= 'quote (first t))) (second t) t)))
 
 ;; Numeric hint -> lattice type. double/float -> :float, long/int -> :int.
-;; Class hints (e.g. ^Foo) fall through to nil (no native numeric type).
+;; A recognized hint that isn't numeric (a class hint like ^String) returns nil:
+;; it has no native param type, so the param stays vm.Value. The routing site
+;; warns rather than dropping it silently (#530 review) — see the routing site.
 (defn- tag->arg-type [t]
-  (let [n (when t (name t))]
+  ;; Only a Named tag (symbol/keyword/string) has a name. A non-Named shape
+  ;; (e.g. ^{:tag [long]}) has no native param type -> nil (warn + box at the
+  ;; routing site) rather than throwing on (name t).
+  (let [n (when (or (symbol? t) (keyword? t) (string? t)) (name t))]
     (cond
       (contains? #{"double" "float"} n) :float
       (contains? #{"long" "int"} n)     :int
@@ -1511,10 +1516,24 @@
         ;; Route numeric param hints (^double/^long) into :arg-types so the param
         ;; lowers to a native Go type instead of vm.Value (#357). infer-arg-types
         ;; leaves an explicitly-typed param alone, so the hint is authoritative.
+        ;; A recognized but non-numeric hint (^String, a class) has no native param
+        ;; type — leave it vm.Value, but warn rather than drop it silently (#530
+        ;; review), so a mistaken or unsupported hint surfaces at build time.
+        ;; build-fn runs several times across the pipeline (collect/inline/emit),
+        ;; so this warning can repeat for one fn; it's diagnostic, not a bug.
         (when-let [tags (and expanded (:arg-tags expanded))]
           (when (some some? tags)
             (swap! f assoc :arg-types
-                   (mapv (fn [t] (or (tag->arg-type t) :unknown))
+                   (mapv (fn [t]
+                           (if (nil? t)
+                             :unknown
+                             (or (tag->arg-type t)
+                                 (do (println (str "WARNING: " name-sym
+                                                   ": ignoring unsupported param type hint ^"
+                                                   (pr-str t)
+                                                   " (only ^double/^float/^long/^int lower to a"
+                                                   " native param; left as vm.Value)"))
+                                     :unknown))))
                          (take arity tags)))))
         f)
       ;; Multi-arity path: preserve each arity as a nested template

--- a/pkg/rt/core/ir/passes/infer_arg_types.lg
+++ b/pkg/rt/core/ir/passes/infer_arg_types.lg
@@ -80,10 +80,19 @@
        (if (seq remaining)
          (let [nid (first remaining)]
            (if (= :load-arg (ir/op nid f))
-             (let [inferred (infer-one-load-arg f nid)
-                   s' (if (not= :unknown inferred)
-                        (lat/join-inst-type! s nid inferred)
-                        s)]
+             ;; An explicit numeric hint (^double/^long routed to :arg-types by
+             ;; build-fn) is authoritative — don't let the op-based backward pass
+             ;; override it with :int (#357). Skip inference for hinted params.
+             (let [idx        (ir/aux nid f)
+                   arg-types  (ir/fn-arg-types f)
+                   explicit   (when (and (vector? arg-types)
+                                         (< (int idx) (count arg-types)))
+                                (nth arg-types (int idx)))
+                   hinted?    (and explicit (not= explicit :unknown))
+                   inferred   (when-not hinted? (infer-one-load-arg f nid))
+                   s'         (if (and inferred (not= :unknown inferred))
+                                (lat/join-inst-type! s nid inferred)
+                                s)]
                (recur (rest remaining) s'))
              (recur (rest remaining) s)))
          s)))))

--- a/pkg/rt/core/ir/passes/infer_arg_types.lg
+++ b/pkg/rt/core/ir/passes/infer_arg_types.lg
@@ -32,6 +32,40 @@
     (contains? int-constraint-ops user-op) :int
     :else                                  :unknown))
 
+;; Numeric lattice types a ^double/^long hint validly stands in for: a hint
+;; declares the param numeric, and these agree with that. Const-tagged numerics
+;; ([:const :int 0]) count too.
+(defn- numeric-type? [t]
+  (or (contains? #{:int :float :number} t)
+      (and (vector? t) (= :const (first t)) (contains? #{:int :float} (second t)))))
+
+;; A proven concrete type that is neither numeric nor a don't-know type.
+;; :unknown/:any/:bottom all lower to vm.Value, so a numeric hint over them is
+;; fine — the hint is strictly more specific. Only a concrete NON-numeric type
+;; (:string, :bool, :char, a collection kind, …) actually contradicts the hint.
+(defn- concrete-non-numeric? [t]
+  (and (not (contains? #{:unknown :any :bottom} t))
+       (not (numeric-type? t))))
+
+;; Guard on the authoritative-hint override (#357). A numeric param hint wins
+;; over op-based inference, which is correct when inference is silent (:unknown)
+;; or agrees (numeric). But if the backward pass proved the param is used as a
+;; concrete non-numeric value, the hint misdescribes the body — keeping it would
+;; emit a native numeric param the code then misuses. Fail loud instead of
+;; silently miscompiling (#530 review).
+;;
+;; Unreachable today: infer-one-load-arg yields only :int or :unknown (see
+;; int-constraint-ops), so concrete-non-numeric? never holds. This is a tripwire
+;; for when arg inference grows concrete non-numeric param types — the
+;; contradiction that would introduce surfaces here instead of downstream.
+(defn- assert-hint-agrees-with-inference! [f idx hint inferred]
+  (when (concrete-non-numeric? inferred)
+    (throw (ex-info (str (ir/fn-name f) ": numeric param hint on arg " idx
+                         " (" (pr-str hint) ") contradicts its inferred type "
+                         (pr-str inferred) " — the param is used as a non-numeric value")
+                    {:pass :infer-arg-types :fn (ir/fn-name f)
+                     :arg idx :hint hint :inferred inferred}))))
+
 (defn- join-types [a b]
   "Conservative join: if either side is :unknown, return the other.
    If both agree, return that. If they disagree, fall back to :unknown
@@ -82,15 +116,20 @@
            (if (= :load-arg (ir/op nid f))
              ;; An explicit numeric hint (^double/^long routed to :arg-types by
              ;; build-fn) is authoritative — don't let the op-based backward pass
-             ;; override it with :int (#357). Skip inference for hinted params.
+             ;; override it with :int (#357). We still compute the inferred type
+             ;; for a hinted param, but only to assert the hint doesn't mask a
+             ;; concrete non-numeric contradiction (#530 review); the hint's value
+             ;; is left in place. Unhinted params join their inference as before.
              (let [idx        (ir/aux nid f)
                    arg-types  (ir/fn-arg-types f)
                    explicit   (when (and (vector? arg-types)
                                          (< (int idx) (count arg-types)))
                                 (nth arg-types (int idx)))
                    hinted?    (and explicit (not= explicit :unknown))
-                   inferred   (when-not hinted? (infer-one-load-arg f nid))
-                   s'         (if (and inferred (not= :unknown inferred))
+                   inferred   (infer-one-load-arg f nid)
+                   _          (when hinted?
+                                (assert-hint-agrees-with-inference! f idx explicit inferred))
+                   s'         (if (and (not hinted?) (not= :unknown inferred))
                                 (lat/join-inst-type! s nid inferred)
                                 s)]
                (recur (rest remaining) s'))

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-8c6e92bdf7f79a9cc2d14d76b143b157c863c513d31146c5c2f306249a00ebc8
+1950ce264d89fc31e9f119c5b7c9c5cf90263a00ff247a60e4ed3c9f1a8c5749

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-0e7bc8745f0e290befa957f17dc351fc1dcd22ed65f1d848704b574b0b615b33
+8c6e92bdf7f79a9cc2d14d76b143b157c863c513d31146c5c2f306249a00ebc8

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-46e61909c8a029c63496cf93af68a92cfdd96eb656e6121e1dd2d2ec269036b1
+0e7bc8745f0e290befa957f17dc351fc1dcd22ed65f1d848704b574b0b615b33


### PR DESCRIPTION
Re: #357. This takes the hint-based path; automatic inference of a primitive param type isn't sound (see Why), so it doesn't fully close the issue — the inference question stays open.

## Why

A float parameter constrained only by float arithmetic was typed `int`, so the lowered Go did `float64 + int` — which doesn't compile, and if it did would truncate the argument at the parameter boundary. That second part makes it a correctness bug, not just a build failure: `escape(-0.75, 0.10)` lowered with an `int` param computes against `(0, 0)` and returns the wrong iteration count.

Pure inference can't reach `float64` soundly here. `(add-to-float 3)` is legal, so the param is genuinely int-or-float, and the sound join of that is boxed — the fixpoint experiment on #357 lands on `vm.Value`, not `float64`. This is the same wall Clojure hit, and its answer is the hint, not inference: `^double`/`^long` declares the primitive, and callers coerce at the boundary.

## What

Adopt that model.

- `build-fn` accepts a `^double`/`^long` param — reified as `(with-meta a {:tag …})` — binding the symbol and routing the tag into the fn's `:arg-types` (double/float → `:float`, long/int → `:int`). Previously the arg-pattern matcher threw `unsupported arg pattern` on any `:tag`-annotated param.
- `infer-arg-types` leaves an explicitly-hinted param alone, so the hint is authoritative instead of being overridden by the op-based `:int` backward pass.
- Call-site coercion for mixed int args already works via `coerce-arg-to-type`, so nothing new is needed there.

`(defn escape [^double cx ^double cy mi] …)` now lowers to `Escape(ec, arg0 float64, arg1 float64, arg2 int) int`, compiles, and runs with correct (untruncated) values. Multi-arity comes along for free: the AOT `:go` path rebuilds each arity as a single-arity `defn` through `build-fn`, so `(defn scale ([^double a] …) ([^double a ^double b] …))` lowers to native `Scale_1`/`Scale_2`.

AOT-path only — the `ir.*` pipeline is excluded from the runtime bundle (#356), so no runtime-bundle footprint.

## Scope

Two things this deliberately leaves alone:

- The first-class multi-arity **closure** (`:multi-fn-template`) stays boxed. It lowers through `MakeNativeMultiArity`/`BoxNativeFn`, a runtime arity-dispatch across a `vm.Value` boundary, so a typed inner param only relocates the box into the reflect adapter rather than removing it — the callee is chosen at runtime, the same reason `invokePrim` doesn't engage through a boxed `IFn`.
- `^long` used in float arithmetic still needs use-site widening (an `l2d` at the op), which is `lower-go` territory.

## Tests

Two regression tests in `pkg/ir/lisp_lower_go_test.go`: single-arity via `build-fn`, and multi-arity via the `lower-ns-to-go` seam (the path that decomposes arities, distinct from `build-fn`'s own closure representation). Full `go test ./...`, the linux/wasm/plan9 cross-builds, `-race` on `pkg/rt`, and the generated-manifest check are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
