### PR TITLE
feat(rt): gate net/bencode off js/wasm; add unix bang-name aliases

### DIFF
--- a/pkg/rt/bencode.go
+++ b/pkg/rt/bencode.go
@@ -1,10 +1,14 @@
+//go:build !js
+
 /*
  * Copyright (c) 2026 let-go contributors
  * SPDX-License-Identifier: MIT
  */
 
 /*
- * bencode namespace — message framing over a net conn.
+ * bencode namespace — message framing over a net conn. Native only; js/wasm
+ * gets a stub (bencode_wasm.go) since it frames over a net conn, which the
+ * browser doesn't have.
  *
  *   (bencode/write! conn value)       → nil. Encodes one bencode value.
  *   (bencode/read! conn)              → decoded value, nil on clean EOF. Blocks.

--- a/pkg/rt/bencode_wasm.go
+++ b/pkg/rt/bencode_wasm.go
@@ -1,0 +1,37 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * bencode namespace — browser stub. bencode framing runs over a net conn,
+ * which the browser doesn't have (see net_wasm.go), so the operations can't
+ * work here. Register the namespace with stubs that fail loudly.
+ */
+
+package rt
+
+import (
+	"fmt"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func init() { RegisterInstaller(installBencodeNS) }
+
+func installBencodeNS() {
+	unsupported := func(name string) vm.Value {
+		fn, _ := vm.NativeFnType.Wrap(func(_ []vm.Value) (vm.Value, error) {
+			return vm.NIL, fmt.Errorf("bencode/%s: not supported in the browser (requires a net conn)", name)
+		})
+		return fn
+	}
+
+	ns := vm.NewNamespace("bencode")
+	for _, name := range []string{"write!", "read!"} {
+		ns.Def(name, unsupported(name))
+	}
+	RegisterNS(ns)
+}

--- a/pkg/rt/net.go
+++ b/pkg/rt/net.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 /*
  * Copyright (c) 2026 let-go contributors
  * SPDX-License-Identifier: MIT
@@ -11,9 +13,11 @@
  *   (net/read! conn max-bytes)    → byte-array, nil on clean EOF.
  *   (net/close! conn)             → nil.
  *
- * Portable (no build tag) — plain TCP. The Boxed conn also carries a
- * lazily-created bencode.Decoder so the bencode namespace (net.go's sibling
- * bencode.go) can frame messages over the same buffered stream.
+ * Native only — js/wasm gets a stub (net_wasm.go), because Go's GOOS=js net
+ * stack is an in-process fake that would connect to nothing. Plain TCP here.
+ * The Boxed conn also carries a lazily-created bencode.Decoder so the bencode
+ * namespace (net.go's sibling bencode.go) can frame messages over the same
+ * buffered stream.
  */
 
 package rt

--- a/pkg/rt/net_wasm.go
+++ b/pkg/rt/net_wasm.go
@@ -1,0 +1,41 @@
+//go:build js && wasm
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * net namespace — browser stub.
+ *
+ * Go's GOOS=js net stack is an in-process fake: net.Dial there resolves against
+ * nothing real, so a browser build would "succeed" and then never talk to a
+ * host. Register the namespace with stubs that fail loudly instead, matching
+ * the native surface (net.go) name-for-name so a require doesn't break and the
+ * error only fires if a program actually reaches for the network.
+ */
+
+package rt
+
+import (
+	"fmt"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func init() { RegisterInstaller(installNetNS) }
+
+func installNetNS() {
+	unsupported := func(name string) vm.Value {
+		fn, _ := vm.NativeFnType.Wrap(func(_ []vm.Value) (vm.Value, error) {
+			return vm.NIL, fmt.Errorf("net/%s: not supported in the browser (no host TCP)", name)
+		})
+		return fn
+	}
+
+	ns := vm.NewNamespace("net")
+	for _, name := range []string{"dial", "write!", "read!", "close!"} {
+		ns.Def(name, unsupported(name))
+	}
+	RegisterNS(ns)
+}

--- a/pkg/rt/unix_alias_test.go
+++ b/pkg/rt/unix_alias_test.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// unixConnPair returns two connected *net.UnixConn via socketpair(2).
+func unixConnPair(t *testing.T) (*net.UnixConn, *net.UnixConn) {
+	t.Helper()
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	mk := func(fd int) *net.UnixConn {
+		f := os.NewFile(uintptr(fd), "unixpair")
+		c, err := net.FileConn(f)
+		_ = f.Close() // FileConn dups the fd; drop ours
+		if err != nil {
+			t.Fatalf("FileConn: %v", err)
+		}
+		uc, ok := c.(*net.UnixConn)
+		if !ok {
+			t.Fatalf("expected *net.UnixConn, got %T", c)
+		}
+		return uc
+	}
+	return mk(fds[0]), mk(fds[1])
+}
+
+// TestUnixBangAliases checks that the canonical bang names (#526) resolve, that
+// they carry data end to end, and that the deprecated pre-bang names still
+// resolve and delegate.
+func TestUnixBangAliases(t *testing.T) {
+	for _, name := range []string{"write!", "read!", "close!", "send", "recv", "close"} {
+		_ = nsFn(t, "unix", name) // fails the test if unregistered or not an Fn
+	}
+
+	a, b := unixConnPair(t)
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	av, bv := vm.NewBoxed(a), vm.NewBoxed(b)
+
+	// write! on one end → read! on the other returns the bytes under :data.
+	if _, err := nsFn(t, "unix", "write!").Invoke([]vm.Value{av, vm.String("ping")}); err != nil {
+		t.Fatalf("unix/write!: %v", err)
+	}
+	res, err := nsFn(t, "unix", "read!").Invoke([]vm.Value{bv, vm.MakeInt(16), vm.MakeInt(0)})
+	if err != nil {
+		t.Fatalf("unix/read!: %v", err)
+	}
+	m, ok := res.(vm.Lookup)
+	if !ok {
+		t.Fatalf("unix/read! returned %T, want a map", res)
+	}
+	if got := m.ValueAt(vm.Keyword("data")); got != vm.String("ping") {
+		t.Fatalf("unix/read! :data = %#v, want \"ping\"", got)
+	}
+
+	// The deprecated alias still delegates (and prints a one-time notice).
+	if _, err := nsFn(t, "unix", "send").Invoke([]vm.Value{av, vm.String("x")}); err != nil {
+		t.Fatalf("unix/send (deprecated alias): %v", err)
+	}
+}

--- a/pkg/rt/unix_linux.go
+++ b/pkg/rt/unix_linux.go
@@ -28,10 +28,29 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 	"syscall"
 
 	"github.com/nooga/let-go/pkg/vm"
 )
+
+// deprecatedAlias wraps fn so the first call in a process prints a one-time
+// notice steering callers to newName, then delegates. Used to keep the
+// pre-bang unix verbs (send/recv/close) working while the bang names
+// (write!/read!/close!) become canonical — matching the net namespace and the
+// Clojure side-effect convention (nooga/let-go#526). sync.Once keeps the
+// warn-once flag race-free under the -race CI.
+func deprecatedAlias(oldName, newName string, fn vm.Value) vm.Value {
+	inner := fn.(vm.Fn)
+	var once sync.Once
+	wrapped, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		once.Do(func() {
+			_ = WriteToErr(nil, fmt.Sprintf("unix/%s is deprecated; use unix/%s\n", oldName, newName))
+		})
+		return inner.Invoke(vs)
+	})
+	return wrapped
+}
 
 func init() { RegisterInstaller(installUnixNS) }
 
@@ -246,9 +265,14 @@ func installUnixNS() {
 	ns.Def("listen", listenFn)
 	ns.Def("accept", acceptFn)
 	ns.Def("connect", connectFn)
-	ns.Def("send", sendFn)
-	ns.Def("recv", recvFn)
-	ns.Def("close", closeFn)
+	// Canonical bang names for the side-effecting ops (#526); send/recv/close
+	// stay as deprecated aliases for one or more releases.
+	ns.Def("write!", sendFn)
+	ns.Def("read!", recvFn)
+	ns.Def("close!", closeFn)
+	ns.Def("send", deprecatedAlias("send", "write!", sendFn))
+	ns.Def("recv", deprecatedAlias("recv", "read!", recvFn))
+	ns.Def("close", deprecatedAlias("close", "close!", closeFn))
 	ns.Def("fd", fdFn)
 	RegisterNS(ns)
 }

--- a/pkg/rt/unix_other.go
+++ b/pkg/rt/unix_other.go
@@ -24,7 +24,12 @@ func installUnixNS() {
 	}
 
 	ns := vm.NewNamespace("unix")
-	for _, name := range []string{"listen", "accept", "connect", "send", "recv", "close", "fd"} {
+	for _, name := range []string{
+		"listen", "accept", "connect",
+		"write!", "read!", "close!", // canonical bang names (#526)
+		"send", "recv", "close", // deprecated aliases, kept for parity with Linux
+		"fd",
+	} {
 		ns.Def(name, unsupported(name))
 	}
 	RegisterNS(ns)


### PR DESCRIPTION
## What

Follow-up to #526, doing the two things the review there asked for.

**WASM gating.** `net.go` and `bencode.go` shipped with no build tag, so they compiled into the browser build too. Go's `GOOS=js` net stack is an in-process fake — `net/dial` there resolves against nothing and "succeeds", so a browser build never fails cleanly. This build-tags both files native (`!js`) and adds browser stubs (`net_wasm.go`, `bencode_wasm.go`) that register the same namespace surface with functions returning a clear "not supported in the browser" error. Matches the existing `pods.go`/`pods_wasm.go` and `unix_linux.go`/`unix_other.go` split. Requiring `net`/`bencode` still works in the browser; the error only fires if a program reaches for the network.

**Naming convergence (#526).** `net` uses the Clojure side-effect bang convention — `write!`/`read!`/`close!`. This adds the same names to `unix` as the canonical verbs and keeps `send`/`recv`/`close` as deprecated aliases: they print a one-time notice (`unix/send is deprecated; use unix/write!`) and delegate. `unix_other.go` mirrors the new names so the namespace surface is identical across platforms.

## Notes

- The deprecation notice is warn-once per name via `sync.Once`, so it's quiet after the first call and race-free under the `-race` CI added in #524.
- Aliases point at the existing `send`/`recv`/`close` implementations unchanged — no behavior change to the ops themselves, just the names and the notice.
- Lifecycle verbs (`unix/connect` vs `net/dial`, `listen`, `accept`) are left alone; the bang convention only speaks to the read/write/close ops.

## Test

`TestUnixBangAliases` (linux): checks the canonical and deprecated names all resolve, round-trips a message through `unix/write!` → `unix/read!` over a `socketpair`, and exercises a deprecated alias to confirm it still delegates. Ran the full `pkg/rt` suite on Linux with `-race` (net, bencode, unix all green, deprecation notice observed); builds clean on `js/wasm`, `wasip1/wasm`, linux, darwin, and plan9.
