### PR TITLE
fix(ir): widen int operand to float64 in mixed int/float native lowering

### DIFF
--- a/pkg/ir/lisp_lower_go_test.go
+++ b/pkg/ir/lisp_lower_go_test.go
@@ -211,6 +211,35 @@ func TestLowerGoStrictMixedIntFloatComparisonWidensIntOperand(t *testing.T) {
 	}
 }
 
+// Regression for #534: the int→float widening is sound for arithmetic and
+// ordering, but NOT for `=`. Clojure `=` is category-sensitive across the
+// numeric tower — (= 1 1.0) is false — whereas widening the int to float64 and
+// comparing with native Go == makes `(= col 1.0)` return true at col=1,
+// diverging from the bytecode VM. A mixed concrete int/float `=` must route to
+// rt.EqValue (which delegates to vm.ValueEquals), not native ==.
+func TestLowerGoStrictMixedIntFloatEqUsesEqValueNotNativeEq(t *testing.T) {
+	ensureLoader()
+
+	fn := buildLispIR(t, `(defn eqf [col] (= col 1.0))`)
+	seedArgTypes(t, fn, "[:int]")
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered status for mixed int/float =, got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "EqValue") {
+		t.Fatalf("expected a mixed int/float = to route to rt.EqValue (Clojure value-equality), got:\n%s", rendered)
+	}
+	// A native `==` here would be the divergence: float64(col) == 1.0 is true at
+	// col=1, but Clojure (= 1 1.0) is false.
+	if strings.Contains(rendered, "==") {
+		t.Fatalf("expected NO native == for a cross-type = (it would violate Clojure's category-sensitive =), got:\n%s", rendered)
+	}
+}
+
 // Regression for PR #235 review (robustness): a genuinely ambiguous :number
 // result — e.g. (+ x x) where x is only known to be {int,float} — has no native
 // Go type, so go-type-spec must give it a lowering target (vm.Value) instead of

--- a/pkg/ir/lisp_lower_go_test.go
+++ b/pkg/ir/lisp_lower_go_test.go
@@ -164,6 +164,53 @@ func TestLowerGoStrictMixedIntFloatInfersNativeFloat(t *testing.T) {
 	}
 }
 
+// Regression for #534: a mixed concrete int/float arithmetic op (int param
+// times a float literal) lowers to a NATIVE float op — but Go rejects `int *
+// float64`, and an untyped float constant against an int operand is a hard
+// compile error ("0.0625 truncated to int"). The int operand must be widened
+// with float64(...) so the emitted Go actually compiles.
+func TestLowerGoStrictMixedIntFloatArithWidensIntOperand(t *testing.T) {
+	ensureLoader()
+
+	fn := buildLispIR(t, `(defn cx [col] (* 0.0625 col))`)
+	seedArgTypes(t, fn, "[:int]")
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered status for mixed int/float arithmetic, got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "float64(") {
+		t.Fatalf("expected the int operand widened to float64 (else the untyped float const truncates to int), got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "MulValue") {
+		t.Fatalf("expected native float multiply, not a boxed rt.MulValue helper, got:\n%s", rendered)
+	}
+}
+
+// Regression for #534: the same int→float widening is required in a mixed
+// int/float COMPARISON — `col < 0.5` with an int param is `int < float64`,
+// which Go likewise rejects. The int side must be widened.
+func TestLowerGoStrictMixedIntFloatComparisonWidensIntOperand(t *testing.T) {
+	ensureLoader()
+
+	fn := buildLispIR(t, `(defn lt [col] (< col 0.5))`)
+	seedArgTypes(t, fn, "[:int]")
+	optimizeLispIR(t, fn)
+	result := lowerGo(t, fn, ":strict")
+
+	if got := result.ValueAt(vm.Keyword("status")); got != vm.Keyword("lowered") {
+		t.Fatalf("expected :lowered status for mixed int/float comparison, got %v (reason=%v)",
+			got, result.ValueAt(vm.Keyword("reason")))
+	}
+	rendered := bindAndRenderGoDecl(t, result)
+	if !strings.Contains(rendered, "float64(") {
+		t.Fatalf("expected the int operand widened to float64 in the comparison, got:\n%s", rendered)
+	}
+}
+
 // Regression for PR #235 review (robustness): a genuinely ambiguous :number
 // result — e.g. (+ x x) where x is only known to be {int,float} — has no native
 // Go type, so go-type-spec must give it a lowering target (vm.Value) instead of

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -824,13 +824,20 @@
             bitwise-rt?  (and bitwise-op?
                               (or (not (= "int" s0))
                                   (not (= "int" s1))))
+            ;; Cross-type `=`: two concrete but DIFFERENT numeric types (int vs
+            ;; float64) must route to rt.EqValue, not native ==. Clojure `=` is
+            ;; category-sensitive across the numeric tower — (= 1 1.0) is false —
+            ;; but widening the int side to float64 (as the arithmetic path does
+            ;; below) and comparing with Go == would make it true. Same-type
+            ;; concrete scalars keep native == below, which is correct. (#534)
+            eq-cross-type? (and (= op :eq) (not= s0 s1))
             ;; rt.LtValue/AddValue/... polymorphic helpers — used when any
             ;; operand is vm.Value (so we don't bail the whole defn), or when
             ;; quot/div need the runtime divide (above). Each helper mirrors the
             ;; bytecode VM's OP_<X>: vm.Int fast path then vm.Num<X> fallback for
             ;; ordering; always-delegate to vm.Num<X> for arithmetic (keeps
             ;; overflow / BigInt / Ratio promotion semantics in one place).
-            vm-helper    (when (or any-vm? quot-rt? div-rt? bitwise-rt?)
+            vm-helper    (when (or any-vm? quot-rt? div-rt? bitwise-rt? eq-cross-type?)
                            (cond
                              (= op-str "<")  "LtValue"
                              (= op-str "<=") "LeValue"
@@ -848,12 +855,15 @@
                              (= op :unsigned-bit-shift-right) "UnsignedBitShiftRightValue"
                              (= op :quot)    "QuotValue"
                              (= op :div)     "DivValue"
-                             ;; = on a vm.Value operand: Clojure value-equality,
-                             ;; NOT Go ==. Go's == panics on non-comparable
-                             ;; dynamic types (vectors/maps/seqs) and compares by
-                             ;; identity, not value. rt.EqValue -> vm.ValueEquals.
-                             ;; (Concrete comparable scalars keep native == since
-                             ;; any-vm? is false and we never reach here.)
+                             ;; = routed here for a vm.Value operand OR two
+                             ;; concrete-but-different numeric types (eq-cross-type?):
+                             ;; Clojure value-equality, NOT Go ==. Go's == panics on
+                             ;; non-comparable dynamic types (vectors/maps/seqs) and
+                             ;; compares by identity, not value — and (= 1 1.0) must
+                             ;; be false, which a widened native float == would break.
+                             ;; rt.EqValue -> vm.ValueEquals. (Same-type concrete
+                             ;; scalars keep native == below: neither any-vm? nor
+                             ;; eq-cross-type? fires.)
                              (= op :eq)      "EqValue"
                              :else           nil))
             ;; Mixed operand types (only meaningful when NOT routing
@@ -891,9 +901,13 @@
           ;; an untyped float constant against an int operand is a hard compile
           ;; error ("0.0625 truncated to int"). Widen the int side to float64 so
           ;; the native op runs in float, same as the VM's int→float promotion.
-          ;; Only int/float64 reach here mixed: quot ("/") is native for int/int
-          ;; only, div for float/float only, and bitwise/shift ops for int/int
-          ;; only — every other mix already routes through a vm-helper. (#534)
+          ;; Only int/float64 arithmetic and ordering reach here mixed: quot ("/")
+          ;; is native for int/int only, div for float/float only, bitwise/shift
+          ;; ops for int/int only, and a cross-type `=` routes to rt.EqValue (Go
+          ;; float == would violate Clojure's category-sensitive =) — every other
+          ;; mix already routes through a vm-helper. Widening the int side is
+          ;; sound for +,-,*,<,<=,>,>= (all numeric), where (< 1 0.5) == (< 1.0
+          ;; 0.5); it would NOT be sound for =, which is why that case is gone. (#534)
           (let [l (if (and (= "int" s0) (= "float64" s1)) (float64-cast lhs-expr) lhs-expr)
                 r (if (and (= "float64" s0) (= "int" s1)) (float64-cast rhs-expr) rhs-expr)
                 raw-binary (cond

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -788,6 +788,8 @@
 
 (def ^:private comparison-op? #{"==" "!=" "<" "<=" ">" ">="})
 
+(defn- float64-cast [expr] (gogen/call (gogen/ident "float64") [expr]))
+
 (defn- inst-rhs [f closed-exprs nid]
   (let [op   (ir/op nid f)
         refs (ir/refs nid f)]
@@ -884,14 +886,24 @@
 
           ;; Native Go binary path: both operands typed compatibly.
           (and lhs-expr rhs-expr)
-          (let [raw-binary (cond
+          ;; Mixed concrete int/float64: typeinfer promotes such an op to :float
+          ;; (matching the numeric tower), but Go rejects `int <op> float64` — and
+          ;; an untyped float constant against an int operand is a hard compile
+          ;; error ("0.0625 truncated to int"). Widen the int side to float64 so
+          ;; the native op runs in float, same as the VM's int→float promotion.
+          ;; Only int/float64 reach here mixed: quot ("/") is native for int/int
+          ;; only, div for float/float only, and bitwise/shift ops for int/int
+          ;; only — every other mix already routes through a vm-helper. (#534)
+          (let [l (if (and (= "int" s0) (= "float64" s1)) (float64-cast lhs-expr) lhs-expr)
+                r (if (and (= "float64" s0) (= "int" s1)) (float64-cast rhs-expr) rhs-expr)
+                raw-binary (cond
                              (= op :unsigned-bit-shift-right)
                              (gogen/call (gogen/ident "int")
                                [(gogen/binary ">>"
-                                  (gogen/call (gogen/ident "uint") [lhs-expr])
-                                  (gogen/call (gogen/ident "uint") [rhs-expr]))])
+                                  (gogen/call (gogen/ident "uint") [l])
+                                  (gogen/call (gogen/ident "uint") [r]))])
                              :else
-                             (gogen/binary op-str lhs-expr rhs-expr))]
+                             (gogen/binary op-str l r))]
             (if (and (comparison-op? op-str) (= "vm.Value" result-spec))
               (gogen/call (gogen/field-sel (gogen/ident "vm") "Boolean") [raw-binary])
               raw-binary))

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-36782d759c49325d2c35bf9fb364f1cd33b4db657d77654f5efb02b038368722
+6c47b43eba78381ba76a784c091129b53ae74d4b6c1626ed81e4b6da6d96719c

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-6c47b43eba78381ba76a784c091129b53ae74d4b6c1626ed81e4b6da6d96719c
+46e61909c8a029c63496cf93af68a92cfdd96eb656e6121e1dd2d2ec269036b1


### PR DESCRIPTION
Closes #534. This is the use-site-widening half flagged in #530's scope: the `l2d`-at-the-op case that param hints don't reach.

## Why

`typeinfer` already promotes a mixed int/float arithmetic op to `:float` by numeric contagion, so the result local is declared `float64`. But the native binary path emitted the operands bare, so an int operand against a float lowered to `int <op> float64`, which Go rejects. Against an untyped float *constant* it's a hard compile error rather than a type mismatch:

```clojure
(defn cx-of [col] (+ -2.5 (* 0.0625 col)))
```

lowered to `arg0 * 0.0625`, and `go build` fails with `0.0625 (untyped float constant) truncated to int`. The same defect hit mixed *comparisons* — `(< col 0.5)` with an int param emits `col < 0.5`, equally invalid.

It surfaced validating #530 on a mandelbrot: the `^double`-hinted escape kernel lowers and runs correctly (2337-cell match against the bytecode VM), but the grid helpers `(* 0.0625 col)` (an unhinted int column times a float step) wouldn't build.

## What

Widen the int side with `float64(...)` in the native binary path, matching the VM's int→float promotion. `cx-of` now lowers to `float64(arg0) * 0.0625`.

The check keys on the operand specs, not the result type (one operand `int`, the other `float64`), so it covers the comparison case too (`float64(col) < 0.5`), where the result is `bool` rather than `float64`.

The widen is unconditional at this site because only int/float64 can reach it mixed: `quot` lowers native for int/int only, `div` for float/float only, and bitwise/shift ops for int/int only — every other operand mix already routes through a `vm.*Value` helper before this branch. So there's no op here where promoting the int to float would be wrong.

Emission-only; `typeinfer` is untouched. `generated.sums` is regenerated (it digests the touched `.lg` source); `core_compiled.lgb` is unaffected, since `ir.lower-go` is the on-demand AOT tool, not an embedded namespace.

## Tests

Two regression tests in `pkg/ir/lisp_lower_go_test.go`: mixed arithmetic and mixed comparison, each asserting the int operand is widened and the op stays native (no boxed `*Value` helper). Full `go test ./...`, the linux and js/wasm and plan9/amd64 cross-builds, `-race` on `pkg/ir` and `pkg/rt`, and the generated-manifest check are green.
