### PR TITLE
fix(lgbgen): stage --target=go output, install atomically, add completeness sentinel

### DIFF
--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -15,6 +15,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -790,20 +791,27 @@ func runGoTarget(outDir, codeDir string) {
 		os.Exit(1)
 	}
 
-	// Hermetic generation: clear the output dir first so orphaned packages
-	// from a previous run (a renamed/removed namespace, or another branch's
-	// output left on disk) can't survive into this run. Such strays are
-	// gitignored — invisible to `jj`/`git status` — yet they break the
-	// `go build -tags gogen_ir ./...` step (a stray package with stale or
-	// invalid Go fails the build). The dir is fully recreated below.
+	// Generate into a staging sibling and swap into place only on success.
+	// Lowering takes minutes (typeinfer), and the old clean-then-write-in-place
+	// flow left the real tree half-deleted for that whole window — a killed or
+	// crashed run broke every subsequent `go build -tags gogen_ir` until the
+	// next full regeneration. Staging starts empty, so hermeticity (no orphaned
+	// packages from a renamed/removed namespace) comes for free; the real dir
+	// is cleaned of previously-generated files at swap time.
 	//
 	// This lives here, not in scripts/generate.lg, because runGoTarget is the
 	// single point where both `--target=go` and `--target=both` converge, so
 	// every caller (make generate, make lowered, make check-generated) gets
-	// the clean.
-	cleanGoOutputDir(outDir)
+	// the same crash-safety.
+	realOutDir := outDir
+	outDir = realOutDir + ".stage"
+	if err := os.RemoveAll(outDir); err != nil {
+		fmt.Fprintf(os.Stderr, "clear staging dir %s: %v\n", outDir, err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(outDir)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "create output dir %s: %v\n", outDir, err)
+		fmt.Fprintf(os.Stderr, "create staging dir %s: %v\n", outDir, err)
 		os.Exit(1)
 	}
 
@@ -947,14 +955,57 @@ func runGoTarget(outDir, codeDir string) {
 		// distinct paths.
 		generated = append(generated, filepath.ToSlash(spec.relDir))
 	}
-	// Emit the //go:build gogen_ir blank-import wireup files from exactly
-	// the set we just wrote — so namespaces that were skipped or failed to
-	// lower are never imported (which would break the tagged build).
-	writeGogenWireup(generated, codeDir)
 	if len(failed) > 0 {
+		// Bail before touching the real tree or the wireup files — a failed
+		// run leaves the previous consistent generation fully intact.
 		fmt.Fprintf(os.Stderr, "lgbgen: %d namespace(s) failed: %v\n", len(failed), failed)
 		os.Exit(1)
 	}
+	// Success: install the staged tree (fast per-file renames — the exposed
+	// window shrinks from the whole lowering to milliseconds), then emit the
+	// //go:build gogen_ir blank-import wireup files from exactly the set we
+	// just installed — so namespaces that were skipped are never imported
+	// (which would break the tagged build).
+	if err := installGeneratedTree(outDir, realOutDir); err != nil {
+		fmt.Fprintf(os.Stderr, "lgbgen: install lowered tree into %s: %v\n", realOutDir, err)
+		os.Exit(1)
+	}
+	writeGogenWireup(generated, codeDir)
+}
+
+// installGeneratedTree moves the staged generation into the real output dir:
+// the completeness sentinel is invalidated first, previously-generated
+// (bannered) files in realDir are removed — same orphan-cleanup contract as
+// before staging existed — then every staged file is renamed into place and a
+// fresh sentinel is written last. Rename is cheap and same-filesystem
+// (sibling dirs), so the tree is only ever inconsistent for the duration of
+// this loop — and that window is positively detectable via the sentinel
+// (genmanifest.CheckTreeManifest).
+func installGeneratedTree(stageDir, realDir string) error {
+	if err := os.Remove(filepath.Join(realDir, genmanifest.TreeManifestName)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	cleanGoOutputDir(realDir)
+	if err := filepath.WalkDir(stageDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(stageDir, path)
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(realDir, rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return err
+		}
+		return os.Rename(path, dst)
+	}); err != nil {
+		return err
+	}
+	return genmanifest.WriteTreeManifest(realDir)
 }
 
 // writeGogenWireup emits the //go:build gogen_ir blank-import files that

--- a/pkg/genmanifest/tree.go
+++ b/pkg/genmanifest/tree.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package genmanifest
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// TreeManifestName is the sentinel file lgbgen writes at the root of the
+// generated lowered tree (pkg/rt/core_go_lowered) as the LAST step of a
+// successful generation. It lists a sha256 per generated file, so consumers
+// can positively distinguish "complete tree" from "torn or partially written
+// tree" instead of discovering the latter via cryptic build failures. The
+// generator removes it first thing on reinstall, so a crash mid-install can
+// never leave a valid sentinel over an inconsistent tree.
+const TreeManifestName = ".lgbgen-tree.sum"
+
+// hashFile returns the hex sha256 of one file's contents.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// treeFiles returns the sorted slash-relative paths of every regular file
+// under dir, excluding the manifest itself.
+func treeFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == TreeManifestName {
+			return nil
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// WriteTreeManifest hashes every file under dir and writes the sentinel
+// manifest ("<sha256>  <relpath>" per line, sorted). Call it only after the
+// tree is fully written — its presence asserts completeness.
+func WriteTreeManifest(dir string) error {
+	files, err := treeFiles(dir)
+	if err != nil {
+		return err
+	}
+	var b strings.Builder
+	for _, rel := range files {
+		sum, err := hashFile(filepath.Join(dir, rel))
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(&b, "%s  %s\n", sum, rel)
+	}
+	return os.WriteFile(filepath.Join(dir, TreeManifestName), []byte(b.String()), 0644)
+}
+
+// CheckTreeManifest verifies the generated tree at dir against its sentinel
+// manifest: the sentinel must exist, every listed file must be present with
+// matching contents, and no unlisted files may have appeared. A nil error
+// means the tree is exactly the one a successful generation wrote.
+func CheckTreeManifest(dir string) error {
+	f, err := os.Open(filepath.Join(dir, TreeManifestName))
+	if os.IsNotExist(err) {
+		return fmt.Errorf("no %s in %s — tree incomplete or never generated", TreeManifestName, dir)
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	want := map[string]string{}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" {
+			continue
+		}
+		sum, rel, ok := strings.Cut(line, "  ")
+		if !ok {
+			return fmt.Errorf("malformed %s line: %q", TreeManifestName, line)
+		}
+		want[rel] = sum
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+
+	have, err := treeFiles(dir)
+	if err != nil {
+		return err
+	}
+	haveSet := map[string]bool{}
+	for _, rel := range have {
+		haveSet[rel] = true
+		sum, ok := want[rel]
+		if !ok {
+			return fmt.Errorf("unlisted file %s in %s (stray or partial regeneration)", rel, dir)
+		}
+		got, err := hashFile(filepath.Join(dir, rel))
+		if err != nil {
+			return err
+		}
+		if got != sum {
+			return fmt.Errorf("checksum mismatch for %s in %s", rel, dir)
+		}
+	}
+	for rel := range want {
+		if !haveSet[rel] {
+			return fmt.Errorf("missing file %s in %s (torn tree)", rel, dir)
+		}
+	}
+	return nil
+}

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-1950ce264d89fc31e9f119c5b7c9c5cf90263a00ff247a60e4ed3c9f1a8c5749
+8ca20b35ebed10708a18ad910054be400b53e1cc22d23096c4ed821e40b21891

--- a/test/e2e/gogen_aot_diff_test.go
+++ b/test/e2e/gogen_aot_diff_test.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/nooga/let-go/pkg/genmanifest"
 )
 
 // Differential self-AOT execution harness.
@@ -103,10 +105,18 @@ func TestGogenAOTDiff(t *testing.T) {
 		t.Skip("differential self-AOT harness builds let-go twice; run via `make gogen-diff`")
 	}
 
+	root := repoRoot(t)
+
+	// The -tags gogen_ir build below imports the gitignored generated tree.
+	// Validate it against its completeness sentinel first, so a torn or
+	// missing tree fails with an actionable message instead of a wall of
+	// "no required module provides package .../core_go_lowered/..." errors.
+	if err := genmanifest.CheckTreeManifest(filepath.Join(root, "pkg/rt/core_go_lowered")); err != nil {
+		t.Fatalf("generated lowered tree is not valid: %v\nrun `make generate` (or `make lowered`) and retry", err)
+	}
+
 	bc := buildLGTags(t, "")
 	aot := buildLGTags(t, "gogen_ir")
-
-	root := repoRoot(t)
 	goldAOTDir := filepath.Join(root, "test/gold-aot")
 	aotXfailFile := filepath.Join(root, "test/gogen_aot_xfail.txt")
 


### PR DESCRIPTION
## Problem

`lgbgen --target=go` deleted the whole `pkg/rt/core_go_lowered/` tree and rewrote it in place. Lowering takes minutes (typeinfer), so a killed or crashed run left a torn, **gitignored** tree — invisible to `git`/`jj status` — that broke every subsequent `-tags gogen_ir` build with a wall of `no required module provides package .../core_go_lowered/...` errors. The tree only self-repaired on the next full regeneration, which made the failures look flaky (this bit the #429 pre-push gate repeatedly before being root-caused).

## Fix

- **Staged install**: generation writes to `core_go_lowered.stage/`, and only on success installs into place via per-file renames. The exposed window shrinks from the whole lowering to milliseconds, and a failed/killed run leaves the previous consistent tree fully intact (previously it left rubble).
- **Completeness sentinel**: a `.lgbgen-tree.sum` file (sha256 per generated file) is written as the last install step and removed as the first step of a reinstall, so its validity positively asserts a complete tree: `genmanifest.WriteTreeManifest` / `CheckTreeManifest`.
- **Actionable failure**: `TestGogenAOTDiff` validates the sentinel before building with `-tags gogen_ir`. A torn tree now fails in 0.01s with `run make generate (or make lowered) and retry` instead of the module-resolution wall.

## Verification

- Full `./test/e2e` (incl. `TestLoweringDeterminism`, which regenerates via the new staged path), `./pkg/genmanifest`, `./cmd/lgbgen` — green.
- Torn-tree simulation (deleted `edn/edn.go` from a valid tree): `TestGogenAOTDiff` fails immediately with `missing file edn/edn.go ... (torn tree)`.
- `generated.sums` refreshed (lgbgen sources are generator inputs); `make check-generated` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
