### PR TITLE
fix(vm): synchronize BoxedTypes cache and Boxed.Hash() lazy cache

### DIFF
--- a/pkg/rt/net.go
+++ b/pkg/rt/net.go
@@ -141,13 +141,6 @@ func installNetNS() {
 		return vm.NIL, nil
 	})
 
-	// Warm vm.NewBoxed's type cache for *netConn now, while installers run
-	// single-threaded. The cache (vm.BoxedTypes) is an unsynchronized map, so
-	// the first boxing of a not-yet-seen type must not race; after this, every
-	// net/dial only reads the cache. (The map itself is shared by all Boxed
-	// types across the VM — a broader fix belongs in pkg/vm, not here.)
-	_ = vm.NewBoxed(&netConn{})
-
 	ns := vm.NewNamespace("net")
 	ns.Def("dial", dialFn)
 	ns.Def("write!", writeFn)

--- a/pkg/vm/boxed.go
+++ b/pkg/vm/boxed.go
@@ -8,6 +8,8 @@ package vm
 import (
 	"fmt"
 	"reflect"
+	"sync"
+	"sync/atomic"
 )
 
 type aBoxedType struct {
@@ -28,10 +30,13 @@ func (t *aBoxedType) Box(value any) (Value, error) {
 }
 
 type Boxed struct {
-	value  any
-	typ    *aBoxedType
-	hash   uint32
-	hashed bool
+	value any
+	typ   *aBoxedType
+	// hash caches the String-based hash lazily. It packs the "computed" flag
+	// into bit 32 so a legitimate hash of 0 still reads as cached: 0 means
+	// uncomputed, otherwise the low 32 bits hold the hash. Atomic so
+	// concurrent Hash() callers don't race (both compute the same value).
+	hash atomic.Uint64
 }
 
 // Type implements Value
@@ -53,11 +58,12 @@ func (n *Boxed) String() string {
 // identical to the old computeHash fallback, so map/set semantics are
 // unchanged — only the repeated Sprintf is eliminated.
 func (n *Boxed) Hash() uint32 {
-	if !n.hashed {
-		n.hash = hashString(n.String())
-		n.hashed = true
+	if packed := n.hash.Load(); packed != 0 {
+		return uint32(packed)
 	}
-	return n.hash
+	h := hashString(n.String())
+	n.hash.Store(uint64(1)<<32 | uint64(h))
+	return h
 }
 
 func (n *Boxed) InvokeMethod(methodName Symbol, args []Value) (Value, error) {
@@ -87,8 +93,14 @@ func (n *Boxed) ValueAtOr(key Value, dflt Value) Value {
 	return v
 }
 
-// BoxedType is the type of NilValues
-var BoxedTypes map[string]*aBoxedType = map[string]*aBoxedType{}
+// BoxedType is the type of NilValues. Guarded by boxedTypesMu: boxing values
+// from multiple goroutines (e.g. parallel lowering) otherwise races on this
+// shared map, which is a runtime panic for concurrent writes, not just a
+// detector warning.
+var (
+	boxedTypesMu sync.RWMutex
+	BoxedTypes   map[string]*aBoxedType = map[string]*aBoxedType{}
+)
 
 func valueType(value any) *aBoxedType {
 	reflected := reflect.TypeOf(value)
@@ -97,10 +109,16 @@ func valueType(value any) *aBoxedType {
 	// distinct pointer types would collide on the empty key and the first
 	// boxed pointer would shadow every subsequent one.
 	key := reflected.String()
+
+	boxedTypesMu.RLock()
 	t, ok := BoxedTypes[key]
+	boxedTypesMu.RUnlock()
 	if ok {
 		return t
 	}
+
+	// Build the method table outside the write lock — reflection is the
+	// expensive part and needs no mutual exclusion.
 	t = &aBoxedType{
 		typ:     reflected,
 		methods: nil,
@@ -122,6 +140,15 @@ func valueType(value any) *aBoxedType {
 			}
 			t.methods[Symbol(m.Name)] = mef
 		}
+	}
+
+	// Recheck under the write lock: a concurrent caller may have inserted the
+	// same key while we built our table. First writer wins so every caller
+	// shares one *aBoxedType per type.
+	boxedTypesMu.Lock()
+	defer boxedTypesMu.Unlock()
+	if existing, ok := BoxedTypes[key]; ok {
+		return existing
 	}
 	BoxedTypes[key] = t
 	return t

--- a/pkg/vm/boxed_race_test.go
+++ b/pkg/vm/boxed_race_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"sync"
+	"testing"
+)
+
+// Fresh types seen for the first time inside these tests, so the concurrent
+// boxing below exercises the BoxedTypes insert path rather than a warm cache.
+type boxRaceMapType struct{ n int }
+type boxRaceHashType struct{ n int }
+
+// TestBoxedTypesConcurrentBoxing pins down the BoxedTypes map race: many
+// goroutines boxing the same not-yet-cached type at once hit lookup+insert
+// concurrently (a plain-map data race, and a "concurrent map writes" panic).
+// All callers must converge on the single shared *aBoxedType for the type.
+func TestBoxedTypesConcurrentBoxing(t *testing.T) {
+	const goroutines = 32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]*Boxed, goroutines)
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i] = NewBoxed(boxRaceMapType{i})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	typ := results[0].typ
+	for i, b := range results {
+		if b.typ != typ {
+			t.Fatalf("goroutine %d resolved a different *aBoxedType (%p vs %p)", i, b.typ, typ)
+		}
+	}
+}
+
+// TestBoxedConcurrentHash pins down the Hash() lazy-cache race: many goroutines
+// racing to first-compute the cached hash of one shared Boxed. The expected
+// value is derived independently so the cache is genuinely cold at spawn time.
+func TestBoxedConcurrentHash(t *testing.T) {
+	const goroutines = 32
+	shared := NewBoxed(boxRaceHashType{7})
+	want := hashString(shared.String()) // independent of the lazy cache
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	got := make([]uint32, goroutines)
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			got[i] = shared.Hash()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, h := range got {
+		if h != want {
+			t.Fatalf("goroutine %d hash = %d, want %d", i, h, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #540.

Two lazy-init sites in `pkg/vm/boxed.go` race under concurrent access. Both are latent today: the VM is effectively single-goroutine on most paths. But they trip `-race`, and become real the moment boxed values are touched from more than one goroutine, which is what the parallel-lowering direction in #464 would introduce (boxed values embedded in IR vectors get hashed during lowering, per the existing `Hash()` comment).

## What was racing

**`BoxedTypes` global map.** `valueType()` did a lock-free read-then-write on a plain `map[string]*aBoxedType`. Two goroutines boxing types concurrently is a concurrent map write — a runtime panic, not just a detector warning.

**`Boxed.Hash()` cache.** The `if !hashed { hash = …; hashed = true }` pattern is a data race on two fields. It's benign in value terms (both goroutines compute the same hash), but `hashed = true` can be observed before `hash` is written under reordering, so a reader can return a zero hash.

## The fixes

**Map:** a `sync.RWMutex` around lookup/insert. The method-table build (the reflection loop, the expensive part) stays outside the write lock; the insert rechecks the key under the lock so a concurrent caller that already inserted wins and every caller shares one `*aBoxedType` per type. Read hits — the common case after warm-up — take only the read lock.

**Hash:** a single `atomic.Uint64` replacing the `uint32` + `bool` pair. The computed flag is packed into bit 32, so `0` means uncomputed and a legitimate hash of `0` still reads as cached (the sentinel subtlety called out in the issue). Concurrent first-computes are harmless — same input, same value, idempotent store.

This also retires a workaround: `pkg/rt/net.go` warmed the `*netConn` type into the cache during single-threaded install because the map was unsafe, with a comment noting the real fix belonged in `pkg/vm`. That's this change, so the warm-up is gone.

## Test

`boxed_race_test.go` adds two `-race` regression tests that fail before this change and pass after: N goroutines box the same freshly-seen type at once (the map insert race), and N race to first-compute `Hash()` on one shared `Boxed` (the cache race). Both are `-short`-compatible and fast, so they run under the race job added in #524 (`go test -race -short ./pkg/vm/...`).

Verified: race tests fail on `origin/main`, pass here; full `-race -short` suite over `pkg/vm` + `pkg/rt` green; `gofmt` and `go vet` clean; builds cross `GOOS=linux`, `GOOS=js/wasm`, `GOOS=plan9`.

Refs #464, #528.
