### PR TITLE
fix(compiler): honor require aliases before the core/* resolution shortcut

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -421,20 +421,15 @@ func (c *Context) compileForm(o vm.Value) error {
 		symVal := o.(vm.Symbol)
 		// If qualified like ns/sym
 		if sns, inner := symVal.Namespaced(); sns != vm.NIL {
-			// Resolve core/* via global core ns so (ns ...) expansion works before refers
-			if string(sns.(vm.Symbol)) == rt.NameCoreNS {
-				target := rt.NS(rt.NameCoreNS)
-				v := target.Lookup(inner.(vm.Symbol))
-				if v == vm.NIL {
-					return c.compileError(fmt.Sprintf("Can't resolve %s in this context", symVal))
-				}
-				varn := c.constant(v)
-				c.emitWithArg(vm.OP_LOAD_VAR, varn)
-				c.incSP(1)
-				return nil
-			}
-			// Non-core qualified: honor aliases and refers in current ns
+			// Honor aliases and refers in current ns first — an alias literally
+			// named `core` must shadow the auto-referred core ns (issue #529).
 			v := c.CurrentNS().Lookup(symVal)
+			if v == vm.NIL && string(sns.(vm.Symbol)) == rt.NameCoreNS {
+				// Fallback: resolve core/* via the global core ns so (ns ...)
+				// expansion works before refers, and so macroexpansions may
+				// reference private core vars qualified.
+				v = rt.NS(rt.NameCoreNS).Lookup(inner.(vm.Symbol))
+			}
 			if v == vm.NIL {
 				if hc, ok := rt.LookupHostClass(string(symVal)); ok {
 					n := c.constant(hc)

--- a/test/ns/alias_named_core_test.lg
+++ b/test/ns/alias_named_core_test.lg
@@ -1,0 +1,21 @@
+;; Regression test for https://github.com/nooga/let-go/issues/529:
+;; a require alias literally named `core` must resolve through the aliased
+;; namespace. The compiler used to short-circuit every `core/*` symbol to the
+;; global core namespace before consulting the current ns's alias table, so
+;; (:require [lib :as core]) compiled to "Can't resolve core/x in this context"
+;; for any lib var. Clojure semantics: aliases win over the auto-referred core.
+;;
+;; `string` is a convenient probe: `join` does NOT exist in core (proves the
+;; alias is consulted at all), and `reverse` exists in BOTH (proves the alias
+;; shadows core rather than merely falling back).
+
+(ns tmp.alias-named-core-test
+  (:require
+   [string :as core]
+   [test :refer :all]))
+
+(deftest alias-named-core-resolves
+  (testing "an alias named `core` resolves vars absent from clojure.core"
+    (is (= "a,b" (core/join "," ["a" "b"]))))
+  (testing "an alias named `core` shadows clojure.core for shared names"
+    (is (= "ba" (core/reverse "ab")))))


### PR DESCRIPTION
Fixes #529.

## Root cause

In the compiler's qualified-symbol path, any symbol whose namespace part was literally `core` (`rt.NameCoreNS`) short-circuited to the global core namespace before the current namespace's alias table was consulted. So `(:require [repro.leaf :as core])` registered the alias fine — runtime `(resolve 'repro.leaf/hi)` worked — but compile-time resolution of `core/hi` only ever looked at clojure.core and failed with "Can't resolve core/hi in this context". Any other alias name worked.

## Fix

The qualified-symbol case now calls `CurrentNS().Lookup(symVal)` first, which resolves aliases before anything else (matching Clojure's alias-wins semantics), and falls back to the global-core-ns lookup only when that misses and the namespace part is `core`. The fallback is kept because it still serves `(ns ...)` expansion before refers exist, and macroexpansions that reference private core vars with a qualified name.

## Verification

- New regression test `test/ns/alias_named_core_test.lg`: fails before the fix, passes after. It checks both that `core/join` resolves through the alias at all (`join` doesn't exist in clojure.core), and that `core/reverse` — a name present in **both** namespaces — resolves to the aliased lib, proving the alias shadows core rather than merely falling back.
- The issue's exact repro (`lg -source-paths . repro/usec.lg` and the `-e` variant) now prints `42`.
- Plain `core/inc`, `clojure.core/inc`, and unqualified resolution are unchanged.
- Full local suite green (`go test ./...` + the vendored Clojure compat suite at its recorded pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
