### PR TITLE
fix(lgbgen): stage --target=go output and install atomically with a completeness sentinel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,10 @@ pkg/rt/.core_compiled.lgb.committed
 # the untagged build and shipped bytecode binary never need them.
 pkg/rt/generated.provenance
 pkg/rt/core_go_lowered/
+# Staging sibling that --target=go generates into before the atomic swap into
+# core_go_lowered/. A successful install renames it away; ignore any residue
+# from an interrupted run so it never gets committed.
+pkg/rt/core_go_lowered.stage/
 /lg_gogen_ir.go
 /cmd/lgbgen/main_gogen_ir.go
 /pkg/ir/zz_gogen_ir_wire_test.go

--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -976,13 +976,23 @@ func runGoTarget(outDir, codeDir string) {
 // installGeneratedTree moves the staged generation into the real output dir:
 // the completeness sentinel is invalidated first, previously-generated
 // (bannered) files in realDir are removed — same orphan-cleanup contract as
-// before staging existed — then every staged file is renamed into place and a
-// fresh sentinel is written last. Rename is cheap and same-filesystem
+// before staging existed — then every staged file is renamed into place and
+// the sentinel is installed last. Rename is cheap and same-filesystem
 // (sibling dirs), so the tree is only ever inconsistent for the duration of
 // this loop — and that window is positively detectable via the sentinel
 // (genmanifest.CheckTreeManifest).
+//
+// The manifest is computed from the STAGE dir, not the real dir: it must list
+// exactly what this generation wrote. The real dir legitimately hosts
+// co-tenant packages other tools install next to the generated tree (e.g.
+// scripts/gogen-trampoline.lg lowers test/gogen fixtures into it so their
+// module imports resolve); snapshotting those into the manifest would make
+// the sentinel assert ownership of files whose lifecycle it doesn't control.
 func installGeneratedTree(stageDir, realDir string) error {
 	if err := os.Remove(filepath.Join(realDir, genmanifest.TreeManifestName)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := genmanifest.WriteTreeManifest(stageDir); err != nil {
 		return err
 	}
 	cleanGoOutputDir(realDir)
@@ -997,6 +1007,9 @@ func installGeneratedTree(stageDir, realDir string) error {
 		if err != nil {
 			return err
 		}
+		if rel == genmanifest.TreeManifestName {
+			return nil // installed last, below
+		}
 		dst := filepath.Join(realDir, rel)
 		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 			return err
@@ -1005,7 +1018,9 @@ func installGeneratedTree(stageDir, realDir string) error {
 	}); err != nil {
 		return err
 	}
-	return genmanifest.WriteTreeManifest(realDir)
+	return os.Rename(
+		filepath.Join(stageDir, genmanifest.TreeManifestName),
+		filepath.Join(realDir, genmanifest.TreeManifestName))
 }
 
 // writeGogenWireup emits the //go:build gogen_ir blank-import files that

--- a/pkg/genmanifest/tree.go
+++ b/pkg/genmanifest/tree.go
@@ -90,9 +90,12 @@ func WriteTreeManifest(dir string) error {
 }
 
 // CheckTreeManifest verifies the generated tree at dir against its sentinel
-// manifest: the sentinel must exist, every listed file must be present with
-// matching contents, and no unlisted files may have appeared. A nil error
-// means the tree is exactly the one a successful generation wrote.
+// manifest: the sentinel must exist and every listed file must be present
+// with matching contents. A nil error means everything the last successful
+// generation wrote is intact. Unlisted files are deliberately tolerated: the
+// tree hosts co-tenant packages installed by other tools (e.g. the
+// gogen-trampoline fixture lowerer), whose lifecycle the sentinel doesn't
+// own — flagging them would make the check fail on every parity run.
 func CheckTreeManifest(dir string) error {
 	f, err := os.Open(filepath.Join(dir, TreeManifestName))
 	if os.IsNotExist(err) {
@@ -121,28 +124,16 @@ func CheckTreeManifest(dir string) error {
 		return err
 	}
 
-	have, err := treeFiles(dir)
-	if err != nil {
-		return err
-	}
-	haveSet := map[string]bool{}
-	for _, rel := range have {
-		haveSet[rel] = true
-		sum, ok := want[rel]
-		if !ok {
-			return fmt.Errorf("unlisted file %s in %s (stray or partial regeneration)", rel, dir)
-		}
+	for rel, sum := range want {
 		got, err := hashFile(filepath.Join(dir, rel))
+		if os.IsNotExist(err) {
+			return fmt.Errorf("missing file %s in %s (torn tree)", rel, dir)
+		}
 		if err != nil {
 			return err
 		}
 		if got != sum {
 			return fmt.Errorf("checksum mismatch for %s in %s", rel, dir)
-		}
-	}
-	for rel := range want {
-		if !haveSet[rel] {
-			return fmt.Errorf("missing file %s in %s (torn tree)", rel, dir)
 		}
 	}
 	return nil

--- a/pkg/genmanifest/tree_test.go
+++ b/pkg/genmanifest/tree_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package genmanifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTreeManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "core/core.go"), "package core\n")
+	writeFile(t, filepath.Join(dir, "ir/passes/dce/dce.go"), "package dce\n")
+
+	if err := WriteTreeManifest(dir); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := CheckTreeManifest(dir); err != nil {
+		t.Fatalf("fresh tree must verify: %v", err)
+	}
+}
+
+func TestTreeManifestToleratesCoTenants(t *testing.T) {
+	// The real tree hosts packages installed by other tools (e.g. the
+	// gogen-trampoline fixture lowerer). Files not listed in the manifest
+	// must not fail verification.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "core/core.go"), "package core\n")
+	if err := WriteTreeManifest(dir); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "examples/fixture/fixture.go"), "package fixture\n")
+	if err := CheckTreeManifest(dir); err != nil {
+		t.Fatalf("co-tenant file must be tolerated: %v", err)
+	}
+}
+
+func TestTreeManifestDetectsTornTree(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "core/core.go"), "package core\n")
+	writeFile(t, filepath.Join(dir, "walk/walk.go"), "package walk\n")
+	if err := WriteTreeManifest(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(dir, "walk/walk.go")); err != nil {
+		t.Fatal(err)
+	}
+	err := CheckTreeManifest(dir)
+	if err == nil || !strings.Contains(err.Error(), "missing file walk/walk.go") {
+		t.Fatalf("want missing-file error, got: %v", err)
+	}
+}
+
+func TestTreeManifestDetectsModifiedFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "core/core.go"), "package core\n")
+	if err := WriteTreeManifest(dir); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "core/core.go"), "package core // edited\n")
+	err := CheckTreeManifest(dir)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("want checksum-mismatch error, got: %v", err)
+	}
+}
+
+func TestTreeManifestMissingSentinel(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "core/core.go"), "package core\n")
+	err := CheckTreeManifest(dir)
+	if err == nil || !strings.Contains(err.Error(), "tree incomplete or never generated") {
+		t.Fatalf("want no-sentinel error, got: %v", err)
+	}
+}

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-b0846056feaf486cd3280098567205eb6fe218e3ae9d64a3f199d48c6abbf825
+a7dc9e523b36e733b9d9e4e92b60e45badf58bed0187c491f47f5abcfb03a0bc


### PR DESCRIPTION
## Problem

`lgbgen --target=go` cleaned the real `pkg/rt/core_go_lowered` tree first and then regenerated into it in place. Lowering takes minutes (typeinfer-bound), so a killed or crashed run left the real tree half-deleted for that whole window — and because the tree is gitignored, the damage was invisible to `jj`/`git status` while breaking every subsequent `go build -tags gogen_ir` with a wall of "no required module provides package .../core_go_lowered/..." errors until the next full regeneration.

## Change

- **Staged install**: generation now writes into a `core_go_lowered.stage` sibling and swaps into place only on success. The swap (`installGeneratedTree`) removes the old sentinel first, cleans previously-generated (bannered) files — same orphan-cleanup contract as before — renames staged files in, and installs a fresh sentinel last. Renames are same-filesystem, so the inconsistency window is the file-move loop, and it is positively detectable.
- **Completeness sentinel** (`pkg/genmanifest/tree.go`): `.lgbgen-tree.sum` lists a sha256 per generated file and is written as the last step of a successful install. `CheckTreeManifest` verifies every listed file is present with matching contents, so consumers can distinguish "complete tree" from "torn or partially written tree".
- The manifest is computed from the **stage** dir, not the real dir: it lists exactly what this generation wrote. The real tree legitimately hosts co-tenant packages installed by other tools (`scripts/gogen-trampoline.lg` lowers `test/gogen` fixtures into it, e.g. `examples/deftype_hyphen_field`, so their module imports resolve); the checker deliberately tolerates unlisted files, otherwise every parity run would invalidate the sentinel.
- `TestGogenAOTDiff` validates the sentinel before its `-tags gogen_ir` build, so a torn or missing tree fails with an actionable "run `make generate`" message instead of cryptic module-resolution errors.

## Verification

- 5 new unit tests in `pkg/genmanifest/tree_test.go`: round-trip, co-tenant tolerance, torn-tree detection, modified-file detection, missing-sentinel detection.
- Full regeneration through the staged path, then `make check-generated` green; sentinel verified to stay valid with a simulated co-tenant package present.
- Full local suite green (`go test ./...` incl. the e2e harnesses + the vendored Clojure compat suite at its recorded pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
