### PR TITLE
docs(guide): document lg-runtime, net/bencode; clarify numeric vs dispatch hints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | Running as a WASI (`GOOS=wasip1`) module | `guide/wasi.md` |
 | let-go under TinyGo (status: not currently supported) | `guide/tinygo.md` |
 | nREPL server + editor setup | `guide/nrepl.md` |
+| TCP client + bencode framing (`net`, `bencode`) | `guide/net.md` |
 | Clojure compatibility: namespace table + differences | `guide/clojure-compatibility.md` |
 | Running, compiling, WASM, project mgmt (lgx) | `guide/usage.md` |
 | IR fixup / link pass | `design/els2023-ir-fixup-audit.md` |

--- a/docs/guide/clojure-compatibility.md
+++ b/docs/guide/clojure-compatibility.md
@@ -68,11 +68,16 @@ site for:
 Ordinary higher-order IFn calls, protocol dispatch, known host targets, and
 successfully direct/native-lowered calls stay silent. A concrete receiver
 shape (a literal, a fresh constructor call) can resolve host warnings.
-**Known phase-1 limitation:** type hints (`^String s`) are NOT yet consulted —
-the compiler does not attach `:tag` metadata to fn params or locals, so a
-hinted receiver still warns; expect the host warning on most interop whose
-receiver is a plain symbol. Direct/native warnings need a supported call
-signature or native registration.
+**Known phase-1 limitation:** *dispatch* type hints (`^String s`) are NOT yet
+consulted — the compiler does not attach `:tag` metadata to fn params or
+locals, so a hinted receiver still warns; expect the host warning on most
+interop whose receiver is a plain symbol. Direct/native warnings need a
+supported call signature or native registration.
+
+This is separate from *numeric* parameter hints (`^double x`, `^long n`),
+which ARE honored: the AOT native-Go lowering pipeline uses them to run
+arithmetic on unboxed Go `float64`/`int64`. Numeric hints have no effect on
+host-member dispatch or on the plain bytecode path.
 
 `*unchecked-math*` is also dynamic and settable for source compatibility.
 let-go's numeric tower has no JVM-style unchecked primitive compilation mode,

--- a/docs/guide/net.md
+++ b/docs/guide/net.md
@@ -1,0 +1,38 @@
+---
+status: active
+last-verified: 2026-07-17
+human-verified:
+---
+
+# net and bencode: TCP clients in pure let-go
+
+The `net` namespace provides a minimal TCP client, and `bencode` provides
+bencode framing over a connection — together enough to write network tools
+(an nREPL client, for one) in pure let-go. Both namespaces are gated off
+`js`/`wasm` builds, where sockets don't exist.
+
+## net
+
+```clojure
+(def conn (net/dial "localhost" 7888)) ; connect, 3s timeout
+(net/write! conn "hello")              ; string or byte-array, raw bytes on the wire
+(net/read! conn 4096)                  ; → byte-array, nil on clean EOF
+(net/close! conn)
+```
+
+`net/dial` takes a host string and an integer port and returns a connection
+value. `net/read!` blocks until data arrives, returning at most `max-bytes`
+bytes as a byte-array, or `nil` when the peer closes cleanly.
+
+## bencode
+
+`bencode/write!` encodes one value onto a connection: maps (string or keyword
+keys), sequences, integers, and strings. `bencode/read!` blocks for the next
+value and returns `nil` on clean EOF; the two-arg form takes a timeout in
+milliseconds and errors when it elapses.
+
+```clojure
+(bencode/write! conn {:op "eval" :code "(+ 1 2)"})
+(bencode/read! conn)      ; blocks for the response
+(bencode/read! conn 2000) ; same, but errors after 2s
+```

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -32,6 +32,28 @@ lg -b myapp app.lg                # bundle into a self-contained binary
 The standalone binary is a copy of `lg` with your bytecode appended — copy it to
 another machine and it runs.
 
+## Compiler-free deployment: lg-runtime
+
+`lg-runtime` executes precompiled `.lgb` bytecode with no reader, compiler, or
+resolver linked in. The guarantee is structural — the binary never links
+`pkg/compiler` or `pkg/resolver` — so the deployed artifact has no `eval`,
+`load-string`, `read-string`, or dynamic source `require`: it runs only
+bytecode compiled ahead of time by a toolchain you trust.
+
+```bash
+go build -o lg-runtime ./cmd/lg-runtime      # build the runtime-only binary
+
+lg -c app.lgb app.lg                         # compile on your machine
+lg-runtime app.lgb a b                       # run it, compiler-free
+
+lg -b myapp -bundle-base lg-runtime app.lg   # standalone AND compiler-free
+./myapp
+```
+
+With `-bundle-base`, the standalone binary appends your bytecode to
+`lg-runtime` instead of the full `lg`, so the shipped executable cannot
+evaluate anything beyond what you compiled.
+
 ## WASM web apps
 
 ```bash


### PR DESCRIPTION
Documents three v1.12-cycle features that shipped without user-facing guide coverage, so the release notes can point at real docs.

## Changes

- **`guide/usage.md`** — new "Compiler-free deployment: lg-runtime" section covering `go build ./cmd/lg-runtime`, running `.lgb` directly, and `lg -b -bundle-base lg-runtime` for a standalone-and-compiler-free bundle (#424). Invocation verified against `lg.go` (`-bundle-base` flag) and `cmd/lg-runtime/main.go`.
- **`guide/net.md`** (new) — `net/dial`/`write!`/`read!`/`close!` and `bencode/write!`/`read!` (incl. the timeout arity), plus the js/wasm gating. API checked against `pkg/rt/net.go` and `pkg/rt/bencode.go` (#526, #533).
- **`guide/clojure-compatibility.md`** — the "type hints are NOT yet consulted" note now distinguishes *dispatch* hints (`^String`, still not consulted) from *numeric* hints (`^double`/`^long`, honored by the AOT native-Go lowering pipeline since #530). Previously a reader would conclude numeric hints do nothing.
- **`docs/README.md`** — index row for the new net page.

Docs-only; no code changes.
