### PR TITLE
fix(compat): re-incorporate the :lg map-order jank patch dropped by #429

### DIFF
--- a/test/fanout_ratchet_test.go
+++ b/test/fanout_ratchet_test.go
@@ -102,6 +102,7 @@ func applyJankPatches() []string {
 	}
 	patchNames := []string{
 		"lg-char-unicode-scalar.patch",
+		"lg-map-order.patch",
 	}
 	applied := make([]string, 0, len(patchNames))
 	for _, name := range patchNames {

--- a/test/patches/lg-map-order.patch
+++ b/test/patches/lg-map-order.patch
@@ -1,0 +1,46 @@
+diff --git a/test/clojure/core_test/cons.cljc b/test/clojure/core_test/cons.cljc
+index 5244799..082d48e 100644
+--- a/test/clojure/core_test/cons.cljc
++++ b/test/clojure/core_test/cons.cljc
+@@ -14,12 +14,13 @@
+                             #?@(:lpy [] :default [1 (sorted-set 1 2 3) [1 1 2 3]])
+                             ;; This works in Basilisp but order is not consistent, so
+                             ;; another test below handles the potential ordering issues.
+-                            #?@(:lpy [] :default [1 {:2 2 :3 3} [1 [:2 2] [:3 3]]])
++                            #?@(:lpy [] :lg [] :default [1 {:2 2 :3 3} [1 [:2 2] [:3 3]]])
+                             [0 1] '(2 3) [[0 1] 2 3])
+ 
+       ;; This is a duplicate of a test above intended to address inconsistent iteration
+       ;; order for map types.
+-      #?(:lpy (is (contains? #{[1 [:2 2] [:3 3]] [1 [:3 3] [:2 2]]} (cons 1 {:2 2 :3 3})))))
++      #?(:lpy (is (contains? #{[1 [:2 2] [:3 3]] [1 [:3 3] [:2 2]]} (cons 1 {:2 2 :3 3})))
++         :lg (is (contains? #{[1 [:2 2] [:3 3]] [1 [:3 3] [:2 2]]} (cons 1 {:2 2 :3 3})))))
+ 
+     (testing "infinite seqs"
+       (is (= -1 (first (cons -1 (range))))))
+diff --git a/test/clojure/core_test/cycle.cljc b/test/clojure/core_test/cycle.cljc
+index 74e0cad..e47669d 100644
+--- a/test/clojure/core_test/cycle.cljc
++++ b/test/clojure/core_test/cycle.cljc
+@@ -21,6 +21,9 @@
+       #?(:lpy (is (contains? #{[[:a 1] [:b 2] [:a 1]]
+                                [[:b 2] [:a 1] [:b 2]]}
+                              (vec (take 3 (cycle {:a 1 :b 2})))))
++         :lg (is (contains? #{[[:a 1] [:b 2] [:a 1]]
++                              [[:b 2] [:a 1] [:b 2]]}
++                            (vec (take 3 (cycle {:a 1 :b 2})))))
+          :default (is (= [[:a 1] [:b 2] [:a 1]] (take 3 (cycle {:a 1 :b 2}))))))
+ 
+     (testing "bad shape"
+diff --git a/test/clojure/core_test/mapcat.cljc b/test/clojure/core_test/mapcat.cljc
+index 935812a..a254fc6 100644
+--- a/test/clojure/core_test/mapcat.cljc
++++ b/test/clojure/core_test/mapcat.cljc
+@@ -30,6 +30,7 @@
+       (is (= [\h \i] (mapcat identity ["hi"]))))
+     (testing "flatten key/value pairs"
+       #?(:lpy (is (contains? #{[:a 1 :b 2] [:b 2 :a 1]} (vec (mapcat identity {:a 1 :b 2}))))
++         :lg (is (contains? #{[:a 1 :b 2] [:b 2 :a 1]} (vec (mapcat identity {:a 1 :b 2}))))
+          :default (is (= [:a 1 :b 2 :c 3] (mapcat identity {:a 1 :b 2 :c 3})))))
+     (testing "function returns nil"
+       (is (= [] (mapcat (constantly nil) [1 2 3]))))


### PR DESCRIPTION
## Problem

Three jank clojure-test-suite cases fail: `cons`, `cycle`, `mapcat` (each one assertion, e.g. `cons.cljc:17`, `cycle.cljc:24`, `mapcat.cljc:33`). All three compare a map iterated into an ordered seq against a fixed-order literal — e.g. `(= [:a 1 :b 2 :c 3] (mapcat identity {:a 1 :b 2 :c 3}))`.

This is **not** a map bug. #397 intentionally made small maps lose a stable iteration order — matching Go's deliberate map-iteration randomization, a security property. To keep the vendored suite green under that behavior, #397 shipped `test/patches/lg-map-order.patch`, giving let-go a `:lg` reader-conditional branch that asserts order-tolerant membership (`(contains? #{both orderings} ...)`) — the same shape the suite already uses for `:lpy` (Basilisp), which is orderless for the same reason.

**#429** (advance upstream pin + resolve compat incompatibilities) dropped that patch from both `test/patches/` and the `applyJankPatches()` list, so the three cases fell back to their fixed-order `:default` assertions and regressed to failing.

## Change

- Restore `test/patches/lg-map-order.patch` (recovered unchanged from #397).
- Re-add it to the `patchNames` list in `test/fanout_ratchet_test.go`.

`:lg` is a real, default-on reader-conditional feature (`pkg/compiler/reader.go`), so the restored branches fire without any harness-feature change.

## Scope

Only these three cases are order-dependent for let-go. `vec.cljc:24` and `vals.cljc:15` are already order-tolerant unconditionally in the current pin (`41290a6`), which covers `vec`/`vals` but left only `:lpy` tolerance for `cons`/`cycle`/`mapcat`.

## Verification

- The patch applies cleanly against the current submodule pin (`41290a6`); reverse-check confirms it wasn't already applied.
- `TestClojureTestSuite/{cons,cycle,mapcat}` pass; full `TestClojureTestSuite` is green; the submodule reverts clean after the run.
- Pre-push gate: **Clojure compatibility suite Passed**. (The gate's only failure is the pre-existing flaky `test/e2e` `os/exec` 60s timeout, unrelated to this test-suite-patch change.)

Docs-only patch infra; no runtime/map-behavior change.
