### PR TITLE
fix(test): self-heal a drifted clojure-test-suite submodule before the compat suite

### DIFF
--- a/test/fanout_ratchet_test.go
+++ b/test/fanout_ratchet_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -28,12 +29,10 @@ func TestMain(m *testing.M) {
 		panic("build lg: " + err.Error() + "\n" + string(out))
 	}
 	repoRoot, _ = filepath.Abs("..")
-	syncJankSubmodule()
-	appliedPatches := applyJankPatches()
 	code := m.Run()
 	// Leave the submodule worktree as we found it — these are test-time
 	// overlays, not checkout changes the run should persist.
-	revertJankPatches(appliedPatches)
+	revertJankPatches(jankPatches)
 	os.RemoveAll(tmp)
 	os.Exit(code)
 }
@@ -81,6 +80,7 @@ func TestPatchOverlayApplyIdempotentAndRevert(t *testing.T) {
 }
 
 func TestJankSuiteCoversLetGoUnicodeScalar(t *testing.T) {
+	ensureJankSuite()
 	fixture := filepath.Join("clojure-test-suite", "test", "clojure", "core_test", "char.cljc")
 	got, err := os.ReadFile(fixture)
 	if os.IsNotExist(err) {
@@ -92,6 +92,26 @@ func TestJankSuiteCoversLetGoUnicodeScalar(t *testing.T) {
 	if !bytes.Contains(got, []byte(`:lg      (= (first "𐅧") (char 65895))`)) {
 		t.Fatal("patched fixture lacks the let-go Unicode scalar expectation")
 	}
+}
+
+// jankSuiteSetup gates suite preparation so it happens once, and only when a
+// test or benchmark that actually reads the suite runs. TestMain must not do
+// this eagerly: it executes before the -run filter applies, so an eager sync
+// would move the submodule checkout for every `go test ./test` invocation,
+// including runs that never touch the suite.
+var (
+	jankSuiteSetup sync.Once
+	jankPatches    []string
+)
+
+// ensureJankSuite syncs the submodule to its pinned SHA and overlays the :lg
+// fixture patches. Call it at the top of anything that reads clojure-test-suite.
+// Patches are reverted by TestMain after the run.
+func ensureJankSuite() {
+	jankSuiteSetup.Do(func() {
+		syncJankSubmodule()
+		jankPatches = applyJankPatches()
+	})
 }
 
 // syncJankSubmodule brings the clojure-test-suite working tree to the commit
@@ -118,8 +138,16 @@ func syncJankSubmodule() {
 	case '-':
 		return // uninitialized — applyJankPatches' os.Stat skip handles it
 	}
-	pinned := strings.TrimLeft(strings.Fields(string(out))[0], "+-U ")
-	fmt.Fprintf(os.Stderr, "note: %s drifted from pin %.12s; running `git submodule update --init`\n", path, pinned)
+	// The SHA `git submodule status` prints for a '+' entry is the CURRENT
+	// checkout, not the pin; the pin is the gitlink recorded in the index.
+	checkout := strings.TrimLeft(strings.Fields(string(out))[0], "+-U ")
+	pin := "?"
+	if idx, err := exec.Command("git", "-C", "..", "ls-files", "-s", path).Output(); err == nil {
+		if f := strings.Fields(string(idx)); len(f) >= 2 {
+			pin = f[1]
+		}
+	}
+	fmt.Fprintf(os.Stderr, "note: %s checkout %.12s differs from pin %.12s; running `git submodule update --init`\n", path, checkout, pin)
 	if o, err := exec.Command("git", "-C", "..", "submodule", "update", "--init", path).CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "note: submodule sync failed (%v); running against the drifted checkout\n%s", err, o)
 	}

--- a/test/fanout_ratchet_test.go
+++ b/test/fanout_ratchet_test.go
@@ -28,6 +28,7 @@ func TestMain(m *testing.M) {
 		panic("build lg: " + err.Error() + "\n" + string(out))
 	}
 	repoRoot, _ = filepath.Abs("..")
+	syncJankSubmodule()
 	appliedPatches := applyJankPatches()
 	code := m.Run()
 	// Leave the submodule worktree as we found it — these are test-time
@@ -90,6 +91,37 @@ func TestJankSuiteCoversLetGoUnicodeScalar(t *testing.T) {
 	}
 	if !bytes.Contains(got, []byte(`:lg      (= (first "𐅧") (char 65895))`)) {
 		t.Fatal("patched fixture lacks the let-go Unicode scalar expectation")
+	}
+}
+
+// syncJankSubmodule brings the clojure-test-suite working tree to the commit
+// the parent repo pins in its gitlink, before the compat suite runs. jj does
+// not update git submodules on checkout, so a jj working copy can sit at an
+// older suite revision than the gitlink records — producing compat failures
+// that do not reproduce on CI (which runs `git submodule update --init`).
+// Self-heal so the local pre-push gate matches CI. Best-effort: never fail the
+// run here; a still-drifted suite fails loudly on its own assertions, which
+// beats a silent stale pass. jj ignores the submodule, so checking out a
+// different SHA in its worktree creates no jj snapshot churn.
+func syncJankSubmodule() {
+	const path = "test/clojure-test-suite"
+	// `git submodule status <path>` leading char: ' ' in sync, '+' the checkout
+	// differs from the pin, '-' uninitialized, 'U' merge conflicts. Run from the
+	// repo root (tests run in test/).
+	out, err := exec.Command("git", "-C", "..", "submodule", "status", path).CombinedOutput()
+	if err != nil || len(out) == 0 {
+		return // not a git checkout / submodule absent — suite skips itself elsewhere
+	}
+	switch out[0] {
+	case ' ':
+		return // already at the pinned SHA — the common fast path
+	case '-':
+		return // uninitialized — applyJankPatches' os.Stat skip handles it
+	}
+	pinned := strings.TrimLeft(strings.Fields(string(out))[0], "+-U ")
+	fmt.Fprintf(os.Stderr, "note: %s drifted from pin %.12s; running `git submodule update --init`\n", path, pinned)
+	if o, err := exec.Command("git", "-C", "..", "submodule", "update", "--init", path).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "note: submodule sync failed (%v); running against the drifted checkout\n%s", err, o)
 	}
 }
 

--- a/test/zz_bench_test.go
+++ b/test/zz_bench_test.go
@@ -89,6 +89,7 @@ import (
 // runs natively, is routing forms through *ir-compile* no worse than the
 // direct bytecode compiler on realistic jank-sized code?
 func BenchmarkClojureTestSuiteCompileAndRun(b *testing.B) {
+	ensureJankSuite()
 	compiler.SetMatchCljConditional(true)
 	defer compiler.SetMatchCljConditional(false)
 
@@ -146,6 +147,7 @@ func BenchmarkClojureTestSuiteCompileAndRun(b *testing.B) {
 }
 
 func BenchmarkClojureTestSuite(b *testing.B) {
+	ensureJankSuite()
 	compiler.SetMatchCljConditional(true)
 	defer compiler.SetMatchCljConditional(false)
 

--- a/test/zz_compat_test.go
+++ b/test/zz_compat_test.go
@@ -67,6 +67,7 @@ func (s *suiteCounters) summary() string {
 // Each .cljc file is compiled and executed through let-go with compat shims.
 // Files that fail to compile (e.g. missing builtins) are reported as skipped.
 func TestClojureTestSuite(t *testing.T) {
+	ensureJankSuite()
 	compiler.SetMatchCljConditional(true)
 	defer compiler.SetMatchCljConditional(false)
 


### PR DESCRIPTION
## Problem

jj does not update git submodules on checkout. So a jj working copy can sit at an older `test/clojure-test-suite` revision than the parent repo's gitlink pins. The local pre-push gate then runs `TestClojureTestSuite` against a **stale** suite and fails on assertions that pass on CI (which runs `git submodule update --init`).

This is exactly what happened after #429 bumped the pin `41290a6` → `bd610c81` (which already carries upstream's `:lg` order-tolerant branches): a jj checkout left the submodule at `41290a6`, so `cons`/`cycle`/`mapcat` failed locally while CI was green. (See the closed #553, which misdiagnosed this as a dropped patch.)

## Change

Add `syncJankSubmodule()`, called from `TestMain` right before `applyJankPatches()`:

- Reads `git submodule status test/clojure-test-suite` (leading char: `' '` in sync, `'+'` drifted, `'-'` uninitialized).
- In sync → no-op fast path. Uninitialized → left to the existing skip. Drifted → warn to stderr and run `git submodule update --init` to **self-heal** to the pinned SHA.
- **Best-effort**: never fails the run; a still-drifted suite fails loudly on its own assertions, which beats a silent stale pass.
- Leaves the submodule at the pin afterward (unlike `revertJankPatches`, which undoes test-time overlays — the pin is the authoritative state).
- jj ignores the submodule, so checking out a different SHA there creates no jj snapshot churn.

## Verification

Forced the submodule to the old `41290a6`, then ran `TestClojureTestSuite/{cons,cycle,mapcat}`: the guard warned, ran `git submodule update`, self-healed to `bd610c81`, and the tests passed — with the submodule left at the pin. `go vet ./test/` clean.

Test-harness only; no runtime change.
