### PR TITLE
feat(gogen): self-contain gogen as embedded core source (#425 Item 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,12 @@ pkg/rt/core_go_lowered/ir/lower_go/lower_go.go: $(CORE-LG-FILES) $(LGBGEN-SOURCE
 # scripts/generate.lg: the three Go-gen files (op_generated.go,
 # ir_bridge_generated.go, ir/data/generated.lg), the core_compiled.lgb bundle,
 # and the lowered-Go tree. Requires ./lg, so it builds first. The orchestrator
-# uses os/sh + os/exec* to run ./lg on the pkg/rt/gogen sources and to run
+# uses os/sh + os/exec* to run ./lg on the IR-gen specs (which require the
+# embedded gogen macros, #425) and to run
 # `go run -tags bootstrap ./cmd/lgbgen [--target=go]` for the bundle/lowered
 # tree. (Replaces the former generate-ir-{ops,bridge,data}.sh shell scripts.)
 generate: build
-	./lg scripts/generate.lg --go "$$(command -v go)" --lg ./lg --source-paths pkg/rt/gogen
+	./lg scripts/generate.lg --go "$$(command -v go)" --lg ./lg
 
 # Short commit for `-X main.commit` so SHA-pin require-letgo checks can fire on
 # `make` builds. Release builds get this from goreleaser; a bare `make` build

--- a/pkg/ir/ir_bridge.lg
+++ b/pkg/ir/ir_bridge.lg
@@ -1,7 +1,7 @@
 ;; Generate pkg/rt/ir_bridge_generated.go — Lisp/Go bridge primitives
 ;; for IR types. See docs/superpowers/specs/2026-05-22-defgostruct.md.
 ;;
-;; Run with: lg -source-paths pkg/rt/gogen pkg/ir/ir_bridge.lg
+;; Run with: lg pkg/ir/ir_bridge.lg
 ;;
 ;; Each struct is declared via defgostruct. Two emission paths:
 ;;

--- a/pkg/ir/ir_data.lg
+++ b/pkg/ir/ir_data.lg
@@ -5,7 +5,7 @@
 ;; types, defirdata declares Lisp-native data types (atom-backed maps)
 ;; and emits the boilerplate accessors / mutators / constructors.
 ;;
-;; Run with: lg -source-paths pkg/rt/gogen pkg/ir/ir_data.lg
+;; Run with: lg pkg/ir/ir_data.lg
 ;;
 ;; Spec shape per type:
 ;;

--- a/pkg/ir/ir_ops.lg
+++ b/pkg/ir/ir_ops.lg
@@ -1,6 +1,6 @@
 ;; Generate pkg/ir/op_generated.go from a single op-spec.
 ;;
-;; Run with: lg -source-paths pkg/rt/gogen pkg/ir/ir_ops.lg
+;; Run with: lg pkg/ir/ir_ops.lg
 ;;
 ;; Architecture: the entire op catalog lives in `ops` below (a vector
 ;; of vectors — deterministic iteration). From it we drive five

--- a/pkg/resolver/gogen_embed_test.go
+++ b/pkg/resolver/gogen_embed_test.go
@@ -1,0 +1,53 @@
+//go:build !bootstrap
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// TestGogenResolvesFromEmbeddedSource locks in nooga/let-go#425 (self-contain
+// gogen): shipped binaries embed gogen.lg (pkg/rt/gogen_src.go) and register it
+// as an auxiliary embedded source, so (require 'gogen) resolves with NO external
+// source path — EmbeddedSource returns it before any search path is consulted.
+// Before #425 gogen was an external classpath dir (deps.edn), so compiling from
+// the wrong cwd failed with `Can't resolve gogen/ns->go-pkg`. The empty
+// search-path slice below is the point: only embedded resolution can satisfy the
+// require.
+//
+// Gated //go:build !bootstrap: the embed is deliberately excluded from the
+// self-hosting bootstrap build (gogen resolves via classpath there — see
+// pkg/rt/gogen_src.go), so this shipped-binary behavior is only asserted for
+// non-bootstrap builds.
+func TestGogenResolvesFromEmbeddedSource(t *testing.T) {
+	if _, ok := rt.EmbeddedSource("gogen"); !ok {
+		t.Fatal("rt.EmbeddedSource(\"gogen\") not found — gogen must be embedded via pkg/rt/gogen_src.go (#425)")
+	}
+
+	prev := rt.GetNSLoader()
+	defer rt.SetNSLoader(prev)
+
+	consts := vm.NewConsts()
+	ctx := compiler.NewCompiler(consts, rt.NS("user"))
+	rt.SetNSLoader(NewNSResolver(ctx, []string{})) // no search paths: embed-only
+	ctx.SetSource("<test>")
+
+	// Reference gogen/ns->go-pkg — a macro-layer .lg defn, not a native fn — so
+	// success proves the embedded *source* loaded, not merely the native ns
+	// installed at boot. If gogen's source didn't resolve, the compile fails with
+	// the pre-#425 "Can't resolve gogen/ns->go-pkg".
+	_, _, err := ctx.CompileMultiple(strings.NewReader("(require 'gogen) (gogen/ns->go-pkg \"ir.lower-go\")"))
+	if err != nil {
+		t.Fatalf("resolving gogen from embedded source failed (regressed #425?): %v", err)
+	}
+}

--- a/pkg/rt/core_embed_fs.go
+++ b/pkg/rt/core_embed_fs.go
@@ -20,17 +20,30 @@ import (
 //go:embed all:core
 var coreFS embed.FS
 
+// auxEmbeddedSources holds embedded namespace sources that live OUTSIDE the
+// core/ tree. They resolve like embedded core but are deliberately excluded
+// from the core lowering universe: EmbeddedNSNames walks core/ only, so an aux
+// source is invisible to the self-hosting bootstrap (lgbgen). gogen is the case
+// (nooga/let-go#425) — it self-contains as embedded source but is the AOT
+// Go-emitter, not core content, and enrolling it in core/ perturbs the
+// interpreted-vs-native lowering fixpoint. Populated from *_src.go init().
+var auxEmbeddedSources = map[string]string{}
+
 // EmbeddedSource returns the source of an embedded namespace by its
-// dotted ns name.
+// dotted ns name. Auxiliary sources (auxEmbeddedSources) are checked first,
+// then the core/ tree.
 //
-// Naming rule (the source-side analog of `cmd/lgbgen.nsToGoRelDir`, which
-// nests the lowered Go tree the same way):
+// Naming rule for the core/ tree (the source-side analog of
+// `cmd/lgbgen.nsToGoRelDir`, which nests the lowered Go tree the same way):
 //   - dots are path separators: `ir.passes.dce` → `ir/passes/dce.lg`
 //   - in the *leaf* segment, hyphens map to underscores so the file
 //     name is a legal Go-style identifier: `ir.lower-go` → `ir/lower_go.lg`
 //
 // Returns ("", false) if no matching file exists.
 func EmbeddedSource(name string) (string, bool) {
+	if src, ok := auxEmbeddedSources[name]; ok {
+		return src, true
+	}
 	path := "core/" + nsNameToPath(name)
 	data, err := coreFS.ReadFile(path)
 	if err != nil {

--- a/pkg/rt/core_embed_fs.go
+++ b/pkg/rt/core_embed_fs.go
@@ -26,8 +26,27 @@ var coreFS embed.FS
 // source is invisible to the self-hosting bootstrap (lgbgen). gogen is the case
 // (nooga/let-go#425) — it self-contains as embedded source but is the AOT
 // Go-emitter, not core content, and enrolling it in core/ perturbs the
-// interpreted-vs-native lowering fixpoint. Populated from *_src.go init().
+// interpreted-vs-native lowering fixpoint.
+//
+// Concurrency: a bare map with no lock, safe ONLY because it is written
+// exclusively from init() (via registerEmbeddedSource), which happens-before
+// every resolver read through EmbeddedSource. Do NOT add a runtime
+// RegisterEmbeddedSource entry point — a write racing a resolver read would be a
+// data race. Keep all registration in init().
 var auxEmbeddedSources = map[string]string{}
+
+// registerEmbeddedSource records an auxiliary embedded namespace source. Call it
+// ONLY from init() (see auxEmbeddedSources for the race invariant). An empty
+// source means the //go:embed directive that feeds it never populated — a broken
+// build — so fail loudly and name the namespace here, rather than let it surface
+// downstream as an obscure "Can't resolve <ns>/..." through the resolver's
+// fallback chain.
+func registerEmbeddedSource(name, src string) {
+	if src == "" {
+		panic("rt: embedded source for namespace " + name + " is empty (//go:embed failed?)")
+	}
+	auxEmbeddedSources[name] = src
+}
 
 // EmbeddedSource returns the source of an embedded namespace by its
 // dotted ns name. Auxiliary sources (auxEmbeddedSources) are checked first,

--- a/pkg/rt/gogen/gogen.lg
+++ b/pkg/rt/gogen/gogen.lg
@@ -1,5 +1,13 @@
 ;; gogen — Way 3 prototype, refactored to use go/ast directly.
 ;;
+;; Self-contained via embedding (nooga/let-go#425): this file is embedded into
+;; the binary by pkg/rt/gogen_src.go (//go:embed) and served to the resolver by
+;; rt.EmbeddedSource as an *auxiliary* embedded namespace — deliberately NOT
+;; under pkg/rt/core/, so gogen (the AOT Go-emitter) stays out of the core
+;; lowering universe (EmbeddedNSNames) and can't perturb the interpreted-vs-
+;; native lowering fixpoint. Was previously an external classpath dir, which
+;; broke `lg-compile` from the wrong cwd / with older binaries.
+;;
 ;; Architecture:
 ;;   user code: (gquote (func ...))
 ;;     ↓ macro expansion (compile time, Clojure)

--- a/pkg/rt/gogen_src.go
+++ b/pkg/rt/gogen_src.go
@@ -25,4 +25,4 @@ import _ "embed"
 //go:embed gogen/gogen.lg
 var gogenSrc string
 
-func init() { auxEmbeddedSources["gogen"] = gogenSrc }
+func init() { registerEmbeddedSource("gogen", gogenSrc) }

--- a/pkg/rt/gogen_src.go
+++ b/pkg/rt/gogen_src.go
@@ -1,0 +1,28 @@
+//go:build !bootstrap
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import _ "embed"
+
+// gogenSrc is the gogen macro layer, embedded into the binary so `(require
+// 'gogen)` resolves with no external source path (nooga/let-go#425: self-contain
+// gogen — it was formerly an external classpath dir, which broke `lg-compile`
+// from the wrong cwd / with older binaries).
+//
+// It is embedded from pkg/rt/gogen/ rather than pkg/rt/core/ on purpose: gogen
+// is the AOT Go-emitter, not core content. Placing it under core/ would enroll
+// it in the embedded-core lowering universe (EmbeddedNSNames), which the
+// self-hosting bootstrap enumerates — enough to perturb the interpreted-vs-
+// native lowering fixpoint (TestLoweringDeterminism). Registered as an
+// auxiliary embedded source (see EmbeddedSource) instead, so it resolves like
+// embedded core without joining that universe.
+//
+//go:embed gogen/gogen.lg
+var gogenSrc string
+
+func init() { auxEmbeddedSources["gogen"] = gogenSrc }

--- a/scripts/generate.lg
+++ b/scripts/generate.lg
@@ -14,7 +14,6 @@
 ;;
 ;;     --go <path>            go compiler          (default "go")
 ;;     --lg <path>            lg binary            (default "./lg")
-;;     --source-paths <dir>   gogen lib require root (default "pkg/rt/gogen")
 ;;
 ;; Bootstrap note: this script runs ON ./lg (built from the bundle) and shells
 ;; out to `<go> run -tags bootstrap ./cmd/lgbgen` for the bundle and lowered
@@ -41,7 +40,6 @@
 (def argv      os/args)
 (def go-bin    (flag argv "--go" "go"))
 (def lg-bin    (flag argv "--lg" "./lg"))
-(def src-paths (flag argv "--source-paths" "pkg/rt/gogen"))
 
 (defn die [msg]
   (println "generate.lg ERROR:" msg)
@@ -133,11 +131,12 @@
         (println "provenance: lg" dir ":" pv "->" cur-version)))))
 
 ;; --- run ---
-(println "generate.lg: go =" go-bin "| lg =" lg-bin "| source-paths =" src-paths)
+(println "generate.lg: go =" go-bin "| lg =" lg-bin)
 (surface-drift (read-prior))
 
-;; The IR-generation specs live with the IR (pkg/ir); src-paths is the require
-;; root for the gogen macro library (pkg/rt/gogen) the specs depend on.
+;; The IR-generation specs live with the IR (pkg/ir) and `(require 'gogen)` for
+;; the emitter macros. gogen now ships as embedded core source (#425), so it
+;; resolves in-process off the running ./lg with no external source path.
 (gen-go   "scripts/gen/op_generated.head"        "pkg/ir/ir_ops.lg"    "pkg/ir/op_generated.go")
 (gen-go   "scripts/gen/ir_bridge_generated.head" "pkg/ir/ir_bridge.lg" "pkg/rt/ir_bridge_generated.go")
 (gen-lisp "pkg/ir/ir_data.lg" "pkg/rt/core/ir/data/generated.lg")


### PR DESCRIPTION
Closes the #425 Item 2 gap: shipped `lg` binaries now embed the `gogen` macro layer, so the AOT lowering path resolves it without any `LG_SOURCE_PATHS` / cwd plumbing.

## Why

`gogen` is the `.lg` macro layer the whole go-lowering path compiles through: `scripts/lg-compile`, the IR-gen specs (`ir_ops` / `ir_bridge` / `ir_data`), and `ir.lower-go`'s emitter all `(require 'gogen)`. It shipped as an external classpath dir (`deps.edn {:paths ["pkg/rt/gogen"]}`), so any `lg-compile` invoked from the wrong cwd (or with a binary predating the gogen native ns) died with `Can't resolve gogen/ns->go-pkg`. That is the turnkey-AOT blocker Item 2 tracks: it gates every kernel-AOT build.

## How

Embed `gogen.lg` into shipped binaries and serve it to the resolver as an auxiliary embedded source (`rt.EmbeddedSource`), so `(require 'gogen)` resolves with no external source path. Two constraints shaped the mechanism — the first is the non-obvious one:

1. **gogen stays out of `pkg/rt/core/`.** The embedded-core tree (`//go:embed all:core`, enumerated by `EmbeddedNSNames`) is the universe the self-hosting bootstrap (`cmd/lgbgen`) walks. gogen is the AOT Go-emitter, not core content, and enrolling it there is enough to break the interpreted-vs-native lowering fixpoint: `TestLoweringDeterminism` starts seeing `clojure.core/apply` (and `str`) lowered as a direct native call in one pass and a trampoline in the other. So gogen is embedded from `pkg/rt/gogen/` via a dedicated `//go:embed` (`pkg/rt/gogen_src.go`) and registered in an `auxEmbeddedSources` map that `EmbeddedSource` checks first — resolvable like embedded core, invisible to the lowering universe.

2. **The embed is gated `//go:build !bootstrap`.** During the self-hosting bootstrap (lgbgen, `-tags bootstrap`) gogen must resolve exactly as it does today — from the classpath (`deps.edn`), which lgbgen always has since it runs from the repo root. Making gogen embedded-resolvable in the bootstrap binary is itself what perturbs the fixpoint; excluding the embed there keeps cold and hot lowering byte-identical. Shipped binaries (no bootstrap tag) get the embed and the self-containment.

`deps.edn` keeps its classpath entry (the bootstrap relies on it). The change is bootstrap-neutral: `core_compiled.lgb`, `core_go_lowered/`, and `generated.sums` are unchanged.

It also drops source-path plumbing that was dead for the shipped path: the Makefile / `generate.lg` `--source-paths pkg/rt/gogen` (`generate.lg` loads the specs in-process on `./lg`, which now embeds gogen) and the IR-spec run-hints. (`test/language_test.go` keeps its classpath entry — it runs under `-tags bootstrap` too, where the embed is absent.)

## Verification

- A shipped `lg` runs a full `lg-compile` of `examples/aot/cross-package` and the mandelbrot AOT kernel from an arbitrary cwd with no `LG_SOURCE_PATHS`, byte-identical Go (escape → native `Escape(ec, float64, float64, int)`).
- A new `!bootstrap` `pkg/resolver` regression test resolves gogen under empty search paths — the pre-Item-2 failure mode.
- `TestLoweringDeterminism` cold == hot; `go test ./...` green under both `-tags bootstrap` and the default build; linux / js-wasm / plan9 / wasip1 cross-builds pass; gofmt clean.

## Scope

This is #425 Item 2 only (self-contain gogen). Item 1 (generate the native-entry frame) and Item 3 (signal the silent perf-cliff) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
