### PR TITLE
perf(vm): use the transient growth reserve in assocTransient inserts

### DIFF
--- a/pkg/vm/persistent_map.go
+++ b/pkg/vm/persistent_map.go
@@ -407,13 +407,33 @@ func (n *hmapBitmapNode) assocTransient(edit *atomic.Bool, shift uint, hash uint
 	*addedLeaf = true
 	nEntries := bits.OnesCount32(n.bitmap)
 	editable := n.ensureEditable(edit)
-	// Need to grow the array
-	newArray := make([]any, 2*(nEntries+1))
-	copy(newArray, editable.array[:2*idx])
-	newArray[2*idx] = key
-	newArray[2*idx+1] = val
-	copy(newArray[2*(idx+1):], editable.array[2*idx:2*nEntries])
-	editable.array = newArray
+	need := 2 * (nEntries + 1)
+	if cap(editable.array) >= need {
+		// Use the growth reserve (ensureEditable over-allocates): shift the
+		// tail right in place and insert. copy is overlap-safe, and every
+		// slot in [0, need) is written or preserved, so stale values beyond
+		// the old length are never observed.
+		arr := editable.array[:need]
+		copy(arr[2*(idx+1):], arr[2*idx:2*nEntries])
+		arr[2*idx] = key
+		arr[2*idx+1] = val
+		editable.array = arr
+	} else {
+		// Reserve exhausted — reallocate with headroom so allocations (and
+		// their full-array copies) amortize across a batch of inserts.
+		// Note the in-place branch above still shifts the tail on every
+		// insert, so slot copying stays O(tail) per insert (bounded by the
+		// 32-entry node fan-out); what this removes is the per-insert
+		// allocation and full-array copy. A bitmap node holds at most 32
+		// entries (64 slots), so cap the reserve there: no unbounded spare
+		// capacity rides along into the persisted map.
+		newArray := make([]any, need, min(2*need, 64))
+		copy(newArray, editable.array[:2*idx])
+		newArray[2*idx] = key
+		newArray[2*idx+1] = val
+		copy(newArray[2*(idx+1):], editable.array[2*idx:2*nEntries])
+		editable.array = newArray
+	}
 	editable.bitmap = n.bitmap | bit
 	return editable
 }

--- a/pkg/vm/persistent_map_transient_boundary_test.go
+++ b/pkg/vm/persistent_map_transient_boundary_test.go
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+// The in-place transient insert reuses an owned node's spare capacity, so
+// its correctness hangs on two boundaries: the shift must be right for any
+// insert position (begin/middle/end), and spare capacity on a persisted
+// node must never be reused by a later transient (ensureEditable must
+// clone). These tests pin both directly.
+
+// nodeSlots reads back the (slot, key) pairs of a bitmap node in slot order.
+func nodeSlots(t *testing.T, n *hmapBitmapNode) []string {
+	t.Helper()
+	var out []string
+	for slot := uint32(0); slot < 32; slot++ {
+		bit := uint32(1) << slot
+		if n.bitmap&bit == 0 {
+			continue
+		}
+		idx := hmapIndex(n.bitmap, bit)
+		k, ok := n.array[2*idx].(Value)
+		if !ok {
+			t.Fatalf("slot %d: key is %T, want Value", slot, n.array[2*idx])
+		}
+		out = append(out, fmt.Sprintf("%d=%s", slot, k.String()))
+	}
+	return out
+}
+
+// Driving assocTransient with crafted hashes (slot = hash & 0x1f at shift 0)
+// gives deterministic control of the insert position within the node array.
+func TestAssocTransientInsertPositions(t *testing.T) {
+	edit := new(atomic.Bool)
+	edit.Store(true)
+	n := &hmapBitmapNode{edit: edit, array: make([]any, 0, 64)}
+
+	var added bool
+	insert := func(slot uint32) {
+		nn := n.assocTransient(edit, 0, slot, String(fmt.Sprintf("k%d", slot)), Int(int(slot)), &added)
+		if nn != n {
+			t.Fatalf("slot %d: owned insert returned a new node (in-place path not taken)", slot)
+		}
+	}
+
+	// middle anchor, then end, begin, and interior positions — each order
+	// exercises a different shift span in the in-place branch.
+	for _, slot := range []uint32{16, 31, 0, 8, 24, 4} {
+		insert(slot)
+	}
+	if cap(n.array) != 64 {
+		t.Fatalf("cap = %d, want 64 (in-place growth must not reallocate)", cap(n.array))
+	}
+	want := []string{`0="k0"`, `4="k4"`, `8="k8"`, `16="k16"`, `24="k24"`, `31="k31"`}
+	got := nodeSlots(t, n)
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("slot layout after in-place inserts:\n got %v\nwant %v", got, want)
+	}
+}
+
+// Capacity-exhaustion boundary: an owned node with len==cap must take the
+// realloc branch, preserve order across it, and then grow in place again
+// within the new headroom.
+func TestAssocTransientReallocBoundary(t *testing.T) {
+	edit := new(atomic.Bool)
+	edit.Store(true)
+	n := &hmapBitmapNode{
+		edit:   edit,
+		bitmap: 1 << 5,
+		array:  []any{String("k5"), Int(5)}, // len == cap == 2, no reserve
+	}
+
+	var added bool
+	// Descending-position insert across the realloc: k2 lands before k5.
+	n = n.assocTransient(edit, 0, 2, String("k2"), Int(2), &added)
+	if len(n.array) != 4 {
+		t.Fatalf("len = %d, want 4", len(n.array))
+	}
+	if cap(n.array) != 8 { // min(2*need, 64) with need=4
+		t.Fatalf("cap = %d, want 8 (realloc headroom)", cap(n.array))
+	}
+	want := []string{`2="k2"`, `5="k5"`}
+	if got := nodeSlots(t, n); fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("layout after realloc insert:\n got %v\nwant %v", got, want)
+	}
+
+	// Next inserts fit the new headroom: node and backing array must be
+	// reused (in-place), including another begin-position shift.
+	before := n
+	n = n.assocTransient(edit, 0, 9, String("k9"), Int(9), &added)
+	n = n.assocTransient(edit, 0, 0, String("k0"), Int(0), &added)
+	if n != before {
+		t.Fatal("in-headroom inserts reallocated the node")
+	}
+	if cap(n.array) != 8 || len(n.array) != 8 {
+		t.Fatalf("len/cap = %d/%d, want 8/8", len(n.array), cap(n.array))
+	}
+	want = []string{`0="k0"`, `2="k2"`, `5="k5"`, `9="k9"`}
+	if got := nodeSlots(t, n); fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("layout after in-headroom inserts:\n got %v\nwant %v", got, want)
+	}
+}
+
+// A persisted map built transiently carries nodes with spare capacity. A
+// second transient over that map must clone before mutating — never write
+// into the frozen map's spare slots.
+func TestTransientPersistedNodeNotReused(t *testing.T) {
+	t1 := NewTransientMap(EmptyPersistentMap)
+	const n = 20
+	for i := 0; i < n; i++ {
+		if _, err := t1.Assoc(Int(i), Int(i*10)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m1, err := t1.Persistent()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutate a second transient over the persisted result: new keys plus
+	// overwrites of existing ones.
+	t2 := NewTransientMap(m1)
+	for i := 0; i < n; i++ {
+		if _, err := t2.Assoc(Int(100+i), Int(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := t2.Assoc(Int(3), String("overwritten")); err != nil {
+		t.Fatal(err)
+	}
+
+	// m1 must be untouched: same count, original values, no new keys.
+	if m1.RawCount() != n {
+		t.Fatalf("persisted map count changed: %d, want %d", m1.RawCount(), n)
+	}
+	for i := 0; i < n; i++ {
+		if got := m1.ValueAtOr(Int(i), NIL); got != Int(i*10) {
+			t.Fatalf("persisted map key %d = %v, want %d", i, got, i*10)
+		}
+	}
+	if got := m1.ValueAtOr(Int(105), NIL); got != NIL {
+		t.Fatalf("persisted map leaked a second-transient key: %v", got)
+	}
+
+	m2, err := t2.Persistent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m2.RawCount() != 2*n {
+		t.Fatalf("second map count = %d, want %d", m2.RawCount(), 2*n)
+	}
+	if got := m2.ValueAtOr(Int(3), NIL); got != String("overwritten") {
+		t.Fatalf("second map overwrite lost: %v", got)
+	}
+}


### PR DESCRIPTION
`ensureEditable` deliberately over-allocates ("avoid frequent realloc during transient batch ops"), but the new-entry branch of `assocTransient` never used the spare capacity: every insert into an owned node allocated a fresh exact-size array and copied all slots. This is the path every map literal (`NewArrayMap`) and `into` take.

The change: when the owned array has room, insert in place with an overlap-safe `copy` shift. When the reserve is exhausted, reallocate with headroom capped at the node's structural max (32 entries / 64 slots).

To be precise about what improves: this removes the per-insert allocation and full-array copy. The in-place shift still moves the tail on every insert (about half the node on average, bounded by the 32-entry fan-out), so slot copying is reduced, not eliminated — allocations are what amortize across a batch.

Benchmarks (interleaved A/B against main, n=8, Apple M2):

| bench | time | B/op |
|---|---|---|
| TransientMapAssocInsertBatch1K | −24% | −52% |
| DepsTransientMapTransientSet64x16 | −27% | −52% |
| DepsTransientMapVector64x16 | −8% | −16% |
| overwrite benches | unchanged | unchanged |

The overwrite benches staying flat is expected: they never hit the new-entry branch.

**Tradeoff:** the headroom is bounded but persists. A transient-built map keeps up to cap−len unused slots per multi-insert node in its frozen form. Measured on a 512-entry `NewArrayMap` build: ~27% capacity slack, vs ~0 before this change (about 5.7 KB extra on that map). Single-insert nodes waste nothing. So this trades some steady-state footprint on batch-built maps for the construction-time win above. If that balance doesn't fit let-go's typical workloads, an alternative is trimming the array on `persistent!`, which keeps the build win and drops the slack at the cost of one final copy per node.

Tests: the mutation boundary is pinned directly — deterministic begin/middle/end in-place inserts (driving `assocTransient` with crafted hashes for position control), the capacity-exhaustion realloc boundary including a descending-position insert across it, and a persisted-map-with-spare-capacity mutated through a second transient without the frozen map observing anything.

Safety notes: in-place growth only ever mutates a privately-owned backing array (any node reachable from a persisted map or another transient fails the edit-token check in `ensureEditable` and gets cloned first). Nothing reads node arrays by capacity, and every slot in the extended region is written or preserved before the new length is exposed, so stale values past the old length are never observable. Collision buckets are a separate node type and don't reach this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #464 (runtime performance & concurrency).
