### PR TITLE
perf(vm): gate lookup-stats noters on an atomic before the mutex

### DIFF
--- a/pkg/vm/lookup_stats.go
+++ b/pkg/vm/lookup_stats.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 type LookupStats struct {
@@ -50,8 +51,13 @@ func writeLookupCounts(b *strings.Builder, prefix string, m map[string]uint64) {
 }
 
 var (
-	lookupStatsMu      sync.Mutex
-	lookupStatsEnabled bool
+	lookupStatsMu sync.Mutex
+	// lookupStatsEnabled is atomic so the noters can bail without taking
+	// lookupStatsMu — they sit on Namespace.Lookup and Symbol.Namespaced,
+	// where an always-taken global mutex is a cross-goroutine serialization
+	// point paid even with stats off (the production case). The mutex still
+	// guards the stats maps themselves.
+	lookupStatsEnabled atomic.Bool
 	lookupStatsGlobal  = LookupStats{
 		NamespacedBySym: map[string]uint64{},
 		LookupByNS:      map[string]uint64{},
@@ -60,9 +66,7 @@ var (
 )
 
 func SetLookupStatsEnabled(enabled bool) {
-	lookupStatsMu.Lock()
-	lookupStatsEnabled = enabled
-	lookupStatsMu.Unlock()
+	lookupStatsEnabled.Store(enabled)
 }
 
 func ResetLookupStats() {
@@ -98,8 +102,17 @@ func SnapshotLookupStats() LookupStats {
 }
 
 func noteNamespaced(sym string) {
+	if !lookupStatsEnabled.Load() {
+		return
+	}
 	lookupStatsMu.Lock()
-	if lookupStatsEnabled {
+	// Re-check under the lock so the maps mutate only while enabled is
+	// observed true. Note SetLookupStatsEnabled(false) is no longer a
+	// recording barrier: a noter already past the fast-path check may
+	// record one final sample after Set returns. (The previous
+	// always-locked version quiesced synchronously; no current caller
+	// relies on that.)
+	if lookupStatsEnabled.Load() {
 		lookupStatsGlobal.NamespacedCalls++
 		lookupStatsGlobal.NamespacedBySym[sym]++
 	}
@@ -107,8 +120,11 @@ func noteNamespaced(sym string) {
 }
 
 func noteLookup(ns, sym string) {
+	if !lookupStatsEnabled.Load() {
+		return
+	}
 	lookupStatsMu.Lock()
-	if lookupStatsEnabled {
+	if lookupStatsEnabled.Load() {
 		lookupStatsGlobal.LookupCalls++
 		lookupStatsGlobal.LookupByNS[ns]++
 		lookupStatsGlobal.LookupByNSSym[ns+"::"+sym]++

--- a/pkg/vm/lookup_stats_bench_test.go
+++ b/pkg/vm/lookup_stats_bench_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// BenchmarkNamespaceLookupStatsDisabled measures Namespace.Lookup with
+// lookup stats off (the production case): the noteLookup gate is the only
+// stats cost on this path.
+func BenchmarkNamespaceLookupStatsDisabled(b *testing.B) {
+	ns := NewNamespace("bench-ns")
+	ns.Def("x", Int(42))
+	sym := Symbol("x")
+	SetLookupStatsEnabled(false)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if v := ns.Lookup(sym); v == nil {
+			b.Fatal("lookup miss")
+		}
+	}
+}
+
+// BenchmarkNamespaceLookupStatsDisabledParallel measures the contended
+// case: with stats off, concurrent lookups previously serialized on
+// lookupStatsMu; after the atomic gate they contend only on the
+// namespace's own read locks.
+func BenchmarkNamespaceLookupStatsDisabledParallel(b *testing.B) {
+	ns := NewNamespace("bench-ns")
+	ns.Def("x", Int(42))
+	sym := Symbol("x")
+	SetLookupStatsEnabled(false)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if v := ns.Lookup(sym); v == nil {
+				b.Fatal("lookup miss")
+			}
+		}
+	})
+}
+
+// BenchmarkNamespaceLookupStatsEnabled keeps the enabled path honest: the
+// gate must not make the measuring configuration slower than the mutex it
+// replaces on the fast path.
+func BenchmarkNamespaceLookupStatsEnabled(b *testing.B) {
+	ns := NewNamespace("bench-ns")
+	ns.Def("x", Int(42))
+	sym := Symbol("x")
+	SetLookupStatsEnabled(true)
+	defer SetLookupStatsEnabled(false)
+	defer ResetLookupStats()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if v := ns.Lookup(sym); v == nil {
+			b.Fatal("lookup miss")
+		}
+	}
+}


### PR DESCRIPTION
`noteLookup` and `noteNamespaced` take the global `lookupStatsMu` on every `Namespace.Lookup` and `Symbol.Namespaced` call just to discover that stats are disabled — so the production configuration pays an always-taken global mutex, and a cross-goroutine serialization point, for a feature that is off.

The change: make the enabled flag an `atomic.Bool` checked before locking. The noters return on a single atomic load when stats are off; when they're on, the flag is re-checked under the lock, so the enabled path records exactly as before (a concurrent disable between the fast check and `Lock` still drops the sample, same as today). The mutex still guards the stats maps.

One behavioral note: `SetLookupStatsEnabled(false)` is no longer a synchronous barrier — a noter already past its fast-path check can record one final sample after the call returns. The previous always-locked version quiesced synchronously; neither current caller (boot-time enable, exit-time snapshot) depends on that.

Measured (interleaved A/B against main, n=8, Apple M2, new benchmarks included in the PR):

- `Namespace.Lookup`, stats disabled: 24.4 ns → 16.4 ns (−33%, p=0.000)
- same, 8-way parallel: 132 ns → 92 ns per op (−30%, p=0.001) — the serialization on the stats mutex is gone; the remainder is the namespace's own read locks
- `Namespace.Lookup`, stats enabled: unchanged (p=0.88)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #464 (runtime performance & concurrency).
