### PR TITLE
perf(vm): typed Keyword/Int fast paths at the top of valueEquiv

### DIFF
--- a/pkg/vm/hash.go
+++ b/pkg/vm/hash.go
@@ -141,6 +141,23 @@ func mixFinishLen(h uint32, length uint32) uint32 {
 // valueEquiv tests if two Values are equivalent for map key purposes.
 // Uses hash as a fast negative check, then structural comparison.
 func valueEquiv(a, b Value) bool {
+	// Typed fast paths for the two dominant map-key types, ahead of the
+	// double isComparable type-switch below. Both are exact reductions of
+	// the general path: a keyword only ever equals a keyword with the same
+	// string (the == identity check plus the hash-negative and Equals
+	// fallbacks all collapse to that), and NumEq on two Ints is ==. A
+	// non-Int b deliberately falls through — Int×Float/BigInt equivalence
+	// belongs to the NumEq path. Neither type can be NIL or EmptyList, so
+	// hoisting past that check is safe.
+	if ak, ok := a.(Keyword); ok {
+		bk, ok := b.(Keyword)
+		return ok && ak == bk
+	}
+	if ai, ok := a.(Int); ok {
+		if bi, ok := b.(Int); ok {
+			return ai == bi
+		}
+	}
 	if (a == NIL && b == EmptyList) || (a == EmptyList && b == NIL) {
 		return true
 	}

--- a/pkg/vm/value_equiv_bench_test.go
+++ b/pkg/vm/value_equiv_bench_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// Direct benchmarks for valueEquiv's dominant map-key type pairs. The
+// map-level benchmarks (MapAssoc/*) exercise these through the trie; these
+// isolate the comparison itself.
+func BenchmarkValueEquiv(b *testing.B) {
+	kw1, kw2 := Keyword("player-position"), Keyword("player-position")
+	kwOther := Keyword("world-seed")
+	i1, i2, iOther := Int(1048576), Int(1048576), Int(99)
+	f := Float(1048576)
+
+	b.Run("Keyword-equal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if !valueEquiv(kw1, kw2) {
+				b.Fatal("expected equal")
+			}
+		}
+	})
+	b.Run("Keyword-unequal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if valueEquiv(kw1, kwOther) {
+				b.Fatal("expected unequal")
+			}
+		}
+	})
+	b.Run("Int-equal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if !valueEquiv(i1, i2) {
+				b.Fatal("expected equal")
+			}
+		}
+	})
+	b.Run("Int-unequal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if valueEquiv(i1, iOther) {
+				b.Fatal("expected unequal")
+			}
+		}
+	})
+	// Mixed numeric must keep falling through to the NumEq path, which
+	// follows Clojure = semantics: Int and Float are never map-key
+	// equivalent (verified identical on the pre-change code). The Int fast
+	// path above must not short-circuit this pair.
+	b.Run("Int-vs-Float", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if valueEquiv(i1, f) {
+				b.Fatal("Int and Float must not be map-key equivalent")
+			}
+		}
+	})
+}


### PR DESCRIPTION
Every map-key comparison through `valueEquiv` paid a double ~20-case `isComparable` type-switch before reaching a verdict, and an unequal pair of keywords additionally murmur-hashed both strings just to produce the negative. Front-load the two dominant key types with exact reductions of the general path: a keyword only ever equals a keyword with the same string, and `NumEq` on two Ints is `==`. A non-Int second operand still falls through, so `Int`×`Float`/`BigInt` equivalence stays with the numeric path. This is the same pattern the keyword-keyed map lookup already proves in `findKeyword`.

Measured (interleaved A/B against main, n=8, Apple M2, benchmarks included in the PR):

- `valueEquiv` Keyword-equal −50%, Keyword-unequal −91% (30 ns → 2.6 ns — the negative previously hashed both keywords)
- Int-equal −64%, Int-unequal −75%
- map-level `MapAssoc/HAMT-Lookup` (Int keys): −14–17% across 10/100/1000 entries (p ≤ 0.01)

One measured cost: the mixed `Int`×`Float` pair now pays the two failed asserts before reaching `NumEq` — +1.2 ns (+13.7%) on that path. The bench suite pins that pair's semantics (Ints and Floats are never map-key equivalent, matching Clojure `=`) so a future fast path can't silently short-circuit it.

The same tradeoff applies more mildly to other key types: a comparison whose first operand is neither a keyword nor an Int now pays two failed type assertions before the previous logic — a small constant on the collection-key path in exchange for the keyword/int win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #464 (runtime performance & concurrency).
