### PR TITLE
perf(vm): box-free keyword lookup in protocol method dispatch

### DIFF
--- a/pkg/vm/protocol.go
+++ b/pkg/vm/protocol.go
@@ -80,15 +80,7 @@ func (p *Protocol) Lookup(methodName Symbol, target Value) (Fn, bool) {
 	key := Keyword(methodName)
 
 	if target == NIL {
-		if p.nilImpl != nil {
-			v := p.nilImpl.ValueAt(key)
-			if v != NIL {
-				if fn, ok := v.(Fn); ok {
-					return fn, true
-				}
-			}
-		}
-		return nil, false
+		return p.lookupIn(p.nilImpl, key)
 	}
 
 	vt := target.Type()
@@ -106,12 +98,18 @@ func (p *Protocol) Lookup(methodName Symbol, target Value) (Fn, bool) {
 	return nil, false
 }
 
-// lookupIn pulls a method fn out of one type's impl map, if present.
-func (p *Protocol) lookupIn(implMap *PersistentMap, key Value) (Fn, bool) {
+// lookupIn pulls a method fn out of one type's impl map, if present. It
+// takes the key as a bare Keyword and goes through ValueAtKeywordOr's
+// box-free typed lookup: the boxed ValueAt path converted the keyword to a
+// Value (a string-kind interface conversion, i.e. one heap alloc) on every
+// protocol-method call — twice when the AnyType fallback was consulted.
+// Impl-map keys are keywords by construction (see Extend), so the typed
+// compare matches exactly what the boxed path did.
+func (p *Protocol) lookupIn(implMap *PersistentMap, key Keyword) (Fn, bool) {
 	if implMap == nil {
 		return nil, false
 	}
-	v := implMap.ValueAt(key)
+	v := implMap.ValueAtKeywordOr(key, NIL)
 	if v == NIL {
 		return nil, false
 	}

--- a/pkg/vm/protocol_bench_test.go
+++ b/pkg/vm/protocol_bench_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// BenchmarkProtocolFnInvoke measures a full protocol-method call on an
+// extended type: ProtocolFn.Invoke → Protocol.Lookup → impl-map fetch →
+// native fn invoke. The lookup path is where the per-call keyword lookup
+// cost lives.
+func BenchmarkProtocolFnInvoke(b *testing.B) {
+	ident, err := NativeFnType.Wrap(func(vs []Value) (Value, error) {
+		return vs[0], nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	impl := NewArrayMap([]Value{Keyword("-frob"), ident})
+	p := NewProtocol("Frobber", []Symbol{Symbol("-frob")})
+	p.Extend(IntType, impl)
+	pf := NewProtocolFn(p, Symbol("-frob"))
+	args := []Value{Int(7)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v, err := pf.Invoke(args)
+		if err != nil || v != Int(7) {
+			b.Fatalf("invoke: %v %v", v, err)
+		}
+	}
+}
+
+// BenchmarkProtocolLookupFallback measures the miss-then-AnyType-default
+// path, which consulted two impl maps per call.
+func BenchmarkProtocolLookupFallback(b *testing.B) {
+	ident, err := NativeFnType.Wrap(func(vs []Value) (Value, error) {
+		return vs[0], nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	impl := NewArrayMap([]Value{Keyword("-frob"), ident})
+	p := NewProtocol("Frobber", []Symbol{Symbol("-frob")})
+	p.Extend(AnyType, impl)
+	target := String("s")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fn, ok := p.Lookup(Symbol("-frob"), target)
+		if !ok || fn == nil {
+			b.Fatal("lookup failed")
+		}
+	}
+}


### PR DESCRIPTION
`Protocol.Lookup` fetched the method fn via the generic `ValueAt`, which boxes the method keyword into a `Value` (a string-kind interface conversion — one heap allocation) on every protocol-method call, twice when the `AnyType` default was consulted, and compares through `valueEquiv`. Route the lookup through the existing `ValueAtKeywordOr` instead: bare `Keyword` in, `findKeyword`'s typed compare, no allocation.

Dispatch semantics are unchanged: impl-map keys are keywords by construction (`Extend`'s contract), and a non-keyword key never matched under the boxed path either. The nil-target branch now shares `lookupIn` instead of duplicating its logic inline.

Measured (interleaved A/B against main, n=8, Apple M2, benchmarks included in the PR):

- full protocol-method call on an extended type: 65 ns → 38 ns (−41%), and 16 B/op down to zero
- lookup through the `AnyType` fallback (two maps consulted): 76 ns → 35 ns (−54%), and 32 B/op down to zero
- the dispatch path no longer allocates in either shape

Remaining per-call cost is the method-name hash (`Keyword.Hash` recomputes the murmur mix per lookup); caching or interning that is a representation question this change leaves alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #464 (runtime performance & concurrency).
