### PR TITLE
perf(vm): strconv.Itoa and plain concat for Int/Keyword String()

### DIFF
--- a/pkg/vm/int.go
+++ b/pkg/vm/int.go
@@ -6,8 +6,8 @@
 package vm
 
 import (
-	"fmt"
 	"reflect"
+	"strconv"
 )
 
 type theIntType struct {
@@ -64,5 +64,5 @@ func (l Int) Unbox() any {
 }
 
 func (l Int) String() string {
-	return fmt.Sprintf("%d", int(l))
+	return strconv.Itoa(int(l))
 }

--- a/pkg/vm/keyword.go
+++ b/pkg/vm/keyword.go
@@ -46,7 +46,7 @@ func (l Keyword) Unbox() any {
 }
 
 func (l Keyword) String() string {
-	return fmt.Sprintf(":%s", string(l))
+	return ":" + string(l)
 }
 
 func (l Keyword) Arity() int {

--- a/pkg/vm/scalar_string_bench_test.go
+++ b/pkg/vm/scalar_string_bench_test.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// String() on the scalar types sits under str/pr-str and any render path
+// that stringifies values.
+func BenchmarkScalarString(b *testing.B) {
+	b.Run("Int", func(b *testing.B) {
+		v := Int(1048576)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if len(v.String()) == 0 {
+				b.Fatal("empty")
+			}
+		}
+	})
+	b.Run("Keyword", func(b *testing.B) {
+		v := Keyword("player-position")
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if len(v.String()) == 0 {
+				b.Fatal("empty")
+			}
+		}
+	})
+}


### PR DESCRIPTION
`Int.String` went through `fmt.Sprintf("%d")` and `Keyword.String` through `fmt.Sprintf(":%s")` — reflection-based formatting plus an interface-box of the operand on every call, on methods that sit under `str`/`pr-str` and any render path that stringifies values. `strconv.Itoa` and a two-string concat produce identical output.

Measured (interleaved A/B against main, n=8, Apple M2, benchmarks included in the PR): `Int.String` 42.9 ns → 16.4 ns (−62%), `Keyword.String` 35.3 ns → 11.5 ns (−67%). The benchmark also shows the keyword path dropping to zero allocations, though part of that is the non-escaping benchmark shape — in escaping positions the concat still allocates its result, just without fmt's extra operand box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #464 (runtime performance & concurrency).
