### PR TITLE
fix(bench-ratchet): report out-of-scope baseline entries as one line, not MISSING rows (stacks on #561)

### DIFF
--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -79,8 +79,10 @@ const (
 	// gate. These metrics are deterministic (no CPU-dependent noise), so the
 	// budget is tight — it only absorbs rare boundary effects (e.g. a map
 	// resize landing one element differently).
-	allocBudget      = 0.02
-	defaultCount     = 1
+	allocBudget = 0.02
+	// 4 reps minimum: the first is discarded as warmup by reduceSamples,
+	// leaving >=3 for a meaningful median (a median of 2 doesn't exist).
+	defaultCount     = 4
 	defaultBenchtime = "1s"
 	defaultTimeout   = "10m"
 	defaultTags      = "gogen_ir"
@@ -678,7 +680,7 @@ var profiles = map[string]profile{
 		// Sized for fast PR feedback, not absolute precision: ~53 cases ×
 		// count 3 × 500ms keeps a two-pass A/B well under the old full-fleet
 		// runtime, and the 12% budget sits above the residual sub-µs jitter.
-		count:     3,
+		count:     4,
 		benchtime: "500ms",
 		budget:    0.12,
 		jobs: func(tags string) ([]captureJob, error) {
@@ -731,12 +733,12 @@ func buildJobs(packages, tags string, full, manual bool, filterRE *regexp.Regexp
 		}
 		jobs := []captureJob{
 			{pkg: anchorPackage, tags: tags, filter: filterRE},
-			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "bytecode", count: 1},
-			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "ir_bytecode", count: 1, env: []string{"LG_SUITE_IR=1"}},
-			{pkg: suitePackage, tags: "gogen_ir", filter: suiteRE, variant: "aot_native", count: 1, env: []string{"LG_SUITE_IR=1"}},
-			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_bytecode", count: 1},
-			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_ir_bytecode", count: 1, env: []string{"LG_SUITE_IR=1"}},
-			{pkg: suitePackage, tags: "gogen_ir", filter: suiteTotalRE, variant: "total_aot_native", count: 1, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "bytecode", count: 4},
+			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "ir_bytecode", count: 4, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "gogen_ir", filter: suiteRE, variant: "aot_native", count: 4, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_bytecode", count: 4},
+			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_ir_bytecode", count: 4, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "gogen_ir", filter: suiteTotalRE, variant: "total_aot_native", count: 4, env: []string{"LG_SUITE_IR=1"}},
 			{pkg: irCompilePackage, tags: "", filter: irCompileRE, variant: "bytecode"},
 			{pkg: irCompilePackage, tags: "gogen_ir", filter: irCompileRE, variant: "gogen_ir"},
 			{pkg: initPackage, tags: "", filter: initRE, variant: "bytecode"},
@@ -765,12 +767,12 @@ func buildJobs(packages, tags string, full, manual bool, filterRE *regexp.Regexp
 		}
 		jobs := []captureJob{
 			{pkg: anchorPackage, tags: "", filter: anchorRE},
-			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "bytecode", count: 1},
-			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "ir_bytecode", count: 1, env: []string{"LG_SUITE_IR=1"}},
-			{pkg: suitePackage, tags: "gogen_ir", filter: suiteRE, variant: "aot_native", count: 1, env: []string{"LG_SUITE_IR=1"}},
-			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_bytecode", count: 1},
-			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_ir_bytecode", count: 1, env: []string{"LG_SUITE_IR=1"}},
-			{pkg: suitePackage, tags: "gogen_ir", filter: suiteTotalRE, variant: "total_aot_native", count: 1, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "bytecode", count: 4},
+			{pkg: suitePackage, tags: "", filter: suiteRE, variant: "ir_bytecode", count: 4, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "gogen_ir", filter: suiteRE, variant: "aot_native", count: 4, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_bytecode", count: 4},
+			{pkg: suitePackage, tags: "", filter: suiteTotalRE, variant: "total_ir_bytecode", count: 4, env: []string{"LG_SUITE_IR=1"}},
+			{pkg: suitePackage, tags: "gogen_ir", filter: suiteTotalRE, variant: "total_aot_native", count: 4, env: []string{"LG_SUITE_IR=1"}},
 			{pkg: irCompilePackage, tags: "", filter: irCompileRE, variant: "bytecode"},
 			{pkg: irCompilePackage, tags: "gogen_ir", filter: irCompileRE, variant: "gogen_ir"},
 			{pkg: initPackage, tags: "", filter: initRE, variant: "bytecode"},
@@ -927,9 +929,35 @@ func captureOnePackage(pkg string, count int, benchtime, timeout, tags string, f
 	return written, nil
 }
 
+// reduceSamples collapses chronological per-rep measurements into one
+// robust value, hyperfine-style: with more than one rep, the FIRST is
+// discarded as warmup (cold caches, first-touch var resolution, and
+// CPU clock ramp make it the systematically slowest — the suite bench
+// visibly climbs across in-process reps), and the median of the rest
+// is taken. Median, not mean: a single contention spike or GC pause
+// skews an average straight into the stored baseline, which is how a
+// concurrently-running pass once manufactured six phantom regressions.
+// With one rep (legacy captures, -count 1) the value passes through.
+func reduceSamples(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	if len(vals) > 1 {
+		vals = vals[1:]
+	}
+	s := append([]float64(nil), vals...)
+	sort.Float64s(s)
+	if n := len(s); n%2 == 1 {
+		return s[n/2]
+	} else {
+		return (s[n/2-1] + s[n/2]) / 2
+	}
+}
+
 // aggregateFromFile reads a .jsonl of StreamRecord lines and returns
-// a Baseline computed from them. Same-named records (e.g. multiple
-// -count repetitions) are averaged.
+// a Baseline computed from them. Same-named records (multiple -count
+// repetitions, in capture order) reduce via reduceSamples: first rep
+// discarded as warmup, median of the remainder.
 func aggregateFromFile(path string) (MachineBaseline, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -938,12 +966,11 @@ func aggregateFromFile(path string) (MachineBaseline, error) {
 	defer f.Close()
 
 	type accum struct {
-		pkg                       string
-		name                      string
-		count                     int
-		nsSum, bytesSum, allocSum float64
-		iters                     int64
-		samples                   []BenchmarkSample
+		pkg               string
+		name              string
+		ns, bytes, allocs []float64
+		iters             int64
+		samples           []BenchmarkSample
 	}
 	byName := map[string]*accum{}
 	dec := json.NewDecoder(f)
@@ -958,10 +985,9 @@ func aggregateFromFile(path string) (MachineBaseline, error) {
 			a = &accum{pkg: rec.Package, name: rec.Name}
 			byName[key] = a
 		}
-		a.count++
-		a.nsSum += rec.NSPerOp
-		a.bytesSum += float64(rec.BytesPerOp)
-		a.allocSum += float64(rec.AllocsPerOp)
+		a.ns = append(a.ns, rec.NSPerOp)
+		a.bytes = append(a.bytes, float64(rec.BytesPerOp))
+		a.allocs = append(a.allocs, float64(rec.AllocsPerOp))
 		if rec.Iterations > a.iters {
 			a.iters = rec.Iterations
 		}
@@ -974,9 +1000,9 @@ func aggregateFromFile(path string) (MachineBaseline, error) {
 			Package:     a.pkg,
 			Name:        a.name,
 			Iterations:  a.iters,
-			NSPerOp:     a.nsSum / float64(a.count),
-			BytesPerOp:  int64(a.bytesSum / float64(a.count)),
-			AllocsPerOp: int64(a.allocSum / float64(a.count)),
+			NSPerOp:     reduceSamples(a.ns),
+			BytesPerOp:  int64(reduceSamples(a.bytes)),
+			AllocsPerOp: int64(reduceSamples(a.allocs)),
 			Samples:     append([]BenchmarkSample(nil), a.samples...),
 		})
 	}
@@ -1401,6 +1427,20 @@ func compareAndReport(baseline, current MachineBaseline, budget float64, format 
 		anchorDrift := (current.Anchor.NSPerOp - baseline.Anchor.NSPerOp) / baseline.Anchor.NSPerOp
 		fmt.Printf("anchor: baseline %.3f ns/op, current %.3f ns/op (%+.1f%%)\n",
 			baseline.Anchor.NSPerOp, current.Anchor.NSPerOp, anchorDrift*100)
+		// The anchor is the divisor for EVERY normalized ratio: on identical
+		// hardware+toolchain it should be stable to a few percent. A large
+		// drift means the anchor ran in a different CPU regime on one side
+		// (P-core vs E-core scheduling, thermal throttle, a concurrent
+		// load) — and every REGRESSION/ok verdict below is scaled by the
+		// same bogus factor. Observed in practice as a bimodal ~1.06 vs
+		// ~1.85 ns anchor on an M3 manufacturing phantom +38% regressions.
+		if anchorDrift < -0.15 || anchorDrift > 0.15 {
+			fmt.Printf("WARNING: anchor moved %+.1f%% on the same machine class — normalized\n", anchorDrift*100)
+			fmt.Printf("  ratios below are scaled by this factor and NOT trustworthy. Likely a\n")
+			fmt.Printf("  polluted capture (CPU scheduling/thermal/concurrent load) on one side;\n")
+			fmt.Printf("  re-run on a quiet machine, and if the drift persists recapture the\n")
+			fmt.Printf("  baseline (bench-ratchet update -force) from a clean checkout.\n")
+		}
 	}
 	fmt.Println()
 

--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -242,7 +242,7 @@ func main() {
 		if mode == "snapshot" {
 			writeSnapshot(*baselinePath, current)
 		} else {
-			writeOrCheck(*baselinePath, current, "update", *budget, *force, *format)
+			writeOrCheck(*baselinePath, current, "update", *budget, *force, *format, nil)
 		}
 		return
 	}
@@ -333,7 +333,7 @@ func main() {
 	if mode == "snapshot" {
 		writeSnapshot(*baselinePath, current)
 	} else {
-		writeOrCheck(*baselinePath, current, mode, effBudget, *force, *format)
+		writeOrCheck(*baselinePath, current, mode, effBudget, *force, *format, jobs)
 	}
 }
 
@@ -355,8 +355,11 @@ func writeSnapshot(path string, current MachineBaseline) {
 	fmt.Printf("\nwrote snapshot → %s (%d benchmarks for %s)\n", path, len(current.Benchmarks), key)
 }
 
-// writeOrCheck dispatches the post-aggregate action.
-func writeOrCheck(baselinePath string, current MachineBaseline, mode string, budget float64, force bool, format string) {
+// writeOrCheck dispatches the post-aggregate action. jobs is the capture
+// scope of THIS run (nil when aggregating from a pre-recorded .jsonl, where
+// the scope is unknown); check reporting uses it to suppress out-of-scope
+// baseline entries instead of listing them as MISSING.
+func writeOrCheck(baselinePath string, current MachineBaseline, mode string, budget float64, force bool, format string, jobs []captureJob) {
 	switch mode {
 	case "show":
 		switch format {
@@ -417,7 +420,7 @@ func writeOrCheck(baselinePath string, current MachineBaseline, mode string, bud
 		// Timing gate: ns/op and ratio_to_anchor are CPU-dependent, so gate
 		// them ONLY against this machine's own profile.
 		if prof, ok := baseline.Machines[key]; ok {
-			if e := compareAndReport(prof, current, budget, format); e != 0 {
+			if e := compareAndReport(prof, current, budget, format, jobs); e != 0 {
 				exit = e
 			}
 		} else {
@@ -1409,9 +1412,46 @@ func printBaseline(b MachineBaseline) {
 // non-zero exit code when any benchmark exceeded the regression budget.
 // format is "text" (default ANSI terminal) or "markdown" (a single
 // GitHub/Slack-friendly table).
-func compareAndReport(baseline, current MachineBaseline, budget float64, format string) int {
+// jobsSelect reports whether fullName (Package + "." + Name, where Name may
+// carry "/sub" segments and a " [variant]" suffix) is selected by any of this
+// run's capture jobs. Check reporting uses it to distinguish a benchmark that
+// is in scope but absent from the run (deleted/renamed — a real MISSING
+// signal) from a baseline entry outside the active profile's scope (e.g. the
+// pkg/vm micro fleet when running the fast gate), which was never going to be
+// measured and must not be reported row-by-row.
+func jobsSelect(jobs []captureJob, fullName string) bool {
+	for _, j := range jobs {
+		rest, ok := strings.CutPrefix(fullName, j.pkg+".")
+		if !ok {
+			continue
+		}
+		// Variant label must agree: variant jobs stamp " [v]" onto the name;
+		// the variant-free anchor job records no label.
+		if j.variant != "" {
+			r2, ok := strings.CutSuffix(rest, " ["+j.variant+"]")
+			if !ok {
+				continue
+			}
+			rest = r2
+		} else if strings.Contains(rest, " [") {
+			continue
+		}
+		// go test -bench matches per slash-segment and the job filters are
+		// family-anchored, so match the family segment only.
+		family := rest
+		if i := strings.IndexByte(family, '/'); i >= 0 {
+			family = family[:i]
+		}
+		if j.filter.MatchString(family) {
+			return true
+		}
+	}
+	return false
+}
+
+func compareAndReport(baseline, current MachineBaseline, budget float64, format string, jobs []captureJob) int {
 	if format == "markdown" {
-		return compareAndReportMarkdown(baseline, current, budget)
+		return compareAndReportMarkdown(baseline, current, budget, jobs)
 	}
 	fmt.Println()
 	if baseline.Machine.CPUModel != current.Machine.CPUModel ||
@@ -1452,8 +1492,16 @@ func compareAndReport(baseline, current MachineBaseline, budget float64, format 
 		present             bool
 	}
 	var drifts []drift
+	outOfScope := 0
 	for name, base := range baseline.Benchmarks {
 		cur, ok := current.Benchmarks[name]
+		// A baseline entry the active profile never selects (e.g. the full
+		// pkg/vm fleet while running the fast gate) is out of scope, not
+		// missing — count it once, don't report it row-by-row.
+		if !ok && len(jobs) > 0 && !jobsSelect(jobs, name) {
+			outOfScope++
+			continue
+		}
 		d := drift{
 			name:      name,
 			baseRatio: base.RatioToAnchor,
@@ -1511,6 +1559,9 @@ func compareAndReport(baseline, current MachineBaseline, budget float64, format 
 	fmt.Println()
 	fmt.Printf("summary: %d regression(s) > %.1f%% budget, %d missing, %d new\n",
 		regressions, budget*100, missing, newCount)
+	if outOfScope > 0 {
+		fmt.Printf("(%d baseline benchmark(s) outside this profile's scope — not run, not compared)\n", outOfScope)
+	}
 	if regressions > 0 {
 		return 1
 	}
@@ -1577,7 +1628,7 @@ func formatWall(ns float64) string {
 //
 // The output is also Slack-friendly when wrapped in a code block, since
 // Slack renders the pipes monospace.
-func compareAndReportMarkdown(baseline, current MachineBaseline, budget float64) int {
+func compareAndReportMarkdown(baseline, current MachineBaseline, budget float64, jobs []captureJob) int {
 	type row struct {
 		name          string
 		baseR, curR   float64
@@ -1591,12 +1642,20 @@ func compareAndReportMarkdown(baseline, current MachineBaseline, budget float64)
 	regressions := 0
 	missing := 0
 	newCount := 0
+	outOfScope := 0
 
 	for name, base := range baseline.Benchmarks {
 		seen[name] = true
 		r := row{name: name, baseR: base.RatioToAnchor, baseNs: base.NSPerOp, bestSinceSHA: base.BestSinceSHA}
 		cur, ok := current.Benchmarks[name]
 		if !ok {
+			// Outside the active profile's scope → never run; count once
+			// instead of emitting a MISSING row per benchmark. (nil jobs =
+			// scope unknown, e.g. aggregate-from-file → classic MISSING.)
+			if len(jobs) > 0 && !jobsSelect(jobs, name) {
+				outOfScope++
+				continue
+			}
 			r.status = "MISSING"
 			missing++
 			rows = append(rows, r)
@@ -1635,6 +1694,9 @@ func compareAndReportMarkdown(baseline, current MachineBaseline, budget float64)
 	fmt.Println()
 	fmt.Printf("**bench-ratchet** — %d regression(s) > %.1f%% budget, %d missing, %d new\n\n",
 		regressions, budget*100, missing, newCount)
+	if outOfScope > 0 {
+		fmt.Printf("_%d baseline benchmark(s) outside this profile's scope — not run, not compared._\n\n", outOfScope)
+	}
 	fmt.Printf("- baseline: `%s` / `%s` / `%s`\n",
 		baseline.Machine.CPUModel, baseline.Machine.GoVersion, baseline.Machine.OS+"-"+baseline.Machine.Arch)
 	fmt.Printf("- current:  `%s` / `%s` / `%s`\n",

--- a/cmd/bench-ratchet/main_test.go
+++ b/cmd/bench-ratchet/main_test.go
@@ -16,11 +16,17 @@ func TestAggregateFromFileRetainsSamples(t *testing.T) {
 		t.Fatal(err)
 	}
 	enc := json.NewEncoder(f)
+	// Reduction semantics: first rep per benchmark is warmup (discarded),
+	// remainder medians. Anchor [10,20] -> 20; BenchmarkA ns [30,60,40,50]
+	// -> median(60,40,50) = 50; bytes [100,200,120,160] -> 160;
+	// allocs [1,3,5,7] -> 5. Raw samples all retained.
 	records := []StreamRecord{
 		{Package: anchorPackage, Name: anchorName, Iterations: 100, NSPerOp: 10, CapturedAt: "2026-06-01T00:00:00Z"},
 		{Package: anchorPackage, Name: anchorName, Iterations: 90, NSPerOp: 20, CapturedAt: "2026-06-01T00:00:01Z"},
 		{Package: "pkg", Name: "BenchmarkA", Iterations: 50, NSPerOp: 30, BytesPerOp: 100, AllocsPerOp: 1, CapturedAt: "2026-06-01T00:00:02Z"},
 		{Package: "pkg", Name: "BenchmarkA", Iterations: 60, NSPerOp: 60, BytesPerOp: 200, AllocsPerOp: 3, CapturedAt: "2026-06-01T00:00:03Z"},
+		{Package: "pkg", Name: "BenchmarkA", Iterations: 55, NSPerOp: 40, BytesPerOp: 120, AllocsPerOp: 5, CapturedAt: "2026-06-01T00:00:04Z"},
+		{Package: "pkg", Name: "BenchmarkA", Iterations: 58, NSPerOp: 50, BytesPerOp: 160, AllocsPerOp: 7, CapturedAt: "2026-06-01T00:00:05Z"},
 	}
 	for _, rec := range records {
 		if err := enc.Encode(rec); err != nil {
@@ -39,23 +45,44 @@ func TestAggregateFromFileRetainsSamples(t *testing.T) {
 		t.Fatalf("anchor samples = %d, want 2", len(baseline.Anchor.Samples))
 	}
 	entry := baseline.Benchmarks["pkg.BenchmarkA"]
-	if entry.NSPerOp != 45 {
-		t.Fatalf("ns/op = %v, want 45", entry.NSPerOp)
+	if entry.NSPerOp != 50 {
+		t.Fatalf("ns/op = %v, want 50 (median of post-warmup reps)", entry.NSPerOp)
 	}
-	if entry.BytesPerOp != 150 {
-		t.Fatalf("bytes/op = %d, want 150", entry.BytesPerOp)
+	if entry.BytesPerOp != 160 {
+		t.Fatalf("bytes/op = %d, want 160", entry.BytesPerOp)
 	}
-	if entry.AllocsPerOp != 2 {
-		t.Fatalf("allocs/op = %d, want 2", entry.AllocsPerOp)
+	if entry.AllocsPerOp != 5 {
+		t.Fatalf("allocs/op = %d, want 5", entry.AllocsPerOp)
 	}
-	if len(entry.Samples) != 2 {
-		t.Fatalf("samples = %d, want 2", len(entry.Samples))
+	if len(entry.Samples) != 4 {
+		t.Fatalf("samples = %d, want 4 (raw reps all retained)", len(entry.Samples))
 	}
-	if entry.Samples[0].RatioToAnchor != 2 {
-		t.Fatalf("first sample ratio = %v, want 2", entry.Samples[0].RatioToAnchor)
+	// Per-sample ratios are raw values against the REDUCED anchor (20).
+	if entry.Samples[0].RatioToAnchor != 1.5 {
+		t.Fatalf("first sample ratio = %v, want 1.5", entry.Samples[0].RatioToAnchor)
 	}
-	if entry.Samples[1].RatioToAnchor != 4 {
-		t.Fatalf("second sample ratio = %v, want 4", entry.Samples[1].RatioToAnchor)
+	if entry.Samples[1].RatioToAnchor != 3 {
+		t.Fatalf("second sample ratio = %v, want 3", entry.Samples[1].RatioToAnchor)
+	}
+}
+
+func TestReduceSamplesWarmupAndMedian(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []float64
+		want float64
+	}{
+		{"empty", nil, 0},
+		{"single passes through", []float64{7}, 7},
+		{"two drops warmup", []float64{100, 40}, 40},
+		{"odd median after warmup", []float64{100, 60, 40, 50}, 50},
+		{"even median after warmup", []float64{100, 10, 20, 30, 40}, 25},
+		{"warmup spike ignored", []float64{9999, 10, 11, 12}, 11},
+	}
+	for _, c := range cases {
+		if got := reduceSamples(c.in); got != c.want {
+			t.Errorf("%s: reduceSamples(%v) = %v, want %v", c.name, c.in, got, c.want)
+		}
 	}
 }
 
@@ -134,9 +161,12 @@ func TestEffectiveCountPrefersJobOverride(t *testing.T) {
 	}
 }
 
-// The full + fast profiles run the Clojure test suite once per execution mode
-// (count=1): a single suite pass takes minutes and run-to-run variance is
-// negligible, so 3 samples would just triple wall time. The cheap,
+// The full + fast profiles run the Clojure test suite 4x per execution mode:
+// the first rep is discarded as warmup by reduceSamples and the remaining 3
+// median (the minimum for a meaningful median). The old count=1 pin assumed
+// run-to-run variance was negligible; in practice single cold samples plus
+// anchor drift manufactured phantom +38% regressions (2026-07-18), and the
+// suite bench visibly climbs across in-process reps. The cheap,
 // benchtime-bounded vm/ir jobs keep the CLI default (count=0 → -count flag).
 //
 // There are exactly three suite modes, distinguished by the LG_SUITE_IR env
@@ -144,7 +174,7 @@ func TestEffectiveCountPrefersJobOverride(t *testing.T) {
 //   - bytecode    : *ir-compile* off, untagged
 //   - ir_bytecode : *ir-compile* on  (LG_SUITE_IR=1), untagged
 //   - aot_native  : *ir-compile* on  (LG_SUITE_IR=1), -tags gogen_ir
-func TestSuiteJobsPinCountToOne(t *testing.T) {
+func TestSuiteJobsPinCountToFour(t *testing.T) {
 	hasEnv := func(env []string, want string) bool {
 		for _, e := range env {
 			if e == want {
@@ -162,8 +192,8 @@ func TestSuiteJobsPinCountToOne(t *testing.T) {
 		total := map[string]captureJob{}
 		for _, j := range jobs {
 			if j.pkg == suitePackage {
-				if j.count != 1 {
-					t.Errorf("full=%v: suite job [%s] count = %d, want 1", full, j.variant, j.count)
+				if j.count != 4 {
+					t.Errorf("full=%v: suite job [%s] count = %d, want 4", full, j.variant, j.count)
 				}
 				switch j.filter.String() {
 				case suiteFilter:

--- a/cmd/bench-ratchet/main_test.go
+++ b/cmd/bench-ratchet/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/nooga/let-go/pkg/perfdata"
@@ -273,4 +274,44 @@ func keysOf(m map[string]captureJob) []string {
 		ks = append(ks, k)
 	}
 	return ks
+}
+
+// TestJobsSelectScope pins the check-report scope predicate: baseline entries
+// the active profile never selects are "out of scope" (skipped, counted once),
+// while in-scope-but-absent entries stay MISSING. Guards the fast-gate report
+// from drowning in MISSING rows for the full-profile pkg/vm fleet.
+func TestJobsSelectScope(t *testing.T) {
+	anchorRE := regexp.MustCompile(`^BenchmarkRatchetAnchor$`)
+	suiteRE := regexp.MustCompile(`^BenchmarkClojureTestSuite$`)
+	irRE := regexp.MustCompile(`^BenchmarkIRCompile$`)
+	jobs := []captureJob{
+		{pkg: "github.com/nooga/let-go/pkg/vm", filter: anchorRE},
+		{pkg: "github.com/nooga/let-go/test", filter: suiteRE, variant: "bytecode"},
+		{pkg: "github.com/nooga/let-go/pkg/ir", filter: irRE, variant: "gogen_ir"},
+	}
+	cases := []struct {
+		name string
+		want bool
+	}{
+		// anchor: variant-free job matches variant-free entry
+		{"github.com/nooga/let-go/pkg/vm.BenchmarkRatchetAnchor", true},
+		// full-fleet vm micro: same pkg, family not in any filter → out of scope
+		{"github.com/nooga/let-go/pkg/vm.BenchmarkVectorCreation/PersistentVector", false},
+		// suite under the selected variant, in scope
+		{"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [bytecode]", true},
+		// suite under a variant this run doesn't measure → out of scope
+		{"github.com/nooga/let-go/test.BenchmarkClojureTestSuite [aot_native]", false},
+		// variant job must not claim the variant-free spelling
+		{"github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile", false},
+		{"github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile [gogen_ir]", true},
+		// sub-benchmark matches on the family segment
+		{"github.com/nooga/let-go/pkg/ir.BenchmarkIRCompile/warm [gogen_ir]", true},
+		// unrelated package
+		{"github.com/nooga/let-go/pkg/compiler.BenchmarkInitFromLGB [bytecode]", false},
+	}
+	for _, c := range cases {
+		if got := jobsSelect(jobs, c.name); got != c.want {
+			t.Errorf("jobsSelect(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
 }


### PR DESCRIPTION
Extracted from the `catalog-dispatch-facets` stack — it's a standalone reporting fix that was riding along with unrelated IR work, and it's newly relevant: every ratchet report during the 2026-07-18 baseline investigation was flooded with **133 MISSING rows** (baseline entries outside the current run's scope), burying the handful of real verdict lines. This collapses them to a single summary line.

**Stacked on #561** (rebased onto it cleanly, same two files, disjoint regions — aggregation vs reporting; `go test ./cmd/bench-ratchet` green on the combined tree). This branch contains #561's commit; only the top commit is under review. Land #561 first and this becomes a one-commit diff.

Together with #561 (sampling) and #564 (baseline recapture), this completes the ratchet-trustworthiness set: clean samples, clean priors, readable reports.