### PR TITLE
perf(vm): divide-free fast path for checkedMulInt overflow guard

### DIFF
--- a/pkg/vm/checked_mul_test.go
+++ b/pkg/vm/checked_mul_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"math/big"
+	"testing"
+)
+
+// TestCheckedMulInt checks checkedMulInt against a math/big oracle over a
+// grid of adversarial operands: the fast-path guard boundary (mulGuardMin/
+// Max and neighbors), the int extremes, and the historical minInt×-1 edge.
+func TestCheckedMulInt(t *testing.T) {
+	vals := []Int{
+		0, 1, -1, 2, -2, 3, 255, 256, -255, -256,
+		mulGuardMax, mulGuardMax - 1, mulGuardMax + 1,
+		mulGuardMin, mulGuardMin + 1, mulGuardMin - 1,
+		maxIntValue, maxIntValue - 1, minIntValue, minIntValue + 1,
+		maxIntValue / 2, minIntValue / 2, mulGuardMax * 2, mulGuardMin * 2,
+	}
+	for _, a := range vals {
+		for _, b := range vals {
+			got, ok := checkedMulInt(a, b)
+			ref := new(big.Int).Mul(big.NewInt(int64(a)), big.NewInt(int64(b)))
+			fits := ref.IsInt64() && Int(ref.Int64()) >= minIntValue && Int(ref.Int64()) <= maxIntValue
+			if fits != ok {
+				t.Fatalf("checkedMulInt(%d, %d): ok=%v, oracle fits=%v", a, b, ok, fits)
+			}
+			if ok && int64(got) != ref.Int64() {
+				t.Fatalf("checkedMulInt(%d, %d) = %d, oracle %s", a, b, got, ref)
+			}
+		}
+	}
+}
+
+// BenchmarkCheckedMulInt measures the common-operand case (values well
+// inside the fast-path guard) and the wide case that still takes the
+// division-checked path.
+func BenchmarkCheckedMulInt(b *testing.B) {
+	b.Run("small", func(b *testing.B) {
+		x, y := Int(31337), Int(-2711)
+		for i := 0; i < b.N; i++ {
+			r, ok := checkedMulInt(x, y)
+			if !ok || r != x*y {
+				b.Fatal("bad result")
+			}
+		}
+	})
+	b.Run("wide", func(b *testing.B) {
+		// Outside the fast-path guard at any int width.
+		x, y := (mulGuardMax+1)*8, Int(3)
+		for i := 0; i < b.N; i++ {
+			r, ok := checkedMulInt(x, y)
+			if !ok || r != x*y {
+				b.Fatal("bad result")
+			}
+		}
+	})
+}

--- a/pkg/vm/numbers.go
+++ b/pkg/vm/numbers.go
@@ -9,6 +9,14 @@ import (
 const maxIntValue = Int(int(^uint(0) >> 1))
 const minIntValue = -maxIntValue - 1
 
+// mulGuard bounds checkedMulInt's divide-free fast path: when both operands
+// fit in half the platform int width, their product cannot overflow, so the
+// division-based checks are skipped. Half-width (not a fixed int32 range)
+// keeps the bound correct on 32-bit-int builds as well as 64-bit.
+const intBits = 32 << (^uint(0) >> 63)
+const mulGuardMax = Int(1)<<(intBits/2-1) - 1
+const mulGuardMin = -mulGuardMax - 1
+
 func checkedAddInt(a, b Int) (Int, bool) {
 	if (b > 0 && a > maxIntValue-b) || (b < 0 && a < minIntValue-b) {
 		return 0, false
@@ -24,6 +32,13 @@ func checkedSubInt(a, b Int) (Int, bool) {
 }
 
 func checkedMulInt(a, b Int) (Int, bool) {
+	// Fast path: both operands within half the int width — the product
+	// cannot overflow (extremes: (-2^31)^2 = 2^62 on 64-bit int). The
+	// signed divides below (~20-40 cycles guarding a ~3-cycle multiply)
+	// run only for wide operands.
+	if a >= mulGuardMin && a <= mulGuardMax && b >= mulGuardMin && b <= mulGuardMax {
+		return a * b, true
+	}
 	if a == 0 || b == 0 {
 		return 0, true
 	}


### PR DESCRIPTION
Every non-zero `Int`×`Int` multiply paid one or two signed divisions as its overflow check — roughly a 20–40-cycle guard on a 3-cycle multiply, sitting on the `OP_MUL` dispatch fast path. The change adds a pre-check: when both operands fit in half the platform int width, the product cannot overflow, so the divide-based checks run only for wide operands. The bound derives from the int width (the int32 range on 64-bit builds, int16 on 32-bit) rather than being hard-coded, so 32-bit-int targets stay correct.

Measured (interleaved A/B against main, n=8, Apple M2, benchmarks in the PR; ambient load widened the intervals, paired deltas significant): common in-range operands 8.3 ns → 3.6 ns (−57%, p=0.000); wide operands 7.2 ns → 10.3 ns (+44%, p=0.021) from the four failed guard compares. Wide checked multiplies are the rare shape: products between 2^31 and 2^63 that don't overflow, and overflow-prone hash-mixing code uses `unchecked-multiply`, which never enters this function.

Correctness is pinned by an exhaustive boundary test against a `math/big` oracle: the guard edges and neighbors, the int extremes, and the historical `minInt`×−1 case, all operand pairs cross-checked for both the overflow verdict and the product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #464 (runtime performance & concurrency).
