### PR TITLE
ci(perf-timeline): revert -count to 3 — a count-4 ubuntu leg measures 104 min, past the 90-min timeout

### DIFF
--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -126,13 +126,15 @@ jobs:
           snapshot_tmp="${RUNNER_TEMP}/${snapshot_name}"
           raw_tmp="${RUNNER_TEMP}/${snapshot_name%.json}.jsonl"
 
-          # -count 4 matches bench-ratchet's warmup-discarding median sampling
-          # (#561): rep 1 is discarded, leaving a median of 3. A count of 3
-          # would reduce to an average of 2 there; under pre-#561 mean
-          # aggregation it's simply one more sample. Safe in either merge order.
+          # -count 3: a count-4 ubuntu leg measured 103.9 min end to end
+          # (pkg/vm bench alone ~97 min), past timeout-minutes: 90 — every
+          # timeline leg would die at the kill. Count 3 keeps the leg in the
+          # measured ~65-min envelope. Note for the #561 sampling rework:
+          # count 3 lands in reduceSamples' discard-warmup-then-average-of-2
+          # branch there; the estimator question lives on that PR.
           go run ./cmd/bench-ratchet \
             -full \
-            -count 4 \
+            -count 3 \
             -benchtime 2s \
             -timeout 30m \
             -out "${raw_tmp}" \


### PR DESCRIPTION
The count-4 bump (cefa144) rode #565's merge a few minutes before the timing probe it was waiting on finished. The probe answers it: one ubuntu `-full` leg at count 4 runs **103.9 min** end to end (101.5 min in the capture step), past `timeout-minutes: 90` — on current main every timeline leg dies at the kill, which would re-stall the timeline #565 just unjammed. Probe run (fork, publish disabled, timeouts raised so it could finish): https://github.com/mparrett/let-go/actions/runs/29653784883

The breakdown matters for #561: the six suite variants at count 4 cost ~4 min combined (each finishes in under a minute) — the 1 → 4 suite pins are not the problem. The cost is the main `pkg/vm` bench invocation at `-count 4`: ~97 min, and it scales with count. The last count-3 leg fit in ~65 min.

This restores `-count 3`, the measured-fit envelope, and leaves the estimator question on #561 (count 3 lands in the new `reduceSamples` average-of-2 branch once that merges — see the discussion there).
