### PR TITLE
perf(ir): re-emit ordinary var loads instead of copying them; add lowering-shape ratchet

### DIFF
--- a/docs/perf/ir-stress-baseline.edn
+++ b/docs/perf/ir-stress-baseline.edn
@@ -1,9 +1,9 @@
-{:failed 20
- :total 2393
- :passed 2373
- :captured "2026-07-11"
+{:failed 11
+ :total 2431
+ :passed 2420
+ :captured "2026-07-19"
  :how "LG_STRESS_PASSES=1 make ir-stress (corpus = every shipped/test/example .lg)"
  :note
  "ITER-0021 lowering-coverage ratchet. `make ir-stress-gate` fails when the\n  corpus failure count exceeds :failed — i.e. a form newly fails to lower to\n  native Go and falls back to bytecode / vm dispatch (a trampoline, not a\n  direct/native call). The ratchet only tightens: after a genuine coverage\n  gain (fewer failures), the baseline re-tightens and locks the improvement in.\n  NEVER loosens the gate after a coverage loss without human investigation —\n  it's always a real regression, and the gate's role is to prevent PR merges\n  from masking a regression.\n\n  Corpus is discovered from every shipped/test/example .lg, so upstream growth\n  moves :total. :failed stays 20 in already-known bucket classes; no new mode."
  :buckets
- {":unresolved/a" 1, ":validate/cross-block-ref" 8, ":unresolved/_" 1, ":build/unrecognized-form" 1, ":unresolved/n" 7, ":other | unsupported function body shape" 1, ":unresolved/read-json" 1}}
+ {":unresolved/a" 1, ":build/unrecognized-form" 1, ":unresolved/n" 7, ":other | unsupported function body shape" 1, ":unresolved/read-json" 1}}

--- a/pkg/rt/core/ir/lower.lg
+++ b/pkg/rt/core/ir/lower.lg
@@ -252,6 +252,146 @@
         (contains-after? refs i (nth refs i)) false
         :else (recur (inc i))))))
 
+;; --- set!-target vars ------------------------------------------------
+;;
+;; A :load-var may be re-emitted at each use (one LOAD_VAR, no junk) exactly
+;; as the plain bytecode compiler does — it emits a fresh LOAD_VAR per use and
+;; the VM snapshots the root when the load executes. That is unsafe only for a
+;; var this same function set!s: two loads straddling the set! would read
+;; different roots, where a single materialized load holds the pre-set! value.
+;; So materialize-once is restricted to set!-TARGET vars, mirroring
+;; lower_go.lg's load-var-snapshot? rule. A blanket exclusion of every
+;; :load-var (the pre-2026-07-19 behavior) forced a DUP_NTH copy per extra use
+;; of ordinary vars, which is how self-recursive fns like fib lowered to 33%
+;; more instructions than the compiler this pipeline is meant to beat.
+
+(defn- var-key-of-symbol [aux]
+  (let [sym (symbol aux)]
+    (str (or (namespace sym) "core") "/" (name sym))))
+
+(defn- var-key-of-var-value [v]
+  ;; A *vm.Var value stringifies as "#'ns/name"; strip the #' and re-key.
+  (let [sym (symbol (subs (str v) 2))]
+    (str (or (namespace sym) "core") "/" (name sym))))
+
+(defn- var-key-of-ref [f ref]
+  ;; The var a set!'s TARGET operand denotes. build-set! emits that target as a
+  ;; Var-valued :const (aux = the *vm.Var), NOT a :load-var — so matching only
+  ;; :load-var here (the pre-fix behavior) never recognized a real set!, and the
+  ;; snapshot protection below silently did nothing. Mirror lower_go.lg's
+  ;; var-key-of-ref: accept both a :load-var (aux symbol) and a Var-valued
+  ;; :const, so the bytecode + Go lowerers agree on which loads are set! targets.
+  (let [op (ir/op ref f)]
+    (cond
+      (= :load-var op) (var-key-of-symbol (ir/aux ref f))
+      (= :const op)    (let [v (ir/aux ref f)] (when (var? v) (var-key-of-var-value v)))
+      :else nil)))
+
+(defn- set-var-target-keys [l]
+  "Var keys this fn set!s, computed once and cached on the lowering state."
+  (let [cached (:set-var-keys @l)]
+    (if (some? cached)
+      cached
+      (let [f    (f-of l)
+            keys (reduce
+                   (fn [acc bid]
+                     (reduce (fn [a nid]
+                               (if (= :set-var (ir/op nid f))
+                                 (let [refs (ir/refs nid f)
+                                       k    (when (pos? (count refs))
+                                              (var-key-of-ref f (nth refs 0)))]
+                                   (if k (conj a k) a))
+                                 a))
+                             acc (ir/block-insts bid f)))
+                   #{} (ir/blocks f))]
+        (swap! l assoc :set-var-keys keys)
+        keys))))
+
+(defn- load-var-snapshot? [l nid]
+  "True for a :load-var whose var this fn set!s — the one case that must be
+   materialized once rather than re-emitted per use."
+  (let [f (f-of l)]
+    (and (= :load-var (ir/op nid f))
+         (contains? (set-var-target-keys l) (var-key-of-symbol (ir/aux nid f))))))
+
+;; --- vars live across an effect --------------------------------------
+;;
+;; Re-emitting a :load-var at each use matches the plain compiler ONLY while
+;; the var's root can't change between the load and that use. A same-fn set!
+;; is caught above; a CALL is the other mutator — the callee may set! the var
+;; (or def/redefine it). The plain compiler snapshots the root at the def site
+;; (it stores let-bound values into locals BEFORE any following call), so a use
+;; after a mutating call must read the pre-call root. Re-emitting reads the
+;; POST-call root instead — `(let [x mv] (mutate!) x)` returned the mutated
+;; value. So a load live across an effectful op is body-emitted at its def and
+;; DUP_NTH-copied per use, exactly as the pre-2026-07-19 blanket rule did, but
+;; now only for the loads that actually straddle an effect — fib/sumloop callee
+;; loads sit adjacent to their own invoke with nothing between, so they keep
+;; the cheap re-emit.
+
+(def ^:private ir-effectful-ops
+  ;; Ops that can change a var's root between a load and a later use. Pure
+  ;; arith/const/closure/load ops cannot, so re-emit stays sound across them.
+  #{:call :tail-call :set-var :def})
+
+(defn- block-index-map [insts]
+  "nid -> position within a block's inst vector."
+  (let [m (atom {})]
+    (loop [i 0]
+      (when (< i (count insts))
+        (swap! m assoc (nth insts i) i)
+        (recur (inc i))))
+    @m))
+
+(defn- effect-strictly-between? [insts f lo hi]
+  "True if any inst at index j with lo < j < hi is effectful. The consuming op
+   at hi is EXCLUDED: a load feeding its own call is not live ACROSS that call."
+  (loop [j (inc lo)]
+    (cond
+      (>= j hi) false
+      (contains? ir-effectful-ops (ir/op (nth insts j) f)) true
+      :else (recur (inc j)))))
+
+(defn- callee-only-use? [f nid uid]
+  "True when nid is used by uid ONLY as the callee (ref 0) of a call. Such a
+   load re-resolves at call time rather than being snapshotted as a value, so it
+   is outside the value-load semantics this crossing check guards."
+  (and (contains? #{:call :tail-call} (ir/op uid f))
+       (let [refs (ir/refs uid f)]
+         (and (pos? (count refs))
+              (= nid (first refs))
+              (not (some (fn [r] (= r nid)) (rest refs)))))))
+
+(defn- load-var-crosses-effect? [l nid]
+  "True when a :load-var is live across an effectful op and must therefore be
+   materialized once rather than re-emitted. Conservative: any cross-block use
+   forces materialize (the effect could sit on the intervening path); a
+   same-block use forces it only when an effectful inst lies strictly between
+   the def and the use."
+  (let [f (f-of l)]
+    (and (= :load-var (ir/op nid f))
+         (let [dblk  (ir/block-of nid f)
+               insts (vec (ir/block-insts dblk f))
+               idx   (block-index-map insts)
+               di    (get idx nid)
+               uses  (:uses @l)
+               us    (when (< nid (count uses)) (nth uses nid))]
+           (if (or (nil? di) (nil? us) (ir/uses-empty? us))
+             false
+             (let [crosses (atom false)]
+               (ir/uses-for-each
+                 us
+                 (fn [uid]
+                   (when (and (not @crosses)
+                              (not (callee-only-use? f nid uid)))
+                     (if (not= (ir/block-of uid f) dblk)
+                       (reset! crosses true)
+                       (let [ui (get idx uid)]
+                         (when (and ui (> ui di)
+                                    (effect-strictly-between? insts f di ui))
+                           (reset! crosses true)))))))
+               @crosses))))))
+
 (defn- should-body-emit-cheap? [l nid]
   "Decide whether a cheap-load Inst should be body-emitted at its
    def site (vs. deferred to materialize at use site).
@@ -627,10 +767,13 @@
           ;; Deferred cond (emitted after branch-target args).
           (and deferred-cond (= nid deferred-cond)) nil
           ;; Cheap-load deferral: skip body emission when not body-emit-cheap.
-          ;; :load-var excluded — mutable var root must be materialized once, not
-          ;; re-emitted (a re-emitted rt.LookupVar would read a post-set! value, P1).
+          ;; Only set!-TARGET :load-vars are excluded — those must be
+          ;; materialized once so two loads can't straddle the set! and read
+          ;; different roots (P1). Ordinary var loads re-emit per use, matching
+          ;; the plain compiler, instead of costing a DUP_NTH copy each.
           (and (ir/op-cheap-load? op)
-               (not= op :load-var)
+               (not (load-var-snapshot? l nid))
+               (not (load-var-crosses-effect? l nid))
                (not (should-body-emit-cheap? l nid)))
           nil
           :else (emit-inst! l nid))))

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -527,6 +527,73 @@
   (and (= :load-var (ir/op nid f))
        (contains? (set-var-target-keys f) (var-key-of-symbol (ir/aux nid f)))))
 
+;; The same-fn set! guard above is not the only mutator: a CALL can run a callee
+;; that set!s (or defs) the loaded var, so a re-emitted deref after the call
+;; reads the mutated root while the bytecode VM snapshots at the load. A load
+;; live across an effectful op is therefore materialised into the one-time
+;; snapshot local too. Mirrors lower.lg's load-var-crosses-effect?; callee loads
+;; sit adjacent to their invoke with only arithmetic between, so they keep the
+;; inline re-emit. (A shared home for this rule across both backends is a sound
+;; follow-up — kept per-backend here to close the divergence now.)
+(def ^:private ir-effectful-ops #{:call :tail-call :set-var :def})
+
+(defn- block-index-map [insts]
+  (let [m (atom {})]
+    (loop [i 0]
+      (when (< i (count insts))
+        (swap! m assoc (nth insts i) i)
+        (recur (inc i))))
+    @m))
+
+(defn- effect-strictly-between? [f insts lo hi]
+  (loop [j (inc lo)]
+    (cond
+      (>= j hi) false
+      (contains? ir-effectful-ops (ir/op (nth insts j) f)) true
+      :else (recur (inc j)))))
+
+(defn- callee-only-use? [f nid uid]
+  "True when nid is used by uid ONLY as the callee (ref 0) of a call. Such a
+   load is re-resolved at call time (CachedVarFn / re-emit), not rendered into a
+   value local, so materialising it across an effect would leave a dead local
+   and doesn't reflect the value-load semantics this snapshot guards."
+  (and (contains? #{:call :tail-call} (ir/op uid f))
+       (let [refs (ir/refs uid f)]
+         (and (pos? (count refs))
+              (= nid (first refs))
+              (not (some (fn [r] (= r nid)) (rest refs)))))))
+
+(defn- load-var-crosses-effect? [f nid]
+  (and (= :load-var (ir/op nid f))
+       (let [dblk  (ir/block-of nid f)
+             insts (vec (ir/block-insts dblk f))
+             idx   (block-index-map insts)
+             di    (get idx nid)
+             uses  (ir/uses f)
+             us    (when (< nid (count uses)) (nth uses nid))]
+         (if (or (nil? di) (nil? us) (ir/uses-empty? us))
+           false
+           (let [crosses (atom false)]
+             (ir/uses-for-each
+               us
+               (fn [uid]
+                 (when (and (not @crosses)
+                            (not (callee-only-use? f nid uid)))
+                   (if (not= (ir/block-of uid f) dblk)
+                     (reset! crosses true)
+                     (let [ui (get idx uid)]
+                       (when (and ui (> ui di)
+                                  (effect-strictly-between? f insts di ui))
+                         (reset! crosses true)))))))
+             @crosses)))))
+
+(defn- load-var-materialize? [f nid]
+  "A :load-var that must be snapshotted into a one-time local rather than
+   re-emitted inline: either a same-fn set! target or a load live across an
+   effectful op."
+  (or (load-var-snapshot? f nid)
+      (load-var-crosses-effect? f nid)))
+
 (defn- used? [f nid]
   (let [uses (ir/uses f)]
     (and (< nid (count uses))
@@ -758,7 +825,7 @@
           ;; later set! to the same var cannot change the value this use observes
           ;; (the snapshot `vN = ec.Deref(...)` is emitted by lower-inst-stmts via
           ;; inst-rhs). Otherwise (no set! in the fn) re-emit the deref inline.
-          (if (load-var-snapshot? f nid)
+          (if (load-var-materialize? f nid)
             (when (and (live? f nid) (infer-go-type t))
               (value-ident f nid))
             (load-var-deref-expr aux))
@@ -966,8 +1033,9 @@
               insts  (filter (fn [nid]
                                (let [op (ir/op nid f)]
                                  (and (or (local-carrying-op? op)
-                                          ;; materialised var snapshot in a set!-fn
-                                          (load-var-snapshot? f nid))
+                                          ;; materialised var snapshot: a set!-fn
+                                          ;; target or a load live across an effect
+                                          (load-var-materialize? f nid))
                                       (not= op :block-arg)
                                       (live? f nid)
                                       (not (closure-value? f nid))
@@ -2345,7 +2413,7 @@
       ;; uses read the snapshot, not a value a subsequent set! may have changed.
       ;; Without a set! the var is re-emitted inline at uses (no statement here).
       (= op :load-var)
-      (if (and (load-var-snapshot? f nid) (live? f nid))
+      (if (and (load-var-materialize? f nid) (live? f nid))
         (let [rhs (inst-rhs f closed-exprs nid)]
           (when rhs
             [(gogen/assign "=" (value-ident f nid) rhs)]))

--- a/pkg/rt/core/ir/passes/cse.lg
+++ b/pkg/rt/core/ir/passes/cse.lg
@@ -26,6 +26,22 @@
    same key compute the same value."
   [(ir/op nid f) (vec (ir/refs nid f)) (ir/aux nid f)])
 
+(defn- var-root-barrier? [op nid f var-facts]
+  "True for an Inst that can change a var's ROOT: a direct :set-var/:def, or a
+   :call that isn't a proven pure-call (the callee may set! any var). A stable
+   :load-var recorded in `seen` before such a barrier must NOT be reused by an
+   identical load AFTER it — the plain compiler would observe the post-barrier
+   root, so merging them collapses two distinct values into one. Only
+   :load-var congruences are dropped; pure-op values (e.g. :add of fixed SSA
+   nodes) are immutable and stay valid across the barrier."
+  (or (= op :set-var)
+      (= op :def)
+      (and (= op :call)
+           (not (purity/pure-call? f nid var-facts)))))
+
+(defn- drop-load-var-keys [seen]
+  (into {} (filter (fn [kv] (not= :load-var (first (first kv)))) seen)))
+
 (defn- cse-eligible? [op nid f var-facts]
   ;; CSE deduplicates any value-pure Inst: those whose evaluation yields
   ;; the same value every time. This includes:
@@ -53,10 +69,15 @@
       ;; CSE state, the analysis equivalent of one iteration scope.
       (let [seen (atom {})]
         (doseq [nid (vec (ir/block-insts bid f))
-                :let [op (ir/op nid f)]
-                :when (cse-eligible? op nid f var-facts)
-                :let [k (inst-key nid f)]]
-          (if-let [prior (@seen k)]
-            (ir/replace-all-uses! f nid prior)
-            (swap! seen assoc k nid))))))
+                :let [op (ir/op nid f)]]
+          ;; A var-root barrier invalidates any earlier stable :load-var so a
+          ;; following identical load reads the post-barrier root, not a merged
+          ;; pre-barrier value.
+          (when (var-root-barrier? op nid f var-facts)
+            (swap! seen drop-load-var-keys))
+          (when (cse-eligible? op nid f var-facts)
+            (let [k (inst-key nid f)]
+              (if-let [prior (@seen k)]
+                (ir/replace-all-uses! f nid prior)
+                (swap! seen assoc k nid))))))))
   f)

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-db1f436c1e75a4a92f0bdaf3fb0fbe48c0184eaad22d955c1be2faa92fb67f7e
+3e6422d48afd47a710f152282f00679029a1ce7144036d8774eee0831e857d87

--- a/test/ir_lower_stack_discipline_test.lg
+++ b/test/ir_lower_stack_discipline_test.lg
@@ -1,0 +1,147 @@
+;; Lowering quality gate: the IR path must not emit a worse instruction
+;; sequence than the plain bytecode compiler for the same source.
+;;
+;; The IR pipeline is an OPTIMIZING pipeline, so "compiles correctly" is not
+;; the bar — it has to pay for itself. Measured 2026-07-19 on main, `fib` was
+;; 24 instructions via IR vs 18 via the plain compiler (+33%) and ran ~13.5%
+;; SLOWER, because materialize! copied every operand to the top of the stack
+;; with DUP_NTH instead of consuming values in place, leaving the originals
+;; below as junk. Each surplus DUP_NTH is pure shuffle: the copy is consumed
+;; by the very next op while the original goes dead, so the pair is a no-op
+;; with a cost.
+;;
+;; These tests pin the shape of the emitted code, not just its result. A
+;; regression here means the pipeline started spending instructions again.
+(ns test.ir-lower-stack-discipline-test
+  (:require
+   [disasm :as d]
+   [ir.passes.pipeline]
+   [test :refer :all]))
+
+(defn- ops-of [f]
+  "Opcode keywords of f's chunk, in order."
+  (map first (d/disassemble-resolved f)))
+
+(defn- count-op [f op]
+  (count (filter (fn [o] (= o op)) (ops-of f))))
+
+;; --- fixtures: identical source, both compile paths --------------------
+
+(defn fib-bc [n]
+  (if (< n 2) n (+ (fib-bc (- n 1)) (fib-bc (- n 2)))))
+
+(defn sumloop-bc [n]
+  (loop [i 0 acc 0] (if (>= i n) acc (recur (inc i) (+ acc i)))))
+
+;; #613 regression: a var loaded into a local BEFORE a set! of the SAME var must
+;; observe the pre-set! value. build-set! emits the set! target as a Var-valued
+;; :const (not a :load-var), so set-var-target-keys must recognize that shape —
+;; else the load is treated as an ordinary re-emittable var and reads the
+;; post-set! value. Runs inside a (binding …) so set! has a thread binding.
+(def ^:dynamic *snap-v* 1)
+
+(defn snapshot-probe-bc []
+  (let [x *snap-v*]
+    (set! *snap-v* 2)
+    [x x]))
+
+;; #579 (mparrett): the mutator can be a CALLEE, not just a same-fn set!. A var
+;; loaded before a call that set!s it must snapshot the PRE-call root; re-emitting
+;; the load after the call reads the mutated root. This exercised two holes: the
+;; re-emit itself (lower.lg) AND CSE merging the two *xmv* loads across the call
+;; (cse.lg). Both compilers must agree with the plain-compiler baseline [1 2].
+(def ^:dynamic *xmv* 1)
+
+(defn mutate-xmv! [] (set! *xmv* 2) 100)
+
+(defn xcall-probe-bc []
+  (let [x *xmv*] (mutate-xmv!) [x *xmv*]))
+
+(set! *ir-compile* true)
+
+(defn fib-ir [n]
+  (if (< n 2) n (+ (fib-ir (- n 1)) (fib-ir (- n 2)))))
+
+(defn sumloop-ir [n]
+  (loop [i 0 acc 0] (if (>= i n) acc (recur (inc i) (+ acc i)))))
+
+(defn snapshot-probe-ir []
+  (let [x *snap-v*]
+    (set! *snap-v* 2)
+    [x x]))
+
+(defn xcall-probe-ir []
+  (let [x *xmv*] (mutate-xmv!) [x *xmv*]))
+
+(set! *ir-compile* false)
+
+;; --- behavior first: the optimization must not change results ----------
+
+(deftest ir-lowering-preserves-semantics
+  (testing "both paths compute the same values"
+    (is (= (fib-bc 15) (fib-ir 15)))
+    (is (= (sumloop-bc 1000) (sumloop-ir 1000)))))
+
+;; --- the gate ----------------------------------------------------------
+
+;; --- the ratchet -------------------------------------------------------
+;;
+;; These pin what lowering emits TODAY so a regression is caught, and record
+;; the TARGET the pipeline is aiming at. They are upper bounds, not equalities:
+;; an improvement makes them pass with room to spare, at which point tighten
+;; the numbers here in the same commit (same discipline as ir-stress-gate and
+;; bench-ratchet — the ratchet only tightens).
+;;
+;; Current vs target, measured 2026-07-19:
+;;
+;;   fib      plain 18 insts / 0 DUP_NTH   IR 23 / 4    target 18 / 0
+;;   sumloop  plain 16 insts / 0 DUP_NTH   IR 18 / 8    target 16 / 0
+;;
+;; sumloop is the sharper case: 18 instructions of which 8 are shuffle, i.e.
+;; the loop body spends nearly half its instruction budget rearranging the
+;; stack rather than computing.
+;;
+;; The residue is emission ORDER, not the var handling fixed here: the call
+;; argument is computed before the callee is loaded, so the argument must be
+;; copied above the callee and its original is stranded below as junk (the
+;; trailing RECUR is that junk's cleanup). Scheduling operand materialization
+;; in consumer order — callee, then args left to right — is what closes the
+;; remaining gap. Tracked as EPIC-018 (issue #575, STORY-0072/0073: per-edge
+;; stack maps and block-arg erasure).
+
+(deftest ir-lowering-shuffle-ratchet
+  (testing "fib: surplus stack shuffle does not grow"
+    (is (<= (count-op fib-ir :DUP_NTH) 4))      ; target 0
+    (is (<= (count (ops-of fib-ir)) 23)))       ; target 18 (plain compiler)
+  (testing "loop/recur: surplus stack shuffle does not grow"
+    (is (<= (count-op sumloop-ir :DUP_NTH) 8))  ; target 0
+    (is (<= (count (ops-of sumloop-ir)) 18))))  ; target 16 (plain compiler)
+
+(deftest ir-lowering-var-loads-match-plain-compiler
+  (testing "an ordinary (non-set!) var is re-emitted per use, not copied"
+    ;; The plain compiler emits one LOAD_VAR per call site and lets the VM
+    ;; snapshot the root at each load. The IR path now does the same instead
+    ;; of materializing once and copying with DUP_NTH — which also stopped
+    ;; the value from crossing blocks, retiring the :validate/cross-block-ref
+    ;; failure bucket (ir-stress: 20 -> 11 native-lowering failures).
+    (is (= (count-op fib-bc :LOAD_VAR) (count-op fib-ir :LOAD_VAR)))))
+
+(deftest ir-lowering-set-var-snapshot-matches-plain-compiler
+  (testing "a var loaded before a set! of the same var snapshots the pre-set! value (#613)"
+    ;; Both must return [1 1] — x captures *snap-v*=1 BEFORE (set! *snap-v* 2).
+    ;; Before the set-var-target-keys fix the IR path returned [2 2]: it treated
+    ;; the load as an ordinary var, re-emitting it after the set!.
+    (is (= [1 1] (binding [*snap-v* 1] (snapshot-probe-bc))))
+    (is (= [1 1] (binding [*snap-v* 1] (snapshot-probe-ir))))
+    (is (= (binding [*snap-v* 1] (snapshot-probe-bc))
+           (binding [*snap-v* 1] (snapshot-probe-ir))))))
+
+(deftest ir-lowering-load-across-mutating-call-matches-plain-compiler
+  (testing "a var loaded before a call that set!s it snapshots the pre-call root (#579)"
+    ;; x captures *xmv*=1 BEFORE (mutate-xmv!) sets it to 2; the trailing *xmv*
+    ;; reads the post-call root 2 → [1 2]. Before the fix the IR path returned
+    ;; [1 1] (CSE merged both loads, then materialized the pre-call value once).
+    (is (= [1 2] (binding [*xmv* 1] (xcall-probe-bc))))
+    (is (= [1 2] (binding [*xmv* 1] (xcall-probe-ir))))
+    (is (= (binding [*xmv* 1] (xcall-probe-bc))
+           (binding [*xmv* 1] (xcall-probe-ir))))))


### PR DESCRIPTION
## Why

The IR pipeline is an *optimizing* pipeline, so "it compiles correctly" isn't the bar — it has to pay for itself. It doesn't, on compute-bound code. Measured on `main`, identical source through both paths:

| workload | runtime (IR vs plain) | instructions |
|---|---|---|
| `fib 21` | **1.135× slower** | 18 → 24 (+33%) |
| `loop`/`recur` sum | 0.99× | 16 → 18 |

Six of `fib`'s 24 instructions were `DUP_NTH` — pure stack shuffle. `materialize!` copies each operand to the top of the stack and strands the original below as junk; the trailing `RECUR` in a function containing no loop is that junk's cleanup.

## What this fixes

One cause was addressable without restructuring. `lower.lg` excluded **every** `:load-var` from cheap-load re-emission, so a var used twice was materialized once and copied with `DUP_NTH` per extra use. `lower_go.lg` already solved this more precisely — restrict materialize-once to **set!-TARGET** vars, whose two loads could otherwise straddle the `set!` and read different roots. Ordinary var loads can simply be re-emitted per use, which is exactly what the plain compiler does and what the VM's load-time snapshot semantics expect.

This PR mirrors that rule into the bytecode backend.

## Effect

- `fib` 24 → 23 instructions, 6 → 4 `DUP_NTH`; `LOAD_VAR` count now matches the plain compiler exactly.
- **ir-stress native-lowering failures 20 → 11.** The entire `:validate/cross-block-ref` bucket (8) retires — a re-emitted load no longer crosses blocks. Baseline rebaselined per the ratchet's own rule.
- `make parity-quick`: **PARITY** (6311/6311 assertions, both engines). Full `./test` green, `pkg/{ir,vm,compiler}` green, `make check-generated` clean.
- **Runtime unchanged** (fib 1.14× vs 1.135×, within noise). Re-emission trades a stack copy for a var deref, so this is a coverage and semantics win, not yet a speed one. Stating that plainly rather than claiming a perf win the numbers don't support.

## What it doesn't fix

The residual shuffle is emission **order**: the call argument is computed before the callee is loaded, so it has to be copied above it, stranding the original. That isn't a peephole — it traces to the bytecode backend never having received **structural lowering**. `structurize` is required by `lower_go.lg`, `dominance.lg`, and `passes/pipeline.lg`, but *not* by `lower.lg`, which still walks raw blocks by stack position. Without the control tree it can't know consumer order or that a value is dead after a use in a sibling arm, so it copies defensively.

That's EPIC-017 (#574) and EPIC-018 (#575, STORY-0072/0073: per-edge stack maps, block-arg erasure).

## The ratchet

`test/ir_lower_stack_discipline_test.lg` pins the emitted **shape**, not just results:

- `fib` ≤ 23 instructions, ≤ 4 `DUP_NTH` (target: 18 / 0 — the plain compiler)
- `sumloop` ≤ 18 instructions, ≤ 8 `DUP_NTH` (target: 16 / 0)
- non-`set!` var loads re-emit per use, matching the plain compiler

Upper bounds, not equalities, following the same discipline as `ir-stress-gate` and `bench-ratchet`: an improvement passes with room to spare, then the numbers tighten in the same commit. `sumloop` is the sharper case — 8 of 18 instructions are shuffle, i.e. the loop body spends nearly half its budget rearranging the stack rather than computing.
