### PR TITLE
bench: document the two AOT mechanisms behind the results table

### DIFF
--- a/benchmark/results.md
+++ b/benchmark/results.md
@@ -55,3 +55,16 @@ Clojure JVM times include full JVM startup (~350-500ms) which dominates short be
 | tak | 2.397s ± 0.022s (1.0x) | **93.7ms ± 0.6ms** (0.0x) | 1.908s ± 0.037s (0.8x) | 0.613s ± 0.046s (0.3x) |
 | transducers | 46.5ms ± 0.9ms (1.0x) | 43.0ms ± 1.0ms (0.9x) | **20.3ms ± 0.5ms** (0.4x) | 0.373s ± 0.011s (8.0x) |
 
+### Reading the AOT column
+
+The AOT numbers mix two mechanisms:
+
+- **Lowered to native code** — fib, tak, loop-recur. The hot code compiles to
+  native Go over unboxed ints (direct recursion, plain loops); only the leaves
+  box. This is where the 20-26x comes from.
+- **Trampolined** — reduce, map-filter, persistent-map, transducers. The entry
+  point compiles, but the hot operations still run through the same boxed
+  runtime the VM uses, so these rows track the VM around parity (0.9-1.0x
+  here) — the reduce row's 1.7x is that wrapper's overhead, not an AOT
+  regression. Lowering doesn't reach these bodies yet.
+


### PR DESCRIPTION
## What

Adds a "Reading the AOT column" section under the Performance table in `benchmark/results.md`, splitting the seven fixtures by what the AOT build does with them: three lower to native Go (fib, tak, loop-recur — the 20-26x wins), four only get a native `run` wrapper around the same boxed runtime calls the VM makes (reduce, map-filter, persistent-map, transducers).

## Why

One undifferentiated AOT column makes the reduce row (1.7x slower under AOT) read as an anomaly. The emitted Go shows it isn't: the reduction never lowers — `reduce.go` calls the identical `rt.Reduce3` with a boxed `+`, plus wrapper dispatch — so parity-or-worse is the expected result for those rows until #270/#358 reach them. Naming the split gives the table a stable interpretation as those issues land, and the map-filter flip in #578 (now a small AOT win) reads the same way: wrapper-cost noise around parity, not lowering.

Continues the read from the #552 review thread. Issue/PR links stay out of the doc itself — README and the benchmark docs carry none, so the section names the boundary plainly and the references live here. Framing only; numbers are unchanged from the #578 recapture.

No urgency on review — docs-only, whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
