### PR TITLE
ci(perf-timeline): raise the macos-14 leg timeout to 150 min

### DIFF
--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -43,7 +43,13 @@ jobs:
         # explorer then shows both an amd64 and an Apple-M line per benchmark.
         os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    # The macos-14 leg needs more headroom: at count 3 the ubuntu leg fits
+    # in 61-83 min, but no macos leg has ever finished under 90 — every one
+    # since the leg landed (#363) died at the kill, so perf-data has zero
+    # arm64 snapshots. 150 is a provisional ceiling until the first
+    # completed leg measures the real envelope; right-size from data then.
+    # Evidence + discussion: #573.
+    timeout-minutes: ${{ matrix.os == 'macos-14' && 150 || 90 }}
     concurrency:
       # Per-OS FIFO queue: legs of the same OS stay serialized (snapshot
       # commits land in commit order), but the two OSes never wait on each

--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -46,9 +46,10 @@ jobs:
     # The macos-14 leg needs more headroom: at count 3 the ubuntu leg fits
     # in 61-83 min, but no macos leg has ever finished under 90 — every one
     # since the leg landed (#363) died at the kill, so perf-data has zero
-    # arm64 snapshots. 150 is a provisional ceiling until the first
-    # completed leg measures the real envelope; right-size from data then.
-    # Evidence + discussion: #573.
+    # arm64 snapshots. Measured envelope: a completed fork probe leg ran
+    # 120 min end to end (118.6 min in the capture step) at count 3, so
+    # 150 gives ~25% headroom — proportionally more than ubuntu's 90 over
+    # its 83-min worst case. Evidence + discussion: #573.
     timeout-minutes: ${{ matrix.os == 'macos-14' && 150 || 90 }}
     concurrency:
       # Per-OS FIFO queue: legs of the same OS stay serialized (snapshot


### PR DESCRIPTION
The one-liner from the #573 discussion (also #581 item 6).

No macos-14 leg has ever finished under the 90-min timeout: every run since the leg landed (#363, 2026-07-06) ran the full 90 minutes and died at the kill — at count 4 and at count 3 alike ("The job has exceeded the maximum execution time of 1h30m0s" in the job annotations). So `perf-data` has zero arm64 snapshots — the Apple-Silicon timeline has never had a data point — and each push to main spends 90 macos runner-minutes producing nothing.

This raises the ceiling for the macos-14 leg only, via a matrix conditional; the ubuntu leg (61–83 min envelope at count 3) stays at 90. Count stays at 3, per the estimator floor from #561.

A completed fork probe measured the macos-14 leg at ~120.5 minutes end to end (118.6 minutes in the capture step) at count 3. A 150-minute ceiling therefore provides about 25% headroom — proportionally more than ubuntu's 90-minute ceiling over its 83-minute worst case. If macos runner supply still makes ~2h legs flaky, the fallback discussed on #573 is a scheduled cadence for the arm64 leg instead of per-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
