### PR TITLE
ci: cancel superseded PR runs; CodeQL v4 + docs paths-ignore

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ on:
 # Cancel the superseded analysis when a PR branch is pushed again; push and
 # scheduled runs get a unique group (run_id) so they never affect each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,11 +14,24 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    # CodeQL analyzes Go source; docs-only changes can't alter its result.
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   schedule:
     - cron: '41 0 * * 1'
+
+# Cancel the superseded analysis when a PR branch is pushed again; push and
+# scheduled runs get a unique group (run_id) so they never affect each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
@@ -46,7 +59,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +70,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -71,4 +84,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,16 @@ on:
   # Manual trigger for the gold-differential job (re-derive goldens vs live Clojure).
   workflow_dispatch:
 
+# Cancel the superseded run when a PR branch is pushed again: ~7% of Go PR
+# runs get a successor within 10 minutes (rebases/force-pushes) and the
+# stale run otherwise burns its full ~11 runner-minutes to completion. For
+# push/dispatch events the run_id makes the group unique, so main-branch
+# runs never coalesce or cancel each other and every merge keeps its own
+# per-commit CI signal.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ on:
 # runs never coalesce or cancel each other and every merge keeps its own
 # per-commit CI signal.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Three small cuts to the always-on per-PR cost, from the same CI audit thread as #581/#583.

**Cancel superseded PR runs.** Neither `go.yml` nor CodeQL had a `concurrency` group, so a rebase or force-push mid-run left the stale run burning to completion — over the last week, ~7% of Go PR runs had a successor within 10 minutes, each wasting ~11 runner-minutes of jobs. The group keys on the stable `github.ref` PR merge ref for `pull_request` events only; push, dispatch, and scheduled runs get `run_id` (always unique), so main-branch runs never coalesce or cancel each other and every merge keeps its per-commit CI signal.

**CodeQL action v3 → v4.** v3 is deprecated December 2026 and every current run logs the deprecation warning. Drop-in bump.

**Skip CodeQL on docs-only changes.** A `docs/**` / `**.md` change can't alter a Go-source scan; the `paths-ignore` saves the 1–2 min analysis on those pushes and PRs. The main ruleset has no required-status-checks rule, so a path-skipped run can't strand a PR waiting on an expected check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
