### PR TITLE
fix(wasm): resolve go.sum for released-binary `lg -w` builds

### DIFF
--- a/wasm.go
+++ b/wasm.go
@@ -241,7 +241,12 @@ func fileExists(path string) bool {
 func generateWasmModuleFiles(tmpDir string) (string, []byte, error) {
 	v := version
 	if v != "dev" && v != "" && v[0] >= '0' && v[0] <= '9' {
-		return fmt.Sprintf("module lg-wasm-app\n\ngo 1.26\n\nrequire github.com/nooga/let-go v%s\n", v), nil, nil
+		// Released binary: pin the require to this exact version. We can't
+		// return a nil go.sum (go build rejects a module with unresolved
+		// sums), so resolve it from the proxy the same way the no-source path
+		// below does. `go get` on the single require writes go.sum without the
+		// `go mod tidy` that the build step deliberately avoids.
+		return resolveWasmModuleFiles(tmpDir, "github.com/nooga/let-go@v"+v)
 	}
 	// Dev build — try local source first
 	srcDir, err := findLetGoModuleDir()
@@ -253,11 +258,19 @@ func generateWasmModuleFiles(tmpDir string) (string, []byte, error) {
 		return goMod, goSum, nil
 	}
 	// No local source — resolve latest version from module proxy
+	return resolveWasmModuleFiles(tmpDir, "github.com/nooga/let-go@latest")
+}
+
+// resolveWasmModuleFiles scaffolds a minimal module in tmpDir and resolves the
+// let-go require named by modRef via `go get`, returning the resulting go.mod
+// and go.sum. Used for both released binaries (pinned version) and dev builds
+// with no local source tree (@latest).
+func resolveWasmModuleFiles(tmpDir, modRef string) (string, []byte, error) {
 	goMod := "module lg-wasm-app\n\ngo 1.26\n"
 	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goMod), 0644); err != nil {
 		return "", nil, err
 	}
-	get := exec.Command(goToolPath(), "get", "github.com/nooga/let-go@latest")
+	get := exec.Command(goToolPath(), "get", modRef)
 	get.Dir = tmpDir
 	get.Stderr = os.Stderr
 	if err := get.Run(); err != nil {


### PR DESCRIPTION
Fixes #590.

## Problem

`lg -w` fails for any version-stamped binary — every `go install`ed lg since v1.12.0:

```
$ go install github.com/nooga/let-go@v1.12.1
$ lg -w dist -w-shell none main.lg
building wasm...
main.go:9:2: missing go.sum entry for module providing package github.com/nooga/let-go/pkg/bytecode (imported by lg-wasm-app); to add:
	go get lg-wasm-app
... (same for pkg/compiler, pkg/resolver, pkg/rt, pkg/vm)
error: go build wasm: exit status 1
```

The release-version branch of `generateWasmModuleFiles` returns a `go.mod` that requires `github.com/nooga/let-go v<version>` with a **nil** go.sum, and the caller only writes go.sum when it's non-empty. v1.11.1 masked this by running `go mod tidy` in the scaffold; #379 removed that tidy on purpose (it walked the replaced local module's test-only deps and could pull network-only packages). The other two paths still produce sums (local-source via `localWasmModuleFiles`, no-source via `go get @latest`), so only the released-version path ships a module `go build` refuses.

This branch became reachable for installed binaries with #366, which derives the version from build info; before that, install builds reported `dev` and took the `go get @latest` path.

## Fix

Resolve the pinned require the same way the no-source path already does — `go get github.com/nooga/let-go@v<version>` in the scaffold module, then read back the go.mod and go.sum. `go get` on the single require writes the sum without the `go mod tidy` that #379 dropped, so tidy-avoidance is preserved. The shared logic is extracted as `resolveWasmModuleFiles(tmpDir, modRef)` and used by both the released-version branch and the no-source `@latest` branch.

## Testing

- `go build ./...` on darwin, linux, `js/wasm`, and `plan9/amd64`; `go vet ./...`; `gofmt`; `pkg/buildmeta` tests all clean.
- End-to-end: built lg with `-ldflags "-X main.version=1.12.1"` and ran `lg -w dist -w-shell none main.lg` in a project with no local let-go checkout. Before: the go.sum error above. After: `go get` resolves `let-go v1.12.1`, and the bundle builds to `dist/index.html`.

Already-installed v1.12.0/v1.12.1 binaries can't be fixed retroactively — they carry the old scaffold and stay broken until reinstalled from a release that includes this.

## Follow-up

A CI guard would have caught this: build lg with a stamped version (`-ldflags "-X main.version=..."`) and run `lg -w` on a hello bundle. The version stamp is what selects this branch, so a source-tree build (`dev`) never exercises it.
