### PR TITLE
feat(wasm): SPSC ring buffer + held-key coalesce for SAB key input

### DIFF
--- a/pkg/rt/keysource_js_wasm.go
+++ b/pkg/rt/keysource_js_wasm.go
@@ -10,8 +10,23 @@
  * — installed at the *keys* root by term_wasm.go's install, resolving the JS
  * globals per call so SAB setup order doesn't matter.
  *
- * SAB layout (Int32Array): [0] key-ready flag, [1] byte count; Uint8Array at
- * offset 8, length 16, holds the key bytes. See pkg/rt/wasm/lg-host.js.
+ * SAB protocol — SPSC ring buffer between the main thread (producer) and
+ * this worker (consumer). Layout MUST stay in sync with the producer in
+ * pkg/rt/wasm/lg-host-core.js; the consts below mirror the JS side. The
+ * producer writes slot [writeIdx % keyCapacity] then advances writeIdx; the
+ * consumer waits on writeIdx, reads slot [readIdx % keyCapacity], then
+ * advances readIdx. The producer never blocks the main thread — when the
+ * ring is full it drops.
+ *
+ * Int32Array view (used cells):
+ *
+ *	[0]  readIdx   — consumer increments after reading a slot
+ *	[1]  writeIdx  — producer increments after writing a slot
+ *
+ * Uint8Array view (full SAB):
+ *
+ *	bytes 64..71   slot lengths (1 byte per slot, 8 slots)
+ *	bytes 72..199  slot keys    (16 bytes per slot, 8 slots)
  */
 
 package rt
@@ -21,7 +36,16 @@ import (
 	"syscall/js"
 )
 
-// HostKeySource reads keys from the bundle's SharedArrayBuffer.
+const (
+	keyCapacity  = 8  // ring slots
+	keyMaxLen    = 16 // bytes per key
+	keyLenOffset = 64 // byte offset of the lengths region
+	keyOffset    = 72 // byte offset of the keys region
+	readIdxCell  = 0  // Int32 index of the read pointer
+	writeIdxCell = 1  // Int32 index of the write pointer
+)
+
+// HostKeySource reads keys from the bundle's SharedArrayBuffer ring.
 type HostKeySource struct{}
 
 // NewHostKeySource returns a HostKeySource for the *keys* root binding.
@@ -38,20 +62,67 @@ func (HostKeySource) ReadKey() (string, error) {
 	// Flush output before parking on the key wait.
 	js.Global().Call("_lgFlush")
 
-	// Block until a key is ready.
-	atomics.Call("wait", keyInt32, 0, 0)
+	// Park while the ring is empty (writeIdx == readIdx). Atomics.wait
+	// returns ok / timed-out / not-equal; in every case we re-check the
+	// predicate, so spurious or early wakes just loop and re-wait. Passing
+	// the observed writeIdx as the expected value means a producer that
+	// advanced before we hit wait returns immediately with "not-equal".
+	r := jsLoadInt(atomics, keyInt32, readIdxCell)
+	for {
+		w := jsLoadInt(atomics, keyInt32, writeIdxCell)
+		if w != r {
+			break
+		}
+		atomics.Call("wait", keyInt32, writeIdxCell, w)
+	}
 
-	keyLen := jsLoadInt(atomics, keyInt32, 1)
-	if keyLen <= 0 || keyLen > 16 {
-		atomics.Call("store", keyInt32, 0, 0)
+	slot := r % keyCapacity
+	keyLen := int(byte(keyUint8.Index(keyLenOffset + slot).Int()))
+	if keyLen <= 0 || keyLen > keyMaxLen {
+		// Drain the bad slot and bail. Never block on it.
+		atomics.Call("store", keyInt32, readIdxCell, r+1)
 		return "", nil
 	}
 
+	// Critical ordering: copy slot bytes into a local Go slice BEFORE
+	// advancing readIdx. If the ring is full, advancing first would invite
+	// the producer to overwrite slot[r%capacity] while we're still reading.
 	keyBytes := make([]byte, keyLen)
+	keyBase := keyOffset + slot*keyMaxLen
 	for i := 0; i < keyLen; i++ {
-		keyBytes[i] = byte(keyUint8.Index(i).Int())
+		keyBytes[i] = byte(keyUint8.Index(keyBase + i).Int())
 	}
-	atomics.Call("store", keyInt32, 0, 0)
+
+	// Tier-1 lazy coalesce: peek r+1, r+2, ... while the next slot matches
+	// both length and bytes, and drain past all matches in a single readIdx
+	// advance. A held key that outruns the game loop becomes one turn
+	// instead of a backlog of queued turns.
+	finalR := r
+	for {
+		nextR := finalR + 1
+		w := jsLoadInt(atomics, keyInt32, writeIdxCell)
+		if nextR >= w {
+			break
+		}
+		nextSlot := nextR % keyCapacity
+		if int(byte(keyUint8.Index(keyLenOffset+nextSlot).Int())) != keyLen {
+			break
+		}
+		matches := true
+		nextBase := keyOffset + nextSlot*keyMaxLen
+		for i := 0; i < keyLen; i++ {
+			if byte(keyUint8.Index(nextBase+i).Int()) != keyBytes[i] {
+				matches = false
+				break
+			}
+		}
+		if !matches {
+			break
+		}
+		finalR = nextR
+	}
+
+	atomics.Call("store", keyInt32, readIdxCell, finalR+1)
 	return string(keyBytes), nil
 }
 
@@ -61,9 +132,8 @@ func (HostKeySource) KeyPending() bool {
 	if keyInt32.IsUndefined() || atomics.IsUndefined() {
 		return false
 	}
-	v := atomics.Call("load", keyInt32, 0)
-	if v.IsUndefined() || v.IsNull() {
-		return false
-	}
-	return v.Int() != 0
+	// Non-consuming: true iff at least one slot is queued in the ring.
+	r := jsLoadInt(atomics, keyInt32, readIdxCell)
+	w := jsLoadInt(atomics, keyInt32, writeIdxCell)
+	return w > r
 }

--- a/pkg/rt/wasm/lg-host-core.js
+++ b/pkg/rt/wasm/lg-host-core.js
@@ -163,40 +163,47 @@ function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
 async function startWorkerMode() {
-  const sab = new SharedArrayBuffer(64);
+  // SPSC ring buffer between this main thread (producer) and the worker
+  // (consumer). Layout MUST stay in sync with pkg/rt/term_wasm.go — the consts
+  // below mirror the Go consts. The producer never blocks the main thread:
+  // when the ring is full, _lgKey returns false and the caller decides (held-
+  // repeat callers ignore the return; 8 slots is plenty for human/auto-repeat
+  // input rates). Replaces the old single-slot busy-wait that spun the main
+  // thread for the worker's whole per-key turn cost under hold-to-repeat.
+  //
+  // Int32 view: [0] readIdx, [1] writeIdx, [6] cols, [7] rows.
+  // Uint8 view: bytes 64..71 slot lengths, bytes 72..199 slot keys (8×16).
+  const CAPACITY = 8, MAX_KEY_LEN = 16, LEN_OFFSET = 64, KEY_OFFSET = 72, READ_IDX = 0, WRITE_IDX = 1;
+  const sab = new SharedArrayBuffer(256);
   const keyInt32 = new Int32Array(sab);
-  const keyUint8 = new Uint8Array(sab, 8, 16);
+  const keyUint8 = new Uint8Array(sab);
 
   // Input is unsafe until the worker has been told to start (init posted):
-  // before that there is no consumer to drain the SAB slot. Drop pre-start
-  // keys rather than write into a slot nothing will ever read.
+  // before that there is no consumer, so pre-start keys would sit in the ring
+  // and be replayed as stale input once the VM boots. Drop them. (Kept from the
+  // single-slot era; with the ring there's no main-thread lock to avoid, but
+  // dropping pre-boot keystrokes is still the correct behavior.)
   let workerReady = false;
 
-  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if dropped (worker not started yet, or input too long >16 bytes).
-  // A shell's keystrokes feed through here via LetGoHost.sendInput.
-  //
-  // Non-blocking: never wait for the consumer to drain (that wait is what froze
-  // the page on key bursts). We drop rather than overwrite while a key is still
-  // pending (ready==1): overwriting concurrently would tear the consumer's
-  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
-  // would stomp our just-set ready flag and lose the accepted key.
-  //
-  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
-  // the program is waiting on input the consumer drains immediately and parks at
-  // ready==0, so the freshest key still lands (the interactive common case).
-  // Drops only happen while a prior key sits unconsumed — i.e. the program is
-  // busy and not reading keys — where keeping the first pending key (the
-  // interrupt) and dropping the rest is the behavior we want anyway.
+  // Public input hook — backs LetGoHost.sendInput. Writes UTF-8 bytes to the
+  // next ring slot and advances writeIdx; never blocks. Returns true if
+  // accepted, false if dropped (worker not started, input >16 bytes, or ring
+  // full). Single producer (only this context writes), so no CAS needed; the
+  // slot write happens-before the writeIdx publish because Atomics.store is
+  // sequentially consistent, so the worker never sees an advanced writeIdx
+  // over an unwritten slot.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
-    if (bytes.length === 0 || bytes.length > 16) return false;
-    if (Atomics.load(keyInt32, 0) !== 0) return false;
-    keyUint8.set(bytes);
-    Atomics.store(keyInt32, 1, bytes.length);
-    Atomics.store(keyInt32, 0, 1);
-    Atomics.notify(keyInt32, 0);
+    if (bytes.length === 0 || bytes.length > MAX_KEY_LEN) return false;
+    const w = Atomics.load(keyInt32, WRITE_IDX);
+    const r = Atomics.load(keyInt32, READ_IDX);
+    if (w - r >= CAPACITY) return false;            // ring full → drop
+    const slot = w % CAPACITY;
+    keyUint8[LEN_OFFSET + slot] = bytes.length;
+    keyUint8.set(bytes, KEY_OFFSET + slot * MAX_KEY_LEN);
+    Atomics.store(keyInt32, WRITE_IDX, w + 1);       // publish
+    Atomics.notify(keyInt32, WRITE_IDX, 1);          // wake the consumer
     return true;
   };
 
@@ -272,7 +279,7 @@ async function startWorkerMode() {
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
-      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      globalThis._lgKeyUint8 = new Uint8Array(sab); // full ring (lengths @64, keys @72)
       // Page URL search string, forwarded from the main thread (the worker's
       // own location is the blob URL, not the page). Read by js/url-param.
       globalThis._lgUrlSearch = urlSearch || '';

--- a/pkg/rt/wasm/testdata/assemble_golden.html
+++ b/pkg/rt/wasm/testdata/assemble_golden.html
@@ -186,40 +186,47 @@ function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
 async function startWorkerMode() {
-  const sab = new SharedArrayBuffer(64);
+  // SPSC ring buffer between this main thread (producer) and the worker
+  // (consumer). Layout MUST stay in sync with pkg/rt/term_wasm.go — the consts
+  // below mirror the Go consts. The producer never blocks the main thread:
+  // when the ring is full, _lgKey returns false and the caller decides (held-
+  // repeat callers ignore the return; 8 slots is plenty for human/auto-repeat
+  // input rates). Replaces the old single-slot busy-wait that spun the main
+  // thread for the worker's whole per-key turn cost under hold-to-repeat.
+  //
+  // Int32 view: [0] readIdx, [1] writeIdx, [6] cols, [7] rows.
+  // Uint8 view: bytes 64..71 slot lengths, bytes 72..199 slot keys (8×16).
+  const CAPACITY = 8, MAX_KEY_LEN = 16, LEN_OFFSET = 64, KEY_OFFSET = 72, READ_IDX = 0, WRITE_IDX = 1;
+  const sab = new SharedArrayBuffer(256);
   const keyInt32 = new Int32Array(sab);
-  const keyUint8 = new Uint8Array(sab, 8, 16);
+  const keyUint8 = new Uint8Array(sab);
 
   // Input is unsafe until the worker has been told to start (init posted):
-  // before that there is no consumer to drain the SAB slot. Drop pre-start
-  // keys rather than write into a slot nothing will ever read.
+  // before that there is no consumer, so pre-start keys would sit in the ring
+  // and be replayed as stale input once the VM boots. Drop them. (Kept from the
+  // single-slot era; with the ring there's no main-thread lock to avoid, but
+  // dropping pre-boot keystrokes is still the correct behavior.)
   let workerReady = false;
 
-  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if dropped (worker not started yet, or input too long >16 bytes).
-  // A shell's keystrokes feed through here via LetGoHost.sendInput.
-  //
-  // Non-blocking: never wait for the consumer to drain (that wait is what froze
-  // the page on key bursts). We drop rather than overwrite while a key is still
-  // pending (ready==1): overwriting concurrently would tear the consumer's
-  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
-  // would stomp our just-set ready flag and lose the accepted key.
-  //
-  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
-  // the program is waiting on input the consumer drains immediately and parks at
-  // ready==0, so the freshest key still lands (the interactive common case).
-  // Drops only happen while a prior key sits unconsumed — i.e. the program is
-  // busy and not reading keys — where keeping the first pending key (the
-  // interrupt) and dropping the rest is the behavior we want anyway.
+  // Public input hook — backs LetGoHost.sendInput. Writes UTF-8 bytes to the
+  // next ring slot and advances writeIdx; never blocks. Returns true if
+  // accepted, false if dropped (worker not started, input >16 bytes, or ring
+  // full). Single producer (only this context writes), so no CAS needed; the
+  // slot write happens-before the writeIdx publish because Atomics.store is
+  // sequentially consistent, so the worker never sees an advanced writeIdx
+  // over an unwritten slot.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
-    if (bytes.length === 0 || bytes.length > 16) return false;
-    if (Atomics.load(keyInt32, 0) !== 0) return false;
-    keyUint8.set(bytes);
-    Atomics.store(keyInt32, 1, bytes.length);
-    Atomics.store(keyInt32, 0, 1);
-    Atomics.notify(keyInt32, 0);
+    if (bytes.length === 0 || bytes.length > MAX_KEY_LEN) return false;
+    const w = Atomics.load(keyInt32, WRITE_IDX);
+    const r = Atomics.load(keyInt32, READ_IDX);
+    if (w - r >= CAPACITY) return false;            // ring full → drop
+    const slot = w % CAPACITY;
+    keyUint8[LEN_OFFSET + slot] = bytes.length;
+    keyUint8.set(bytes, KEY_OFFSET + slot * MAX_KEY_LEN);
+    Atomics.store(keyInt32, WRITE_IDX, w + 1);       // publish
+    Atomics.notify(keyInt32, WRITE_IDX, 1);          // wake the consumer
     return true;
   };
 
@@ -295,7 +302,7 @@ async function startWorkerMode() {
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
-      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      globalThis._lgKeyUint8 = new Uint8Array(sab); // full ring (lengths @64, keys @72)
       // Page URL search string, forwarded from the main thread (the worker's
       // own location is the blob URL, not the page). Read by js/url-param.
       globalThis._lgUrlSearch = urlSearch || '';

--- a/pkg/rt/wasm/testdata/assemble_golden_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_external.html
@@ -186,40 +186,47 @@ function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
 async function startWorkerMode() {
-  const sab = new SharedArrayBuffer(64);
+  // SPSC ring buffer between this main thread (producer) and the worker
+  // (consumer). Layout MUST stay in sync with pkg/rt/term_wasm.go — the consts
+  // below mirror the Go consts. The producer never blocks the main thread:
+  // when the ring is full, _lgKey returns false and the caller decides (held-
+  // repeat callers ignore the return; 8 slots is plenty for human/auto-repeat
+  // input rates). Replaces the old single-slot busy-wait that spun the main
+  // thread for the worker's whole per-key turn cost under hold-to-repeat.
+  //
+  // Int32 view: [0] readIdx, [1] writeIdx, [6] cols, [7] rows.
+  // Uint8 view: bytes 64..71 slot lengths, bytes 72..199 slot keys (8×16).
+  const CAPACITY = 8, MAX_KEY_LEN = 16, LEN_OFFSET = 64, KEY_OFFSET = 72, READ_IDX = 0, WRITE_IDX = 1;
+  const sab = new SharedArrayBuffer(256);
   const keyInt32 = new Int32Array(sab);
-  const keyUint8 = new Uint8Array(sab, 8, 16);
+  const keyUint8 = new Uint8Array(sab);
 
   // Input is unsafe until the worker has been told to start (init posted):
-  // before that there is no consumer to drain the SAB slot. Drop pre-start
-  // keys rather than write into a slot nothing will ever read.
+  // before that there is no consumer, so pre-start keys would sit in the ring
+  // and be replayed as stale input once the VM boots. Drop them. (Kept from the
+  // single-slot era; with the ring there's no main-thread lock to avoid, but
+  // dropping pre-boot keystrokes is still the correct behavior.)
   let workerReady = false;
 
-  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if dropped (worker not started yet, or input too long >16 bytes).
-  // A shell's keystrokes feed through here via LetGoHost.sendInput.
-  //
-  // Non-blocking: never wait for the consumer to drain (that wait is what froze
-  // the page on key bursts). We drop rather than overwrite while a key is still
-  // pending (ready==1): overwriting concurrently would tear the consumer's
-  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
-  // would stomp our just-set ready flag and lose the accepted key.
-  //
-  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
-  // the program is waiting on input the consumer drains immediately and parks at
-  // ready==0, so the freshest key still lands (the interactive common case).
-  // Drops only happen while a prior key sits unconsumed — i.e. the program is
-  // busy and not reading keys — where keeping the first pending key (the
-  // interrupt) and dropping the rest is the behavior we want anyway.
+  // Public input hook — backs LetGoHost.sendInput. Writes UTF-8 bytes to the
+  // next ring slot and advances writeIdx; never blocks. Returns true if
+  // accepted, false if dropped (worker not started, input >16 bytes, or ring
+  // full). Single producer (only this context writes), so no CAS needed; the
+  // slot write happens-before the writeIdx publish because Atomics.store is
+  // sequentially consistent, so the worker never sees an advanced writeIdx
+  // over an unwritten slot.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
-    if (bytes.length === 0 || bytes.length > 16) return false;
-    if (Atomics.load(keyInt32, 0) !== 0) return false;
-    keyUint8.set(bytes);
-    Atomics.store(keyInt32, 1, bytes.length);
-    Atomics.store(keyInt32, 0, 1);
-    Atomics.notify(keyInt32, 0);
+    if (bytes.length === 0 || bytes.length > MAX_KEY_LEN) return false;
+    const w = Atomics.load(keyInt32, WRITE_IDX);
+    const r = Atomics.load(keyInt32, READ_IDX);
+    if (w - r >= CAPACITY) return false;            // ring full → drop
+    const slot = w % CAPACITY;
+    keyUint8[LEN_OFFSET + slot] = bytes.length;
+    keyUint8.set(bytes, KEY_OFFSET + slot * MAX_KEY_LEN);
+    Atomics.store(keyInt32, WRITE_IDX, w + 1);       // publish
+    Atomics.notify(keyInt32, WRITE_IDX, 1);          // wake the consumer
     return true;
   };
 
@@ -295,7 +302,7 @@ async function startWorkerMode() {
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
-      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      globalThis._lgKeyUint8 = new Uint8Array(sab); // full ring (lengths @64, keys @72)
       // Page URL search string, forwarded from the main thread (the worker's
       // own location is the blob URL, not the page). Read by js/url-param.
       globalThis._lgUrlSearch = urlSearch || '';

--- a/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_hosteval.html
@@ -184,40 +184,47 @@ function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
 async function startWorkerMode() {
-  const sab = new SharedArrayBuffer(64);
+  // SPSC ring buffer between this main thread (producer) and the worker
+  // (consumer). Layout MUST stay in sync with pkg/rt/term_wasm.go — the consts
+  // below mirror the Go consts. The producer never blocks the main thread:
+  // when the ring is full, _lgKey returns false and the caller decides (held-
+  // repeat callers ignore the return; 8 slots is plenty for human/auto-repeat
+  // input rates). Replaces the old single-slot busy-wait that spun the main
+  // thread for the worker's whole per-key turn cost under hold-to-repeat.
+  //
+  // Int32 view: [0] readIdx, [1] writeIdx, [6] cols, [7] rows.
+  // Uint8 view: bytes 64..71 slot lengths, bytes 72..199 slot keys (8×16).
+  const CAPACITY = 8, MAX_KEY_LEN = 16, LEN_OFFSET = 64, KEY_OFFSET = 72, READ_IDX = 0, WRITE_IDX = 1;
+  const sab = new SharedArrayBuffer(256);
   const keyInt32 = new Int32Array(sab);
-  const keyUint8 = new Uint8Array(sab, 8, 16);
+  const keyUint8 = new Uint8Array(sab);
 
   // Input is unsafe until the worker has been told to start (init posted):
-  // before that there is no consumer to drain the SAB slot. Drop pre-start
-  // keys rather than write into a slot nothing will ever read.
+  // before that there is no consumer, so pre-start keys would sit in the ring
+  // and be replayed as stale input once the VM boots. Drop them. (Kept from the
+  // single-slot era; with the ring there's no main-thread lock to avoid, but
+  // dropping pre-boot keystrokes is still the correct behavior.)
   let workerReady = false;
 
-  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if dropped (worker not started yet, or input too long >16 bytes).
-  // A shell's keystrokes feed through here via LetGoHost.sendInput.
-  //
-  // Non-blocking: never wait for the consumer to drain (that wait is what froze
-  // the page on key bursts). We drop rather than overwrite while a key is still
-  // pending (ready==1): overwriting concurrently would tear the consumer's
-  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
-  // would stomp our just-set ready flag and lose the accepted key.
-  //
-  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
-  // the program is waiting on input the consumer drains immediately and parks at
-  // ready==0, so the freshest key still lands (the interactive common case).
-  // Drops only happen while a prior key sits unconsumed — i.e. the program is
-  // busy and not reading keys — where keeping the first pending key (the
-  // interrupt) and dropping the rest is the behavior we want anyway.
+  // Public input hook — backs LetGoHost.sendInput. Writes UTF-8 bytes to the
+  // next ring slot and advances writeIdx; never blocks. Returns true if
+  // accepted, false if dropped (worker not started, input >16 bytes, or ring
+  // full). Single producer (only this context writes), so no CAS needed; the
+  // slot write happens-before the writeIdx publish because Atomics.store is
+  // sequentially consistent, so the worker never sees an advanced writeIdx
+  // over an unwritten slot.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
-    if (bytes.length === 0 || bytes.length > 16) return false;
-    if (Atomics.load(keyInt32, 0) !== 0) return false;
-    keyUint8.set(bytes);
-    Atomics.store(keyInt32, 1, bytes.length);
-    Atomics.store(keyInt32, 0, 1);
-    Atomics.notify(keyInt32, 0);
+    if (bytes.length === 0 || bytes.length > MAX_KEY_LEN) return false;
+    const w = Atomics.load(keyInt32, WRITE_IDX);
+    const r = Atomics.load(keyInt32, READ_IDX);
+    if (w - r >= CAPACITY) return false;            // ring full → drop
+    const slot = w % CAPACITY;
+    keyUint8[LEN_OFFSET + slot] = bytes.length;
+    keyUint8.set(bytes, KEY_OFFSET + slot * MAX_KEY_LEN);
+    Atomics.store(keyInt32, WRITE_IDX, w + 1);       // publish
+    Atomics.notify(keyInt32, WRITE_IDX, 1);          // wake the consumer
     return true;
   };
 
@@ -293,7 +300,7 @@ async function startWorkerMode() {
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
-      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      globalThis._lgKeyUint8 = new Uint8Array(sab); // full ring (lengths @64, keys @72)
       // Page URL search string, forwarded from the main thread (the worker's
       // own location is the blob URL, not the page). Read by js/url-param.
       globalThis._lgUrlSearch = urlSearch || '';

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless.html
@@ -184,40 +184,47 @@ function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
 async function startWorkerMode() {
-  const sab = new SharedArrayBuffer(64);
+  // SPSC ring buffer between this main thread (producer) and the worker
+  // (consumer). Layout MUST stay in sync with pkg/rt/term_wasm.go — the consts
+  // below mirror the Go consts. The producer never blocks the main thread:
+  // when the ring is full, _lgKey returns false and the caller decides (held-
+  // repeat callers ignore the return; 8 slots is plenty for human/auto-repeat
+  // input rates). Replaces the old single-slot busy-wait that spun the main
+  // thread for the worker's whole per-key turn cost under hold-to-repeat.
+  //
+  // Int32 view: [0] readIdx, [1] writeIdx, [6] cols, [7] rows.
+  // Uint8 view: bytes 64..71 slot lengths, bytes 72..199 slot keys (8×16).
+  const CAPACITY = 8, MAX_KEY_LEN = 16, LEN_OFFSET = 64, KEY_OFFSET = 72, READ_IDX = 0, WRITE_IDX = 1;
+  const sab = new SharedArrayBuffer(256);
   const keyInt32 = new Int32Array(sab);
-  const keyUint8 = new Uint8Array(sab, 8, 16);
+  const keyUint8 = new Uint8Array(sab);
 
   // Input is unsafe until the worker has been told to start (init posted):
-  // before that there is no consumer to drain the SAB slot. Drop pre-start
-  // keys rather than write into a slot nothing will ever read.
+  // before that there is no consumer, so pre-start keys would sit in the ring
+  // and be replayed as stale input once the VM boots. Drop them. (Kept from the
+  // single-slot era; with the ring there's no main-thread lock to avoid, but
+  // dropping pre-boot keystrokes is still the correct behavior.)
   let workerReady = false;
 
-  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if dropped (worker not started yet, or input too long >16 bytes).
-  // A shell's keystrokes feed through here via LetGoHost.sendInput.
-  //
-  // Non-blocking: never wait for the consumer to drain (that wait is what froze
-  // the page on key bursts). We drop rather than overwrite while a key is still
-  // pending (ready==1): overwriting concurrently would tear the consumer's
-  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
-  // would stomp our just-set ready flag and lose the accepted key.
-  //
-  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
-  // the program is waiting on input the consumer drains immediately and parks at
-  // ready==0, so the freshest key still lands (the interactive common case).
-  // Drops only happen while a prior key sits unconsumed — i.e. the program is
-  // busy and not reading keys — where keeping the first pending key (the
-  // interrupt) and dropping the rest is the behavior we want anyway.
+  // Public input hook — backs LetGoHost.sendInput. Writes UTF-8 bytes to the
+  // next ring slot and advances writeIdx; never blocks. Returns true if
+  // accepted, false if dropped (worker not started, input >16 bytes, or ring
+  // full). Single producer (only this context writes), so no CAS needed; the
+  // slot write happens-before the writeIdx publish because Atomics.store is
+  // sequentially consistent, so the worker never sees an advanced writeIdx
+  // over an unwritten slot.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
-    if (bytes.length === 0 || bytes.length > 16) return false;
-    if (Atomics.load(keyInt32, 0) !== 0) return false;
-    keyUint8.set(bytes);
-    Atomics.store(keyInt32, 1, bytes.length);
-    Atomics.store(keyInt32, 0, 1);
-    Atomics.notify(keyInt32, 0);
+    if (bytes.length === 0 || bytes.length > MAX_KEY_LEN) return false;
+    const w = Atomics.load(keyInt32, WRITE_IDX);
+    const r = Atomics.load(keyInt32, READ_IDX);
+    if (w - r >= CAPACITY) return false;            // ring full → drop
+    const slot = w % CAPACITY;
+    keyUint8[LEN_OFFSET + slot] = bytes.length;
+    keyUint8.set(bytes, KEY_OFFSET + slot * MAX_KEY_LEN);
+    Atomics.store(keyInt32, WRITE_IDX, w + 1);       // publish
+    Atomics.notify(keyInt32, WRITE_IDX, 1);          // wake the consumer
     return true;
   };
 
@@ -293,7 +300,7 @@ async function startWorkerMode() {
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
-      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      globalThis._lgKeyUint8 = new Uint8Array(sab); // full ring (lengths @64, keys @72)
       // Page URL search string, forwarded from the main thread (the worker's
       // own location is the blob URL, not the page). Read by js/url-param.
       globalThis._lgUrlSearch = urlSearch || '';

--- a/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
+++ b/pkg/rt/wasm/testdata/assemble_golden_shellless_external.html
@@ -184,40 +184,47 @@ function setStatus(t) { if (status) status.textContent = t; }
 
 // --- Worker mode (interactive, needs cross-origin isolation) ---
 async function startWorkerMode() {
-  const sab = new SharedArrayBuffer(64);
+  // SPSC ring buffer between this main thread (producer) and the worker
+  // (consumer). Layout MUST stay in sync with pkg/rt/term_wasm.go — the consts
+  // below mirror the Go consts. The producer never blocks the main thread:
+  // when the ring is full, _lgKey returns false and the caller decides (held-
+  // repeat callers ignore the return; 8 slots is plenty for human/auto-repeat
+  // input rates). Replaces the old single-slot busy-wait that spun the main
+  // thread for the worker's whole per-key turn cost under hold-to-repeat.
+  //
+  // Int32 view: [0] readIdx, [1] writeIdx, [6] cols, [7] rows.
+  // Uint8 view: bytes 64..71 slot lengths, bytes 72..199 slot keys (8×16).
+  const CAPACITY = 8, MAX_KEY_LEN = 16, LEN_OFFSET = 64, KEY_OFFSET = 72, READ_IDX = 0, WRITE_IDX = 1;
+  const sab = new SharedArrayBuffer(256);
   const keyInt32 = new Int32Array(sab);
-  const keyUint8 = new Uint8Array(sab, 8, 16);
+  const keyUint8 = new Uint8Array(sab);
 
   // Input is unsafe until the worker has been told to start (init posted):
-  // before that there is no consumer to drain the SAB slot. Drop pre-start
-  // keys rather than write into a slot nothing will ever read.
+  // before that there is no consumer, so pre-start keys would sit in the ring
+  // and be replayed as stale input once the VM boots. Drop them. (Kept from the
+  // single-slot era; with the ring there's no main-thread lock to avoid, but
+  // dropping pre-boot keystrokes is still the correct behavior.)
   let workerReady = false;
 
-  // Public input hook — backs LetGoHost.sendInput. Returns true if accepted,
-  // false if dropped (worker not started yet, or input too long >16 bytes).
-  // A shell's keystrokes feed through here via LetGoHost.sendInput.
-  //
-  // Non-blocking: never wait for the consumer to drain (that wait is what froze
-  // the page on key bursts). We drop rather than overwrite while a key is still
-  // pending (ready==1): overwriting concurrently would tear the consumer's
-  // byte-by-byte copy and, worse, the consumer's unconditional clear after copy
-  // would stomp our just-set ready flag and lose the accepted key.
-  //
-  // This makes the slot oldest-pending-wins, not newest-wins. In practice when
-  // the program is waiting on input the consumer drains immediately and parks at
-  // ready==0, so the freshest key still lands (the interactive common case).
-  // Drops only happen while a prior key sits unconsumed — i.e. the program is
-  // busy and not reading keys — where keeping the first pending key (the
-  // interrupt) and dropping the rest is the behavior we want anyway.
+  // Public input hook — backs LetGoHost.sendInput. Writes UTF-8 bytes to the
+  // next ring slot and advances writeIdx; never blocks. Returns true if
+  // accepted, false if dropped (worker not started, input >16 bytes, or ring
+  // full). Single producer (only this context writes), so no CAS needed; the
+  // slot write happens-before the writeIdx publish because Atomics.store is
+  // sequentially consistent, so the worker never sees an advanced writeIdx
+  // over an unwritten slot.
   window._lgKey = function(data) {
     if (!workerReady) return false;
     const bytes = new TextEncoder().encode(data);
-    if (bytes.length === 0 || bytes.length > 16) return false;
-    if (Atomics.load(keyInt32, 0) !== 0) return false;
-    keyUint8.set(bytes);
-    Atomics.store(keyInt32, 1, bytes.length);
-    Atomics.store(keyInt32, 0, 1);
-    Atomics.notify(keyInt32, 0);
+    if (bytes.length === 0 || bytes.length > MAX_KEY_LEN) return false;
+    const w = Atomics.load(keyInt32, WRITE_IDX);
+    const r = Atomics.load(keyInt32, READ_IDX);
+    if (w - r >= CAPACITY) return false;            // ring full → drop
+    const slot = w % CAPACITY;
+    keyUint8[LEN_OFFSET + slot] = bytes.length;
+    keyUint8.set(bytes, KEY_OFFSET + slot * MAX_KEY_LEN);
+    Atomics.store(keyInt32, WRITE_IDX, w + 1);       // publish
+    Atomics.notify(keyInt32, WRITE_IDX, 1);          // wake the consumer
     return true;
   };
 
@@ -293,7 +300,7 @@ async function startWorkerMode() {
       if (e.data.t !== 'init') return;
       const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, urlSearch } = e.data;
       globalThis._lgKeyInt32 = new Int32Array(sab);
-      globalThis._lgKeyUint8 = new Uint8Array(sab, 8, 16);
+      globalThis._lgKeyUint8 = new Uint8Array(sab); // full ring (lengths @64, keys @72)
       // Page URL search string, forwarded from the main thread (the worker's
       // own location is the blob URL, not the page). Read by js/url-param.
       globalThis._lgUrlSearch = urlSearch || '';


### PR DESCRIPTION

The wasm bundle's key input is a single SAB slot: while the worker is mid-turn with a key pending, `LetGoHost.sendInput` drops every further press (oldest-pending-wins, per the comment in `lg-host-core.js`). For interactive programs that means fast typing and held keys mostly vanish — in a game bundle driving a burst of 10 presses into a busy worker, 0 of 10 were accepted. The slower the program's read loop, the worse it gets.

This replaces the slot with an 8-slot SPSC ring in the same SharedArrayBuffer. The producer writes `slot[writeIdx % 8]`, publishes with `Atomics.store` + `notify`, and never blocks the main thread — it returns false only when the ring is full. The consumer (`HostKeySource.ReadKey`) parks on `Atomics.wait(writeIdx)`, copies the slot before advancing `readIdx` (so a full-ring producer can't overwrite mid-read), then lazily coalesces: adjacent queued slots with identical bytes drain in a single advance, so a held key that outruns the read loop becomes one keypress instead of a backlog of queued turns. Distinct keys are never merged and nothing is reordered.

Same burst against this branch: 7 of 10 accepted (ring capacity while one is in flight), producer wall time for the whole burst 0.07 ms. An earlier measurement of the same design on the pre-#245 host layout also had the consumer side: 12 render ticks for a 10-press held-key burst down to 3.

Layout notes: the ring lives in the existing SAB (256 bytes) — cells 0/1 are read/write indices, slot lengths at byte 64, slot bytes (16 per key) at 72; the protocol comment is duplicated in `keysource_js_wasm.go` and `lg-host-core.js` with a keep-in-sync warning; the two sides ship together in a bundle, so there is no cross-version concern. `key-pending?` keeps its semantics (non-consuming, true iff the ring is non-empty). Goldens regenerated via `go test ./pkg/rt/wasm -update`.

The one behavior change to weigh in review: coalescing means N held-key repeats can execute as one read rather than N. For read-key-driven programs that's the point (input stays live instead of replaying a stale backlog), but if you'd rather ship the ring without coalesce and leave merging to programs, that's a clean 20-line subtraction — the ring stands on its own.
