### PR TITLE
feat(scripts): lgbdump.lg — canonical .lgb dump for diffing bundles

### DIFF
--- a/scripts/lgbdump.lg
+++ b/scripts/lgbdump.lg
@@ -1,0 +1,75 @@
+;; scripts/lgbdump.lg — canonical text dump of a .lgb bundle, for diffing.
+;;
+;;     ./lg scripts/lgbdump.lg <bundle.lgb>
+;;
+;; Diff two bundles by diffing two dumps:
+;;
+;;     diff -u <(./lg scripts/lgbdump.lg old.lgb) <(./lg scripts/lgbdump.lg new.lgb)
+;;
+;; Builds on disasm/decode-bundle (decodes without executing) and
+;; disassemble-resolved (LOAD_CONST/LOAD_VAR rows carry the referenced
+;; identifier, so const-pool index shifts don't drown a diff). Output is
+;; deterministic: namespaces sorted by name, no addresses or pool order.
+;;
+;; Named functions from the shared const pool are dumped under their name;
+;; anonymous ones under a bare "fn anon" label (a pool index would shift on
+;; any insertion, making identical fns diff as different).
+
+(ns lgbdump
+  (:require [disasm]))
+
+;; A resolved LOAD_CONST/LOAD_VAR row is [op pool-idx identifier]. The pool
+;; index shifts whenever any earlier const is added or removed, which turns a
+;; one-fn change into a whole-bundle diff — so for diffing, keep only the
+;; identifier. Unresolved rows keep their index (it's all we have).
+(defn scrub-row [row]
+  (if (and (>= (count row) 3)
+           (or (= :LOAD_CONST (first row)) (= :LOAD_VAR (first row))))
+    (vector (first row) (nth row 2))
+    row))
+
+;; Top-level comments and #_ discards compile to a LOAD_CONST-VOID/POP pair
+;; (dead code; being removed by #600). Rendering each pair would make "added
+;; a comment" look like bytecode churn, so suppress them and print one count
+;; line per chunk instead — the count still diffs when it changes.
+(defn void-load? [row]
+  (and (= :LOAD_CONST (first row))
+       (let [x (nth row (dec (count row)))]
+         (and (vector? x) (= :opaque (first x)) (= "VOID" (second x))))))
+
+(defn dump-chunk [label chunk]
+  (println (str "== " label " =="))
+  (loop [rows (seq (disasm/disassemble-resolved chunk)) skipped 0]
+    (if (nil? rows)
+      (when (> skipped 0)
+        (println (str ";; " skipped " no-value pairs suppressed")))
+      (let [row (first rows)
+            nxt (next rows)]
+        (if (and (void-load? row) nxt (= :POP (first (first nxt))))
+          (recur (next nxt) (inc skipped))
+          (do (println (pr-str (scrub-row row)))
+              (recur nxt skipped)))))))
+
+(defn dump-bundle [path]
+  (let [b (disasm/decode-bundle path)
+        nss (sort-by (fn [m] (get m :ns)) (get b :namespaces))]
+    (println (str ";; lgbdump: " (count nss) " namespaces, "
+                  (count (get b :consts)) " consts"))
+    (dump-chunk "main" (get b :main))
+    (doseq [m nss]
+      (dump-chunk (str "ns " (get m :ns)) (get m :chunk)))
+    ;; Nested fns live in the bundle-wide shared const pool: raw values give
+    ;; the chunks, the projected view gives stable [:fn name] labels.
+    (let [raw (disasm/constants (get b :main))
+          proj (get b :consts)]
+      (doseq [i (range (count raw))]
+        (let [p (nth proj i)]
+          (when (and (vector? p) (= :fn (first p)))
+            (dump-chunk (str "fn " (if (> (count p) 1) (second p) "anon"))
+                        (nth raw i))))))))
+
+(let [path (first *command-line-args*)]
+  (if (nil? path)
+    (do (println "usage: lg scripts/lgbdump.lg <bundle.lgb>")
+        (os/exit 2))
+    (dump-bundle path)))


### PR DESCRIPTION
`core_compiled.lgb` shows up in PRs as an opaque binary bump. This adds a script that prints a canonical text dump of any `.lgb`, so bundle changes can be read and diffed:

    ./lg scripts/lgbdump.lg pkg/rt/core_compiled.lgb
    diff -u <(./lg scripts/lgbdump.lg old.lgb) <(./lg scripts/lgbdump.lg new.lgb)

It's a thin layer over the existing `disasm` namespace (`decode-bundle` + `disassemble-resolved`). Three choices aim at diff quality:

- Resolved `LOAD_CONST`/`LOAD_VAR` rows print only the referenced identifier, not the pool index. A pool insertion shifts every later index, which turns a one-fn change into a whole-bundle diff — on the #558 bundle bump, the index-bearing dump diffs at 16.7k lines, the identifier-only dump at 763.
- Anonymous fns get a bare `fn anon` label instead of their pool index, for the same reason; named fns keep their names. Identical anonymous fns diff as equal.
- The `LOAD_CONST`-VOID/`POP` pairs that top-level comments compile to (#600 removes them) collapse to one count line per chunk, so adding a comment reads as a count bump, not bytecode churn.

Namespaces print sorted by name, and constants are projected the way `disasm` already projects them (identifiers pass through, everything else becomes a type tag), so the output is deterministic for a given bundle — no addresses, no pool order.

Reading bundle bumps this way is how #600's dead comment pairs turned up, and it made #580's bump checkable: the diff reduces to the `*ir-compile-strict*` var plus the strict-mode throw, matching the PR description. One caveat: dump with an `lg` whose opcode enum matches the bundle's producer — for PR review that's the tree you're already in.

Possible follow-ups, not included here: a `diff.lgb.textconv` line in `install-hooks` so `git diff` renders bundle bumps semantically, and an opt-in CI label that posts the bundle diff as a PR comment.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
