### PR TITLE
feat(api): IsIncomplete — sanctioned incomplete-input check for REPL loops

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -237,3 +237,24 @@ func (l *LetGo) Run(expr string) (vm.Value, error) {
 	vm.ReleaseFrame(frame)
 	return result, err
 }
+
+// IsIncomplete reports whether err, as returned by Run, means the input
+// ended in the middle of an open form (e.g. "(defn foo [x]") rather than
+// being wrong. Interactive frontends use it to decide between reading
+// more lines and reporting the error:
+//
+//	v, err := lg.Run(buffer)
+//	if err != nil {
+//		if api.IsIncomplete(err) {
+//			continue // prompt for another line, re-Run the whole buffer
+//		}
+//		report(err)
+//	}
+//
+// Empty and whitespace-only input also read as incomplete, which a REPL
+// loop treats the same way: keep prompting. A hard syntax error such as
+// an unmatched delimiter ("(]") is not incomplete — more input can never
+// complete it — and should be reported immediately.
+func IsIncomplete(err error) bool {
+	return compiler.IsErrorEOF(err)
+}

--- a/pkg/api/incomplete_test.go
+++ b/pkg/api/incomplete_test.go
@@ -1,0 +1,50 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsIncomplete pins the REPL-loop contract: input that ends inside an
+// open form is incomplete (keep reading), a hard syntax error is not
+// (report now), and a successful evaluation returns no error at all.
+func TestIsIncomplete(t *testing.T) {
+	lg, err := api.NewLetGo("incomplete-test")
+	assert.NoError(t, err)
+
+	// Ends inside an open form: accumulate more input.
+	_, err = lg.Run("(defn foo [x]")
+	assert.Error(t, err)
+	assert.True(t, api.IsIncomplete(err))
+
+	// Ends inside an open string literal: same story.
+	_, err = lg.Run(`(println "unterminated`)
+	assert.Error(t, err)
+	assert.True(t, api.IsIncomplete(err))
+
+	// Unmatched delimiter: no amount of further input completes this.
+	_, err = lg.Run("(]")
+	assert.Error(t, err)
+	assert.False(t, api.IsIncomplete(err))
+
+	// Empty and whitespace-only input read as incomplete: a REPL keeps
+	// prompting rather than reporting an error.
+	_, err = lg.Run("")
+	assert.Error(t, err)
+	assert.True(t, api.IsIncomplete(err))
+	_, err = lg.Run("   \n\n")
+	assert.Error(t, err)
+	assert.True(t, api.IsIncomplete(err))
+
+	// Comment-only input evaluates cleanly (no error), so a REPL never
+	// consults IsIncomplete for it.
+	_, err = lg.Run("; just a comment")
+	assert.NoError(t, err)
+
+	// The accumulate-and-retry loop converges: the completed form runs.
+	v, err := lg.Run("(defn foo [x]\n  (+ x 1))\n")
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+}


### PR DESCRIPTION
Closes #587.

One exported function, `api.IsIncomplete(err) bool`, delegating to `compiler.IsErrorEOF` — which already makes the right distinction: input that ended inside an open form has an `io.EOF` cause, an unmatched delimiter does not. The doc comment carries the worked REPL loop (accumulate lines while incomplete, report otherwise), which is the contract the test pins: open form and open string are incomplete, `(]` is not, and the accumulate-and-retry loop converges.

One behavior surfaced while pinning the contract: comment-only input evaluates cleanly (no error), so only empty/whitespace-only input reads as incomplete alongside open forms. The doc comment states that.

No behavior change anywhere else — this exports and documents an existing predicate at the surface embedders see.
