### PR TITLE
feat(api): namespace facade — lg.NS with Def/DefShadowing

### DIFF
--- a/pkg/api/ns.go
+++ b/pkg/api/ns.go
@@ -43,7 +43,17 @@ func (n *NS) Def(name string, value any) error {
 // (:refer-clojure :exclude [name]). The definition is silent and
 // unqualified references in the namespace resolve to it instead of the
 // core var.
+//
+// Boxing happens before any namespace mutation: if value is unboxable the
+// namespace is left untouched, so a failed call is a true no-op rather than
+// leaving name excluded-but-undefined (which would silently strip the
+// unqualified clojure.core/<name> resolution).
 func (n *NS) DefShadowing(name string, value any) error {
+	val, err := vm.BoxValue(reflect.ValueOf(value))
+	if err != nil {
+		return err
+	}
 	n.ns.Exclude(name)
-	return n.Def(name, value)
+	n.ns.Def(name, val)
+	return nil
 }

--- a/pkg/api/ns.go
+++ b/pkg/api/ns.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"reflect"
+
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// NS is a handle for registering host values into one namespace. It is
+// the namespace-targeted counterpart of LetGo.Def: same boxing, explicit
+// destination. Obtain one from LetGo.NS.
+type NS struct {
+	ns *vm.Namespace
+}
+
+// NS resolves the named namespace, creating it if it does not exist yet,
+// and returns a registration handle for it. Typical embedder use is
+// grouping host functions into their own namespaces at startup:
+//
+//	patch := lg.NS("music.patch")
+//	patch.Def("oscillator", oscillatorFn)
+//	patch.DefShadowing("filter", filterFn) // collides with clojure.core/filter
+func (l *LetGo) NS(name string) *NS {
+	return &NS{ns: rt.NS(name)}
+}
+
+// Def boxes value exactly as LetGo.Def does and defines it in this
+// namespace. Defining a name that is referred in from clojure.core works
+// (the local var wins) but emits the Clojure-parity shadow warning; use
+// DefShadowing when the collision is intentional.
+func (n *NS) Def(name string, value any) error {
+	val, err := vm.BoxValue(reflect.ValueOf(value))
+	if err != nil {
+		return err
+	}
+	n.ns.Def(name, val)
+	return nil
+}
+
+// DefShadowing defines name in this namespace, first excluding it from
+// the clojure.core auto-refer — the programmatic equivalent of
+// (:refer-clojure :exclude [name]). The definition is silent and
+// unqualified references in the namespace resolve to it instead of the
+// core var.
+func (n *NS) DefShadowing(name string, value any) error {
+	n.ns.Exclude(name)
+	return n.Def(name, value)
+}

--- a/pkg/api/ns_test.go
+++ b/pkg/api/ns_test.go
@@ -1,0 +1,68 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNSDef proves the organized-registration story: host functions
+// defined into a dedicated namespace via lg.NS are callable through
+// their qualified names, with the same boxing LetGo.Def performs.
+func TestNSDef(t *testing.T) {
+	lg, err := api.NewLetGo("nsdef-test")
+	assert.NoError(t, err)
+
+	music := lg.NS("nsdef-test.music")
+	assert.NoError(t, music.Def("add2", func(a, b int) int { return a + b }))
+	assert.NoError(t, music.Def("answer", 42))
+
+	v, err := lg.Run("(nsdef-test.music/add2 20 2)")
+	assert.NoError(t, err)
+	assert.Equal(t, "22", v.String())
+
+	v, err = lg.Run("nsdef-test.music/answer")
+	assert.NoError(t, err)
+	assert.Equal(t, "42", v.String())
+}
+
+// TestNSDefShadowing proves the intentional-collision story: a host DSL
+// name that collides with clojure.core (here `filter`) is defined via
+// DefShadowing, and unqualified references in that namespace resolve to
+// the host definition rather than the core var.
+func TestNSDefShadowing(t *testing.T) {
+	lg, err := api.NewLetGo("nsshadow-test")
+	assert.NoError(t, err)
+
+	ns := lg.NS("nsshadow-test")
+	assert.NoError(t, ns.DefShadowing("filter", func(freq int) string {
+		return "lowpass"
+	}))
+
+	// Unqualified `filter` in the instance namespace is the host's, not
+	// clojure.core's lazy-seq filter.
+	v, err := lg.Run("(filter 220)")
+	assert.NoError(t, err)
+	assert.Equal(t, `"lowpass"`, v.String())
+
+	// Core's filter is still reachable qualified.
+	v, err = lg.Run("(clojure.core/filter odd? [1 2 3])")
+	assert.NoError(t, err)
+	assert.Equal(t, "(1 3)", v.String())
+}
+
+// TestNSCreatesNamespace pins resolve-or-create: NS on a name that was
+// never mentioned before returns a usable handle rather than nil.
+func TestNSCreatesNamespace(t *testing.T) {
+	lg, err := api.NewLetGo("nscreate-test")
+	assert.NoError(t, err)
+
+	fresh := lg.NS("nscreate-test.brand.new")
+	assert.NotNil(t, fresh)
+	assert.NoError(t, fresh.Def("marker", "here"))
+
+	v, err := lg.Run("nscreate-test.brand.new/marker")
+	assert.NoError(t, err)
+	assert.Equal(t, `"here"`, v.String())
+}

--- a/pkg/api/ns_test.go
+++ b/pkg/api/ns_test.go
@@ -52,6 +52,25 @@ func TestNSDefShadowing(t *testing.T) {
 	assert.Equal(t, "(1 3)", v.String())
 }
 
+// TestNSDefShadowingFailureLeavesNamespaceUntouched pins the atomicity
+// fix: when the value is unboxable, DefShadowing returns an error before
+// mutating the namespace, so the name is not left excluded-but-undefined.
+// An unqualified reference must still resolve to clojure.core.
+func TestNSDefShadowingFailureLeavesNamespaceUntouched(t *testing.T) {
+	lg, err := api.NewLetGo("nsshadow-fail-test")
+	assert.NoError(t, err)
+
+	ns := lg.NS("nsshadow-fail-test")
+	// nil is unboxable: DefShadowing must fail before Exclude runs.
+	assert.Error(t, ns.DefShadowing("filter", nil))
+
+	// The failed call was a no-op: unqualified `filter` still resolves to
+	// clojure.core's lazy-seq filter rather than to nothing.
+	v, err := lg.Run("(filter odd? [1 2 3])")
+	assert.NoError(t, err)
+	assert.Equal(t, "(1 3)", v.String())
+}
+
 // TestNSCreatesNamespace pins resolve-or-create: NS on a name that was
 // never mentioned before returns a usable handle rather than nil.
 func TestNSCreatesNamespace(t *testing.T) {


### PR DESCRIPTION
Closes #593.

The three methods from the issue, nothing more: `lg.NS(name)` resolves or creates a namespace (it's `rt.NS` underneath, which is already resolve-or-create) and returns a handle; `Def` boxes with the same `vm.BoxValue` path as `LetGo.Def` and defines into that namespace; `DefShadowing` is the programmatic `(:refer-clojure :exclude [name])` — `Exclude` then `Def`, so an intentional core-name collision is silent and unqualified references in the namespace resolve to the host definition.

The tests pin the three stories: qualified calls into a dedicated host-function namespace, shadowing `filter` (host def wins unqualified, `clojure.core/filter` stays reachable qualified), and resolve-or-create on a never-mentioned name.

With this an embedder's registration code stays inside `pkg/api` — the motivating example in #593 needed `rt`, `vm`, and hand-rolled `NativeFnType.Wrap` boxing for the same job. `Refer`/aliasing are left out per the issue; can follow if there's a use.
