### PR TITLE
feat(bytecode): actionable hint on capability-mask reject

### DIFF
--- a/pkg/bytecode/bytecode_test.go
+++ b/pkg/bytecode/bytecode_test.go
@@ -1146,6 +1146,9 @@ func TestUnsupportedCapabilityMask(t *testing.T) {
 	if !strings.Contains(err.Error(), "unsupported capability mask") {
 		t.Fatalf("expected 'unsupported capability mask' in error, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "recompile it with a matching lg") {
+		t.Fatalf("expected the recompile hint in error, got: %v", err)
+	}
 }
 
 func TestSupportedCapabilityMask(t *testing.T) {

--- a/pkg/bytecode/decoder.go
+++ b/pkg/bytecode/decoder.go
@@ -200,7 +200,9 @@ func (d *decoder) readCapabilities() error {
 	}
 	const supportedCaps = CapOpcodeSet
 	if caps&^supportedCaps != 0 {
-		return fmt.Errorf("unsupported capability mask 0x%08x (supported: 0x%08x)", caps, supportedCaps)
+		return fmt.Errorf(
+			"unsupported capability mask 0x%08x (supported: 0x%08x) — bundle was produced by a newer lg than this runtime; recompile it with a matching lg or run it on a newer runtime",
+			caps, supportedCaps)
 	}
 	if caps&CapOpcodeSet != 0 {
 		bundleCount, err := d.r.ReadVarint()


### PR DESCRIPTION
Addresses the error-ergonomics item (question 3) in #607.

When the decoder rejects a bundle whose capability mask has bits the runtime doesn't support, the error now says what that means and what to do about it:

```
unsupported capability mask 0x00000001 (supported: 0x00000000) — bundle was produced by a newer lg than this runtime; recompile it with a matching lg or run it on a newer runtime
```

Previously it printed only the two masks, which is opaque at the point where users hit it: a pre-#443 runtime (v1.9.0–v1.11.1) handed a v1.12.0+ bundle — the skew behind #607. The opcode-set mismatch path one branch below already carries a "recompile the bundle with a matching lg" hint; this brings the capability reject in line with it.

Scope note: this only improves the message in future runtimes. The shipped v1.9–v1.11 decoders keep printing the terse form, so it changes nothing for the #607 report itself — that one is resolved on the producer side (see the issue).

Extended `TestUnsupportedCapabilityMask` to pin the hint text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)