### PR TITLE
fix(hooks): pass -short to the pre-push go-test gate (match CI)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
       - id: go-test
         name: go test ./... -skip TestClojureTestSuite
         description: Run Go test suite excluding the slow Clojure compat suite (mirrors CI test step)
-        entry: go test -timeout 60s ./... -skip TestClojureTestSuite
+        entry: go test -short -timeout 60s ./... -skip TestClojureTestSuite
         language: system
         types: [go]
         pass_filenames: false


### PR DESCRIPTION
The pre-push `go-test` hook ran `go test -timeout 60s ./...` **without `-short`**, unlike CI (`.github/workflows/go.yml`). So the expensive lowering harnesses (`TestLoweringDeterminism`, AOT-diff) — which self-skip under `-short` — ran and hit the 60s per-package timeout, blocking every push. Add `-short` to match CI; the slow harnesses stay covered by their dedicated lowering steps.

Verified: `go test -short -timeout 60s ./... -skip TestClojureTestSuite` runs test/e2e in ~20s, whole suite green.