### PR TITLE
perf(ir): catalog-driven op dispatch — generated OpByKeyword string switch (§1/§2/§2b)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
       - id: go-test
         name: go test ./... -skip TestClojureTestSuite
         description: Run Go test suite excluding the slow Clojure compat suite (mirrors CI test step)
-        entry: go test -timeout 60s ./... -skip TestClojureTestSuite
+        entry: go test -short -timeout 60s ./... -skip TestClojureTestSuite
         language: system
         types: [go]
         pass_filenames: false

--- a/pkg/ir/ir_bridge.lg
+++ b/pkg/ir/ir_bridge.lg
@@ -301,6 +301,24 @@
     :args [OpKw]
     :body "return vm.Boolean(arg0.LocalCarrying()), nil"}
 
+   {:name "op-infer-facet?" :lisp-name "ir/op-infer-facet?"
+    :args [OpKw]
+    :body "return vm.Boolean(arg0.InferFacet()), nil"}
+
+   {:name "op-lower-facet?" :lisp-name "ir/op-lower-facet?"
+    :args [OpKw]
+    :body "return vm.Boolean(arg0.LowerFacet()), nil"}
+
+   ;; Every catalogued op as a vector of kebab-case keywords, in Op order.
+   ;; Lets .lg-side exhaustiveness checks (ir.ops) enumerate the closed op
+   ;; set from the catalog instead of a hand-maintained list.
+   {:name "op-kws" :lisp-name "ir/op-kws"
+    :args []
+    :body "kws := ir.OpKeywords()
+             out := make([]vm.Value, 0, len(kws))
+             for _, k := range kws { out = append(out, vm.Keyword(k)) }
+             return vm.NewArrayVector(out), nil"}
+
    {:name "op-cheap-load?" :lisp-name "ir/op-cheap-load?"
     :args [OpKw]
     :body "return vm.Boolean(ir.IsCheapMaterializeOp(arg0)), nil"}

--- a/pkg/ir/ir_bridge.lg
+++ b/pkg/ir/ir_bridge.lg
@@ -297,6 +297,10 @@
     :args [OpKw]
     :body "return vm.Boolean(arg0.IsPure()), nil"}
 
+   {:name "op-local-carrying?" :lisp-name "ir/op-local-carrying?"
+    :args [OpKw]
+    :body "return vm.Boolean(arg0.LocalCarrying()), nil"}
+
    {:name "op-cheap-load?" :lisp-name "ir/op-cheap-load?"
     :args [OpKw]
     :body "return vm.Boolean(ir.IsCheapMaterializeOp(arg0)), nil"}

--- a/pkg/ir/ir_ops.lg
+++ b/pkg/ir/ir_ops.lg
@@ -33,6 +33,9 @@
 ;;   bytecode    — corresponding vm.OP_XXX symbol, or nil if none
 ;;   cheap?      — true for ops materialize re-emits on demand
 ;;                  (Const/LoadArg/LoadVar/LoadClosed)
+;;   local-carry?— true when the op's result is materialised into a Go
+;;                  local by lowering (lower_go's local-carrying-op?).
+;;                  A static fact about the op, like pure?/terminator?.
 ;;   display     — string for opTable.name (usually = name; OpInvalid
 ;;                  uses "INVALID" for diagnostic clarity)
 ;;   comment     — trailing line comment on the const decl + opTable row
@@ -41,57 +44,57 @@
 ;; breaks every file that references Op<X> constants.
 
 (def ops
-  ;;  name         stk-in stk-out  pure?  term?  bytecode           cheap?  display      comment
-  '[["Invalid"    0  0 false false nil                false "INVALID"    ""]
+  ;;  name         stk-in stk-out  pure?  term?  bytecode           cheap?  local-carry? display      comment
+  '[["Invalid"    0  0 false false nil                false false "INVALID"    ""]
 
     ;; --- Values ---
-    ["Const"      0  1 true  false OP_LOAD_CONST      true  "Const"      ".Aux = vm.Value (the constant; lowered as OP_LOAD_CONST with interned index)"]
-    ["LoadArg"    0  1 true  false OP_LOAD_ARG        true  "LoadArg"    ".Aux = int (arg index)"]
-    ["LoadVar"    0  1 false false OP_LOAD_VAR        true  "LoadVar"    ".Aux = *vm.Var; var roots are mutable"]
-    ["LoadClosed" 0  1 true  false OP_LOAD_CLOSEDOVER true  "LoadClosed" ".Aux = int (closed-over index)"]
+    ["Const"      0  1 true  false OP_LOAD_CONST      true  false "Const"      ".Aux = vm.Value (the constant; lowered as OP_LOAD_CONST with interned index)"]
+    ["LoadArg"    0  1 true  false OP_LOAD_ARG        true  false "LoadArg"    ".Aux = int (arg index)"]
+    ["LoadVar"    0  1 false false OP_LOAD_VAR        true  false "LoadVar"    ".Aux = *vm.Var; var roots are mutable"]
+    ["LoadClosed" 0  1 true  false OP_LOAD_CLOSEDOVER true  false "LoadClosed" ".Aux = int (closed-over index)"]
 
     ;; Block parameter — value flowing in from a predecessor's
     ;; branch-with-args. No Refs; (block-id, param-index) is implicit
     ;; via position in Block.Params.
-    ["BlockArg"   0  1 true  false nil                false "BlockArg"   "block parameter"]
+    ["BlockArg"   0  1 true  false nil                false true  "BlockArg"   "block parameter"]
 
     ;; --- Side-effecting ---
-    ["SetVar"     2  1 false false OP_SET_VAR         false "SetVar"     ".Refs[0] = var (Const aux=*vm.Var), .Refs[1] = value; pushes var back"]
-    ["Call"      -1  1 false false OP_INVOKE          false "Call"       ".Refs[0] = fn, .Refs[1:] = args; .Aux = arity int"]
-    ["TailCall"  -1  1 false true  OP_TAIL_CALL       false "TailCall"   "tail call ends a block"]
+    ["SetVar"     2  1 false false OP_SET_VAR         false false "SetVar"     ".Refs[0] = var (Const aux=*vm.Var), .Refs[1] = value; pushes var back"]
+    ["Call"      -1  1 false false OP_INVOKE          false true  "Call"       ".Refs[0] = fn, .Refs[1:] = args; .Aux = arity int"]
+    ["TailCall"  -1  1 false true  OP_TAIL_CALL       false false "TailCall"   "tail call ends a block"]
 
-    ;; --- Pure arithmetic / comparison ---
-    ["Add"        2  1 true  false OP_ADD             false "Add"        ""]
-    ["Sub"        2  1 true  false OP_SUB             false "Sub"        ""]
-    ["Mul"        2  1 true  false OP_MUL             false "Mul"        ""]
-    ["BitAnd"     2  1 true  false OP_BIT_AND         false "BitAnd"     "clojure.core/bit-and — integer bitwise and"]
-    ["BitOr"      2  1 true  false OP_BIT_OR          false "BitOr"      "clojure.core/bit-or — integer bitwise or"]
-    ["BitXor"     2  1 true  false OP_BIT_XOR         false "BitXor"     "clojure.core/bit-xor — integer bitwise xor"]
-    ["BitAndNot"  2  1 true  false OP_BIT_AND_NOT     false "BitAndNot"  "clojure.core/bit-and-not — integer bit clear (&^)"]
-    ["BitShiftLeft" 2 1 true false OP_BIT_SHIFT_LEFT  false "BitShiftLeft" "clojure.core/bit-shift-left — integer left shift"]
-    ["BitShiftRight" 2 1 true false OP_BIT_SHIFT_RIGHT false "BitShiftRight" "clojure.core/bit-shift-right — integer arithmetic right shift"]
-    ["UnsignedBitShiftRight" 2 1 true false OP_UNSIGNED_BIT_SHIFT_RIGHT false "UnsignedBitShiftRight" "clojure.core/unsigned-bit-shift-right — integer logical right shift"]
-    ["Quot"       2  1 true  false OP_QUOT            false "Quot"       "clojure.core/quot — integer quotient truncated toward zero. int/int lowers to native Go `/` (which truncates identically); any float/ratio/boxed operand lowers via rt.QuotValue (native float `/` does NOT truncate)"]
-    ["Div"        2  1 true  false OP_DIV             false "Div"        "clojure.core// — true division. float/float lowers to native Go `/`; any other operand mix (int/int -> Ratio, mixed -> Float) lowers via rt.DivValue. Distinguished from Quot by op-kw in lower-go (both render Go `/`)"]
-    ["Lt"         2  1 true  false OP_LT              false "Lt"         ""]
-    ["Lte"        2  1 true  false OP_LTE             false "Lte"        ""]
-    ["Gt"         2  1 true  false OP_GT              false "Gt"         ""]
-    ["Gte"        2  1 true  false OP_GTE             false "Gte"        ""]
-    ["Eq"         2  1 true  false OP_EQ              false "Eq"         ""]
-    ["Inc"        1  1 true  false OP_INC             false "Inc"        ""]
-    ["Dec"        1  1 true  false OP_DEC             false "Dec"        ""]
-    ["BitNot"     1  1 true  false OP_BIT_NOT         false "BitNot"     "clojure.core/bit-not — integer bitwise complement"]
+    ;; --- Pure arithmetic / comparison (results materialised into locals) ---
+    ["Add"        2  1 true  false OP_ADD             false true  "Add"        ""]
+    ["Sub"        2  1 true  false OP_SUB             false true  "Sub"        ""]
+    ["Mul"        2  1 true  false OP_MUL             false true  "Mul"        ""]
+    ["BitAnd"     2  1 true  false OP_BIT_AND         false true  "BitAnd"     "clojure.core/bit-and — integer bitwise and"]
+    ["BitOr"      2  1 true  false OP_BIT_OR          false true  "BitOr"      "clojure.core/bit-or — integer bitwise or"]
+    ["BitXor"     2  1 true  false OP_BIT_XOR         false true  "BitXor"     "clojure.core/bit-xor — integer bitwise xor"]
+    ["BitAndNot"  2  1 true  false OP_BIT_AND_NOT     false true  "BitAndNot"  "clojure.core/bit-and-not — integer bit clear (&^)"]
+    ["BitShiftLeft" 2 1 true false OP_BIT_SHIFT_LEFT  false true  "BitShiftLeft" "clojure.core/bit-shift-left — integer left shift"]
+    ["BitShiftRight" 2 1 true false OP_BIT_SHIFT_RIGHT false true  "BitShiftRight" "clojure.core/bit-shift-right — integer arithmetic right shift"]
+    ["UnsignedBitShiftRight" 2 1 true false OP_UNSIGNED_BIT_SHIFT_RIGHT false true  "UnsignedBitShiftRight" "clojure.core/unsigned-bit-shift-right — integer logical right shift"]
+    ["Quot"       2  1 true  false OP_QUOT            false true  "Quot"       "clojure.core/quot — integer quotient truncated toward zero. int/int lowers to native Go `/` (which truncates identically); any float/ratio/boxed operand lowers via rt.QuotValue (native float `/` does NOT truncate)"]
+    ["Div"        2  1 true  false OP_DIV             false true  "Div"        "clojure.core// — true division. float/float lowers to native Go `/`; any other operand mix (int/int -> Ratio, mixed -> Float) lowers via rt.DivValue. Distinguished from Quot by op-kw in lower-go (both render Go `/`)"]
+    ["Lt"         2  1 true  false OP_LT              false true  "Lt"         ""]
+    ["Lte"        2  1 true  false OP_LTE             false true  "Lte"        ""]
+    ["Gt"         2  1 true  false OP_GT              false true  "Gt"         ""]
+    ["Gte"        2  1 true  false OP_GTE             false true  "Gte"        ""]
+    ["Eq"         2  1 true  false OP_EQ              false true  "Eq"         ""]
+    ["Inc"        1  1 true  false OP_INC             false true  "Inc"        ""]
+    ["Dec"        1  1 true  false OP_DEC             false true  "Dec"        ""]
+    ["BitNot"     1  1 true  false OP_BIT_NOT         false true  "BitNot"     "clojure.core/bit-not — integer bitwise complement"]
 
-    ["Pop"        1  0 false false nil                false "Pop"        "discard top stack value; no result (OP_POP)"]
+    ["Pop"        1  0 false false nil                false false "Pop"        "discard top stack value; no result (OP_POP)"]
 
     ;; --- Terminators ---
-    ["Return"     1  0 false true  OP_RETURN          false "Return"     ".Refs[0] = value"]
-    ["Branch"     0  0 false true  OP_JUMP            false "Branch"     "unconditional; .Aux = *BranchTarget"]
-    ["BranchIf"   1  0 false true  OP_BRANCH_FALSE    false "BranchIf"   ".Refs[0] = cond; .Aux = struct{True,False *BranchTarget}"]
+    ["Return"     1  0 false true  OP_RETURN          false false "Return"     ".Refs[0] = value"]
+    ["Branch"     0  0 false true  OP_JUMP            false false "Branch"     "unconditional; .Aux = *BranchTarget"]
+    ["BranchIf"   1  0 false true  OP_BRANCH_FALSE    false false "BranchIf"   ".Refs[0] = cond; .Aux = struct{True,False *BranchTarget}"]
 
     ;; --- Closures ---
-    ["MakeClosure" 1  1 false false OP_MAKE_CLOSURE    false "MakeClosure" ".Refs[0] = *Func value (the func to wrap as a closure)"]
-    ["PushClosed"  2  1 false false OP_PUSH_CLOSEDOVER false "PushClosed"  ".Refs[0] = closure, .Refs[1] = value to attach"]
+    ["MakeClosure" 1  1 false false OP_MAKE_CLOSURE    false false "MakeClosure" ".Refs[0] = *Func value (the func to wrap as a closure)"]
+    ["PushClosed"  2  1 false false OP_PUSH_CLOSEDOVER false false "PushClosed"  ".Refs[0] = closure, .Refs[1] = value to attach"]
 
     ;; --- Exception handling (gogen_ir self-AOT) ---
     ;; A guarded region whose body/handler/finally are inner fn* closures.
@@ -100,13 +103,13 @@
     ;; as straight-line Go by lower_go's try-assign-stmts. No bytecode op (the
     ;; bytecode VM compiles try natively via OP_TRY_PUSH/POP); this op exists
     ;; only on the IR→Go lowering path.
-    ["Try"       -1  1 false false nil                false "Try"        ".Refs[0] = body closure; then optional handler closure (binds the caught value), then optional finally closure; .Aux = {:has-handler bool :has-finally bool}"]
+    ["Try"       -1  1 false false nil                false true  "Try"        ".Refs[0] = body closure; then optional handler closure (binds the caught value), then optional finally closure; .Aux = {:has-handler bool :has-finally bool}"]
 
     ;; Struct field selector for native deftype lowering: (. obj field)
     ;; lowers to Go `obj.field`. Aux = field symbol, Refs[0] = obj. No
     ;; bytecode op (the bytecode path accesses deftype fields via runtime
     ;; DType dispatch); this op exists only on the IR→Go lowering path.
-    ["Dot"        1  1 false false nil                false "Dot"        ".Refs[0] = obj; .Aux = field symbol; Go struct field selector obj.field (gogen_ir path only)"]
+    ["Dot"        1  1 false false nil                false true  "Dot"        ".Refs[0] = obj; .Aux = field symbol; Go struct field selector obj.field (gogen_ir path only)"]
 
     ;; (def NAME [val]) — interns NAME in the current ns and returns the var;
     ;; the 2-ref form also sets its root. Like SetVar (no dedicated opcode: the
@@ -114,7 +117,7 @@
     ;; the bytecode defCompiler does), EXCEPT gogen must INTERN the var at
     ;; runtime (rt.InternVar) rather than look it up. .Refs[0] = var (Const
     ;; aux=*vm.Var), optional .Refs[1] = value. stack-in -1: 1 or 2 refs.
-    ["Def"       -1  1 false false nil                false "Def"        ".Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)"]])
+    ["Def"       -1  1 false false nil                false true  "Def"        ".Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)"]])
 
 (g/check-spec ops)
 
@@ -149,7 +152,7 @@
   (let [rows (map-indexed
                (fn [i row]
                  (let [name    (op-const-name row)
-                       comment (nth row 8)]
+                       comment (nth row 9)]
                    (if (= i 0)
                      [name 'Op 'iota comment]
                      [name '_ '_ comment])))
@@ -160,11 +163,12 @@
   (g/gquote
     (doc "opInfo describes an Op's structural metadata."
       (type-decl opInfo
-                 (struct [name       string ""]
-                         [stackIn    int    "-1 = variable (decoded from Aux/arity)"]
-                         [stackOut   int    "0 or 1"]
-                         [pure       bool   "safe to CSE, fold, hoist"]
-                         [terminator bool   "ends a basic block"])))))
+                 (struct [name          string ""]
+                         [stackIn       int    "-1 = variable (decoded from Aux/arity)"]
+                         [stackOut      int    "0 or 1"]
+                         [pure          bool   "safe to CSE, fold, hoist"]
+                         [terminator    bool   "ends a basic block"]
+                         [localCarrying bool   "lowering materialises the result into a Go local"])))))
 
 (defn emit-op-table []
   ;; var opTable = [...]opInfo{
@@ -173,7 +177,7 @@
   ;; }
   (let [kvs (map
               (fn [row]
-                (let [[_ stack-in stack-out pure? term? _bytecode _cheap? display _] row
+                (let [[_ stack-in stack-out pure? term? _bytecode _cheap? local-carry? display _] row
                       name (op-const-name row)]
                   (g/gquote
                     (kv ~name (composite nil
@@ -181,7 +185,8 @@
                                 ~stack-in
                                 ~stack-out
                                 ~pure?
-                                ~term?)))))
+                                ~term?
+                                ~local-carry?)))))
               ops)]
     (g/gquote
       (var-decl opTable
@@ -214,7 +219,13 @@
        (method [(op Op)] StackOut [] int
          (if (< (cast int op) (call len opTable))
              [(return (field (index opTable op) stackOut))])
-         (return 0))))])
+         (return 0))))
+   (g/gquote
+     (doc "LocalCarrying reports whether lowering materialises op's result into a Go local."
+       (method [(op Op)] LocalCarrying [] bool
+         (if (< (cast int op) (call len opTable))
+             [(return (field (index opTable op) localCarrying))])
+         (return false))))])
 
 ;; --- switch builders ------------------------------------------------
 ;;

--- a/pkg/ir/ir_ops.lg
+++ b/pkg/ir/ir_ops.lg
@@ -19,6 +19,7 @@
 
 (ns ir-ops-gen
   (:require
+   [clojure.string :as string]
    [gogen :as g]))
 
 ;; --- the op catalog -------------------------------------------------
@@ -36,6 +37,13 @@
 ;;   local-carry?— true when the op's result is materialised into a Go
 ;;                  local by lowering (lower_go's local-carrying-op?).
 ;;                  A static fact about the op, like pure?/terminator?.
+;;   infer?      — the op's typeinfer facet is reified on an ir.ops
+;;                  op-type (ir.ops/op-registry). infer-one dispatches
+;;                  through ops/infer-op for these; the rest keep their
+;;                  legacy cond arms (:call) or default to :unknown.
+;;   lower?      — the op's lower-go facet is reified on an ir.ops
+;;                  op-type; lower-inst-stmts dispatches through
+;;                  ops/lower-op for these.
 ;;   display     — string for opTable.name (usually = name; OpInvalid
 ;;                  uses "INVALID" for diagnostic clarity)
 ;;   comment     — trailing line comment on the const decl + opTable row
@@ -44,57 +52,57 @@
 ;; breaks every file that references Op<X> constants.
 
 (def ops
-  ;;  name         stk-in stk-out  pure?  term?  bytecode           cheap?  local-carry? display      comment
-  '[["Invalid"    0  0 false false nil                false false "INVALID"    ""]
+  ;;  name         stk-in stk-out  pure?  term?  bytecode           cheap?  local-carry? infer? lower? display      comment
+  '[["Invalid"    0  0 false false nil                false false false false "INVALID"    ""]
 
     ;; --- Values ---
-    ["Const"      0  1 true  false OP_LOAD_CONST      true  false "Const"      ".Aux = vm.Value (the constant; lowered as OP_LOAD_CONST with interned index)"]
-    ["LoadArg"    0  1 true  false OP_LOAD_ARG        true  false "LoadArg"    ".Aux = int (arg index)"]
-    ["LoadVar"    0  1 false false OP_LOAD_VAR        true  false "LoadVar"    ".Aux = *vm.Var; var roots are mutable"]
-    ["LoadClosed" 0  1 true  false OP_LOAD_CLOSEDOVER true  false "LoadClosed" ".Aux = int (closed-over index)"]
+    ["Const"      0  1 true  false OP_LOAD_CONST      true  false true  true  "Const"      ".Aux = vm.Value (the constant; lowered as OP_LOAD_CONST with interned index)"]
+    ["LoadArg"    0  1 true  false OP_LOAD_ARG        true  false true  false "LoadArg"    ".Aux = int (arg index)"]
+    ["LoadVar"    0  1 false false OP_LOAD_VAR        true  false true  false "LoadVar"    ".Aux = *vm.Var; var roots are mutable"]
+    ["LoadClosed" 0  1 true  false OP_LOAD_CLOSEDOVER true  false true  false "LoadClosed" ".Aux = int (closed-over index)"]
 
     ;; Block parameter — value flowing in from a predecessor's
     ;; branch-with-args. No Refs; (block-id, param-index) is implicit
     ;; via position in Block.Params.
-    ["BlockArg"   0  1 true  false nil                false true  "BlockArg"   "block parameter"]
+    ["BlockArg"   0  1 true  false nil                false true  true  false "BlockArg"   "block parameter"]
 
     ;; --- Side-effecting ---
-    ["SetVar"     2  1 false false OP_SET_VAR         false false "SetVar"     ".Refs[0] = var (Const aux=*vm.Var), .Refs[1] = value; pushes var back"]
-    ["Call"      -1  1 false false OP_INVOKE          false true  "Call"       ".Refs[0] = fn, .Refs[1:] = args; .Aux = arity int"]
-    ["TailCall"  -1  1 false true  OP_TAIL_CALL       false false "TailCall"   "tail call ends a block"]
+    ["SetVar"     2  1 false false OP_SET_VAR         false false false false "SetVar"     ".Refs[0] = var (Const aux=*vm.Var), .Refs[1] = value; pushes var back"]
+    ["Call"      -1  1 false false OP_INVOKE          false true  false false "Call"       ".Refs[0] = fn, .Refs[1:] = args; .Aux = arity int. infer? stays false: the :call arm (call-dtype/call-core-type) is typeinfer-coupled, not yet reified"]
+    ["TailCall"  -1  1 false true  OP_TAIL_CALL       false false false false "TailCall"   "tail call ends a block. NOT in typeinfer's terminator-ops set (infers :unknown via default), so infer? is false"]
 
     ;; --- Pure arithmetic / comparison (results materialised into locals) ---
-    ["Add"        2  1 true  false OP_ADD             false true  "Add"        ""]
-    ["Sub"        2  1 true  false OP_SUB             false true  "Sub"        ""]
-    ["Mul"        2  1 true  false OP_MUL             false true  "Mul"        ""]
-    ["BitAnd"     2  1 true  false OP_BIT_AND         false true  "BitAnd"     "clojure.core/bit-and — integer bitwise and"]
-    ["BitOr"      2  1 true  false OP_BIT_OR          false true  "BitOr"      "clojure.core/bit-or — integer bitwise or"]
-    ["BitXor"     2  1 true  false OP_BIT_XOR         false true  "BitXor"     "clojure.core/bit-xor — integer bitwise xor"]
-    ["BitAndNot"  2  1 true  false OP_BIT_AND_NOT     false true  "BitAndNot"  "clojure.core/bit-and-not — integer bit clear (&^)"]
-    ["BitShiftLeft" 2 1 true false OP_BIT_SHIFT_LEFT  false true  "BitShiftLeft" "clojure.core/bit-shift-left — integer left shift"]
-    ["BitShiftRight" 2 1 true false OP_BIT_SHIFT_RIGHT false true  "BitShiftRight" "clojure.core/bit-shift-right — integer arithmetic right shift"]
-    ["UnsignedBitShiftRight" 2 1 true false OP_UNSIGNED_BIT_SHIFT_RIGHT false true  "UnsignedBitShiftRight" "clojure.core/unsigned-bit-shift-right — integer logical right shift"]
-    ["Quot"       2  1 true  false OP_QUOT            false true  "Quot"       "clojure.core/quot — integer quotient truncated toward zero. int/int lowers to native Go `/` (which truncates identically); any float/ratio/boxed operand lowers via rt.QuotValue (native float `/` does NOT truncate)"]
-    ["Div"        2  1 true  false OP_DIV             false true  "Div"        "clojure.core// — true division. float/float lowers to native Go `/`; any other operand mix (int/int -> Ratio, mixed -> Float) lowers via rt.DivValue. Distinguished from Quot by op-kw in lower-go (both render Go `/`)"]
-    ["Lt"         2  1 true  false OP_LT              false true  "Lt"         ""]
-    ["Lte"        2  1 true  false OP_LTE             false true  "Lte"        ""]
-    ["Gt"         2  1 true  false OP_GT              false true  "Gt"         ""]
-    ["Gte"        2  1 true  false OP_GTE             false true  "Gte"        ""]
-    ["Eq"         2  1 true  false OP_EQ              false true  "Eq"         ""]
-    ["Inc"        1  1 true  false OP_INC             false true  "Inc"        ""]
-    ["Dec"        1  1 true  false OP_DEC             false true  "Dec"        ""]
-    ["BitNot"     1  1 true  false OP_BIT_NOT         false true  "BitNot"     "clojure.core/bit-not — integer bitwise complement"]
+    ["Add"        2  1 true  false OP_ADD             false true  true  false "Add"        ""]
+    ["Sub"        2  1 true  false OP_SUB             false true  true  false "Sub"        ""]
+    ["Mul"        2  1 true  false OP_MUL             false true  true  false "Mul"        ""]
+    ["BitAnd"     2  1 true  false OP_BIT_AND         false true  true  false "BitAnd"     "clojure.core/bit-and — integer bitwise and"]
+    ["BitOr"      2  1 true  false OP_BIT_OR          false true  true  false "BitOr"      "clojure.core/bit-or — integer bitwise or"]
+    ["BitXor"     2  1 true  false OP_BIT_XOR         false true  true  false "BitXor"     "clojure.core/bit-xor — integer bitwise xor"]
+    ["BitAndNot"  2  1 true  false OP_BIT_AND_NOT     false true  true  false "BitAndNot"  "clojure.core/bit-and-not — integer bit clear (&^)"]
+    ["BitShiftLeft" 2 1 true false OP_BIT_SHIFT_LEFT  false true  true  false "BitShiftLeft" "clojure.core/bit-shift-left — integer left shift"]
+    ["BitShiftRight" 2 1 true false OP_BIT_SHIFT_RIGHT false true  true  false "BitShiftRight" "clojure.core/bit-shift-right — integer arithmetic right shift"]
+    ["UnsignedBitShiftRight" 2 1 true false OP_UNSIGNED_BIT_SHIFT_RIGHT false true  true  false "UnsignedBitShiftRight" "clojure.core/unsigned-bit-shift-right — integer logical right shift"]
+    ["Quot"       2  1 true  false OP_QUOT            false true  true  false "Quot"       "clojure.core/quot — integer quotient truncated toward zero. int/int lowers to native Go `/` (which truncates identically); any float/ratio/boxed operand lowers via rt.QuotValue (native float `/` does NOT truncate)"]
+    ["Div"        2  1 true  false OP_DIV             false true  true  false "Div"        "clojure.core// — true division. float/float lowers to native Go `/`; any other operand mix (int/int -> Ratio, mixed -> Float) lowers via rt.DivValue. Distinguished from Quot by op-kw in lower-go (both render Go `/`)"]
+    ["Lt"         2  1 true  false OP_LT              false true  true  false "Lt"         ""]
+    ["Lte"        2  1 true  false OP_LTE             false true  true  false "Lte"        ""]
+    ["Gt"         2  1 true  false OP_GT              false true  true  false "Gt"         ""]
+    ["Gte"        2  1 true  false OP_GTE             false true  true  false "Gte"        ""]
+    ["Eq"         2  1 true  false OP_EQ              false true  true  false "Eq"         ""]
+    ["Inc"        1  1 true  false OP_INC             false true  true  false "Inc"        ""]
+    ["Dec"        1  1 true  false OP_DEC             false true  true  false "Dec"        ""]
+    ["BitNot"     1  1 true  false OP_BIT_NOT         false true  true  false "BitNot"     "clojure.core/bit-not — integer bitwise complement"]
 
-    ["Pop"        1  0 false false nil                false false "Pop"        "discard top stack value; no result (OP_POP)"]
+    ["Pop"        1  0 false false nil                false false false false "Pop"        "discard top stack value; no result (OP_POP)"]
 
     ;; --- Terminators ---
-    ["Return"     1  0 false true  OP_RETURN          false false "Return"     ".Refs[0] = value"]
-    ["Branch"     0  0 false true  OP_JUMP            false false "Branch"     "unconditional; .Aux = *BranchTarget"]
-    ["BranchIf"   1  0 false true  OP_BRANCH_FALSE    false false "BranchIf"   ".Refs[0] = cond; .Aux = struct{True,False *BranchTarget}"]
+    ["Return"     1  0 false true  OP_RETURN          false false true  false "Return"     ".Refs[0] = value"]
+    ["Branch"     0  0 false true  OP_JUMP            false false true  false "Branch"     "unconditional; .Aux = *BranchTarget"]
+    ["BranchIf"   1  0 false true  OP_BRANCH_FALSE    false false true  false "BranchIf"   ".Refs[0] = cond; .Aux = struct{True,False *BranchTarget}"]
 
     ;; --- Closures ---
-    ["MakeClosure" 1  1 false false OP_MAKE_CLOSURE    false false "MakeClosure" ".Refs[0] = *Func value (the func to wrap as a closure)"]
-    ["PushClosed"  2  1 false false OP_PUSH_CLOSEDOVER false false "PushClosed"  ".Refs[0] = closure, .Refs[1] = value to attach"]
+    ["MakeClosure" 1  1 false false OP_MAKE_CLOSURE    false false false false "MakeClosure" ".Refs[0] = *Func value (the func to wrap as a closure)"]
+    ["PushClosed"  2  1 false false OP_PUSH_CLOSEDOVER false false false false "PushClosed"  ".Refs[0] = closure, .Refs[1] = value to attach"]
 
     ;; --- Exception handling (gogen_ir self-AOT) ---
     ;; A guarded region whose body/handler/finally are inner fn* closures.
@@ -103,13 +111,13 @@
     ;; as straight-line Go by lower_go's try-assign-stmts. No bytecode op (the
     ;; bytecode VM compiles try natively via OP_TRY_PUSH/POP); this op exists
     ;; only on the IR→Go lowering path.
-    ["Try"       -1  1 false false nil                false true  "Try"        ".Refs[0] = body closure; then optional handler closure (binds the caught value), then optional finally closure; .Aux = {:has-handler bool :has-finally bool}"]
+    ["Try"       -1  1 false false nil                false true  false true  "Try"        ".Refs[0] = body closure; then optional handler closure (binds the caught value), then optional finally closure; .Aux = {:has-handler bool :has-finally bool}. lower? -> TryOp delegates to try-assign-stmts (registered by ir.lower-go)"]
 
     ;; Struct field selector for native deftype lowering: (. obj field)
     ;; lowers to Go `obj.field`. Aux = field symbol, Refs[0] = obj. No
     ;; bytecode op (the bytecode path accesses deftype fields via runtime
     ;; DType dispatch); this op exists only on the IR→Go lowering path.
-    ["Dot"        1  1 false false nil                false true  "Dot"        ".Refs[0] = obj; .Aux = field symbol; Go struct field selector obj.field (gogen_ir path only)"]
+    ["Dot"        1  1 false false nil                false true  false false "Dot"        ".Refs[0] = obj; .Aux = field symbol; Go struct field selector obj.field (gogen_ir path only)"]
 
     ;; (def NAME [val]) — interns NAME in the current ns and returns the var;
     ;; the 2-ref form also sets its root. Like SetVar (no dedicated opcode: the
@@ -117,7 +125,7 @@
     ;; the bytecode defCompiler does), EXCEPT gogen must INTERN the var at
     ;; runtime (rt.InternVar) rather than look it up. .Refs[0] = var (Const
     ;; aux=*vm.Var), optional .Refs[1] = value. stack-in -1: 1 or 2 refs.
-    ["Def"       -1  1 false false nil                false true  "Def"        ".Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)"]])
+    ["Def"       -1  1 false false nil                false true  false false "Def"        ".Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)"]])
 
 (g/check-spec ops)
 
@@ -137,6 +145,21 @@
 (defn- has-bytecode? [row]
   (some? (op-bytecode row)))
 
+(defn- op-keyword-name [row]
+  ;; CamelCase op name -> the kebab-case keyword string the .lg pipeline
+  ;; uses ("LoadArg" -> "load-arg"). Must agree with the keywords ir.build
+  ;; emits; OpByKeyword's dash/case-insensitive match makes them mutually
+  ;; consistent by construction.
+  (string/join
+    (map-indexed
+      (fn [i ch]
+        (let [c  (str ch)
+              lc (string/lower-case c)]
+          (if (and (pos? i) (not= c lc))
+            (str "-" lc)
+            lc)))
+      (seq (str (nth row 0))))))
+
 ;; --- emit pieces ----------------------------------------------------
 
 (defn emit-type-decl []
@@ -152,7 +175,7 @@
   (let [rows (map-indexed
                (fn [i row]
                  (let [name    (op-const-name row)
-                       comment (nth row 9)]
+                       comment (nth row 11)]
                    (if (= i 0)
                      [name 'Op 'iota comment]
                      [name '_ '_ comment])))
@@ -168,7 +191,9 @@
                          [stackOut      int    "0 or 1"]
                          [pure          bool   "safe to CSE, fold, hoist"]
                          [terminator    bool   "ends a basic block"]
-                         [localCarrying bool   "lowering materialises the result into a Go local"])))))
+                         [localCarrying bool   "lowering materialises the result into a Go local"]
+                         [inferFacet    bool   "typeinfer facet reified on an ir.ops op-type"]
+                         [lowerFacet    bool   "lower-go facet reified on an ir.ops op-type"])))))
 
 (defn emit-op-table []
   ;; var opTable = [...]opInfo{
@@ -177,7 +202,7 @@
   ;; }
   (let [kvs (map
               (fn [row]
-                (let [[_ stack-in stack-out pure? term? _bytecode _cheap? local-carry? display _] row
+                (let [[_ stack-in stack-out pure? term? _bytecode _cheap? local-carry? infer? lower? display _] row
                       name (op-const-name row)]
                   (g/gquote
                     (kv ~name (composite nil
@@ -186,7 +211,9 @@
                                 ~stack-out
                                 ~pure?
                                 ~term?
-                                ~local-carry?)))))
+                                ~local-carry?
+                                ~infer?
+                                ~lower?)))))
               ops)]
     (g/gquote
       (var-decl opTable
@@ -225,6 +252,18 @@
        (method [(op Op)] LocalCarrying [] bool
          (if (< (cast int op) (call len opTable))
              [(return (field (index opTable op) localCarrying))])
+         (return false))))
+   (g/gquote
+     (doc "InferFacet reports whether op's typeinfer facet is reified on an ir.ops op-type."
+       (method [(op Op)] InferFacet [] bool
+         (if (< (cast int op) (call len opTable))
+             [(return (field (index opTable op) inferFacet))])
+         (return false))))
+   (g/gquote
+     (doc "LowerFacet reports whether op's lower-go facet is reified on an ir.ops op-type."
+       (method [(op Op)] LowerFacet [] bool
+         (if (< (cast int op) (call len opTable))
+             [(return (field (index opTable op) lowerFacet))])
          (return false))))])
 
 ;; --- switch builders ------------------------------------------------
@@ -279,6 +318,23 @@
       (func bytecodeToIROp [(op int32)] [Op]
         ~switch-stmt))))
 
+(defn emit-op-keywords-fn []
+  ;; var opKeywordNames = []string{"invalid", "const", ...}
+  ;; func OpKeywords() []string { return opKeywordNames }
+  ;;
+  ;; The full catalog as kebab-case keyword strings, in iota order. Feeds
+  ;; the ir/op-kws bridge so .lg-side exhaustiveness checks can enumerate
+  ;; the closed op set without a hand-maintained list.
+  [(g/gquote
+     (var-decl opKeywordNames
+               nil
+               (composite-multi (type "[]string")
+                 ~@(map (fn [row] (g/gquote ~(op-keyword-name row))) ops))))
+   (g/gquote
+     (doc "OpKeywords returns every catalogued op as its kebab-case keyword name, in Op order."
+       (func OpKeywords [] [(type "[]string")]
+         (return opKeywordNames))))])
+
 ;; --- assemble + emit -------------------------------------------------
 
 (println (g/render (emit-type-decl)))
@@ -298,3 +354,6 @@
 (println)
 (println (g/render (emit-bytecode-to-ir-fn)))
 (println)
+(doseq [d (emit-op-keywords-fn)]
+  (println (g/render d))
+  (println))

--- a/pkg/ir/ir_ops.lg
+++ b/pkg/ir/ir_ops.lg
@@ -335,6 +335,37 @@
        (func OpKeywords [] [(type "[]string")]
          (return opKeywordNames))))])
 
+(defn emit-op-by-keyword-fn []
+  ;; func opByKeywordExact(name string) (Op, bool) {
+  ;;     switch name {
+  ;;     case "const": return OpConst, true
+  ;;     ...
+  ;;     }
+  ;;     return OpInvalid, false
+  ;; }
+  ;;
+  ;; The zero-alloc fast path behind OpByKeyword (op_lookup.go). Inputs
+  ;; arrive as canonical kebab-case keywords — the exact form ir.build
+  ;; emits and OpKeywords returns — so an exact string switch hits every
+  ;; time. Go compiles a string switch to a length-bucketed binary search
+  ;; (sub-linear) with no per-call allocation, versus the old ReplaceAll +
+  ;; O(n) EqualFold scan. OpByKeyword keeps that scan as a defensive
+  ;; fallback for the (unused-in-practice) non-canonical case, so behaviour
+  ;; is preserved exactly.
+  (let [case-clauses (mapv
+                       (fn [row]
+                         (gogen/case-clause
+                           [(g/gquote ~(op-keyword-name row))]
+                           [(g/gquote (return ~(op-const-name row) true))]))
+                       ops)
+        default-clause (gogen/case-clause
+                         nil
+                         [(g/gquote (return OpInvalid false))])
+        switch-stmt (gogen/switch-stmt nil (g/gquote name) (conj case-clauses default-clause))]
+    (g/gquote
+      (func opByKeywordExact [(name string)] [Op bool]
+        ~switch-stmt))))
+
 ;; --- assemble + emit -------------------------------------------------
 
 (println (g/render (emit-type-decl)))
@@ -357,3 +388,5 @@
 (doseq [d (emit-op-keywords-fn)]
   (println (g/render d))
   (println))
+(println (g/render (emit-op-by-keyword-fn)))
+(println)

--- a/pkg/ir/op_generated.go
+++ b/pkg/ir/op_generated.go
@@ -69,52 +69,53 @@ const (
 
 // opInfo describes an Op's structural metadata.
 type opInfo struct {
-	name       string
-	stackIn    int  // -1 = variable (decoded from Aux/arity)
-	stackOut   int  // 0 or 1
-	pure       bool // safe to CSE, fold, hoist
-	terminator bool // ends a basic block
+	name          string
+	stackIn       int  // -1 = variable (decoded from Aux/arity)
+	stackOut      int  // 0 or 1
+	pure          bool // safe to CSE, fold, hoist
+	terminator    bool // ends a basic block
+	localCarrying bool // lowering materialises the result into a Go local
 }
 
 var opTable = [...]opInfo{
-	OpInvalid:               {"INVALID", 0, 0, false, false},
-	OpConst:                 {"Const", 0, 1, true, false},
-	OpLoadArg:               {"LoadArg", 0, 1, true, false},
-	OpLoadVar:               {"LoadVar", 0, 1, false, false},
-	OpLoadClosed:            {"LoadClosed", 0, 1, true, false},
-	OpBlockArg:              {"BlockArg", 0, 1, true, false},
-	OpSetVar:                {"SetVar", 2, 1, false, false},
-	OpCall:                  {"Call", -1, 1, false, false},
-	OpTailCall:              {"TailCall", -1, 1, false, true},
-	OpAdd:                   {"Add", 2, 1, true, false},
-	OpSub:                   {"Sub", 2, 1, true, false},
-	OpMul:                   {"Mul", 2, 1, true, false},
-	OpBitAnd:                {"BitAnd", 2, 1, true, false},
-	OpBitOr:                 {"BitOr", 2, 1, true, false},
-	OpBitXor:                {"BitXor", 2, 1, true, false},
-	OpBitAndNot:             {"BitAndNot", 2, 1, true, false},
-	OpBitShiftLeft:          {"BitShiftLeft", 2, 1, true, false},
-	OpBitShiftRight:         {"BitShiftRight", 2, 1, true, false},
-	OpUnsignedBitShiftRight: {"UnsignedBitShiftRight", 2, 1, true, false},
-	OpQuot:                  {"Quot", 2, 1, true, false},
-	OpDiv:                   {"Div", 2, 1, true, false},
-	OpLt:                    {"Lt", 2, 1, true, false},
-	OpLte:                   {"Lte", 2, 1, true, false},
-	OpGt:                    {"Gt", 2, 1, true, false},
-	OpGte:                   {"Gte", 2, 1, true, false},
-	OpEq:                    {"Eq", 2, 1, true, false},
-	OpInc:                   {"Inc", 1, 1, true, false},
-	OpDec:                   {"Dec", 1, 1, true, false},
-	OpBitNot:                {"BitNot", 1, 1, true, false},
-	OpPop:                   {"Pop", 1, 0, false, false},
-	OpReturn:                {"Return", 1, 0, false, true},
-	OpBranch:                {"Branch", 0, 0, false, true},
-	OpBranchIf:              {"BranchIf", 1, 0, false, true},
-	OpMakeClosure:           {"MakeClosure", 1, 1, false, false},
-	OpPushClosed:            {"PushClosed", 2, 1, false, false},
-	OpTry:                   {"Try", -1, 1, false, false},
-	OpDot:                   {"Dot", 1, 1, false, false},
-	OpDef:                   {"Def", -1, 1, false, false},
+	OpInvalid:               {"INVALID", 0, 0, false, false, false},
+	OpConst:                 {"Const", 0, 1, true, false, false},
+	OpLoadArg:               {"LoadArg", 0, 1, true, false, false},
+	OpLoadVar:               {"LoadVar", 0, 1, false, false, false},
+	OpLoadClosed:            {"LoadClosed", 0, 1, true, false, false},
+	OpBlockArg:              {"BlockArg", 0, 1, true, false, true},
+	OpSetVar:                {"SetVar", 2, 1, false, false, false},
+	OpCall:                  {"Call", -1, 1, false, false, true},
+	OpTailCall:              {"TailCall", -1, 1, false, true, false},
+	OpAdd:                   {"Add", 2, 1, true, false, true},
+	OpSub:                   {"Sub", 2, 1, true, false, true},
+	OpMul:                   {"Mul", 2, 1, true, false, true},
+	OpBitAnd:                {"BitAnd", 2, 1, true, false, true},
+	OpBitOr:                 {"BitOr", 2, 1, true, false, true},
+	OpBitXor:                {"BitXor", 2, 1, true, false, true},
+	OpBitAndNot:             {"BitAndNot", 2, 1, true, false, true},
+	OpBitShiftLeft:          {"BitShiftLeft", 2, 1, true, false, true},
+	OpBitShiftRight:         {"BitShiftRight", 2, 1, true, false, true},
+	OpUnsignedBitShiftRight: {"UnsignedBitShiftRight", 2, 1, true, false, true},
+	OpQuot:                  {"Quot", 2, 1, true, false, true},
+	OpDiv:                   {"Div", 2, 1, true, false, true},
+	OpLt:                    {"Lt", 2, 1, true, false, true},
+	OpLte:                   {"Lte", 2, 1, true, false, true},
+	OpGt:                    {"Gt", 2, 1, true, false, true},
+	OpGte:                   {"Gte", 2, 1, true, false, true},
+	OpEq:                    {"Eq", 2, 1, true, false, true},
+	OpInc:                   {"Inc", 1, 1, true, false, true},
+	OpDec:                   {"Dec", 1, 1, true, false, true},
+	OpBitNot:                {"BitNot", 1, 1, true, false, true},
+	OpPop:                   {"Pop", 1, 0, false, false, false},
+	OpReturn:                {"Return", 1, 0, false, true, false},
+	OpBranch:                {"Branch", 0, 0, false, true, false},
+	OpBranchIf:              {"BranchIf", 1, 0, false, true, false},
+	OpMakeClosure:           {"MakeClosure", 1, 1, false, false, false},
+	OpPushClosed:            {"PushClosed", 2, 1, false, false, false},
+	OpTry:                   {"Try", -1, 1, false, false, true},
+	OpDot:                   {"Dot", 1, 1, false, false, true},
+	OpDef:                   {"Def", -1, 1, false, false, true},
 }
 
 // String returns the op's display name (or "Op?" for an unknown op).
@@ -147,6 +148,14 @@ func (op Op) StackOut() int {
 		return opTable[op].stackOut
 	}
 	return 0
+}
+
+// LocalCarrying reports whether lowering materialises op's result into a Go local.
+func (op Op) LocalCarrying() bool {
+	if int(op) < len(opTable) {
+		return opTable[op].localCarrying
+	}
+	return false
 }
 
 func isCheapMaterializeOp(op Op) bool {

--- a/pkg/ir/op_generated.go
+++ b/pkg/ir/op_generated.go
@@ -34,8 +34,8 @@ const (
 	OpLoadClosed    // .Aux = int (closed-over index)
 	OpBlockArg      // block parameter
 	OpSetVar        // .Refs[0] = var (Const aux=*vm.Var), .Refs[1] = value; pushes var back
-	OpCall          // .Refs[0] = fn, .Refs[1:] = args; .Aux = arity int
-	OpTailCall      // tail call ends a block
+	OpCall          // .Refs[0] = fn, .Refs[1:] = args; .Aux = arity int. infer? stays false: the :call arm (call-dtype/call-core-type) is typeinfer-coupled, not yet reified
+	OpTailCall      // tail call ends a block. NOT in typeinfer's terminator-ops set (infers :unknown via default), so infer? is false
 	OpAdd
 	OpSub
 	OpMul
@@ -62,7 +62,7 @@ const (
 	OpBranchIf    // .Refs[0] = cond; .Aux = struct{True,False *BranchTarget}
 	OpMakeClosure // .Refs[0] = *Func value (the func to wrap as a closure)
 	OpPushClosed  // .Refs[0] = closure, .Refs[1] = value to attach
-	OpTry         // .Refs[0] = body closure; then optional handler closure (binds the caught value), then optional finally closure; .Aux = {:has-handler bool :has-finally bool}
+	OpTry         // .Refs[0] = body closure; then optional handler closure (binds the caught value), then optional finally closure; .Aux = {:has-handler bool :has-finally bool}. lower? -> TryOp delegates to try-assign-stmts (registered by ir.lower-go)
 	OpDot         // .Refs[0] = obj; .Aux = field symbol; Go struct field selector obj.field (gogen_ir path only)
 	OpDef         // .Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)
 )
@@ -75,47 +75,49 @@ type opInfo struct {
 	pure          bool // safe to CSE, fold, hoist
 	terminator    bool // ends a basic block
 	localCarrying bool // lowering materialises the result into a Go local
+	inferFacet    bool // typeinfer facet reified on an ir.ops op-type
+	lowerFacet    bool // lower-go facet reified on an ir.ops op-type
 }
 
 var opTable = [...]opInfo{
-	OpInvalid:               {"INVALID", 0, 0, false, false, false},
-	OpConst:                 {"Const", 0, 1, true, false, false},
-	OpLoadArg:               {"LoadArg", 0, 1, true, false, false},
-	OpLoadVar:               {"LoadVar", 0, 1, false, false, false},
-	OpLoadClosed:            {"LoadClosed", 0, 1, true, false, false},
-	OpBlockArg:              {"BlockArg", 0, 1, true, false, true},
-	OpSetVar:                {"SetVar", 2, 1, false, false, false},
-	OpCall:                  {"Call", -1, 1, false, false, true},
-	OpTailCall:              {"TailCall", -1, 1, false, true, false},
-	OpAdd:                   {"Add", 2, 1, true, false, true},
-	OpSub:                   {"Sub", 2, 1, true, false, true},
-	OpMul:                   {"Mul", 2, 1, true, false, true},
-	OpBitAnd:                {"BitAnd", 2, 1, true, false, true},
-	OpBitOr:                 {"BitOr", 2, 1, true, false, true},
-	OpBitXor:                {"BitXor", 2, 1, true, false, true},
-	OpBitAndNot:             {"BitAndNot", 2, 1, true, false, true},
-	OpBitShiftLeft:          {"BitShiftLeft", 2, 1, true, false, true},
-	OpBitShiftRight:         {"BitShiftRight", 2, 1, true, false, true},
-	OpUnsignedBitShiftRight: {"UnsignedBitShiftRight", 2, 1, true, false, true},
-	OpQuot:                  {"Quot", 2, 1, true, false, true},
-	OpDiv:                   {"Div", 2, 1, true, false, true},
-	OpLt:                    {"Lt", 2, 1, true, false, true},
-	OpLte:                   {"Lte", 2, 1, true, false, true},
-	OpGt:                    {"Gt", 2, 1, true, false, true},
-	OpGte:                   {"Gte", 2, 1, true, false, true},
-	OpEq:                    {"Eq", 2, 1, true, false, true},
-	OpInc:                   {"Inc", 1, 1, true, false, true},
-	OpDec:                   {"Dec", 1, 1, true, false, true},
-	OpBitNot:                {"BitNot", 1, 1, true, false, true},
-	OpPop:                   {"Pop", 1, 0, false, false, false},
-	OpReturn:                {"Return", 1, 0, false, true, false},
-	OpBranch:                {"Branch", 0, 0, false, true, false},
-	OpBranchIf:              {"BranchIf", 1, 0, false, true, false},
-	OpMakeClosure:           {"MakeClosure", 1, 1, false, false, false},
-	OpPushClosed:            {"PushClosed", 2, 1, false, false, false},
-	OpTry:                   {"Try", -1, 1, false, false, true},
-	OpDot:                   {"Dot", 1, 1, false, false, true},
-	OpDef:                   {"Def", -1, 1, false, false, true},
+	OpInvalid:               {"INVALID", 0, 0, false, false, false, false, false},
+	OpConst:                 {"Const", 0, 1, true, false, false, true, true},
+	OpLoadArg:               {"LoadArg", 0, 1, true, false, false, true, false},
+	OpLoadVar:               {"LoadVar", 0, 1, false, false, false, true, false},
+	OpLoadClosed:            {"LoadClosed", 0, 1, true, false, false, true, false},
+	OpBlockArg:              {"BlockArg", 0, 1, true, false, true, true, false},
+	OpSetVar:                {"SetVar", 2, 1, false, false, false, false, false},
+	OpCall:                  {"Call", -1, 1, false, false, true, false, false},
+	OpTailCall:              {"TailCall", -1, 1, false, true, false, false, false},
+	OpAdd:                   {"Add", 2, 1, true, false, true, true, false},
+	OpSub:                   {"Sub", 2, 1, true, false, true, true, false},
+	OpMul:                   {"Mul", 2, 1, true, false, true, true, false},
+	OpBitAnd:                {"BitAnd", 2, 1, true, false, true, true, false},
+	OpBitOr:                 {"BitOr", 2, 1, true, false, true, true, false},
+	OpBitXor:                {"BitXor", 2, 1, true, false, true, true, false},
+	OpBitAndNot:             {"BitAndNot", 2, 1, true, false, true, true, false},
+	OpBitShiftLeft:          {"BitShiftLeft", 2, 1, true, false, true, true, false},
+	OpBitShiftRight:         {"BitShiftRight", 2, 1, true, false, true, true, false},
+	OpUnsignedBitShiftRight: {"UnsignedBitShiftRight", 2, 1, true, false, true, true, false},
+	OpQuot:                  {"Quot", 2, 1, true, false, true, true, false},
+	OpDiv:                   {"Div", 2, 1, true, false, true, true, false},
+	OpLt:                    {"Lt", 2, 1, true, false, true, true, false},
+	OpLte:                   {"Lte", 2, 1, true, false, true, true, false},
+	OpGt:                    {"Gt", 2, 1, true, false, true, true, false},
+	OpGte:                   {"Gte", 2, 1, true, false, true, true, false},
+	OpEq:                    {"Eq", 2, 1, true, false, true, true, false},
+	OpInc:                   {"Inc", 1, 1, true, false, true, true, false},
+	OpDec:                   {"Dec", 1, 1, true, false, true, true, false},
+	OpBitNot:                {"BitNot", 1, 1, true, false, true, true, false},
+	OpPop:                   {"Pop", 1, 0, false, false, false, false, false},
+	OpReturn:                {"Return", 1, 0, false, true, false, true, false},
+	OpBranch:                {"Branch", 0, 0, false, true, false, true, false},
+	OpBranchIf:              {"BranchIf", 1, 0, false, true, false, true, false},
+	OpMakeClosure:           {"MakeClosure", 1, 1, false, false, false, false, false},
+	OpPushClosed:            {"PushClosed", 2, 1, false, false, false, false, false},
+	OpTry:                   {"Try", -1, 1, false, false, true, false, true},
+	OpDot:                   {"Dot", 1, 1, false, false, true, false, false},
+	OpDef:                   {"Def", -1, 1, false, false, true, false, false},
 }
 
 // String returns the op's display name (or "Op?" for an unknown op).
@@ -154,6 +156,22 @@ func (op Op) StackOut() int {
 func (op Op) LocalCarrying() bool {
 	if int(op) < len(opTable) {
 		return opTable[op].localCarrying
+	}
+	return false
+}
+
+// InferFacet reports whether op's typeinfer facet is reified on an ir.ops op-type.
+func (op Op) InferFacet() bool {
+	if int(op) < len(opTable) {
+		return opTable[op].inferFacet
+	}
+	return false
+}
+
+// LowerFacet reports whether op's lower-go facet is reified on an ir.ops op-type.
+func (op Op) LowerFacet() bool {
+	if int(op) < len(opTable) {
+		return opTable[op].lowerFacet
 	}
 	return false
 }
@@ -308,3 +326,8 @@ func bytecodeToIROp(op int32) Op {
 		return OpInvalid
 	}
 }
+
+var opKeywordNames = []string{"invalid", "const", "load-arg", "load-var", "load-closed", "block-arg", "set-var", "call", "tail-call", "add", "sub", "mul", "bit-and", "bit-or", "bit-xor", "bit-and-not", "bit-shift-left", "bit-shift-right", "unsigned-bit-shift-right", "quot", "div", "lt", "lte", "gt", "gte", "eq", "inc", "dec", "bit-not", "pop", "return", "branch", "branch-if", "make-closure", "push-closed", "try", "dot", "def"}
+
+// OpKeywords returns every catalogued op as its kebab-case keyword name, in Op order.
+func OpKeywords() []string { return opKeywordNames }

--- a/pkg/ir/op_generated.go
+++ b/pkg/ir/op_generated.go
@@ -331,3 +331,86 @@ var opKeywordNames = []string{"invalid", "const", "load-arg", "load-var", "load-
 
 // OpKeywords returns every catalogued op as its kebab-case keyword name, in Op order.
 func OpKeywords() []string { return opKeywordNames }
+
+func opByKeywordExact(name string) (Op, bool) {
+	switch name {
+	case "invalid":
+		return OpInvalid, true
+	case "const":
+		return OpConst, true
+	case "load-arg":
+		return OpLoadArg, true
+	case "load-var":
+		return OpLoadVar, true
+	case "load-closed":
+		return OpLoadClosed, true
+	case "block-arg":
+		return OpBlockArg, true
+	case "set-var":
+		return OpSetVar, true
+	case "call":
+		return OpCall, true
+	case "tail-call":
+		return OpTailCall, true
+	case "add":
+		return OpAdd, true
+	case "sub":
+		return OpSub, true
+	case "mul":
+		return OpMul, true
+	case "bit-and":
+		return OpBitAnd, true
+	case "bit-or":
+		return OpBitOr, true
+	case "bit-xor":
+		return OpBitXor, true
+	case "bit-and-not":
+		return OpBitAndNot, true
+	case "bit-shift-left":
+		return OpBitShiftLeft, true
+	case "bit-shift-right":
+		return OpBitShiftRight, true
+	case "unsigned-bit-shift-right":
+		return OpUnsignedBitShiftRight, true
+	case "quot":
+		return OpQuot, true
+	case "div":
+		return OpDiv, true
+	case "lt":
+		return OpLt, true
+	case "lte":
+		return OpLte, true
+	case "gt":
+		return OpGt, true
+	case "gte":
+		return OpGte, true
+	case "eq":
+		return OpEq, true
+	case "inc":
+		return OpInc, true
+	case "dec":
+		return OpDec, true
+	case "bit-not":
+		return OpBitNot, true
+	case "pop":
+		return OpPop, true
+	case "return":
+		return OpReturn, true
+	case "branch":
+		return OpBranch, true
+	case "branch-if":
+		return OpBranchIf, true
+	case "make-closure":
+		return OpMakeClosure, true
+	case "push-closed":
+		return OpPushClosed, true
+	case "try":
+		return OpTry, true
+	case "dot":
+		return OpDot, true
+	case "def":
+		return OpDef, true
+	default:
+		return OpInvalid, false
+	}
+}

--- a/pkg/ir/op_lookup.go
+++ b/pkg/ir/op_lookup.go
@@ -14,7 +14,16 @@ import "strings"
 //
 // Used by Lisp-side IR construction primitives, where ops are passed
 // as kebab-case keywords (the Clojure idiom).
+//
+// The common case — a canonical kebab-case keyword, the exact form
+// ir.build emits — hits the generated opByKeywordExact string switch
+// (op_generated.go): sub-linear and allocation-free. Only a
+// non-canonical spelling falls through to the dash/case-insensitive
+// scan below, which preserves the historical lenient semantics.
 func OpByKeyword(name string) (Op, bool) {
+	if op, ok := opByKeywordExact(name); ok {
+		return op, true
+	}
 	normalized := strings.ReplaceAll(name, "-", "")
 	for i, info := range opTable {
 		if strings.EqualFold(info.name, normalized) {

--- a/pkg/ir/op_lookup_test.go
+++ b/pkg/ir/op_lookup_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/ir"
+)
+
+// Every catalogued op must round-trip through its canonical kebab-case
+// keyword (the form ir.build emits and OpKeywords returns) back to its Op.
+// This proves the generated opByKeywordExact switch covers the whole
+// catalog and agrees with OpKeywords index-for-index — if op-keyword-name
+// and the switch ever drift, this fails.
+func TestOpByKeywordRoundTrip(t *testing.T) {
+	for i, name := range ir.OpKeywords() {
+		op, ok := ir.OpByKeyword(name)
+		if !ok {
+			t.Errorf("OpByKeyword(%q) = _, false; want the op at index %d", name, i)
+			continue
+		}
+		if int(op) != i {
+			t.Errorf("OpByKeyword(%q) = %d; want %d", name, int(op), i)
+		}
+	}
+}
+
+// The canonical fast path (the generated string switch) must resolve
+// without falling through to the ReplaceAll + scan fallback, so it does
+// not allocate. This pins the reason the switch exists.
+func TestOpByKeywordCanonicalIsAllocFree(t *testing.T) {
+	var sink ir.Op
+	allocs := testing.AllocsPerRun(1000, func() {
+		sink, _ = ir.OpByKeyword("load-arg")
+	})
+	if allocs != 0 {
+		t.Errorf("OpByKeyword(\"load-arg\") allocated %v times; want 0 (canonical input must hit the switch, not the fallback scan)", allocs)
+	}
+	_ = sink
+}
+
+// The dash/case-insensitive fallback semantics are preserved for
+// non-canonical spellings, and an unknown keyword still reports absence.
+func TestOpByKeywordFallbackSemantics(t *testing.T) {
+	canonical, ok := ir.OpByKeyword("load-arg")
+	if !ok {
+		t.Fatal("OpByKeyword(\"load-arg\") should resolve")
+	}
+	for _, spelling := range []string{"loadarg", "LoadArg", "LOAD-ARG"} {
+		got, ok := ir.OpByKeyword(spelling)
+		if !ok || got != canonical {
+			t.Errorf("OpByKeyword(%q) = %d, %v; want %d, true (lenient fallback)", spelling, int(got), ok, int(canonical))
+		}
+	}
+	if op, ok := ir.OpByKeyword("no-such-op"); ok {
+		t.Errorf("OpByKeyword(\"no-such-op\") = %d, true; want OpInvalid, false", int(op))
+	}
+}

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -2293,6 +2293,12 @@
                (gogen/assign "=" target bodyV)])]
         [(gogen/block-stmt stmts)]))))
 
+;; Register :try's lower facet with the op catalog machinery. The body
+;; (try-assign-stmts) needs this namespace's emission helpers, so it stays
+;; here; ir.ops/TryOp delegates through this registration. The catalog's
+;; lower? column (pkg/ir/ir_ops.lg) routes :try to ops/lower-op.
+(ops/register-lower-impl! :try try-assign-stmts)
+
 (defn- def-assign-stmts [f closed-exprs nid]
   "Lower a :def op (def NAME [val]) to straight-line Go. Refs[0] is the var (a
    Const whose aux is the *vm.Var); optional Refs[1] is the value; the :def's own
@@ -2347,7 +2353,10 @@
       (= op :load-closed) []
       (and (= op :const) (any-fn-template? aux))
       []
-      (and (= op :const) (some? (ops/op-type-for op)))
+      ;; Reified lower facets: the catalog's lower? column
+      ;; (pkg/ir/ir_ops.lg) names the members; ops/lower-op throws —
+      ;; never silently nil — on catalog/bridge drift.
+      (ir/op-lower-facet? op)
       (ops/lower-op op f closed-exprs nid)
       (= op :const)
       []
@@ -2374,8 +2383,8 @@
         [])
       (= op :call)
       (call-assign-stmts f closed-exprs nid)
-      (= op :try)
-      (try-assign-stmts f closed-exprs nid)
+      ;; (:try is handled by the catalog-gated ops/lower-op arm above:
+      ;; TryOp delegates back to try-assign-stmts via register-lower-impl!.)
       (= op :def)
       (def-assign-stmts f closed-exprs nid)
       (= op :set-var)

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -473,15 +473,10 @@
     :else                    []))
 
 (defn- local-carrying-op? [op]
-  (or (= op :block-arg)
-      (= op :call)
-      (= op :try)   ; try-assign-stmts materialises the result into a local
-      (= op :inc)
-      (= op :dec)
-      (= op :bit-not)
-      (= op :dot)   ; (. obj field) materialised into a local: vN := obj.field
-      (= op :def)   ; def-assign-stmts materialises the interned var into a local
-      (contains? binary-op op)))
+  ;; Catalog-driven: the `local-carry?` column in pkg/ir/ir_ops.lg is the
+  ;; single source of truth (true for :block-arg :call :try :inc :dec
+  ;; :bit-not :dot :def and the binary arith/cmp/bit ops incl :quot/:div).
+  (ir/op-local-carrying? op))
 
 ;; A :load-var is normally re-emitted inline as ec.Deref(rt.LookupVar(...)) at
 ;; each use. That is unsafe for a var the same function set!s: a root mutated

--- a/pkg/rt/core/ir/ops.lg
+++ b/pkg/rt/core/ir/ops.lg
@@ -3,14 +3,25 @@
 ;; Each op's per-op behavior facets (lower-stmts, infer) are co-located on a
 ;; single op-type (a deftype implementing IROp), instead of scattered across
 ;; cond/case arms in lower_go.lg + typeinfer.lg. op-registry maps the op
-;; keyword to its op-type instance; the dispatch sites consult it first and
-;; fall back to their existing cond for ops not yet reified.
+;; keyword to its op-type instance; the dispatch sites consult the catalog's
+;; facet columns (pkg/ir/ir_ops.lg: infer?/lower?) first and fall back to
+;; their existing cond for ops not yet reified.
+;;
+;; Catalog coherence: the facet columns are the closed member set. The
+;; check at the end of this file throws at load time (bundle compile /
+;; binary boot) if the columns and op-registry drift, and infer-op/lower-op
+;; throw — never silently nil — when asked for a facet'd op they have no
+;; devirtualized arm for. Adding an op facet is a red build until all three
+;; agree: catalog column, op-registry entry, dispatch arm.
 ;;
 ;; Leaf namespace: requires ONLY ir.data + ir.lattice (must stay below
 ;; typeinfer/lower-go in the load order, else the require graph cycles).
+;; ir.data is required un-aliased: it interns the ir/* accessors AND the
+;; Go bridge primitives (ir/op-infer-facet?, ir/op-kws, ...) into the
+;; native `ir` namespace, which is what ir/ resolves to here.
 (ns ir.ops
   (:require
-   [ir.data :as ir]
+   [ir.data]
    [ir.lattice :as lat]))
 
 (defprotocol IROp
@@ -19,6 +30,102 @@
   ;; typeinfer facet: result type for this inst (mirrors infer-one's arm).
   (op-infer [this inst f state]))
 
+;; --- shared type rules (moved from typeinfer.lg's infer-one arms) ------
+
+(defn- ref-types [inst f state]
+  (map (fn [r] (lat/state-type state r)) (ir/refs inst f)))
+
+(defn- numeric-type? [t]
+  (or (= t :int)
+      (= t :float)
+      (= t :number)
+      (= t [:const :int 0])
+      (= t [:const :float 0.0])))
+
+(defn- numeric-op-type [types]
+  ;; Caller passes types pulled from ir/type-of (canonical post-storage),
+  ;; so we don't need to re-normalize.
+  (cond
+    (some #(= :bottom %) types)
+    :bottom
+    (every? numeric-type? types)
+    ;; Numeric contagion, matching the let-go/Clojure runtime: a float operand
+    ;; makes the result a float — (+ 1 2.0) => 3.0 (Float), (+ 1 2) => 3 (Int).
+    ;; So a CONCRETE float operand forces :float even mixed with ints or with an
+    ;; ambiguous :number (number+float is float whichever the number turns out
+    ;; to be). Only when no concrete float is present and some operand is the
+    ;; ambiguous {int,float} :number do we stay :number; all-int stays :int.
+    ;; (Previously int+float wrongly yielded :number, which has no native Go
+    ;; type and crashed strict lower-go with "unsupported result type".)
+    (cond
+      (some #(or (= % :float) (= % [:const :float 0.0])) types) :float
+      (some #(= :number %) types) :number
+      :else :int)
+    :else
+    :unknown))
+
+(defn- quot-op-type [types]
+  ;; clojure.core/quot is NOT plain numeric contagion. int/int yields an int
+  ;; (native Go `/` truncates toward zero exactly like quot), so keep it native
+  ;; and precisely typed. ANY other operand mix (float, ratio, :number,
+  ;; :unknown, vm.Value) must be computed by rt.QuotValue at runtime — native
+  ;; float `/` does NOT truncate and a native int/float `/` isn't valid Go — so
+  ;; the result is boxed; type it :unknown (-> vm.Value) so lower-go routes it
+  ;; through the helper instead of emitting a wrong native division.
+  (cond
+    (some #(= :bottom %) types)                            :bottom
+    (every? #(or (= % :int) (= % [:const :int 0])) types)  :int
+    :else                                                  :unknown))
+
+(defn- div-op-type [types]
+  ;; clojure.core// is value-dependent: int/int -> Ratio (or Int when exact),
+  ;; any float -> Float (IEEE division). Only all-float operands give a result
+  ;; with a native Go type (:float -> float64, lowered to native `/`); every
+  ;; other mix (int/int Ratio, mixed Float) is boxed and computed by rt.DivValue
+  ;; at runtime, so type it :unknown (-> vm.Value).
+  (cond
+    (some #(= :bottom %) types)                                 :bottom
+    (every? #(or (= % :float) (= % [:const :float 0.0])) types) :float
+    :else                                                       :unknown))
+
+(defn- bitwise-op-type [types]
+  (cond
+    (some #(= :bottom %) types) :bottom
+    (every? #(or (= % :int) (= % [:const :int 0])) types) :int
+    :else :unknown))
+
+;; --- per-layer lower-facet implementations ------------------------------
+;;
+;; Some lower facets need ir.lower-go internals (gogen emission helpers,
+;; value-ident, box-as-value, ...). Those bodies STAY in ir.lower-go —
+;; keeping this namespace a leaf — and register here when ir.lower-go
+;; loads; the op-type delegates. The catalog's lower? column still owns
+;; membership, and an unregistered impl throws naming the op.
+
+(def lower-impls (atom {}))
+
+(defn register-lower-impl! [op-kw impl]
+  (swap! lower-impls assoc op-kw impl))
+
+(defn- delegated-lower [op-kw f closed-exprs nid]
+  (let [impl (get (deref lower-impls) op-kw)]
+    (when (nil? impl)
+      (throw (str "ir.ops: op " op-kw " has the lower? facet but no "
+                  "registered impl — ir.lower-go must load (and call "
+                  "register-lower-impl!) before lowering")))
+    (impl f closed-exprs nid)))
+
+;; --- op-types -----------------------------------------------------------
+;;
+;; Ops with only the infer facet reified implement op-lower-stmts as a
+;; throw: lower-inst-stmts gates on the catalog's lower? column, so
+;; reaching that throw means the catalog and this file drifted.
+
+(defn- no-lower-facet [op-kw]
+  (throw (str "ir.ops: op " op-kw " has no reified lower facet — "
+              "lower-inst-stmts must not dispatch here (check the lower? "
+              "column in pkg/ir/ir_ops.lg)")))
+
 (deftype ConstOp []
   IROp
   ;; Consts emit no statement; the value is inlined at uses by value-expr.
@@ -26,9 +133,121 @@
   ;; Type comes from the constant value itself.
   (op-infer [this inst f state] (lat/classify-const (ir/aux inst f))))
 
-;; op-keyword -> op-type instance. Only reified ops appear here; everything
-;; else returns nil from op-type-for and falls back to legacy dispatch.
-(def op-registry {:const (->ConstOp)})
+(deftype LoadArgOp []
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :load-arg))
+  ;; Seed sources, in priority order:
+  ;;   1. Type already stored on the load-arg inst (e.g. by the
+  ;;      infer-arg-types backward pass) — strongest signal because it
+  ;;      reflects what callers actually pass.
+  ;;   2. fn-arg-types metadata, if explicitly populated.
+  ;;   3. :unknown.
+  (op-infer [this inst f state]
+    (let [stored    (lat/state-type state inst)
+          arg-types (ir/fn-arg-types f)
+          idx       (ir/aux inst f)]
+      (cond
+        (and (not= stored :unknown)
+             (not= stored :bottom))
+        (lat/normalize-type stored)
+        (and (vector? arg-types)
+             (< (int idx) (count arg-types)))
+        (lat/normalize-type (nth arg-types (int idx)))
+        :else
+        :unknown))))
+
+(deftype LoadOpaqueOp []
+  ;; :load-var / :load-closed — the loaded value's type is not tracked.
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :load-var))
+  (op-infer [this inst f state] :unknown))
+
+(deftype BlockArgOp []
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :block-arg))
+  ;; Block params are joined from predecessor edge args by the fixpoint
+  ;; driver; the inst's stored state is the current join.
+  (op-infer [this inst f state]
+    (lat/normalize-type (lat/state-type state inst))))
+
+(deftype TerminatorOp []
+  ;; :return / :branch / :branch-if produce no value. (:tail-call is NOT
+  ;; here: it infers :unknown via the default, preserving infer-one's
+  ;; historical terminator-ops set.)
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :terminator))
+  (op-infer [this inst f state] :nil))
+
+(deftype CmpOp []
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :cmp))
+  (op-infer [this inst f state] :bool))
+
+(deftype NumericOp []
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :numeric))
+  (op-infer [this inst f state] (numeric-op-type (ref-types inst f state))))
+
+(deftype BitwiseOp []
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :bitwise))
+  (op-infer [this inst f state] (bitwise-op-type (ref-types inst f state))))
+
+(deftype QuotOp []
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :quot))
+  (op-infer [this inst f state] (quot-op-type (ref-types inst f state))))
+
+(deftype DivOp []
+  IROp
+  (op-lower-stmts [this f closed-exprs nid] (no-lower-facet :div))
+  (op-infer [this inst f state] (div-op-type (ref-types inst f state))))
+
+(deftype TryOp []
+  ;; :try — the op whose eight scattered dispatch sites motivated this
+  ;; catalog (openspec: catalog-driven-op-dispatch). Its lowering
+  ;; (try-assign-stmts) needs ir.lower-go internals, so the body lives
+  ;; there and registers via register-lower-impl!.
+  IROp
+  (op-lower-stmts [this f closed-exprs nid]
+    (delegated-lower :try f closed-exprs nid))
+  ;; No infer facet (infer? column is false): typeinfer's default :unknown
+  ;; applies; this body is unreachable via the catalog gate.
+  (op-infer [this inst f state] :unknown))
+
+;; op-keyword -> op-type instance. Membership MUST match the catalog's
+;; facet columns (checked below at load time). Ops without any reified
+;; facet do not appear here and fall back to legacy dispatch.
+(def op-registry
+  {:const       (->ConstOp)
+   :load-arg    (->LoadArgOp)
+   :load-var    (->LoadOpaqueOp)
+   :load-closed (->LoadOpaqueOp)
+   :block-arg   (->BlockArgOp)
+   :return      (->TerminatorOp)
+   :branch      (->TerminatorOp)
+   :branch-if   (->TerminatorOp)
+   :lt          (->CmpOp)
+   :lte         (->CmpOp)
+   :gt          (->CmpOp)
+   :gte         (->CmpOp)
+   :eq          (->CmpOp)
+   :add         (->NumericOp)
+   :sub         (->NumericOp)
+   :mul         (->NumericOp)
+   :inc         (->NumericOp)
+   :dec         (->NumericOp)
+   :bit-and     (->BitwiseOp)
+   :bit-or      (->BitwiseOp)
+   :bit-xor     (->BitwiseOp)
+   :bit-and-not (->BitwiseOp)
+   :bit-shift-left           (->BitwiseOp)
+   :bit-shift-right          (->BitwiseOp)
+   :unsigned-bit-shift-right (->BitwiseOp)
+   :bit-not     (->BitwiseOp)
+   :quot        (->QuotOp)
+   :div         (->DivOp)
+   :try         (->TryOp)})
 
 (defn op-type-for [op-kw]
   (get op-registry op-kw))
@@ -37,14 +256,70 @@
 ;; arm constructs the concrete op-type inline: typeinfer types (->ConstOp) as
 ;; [:dtype ConstOp], so under gogen_ir the protocol call lowers to a DIRECT
 ;; native method call (recv.OpInfer / recv.OpLowerStmts) instead of boxed var
-;; dispatch. Callers gate on (op-type-for op) first, so the :else arms are
-;; unreachable in practice (defensive nil).
+;; dispatch. Callers gate on the catalog facet columns (ir/op-infer-facet?,
+;; ir/op-lower-facet?), so the :else arms fire only on catalog/bridge drift —
+;; they throw, naming the op, instead of silently returning nil.
 (defn infer-op [op inst f state]
   (cond
-    (= op :const) (op-infer (->ConstOp) inst f state)
-    :else nil))
+    (= op :const)       (op-infer (->ConstOp) inst f state)
+    (= op :block-arg)   (op-infer (->BlockArgOp) inst f state)
+    (= op :load-arg)    (op-infer (->LoadArgOp) inst f state)
+    (= op :eq)          (op-infer (->CmpOp) inst f state)
+    (= op :lt)          (op-infer (->CmpOp) inst f state)
+    (= op :lte)         (op-infer (->CmpOp) inst f state)
+    (= op :gt)          (op-infer (->CmpOp) inst f state)
+    (= op :gte)         (op-infer (->CmpOp) inst f state)
+    (= op :add)         (op-infer (->NumericOp) inst f state)
+    (= op :sub)         (op-infer (->NumericOp) inst f state)
+    (= op :mul)         (op-infer (->NumericOp) inst f state)
+    (= op :inc)         (op-infer (->NumericOp) inst f state)
+    (= op :dec)         (op-infer (->NumericOp) inst f state)
+    (= op :load-var)    (op-infer (->LoadOpaqueOp) inst f state)
+    (= op :load-closed) (op-infer (->LoadOpaqueOp) inst f state)
+    (= op :return)      (op-infer (->TerminatorOp) inst f state)
+    (= op :branch)      (op-infer (->TerminatorOp) inst f state)
+    (= op :branch-if)   (op-infer (->TerminatorOp) inst f state)
+    (= op :bit-and)     (op-infer (->BitwiseOp) inst f state)
+    (= op :bit-or)      (op-infer (->BitwiseOp) inst f state)
+    (= op :bit-xor)     (op-infer (->BitwiseOp) inst f state)
+    (= op :bit-and-not) (op-infer (->BitwiseOp) inst f state)
+    (= op :bit-shift-left)           (op-infer (->BitwiseOp) inst f state)
+    (= op :bit-shift-right)          (op-infer (->BitwiseOp) inst f state)
+    (= op :unsigned-bit-shift-right) (op-infer (->BitwiseOp) inst f state)
+    (= op :bit-not)     (op-infer (->BitwiseOp) inst f state)
+    (= op :quot)        (op-infer (->QuotOp) inst f state)
+    (= op :div)         (op-infer (->DivOp) inst f state)
+    :else (throw (str "ir.ops/infer-op: op " op " has the infer? facet in "
+                      "pkg/ir/ir_ops.lg but no devirtualized arm here — add "
+                      "the arm and the op-registry entry"))))
 
 (defn lower-op [op f closed-exprs nid]
   (cond
     (= op :const) (op-lower-stmts (->ConstOp) f closed-exprs nid)
-    :else nil))
+    (= op :try)   (op-lower-stmts (->TryOp) f closed-exprs nid)
+    :else (throw (str "ir.ops/lower-op: op " op " has the lower? facet in "
+                      "pkg/ir/ir_ops.lg but no devirtualized arm here — add "
+                      "the arm and the op-registry entry"))))
+
+;; --- catalog coherence (exhaustiveness) --------------------------------
+;;
+;; The catalog's facet columns are the single source of truth for which
+;; ops are reified. This check runs at namespace load — i.e. at bundle
+;; compile (`make generate`) and at binary boot — so catalog/registry
+;; drift is a red build naming the op, never a silent nil at dispatch.
+(def ^:private catalog-coherent?
+  (let [facet-kws  (set (filter (fn [k] (or (ir/op-infer-facet? k)
+                                            (ir/op-lower-facet? k)))
+                                (ir/op-kws)))
+        registered (set (keys op-registry))]
+    (if (= facet-kws registered)
+      true
+      (let [missing (vec (filter (fn [k] (not (contains? registered k))) facet-kws))
+            extra   (vec (filter (fn [k] (not (contains? facet-kws k))) registered))]
+        (throw (str "ir.ops: catalog/registry drift —"
+                    (if (seq missing)
+                      (str " facet'd ops in pkg/ir/ir_ops.lg missing from op-registry: " missing)
+                      "")
+                    (if (seq extra)
+                      (str " op-registry entries without a facet column in pkg/ir/ir_ops.lg: " extra)
+                      "")))))))

--- a/pkg/rt/core/ir/passes/typeinfer.lg
+++ b/pkg/rt/core/ir/passes/typeinfer.lg
@@ -132,58 +132,9 @@
 
             :else nil))))))
 
-(defn- numeric-type? [t]
-  (or (= t :int)
-      (= t :float)
-      (= t :number)
-      (= t [:const :int 0])
-      (= t [:const :float 0.0])))
-
-(defn- numeric-op-type [types]
-  ;; Caller passes types pulled from ir/type-of (canonical post-storage),
-  ;; so we don't need to re-normalize.
-  (cond
-    (some #(= :bottom %) types)
-    :bottom
-    (every? numeric-type? types)
-    ;; Numeric contagion, matching the let-go/Clojure runtime: a float operand
-    ;; makes the result a float — (+ 1 2.0) => 3.0 (Float), (+ 1 2) => 3 (Int).
-    ;; So a CONCRETE float operand forces :float even mixed with ints or with an
-    ;; ambiguous :number (number+float is float whichever the number turns out
-    ;; to be). Only when no concrete float is present and some operand is the
-    ;; ambiguous {int,float} :number do we stay :number; all-int stays :int.
-    ;; (Previously int+float wrongly yielded :number, which has no native Go
-    ;; type and crashed strict lower-go with "unsupported result type".)
-    (cond
-      (some #(or (= % :float) (= % [:const :float 0.0])) types) :float
-      (some #(= :number %) types) :number
-      :else :int)
-    :else
-    :unknown))
-
-(defn- quot-op-type [types]
-  ;; clojure.core/quot is NOT plain numeric contagion. int/int yields an int
-  ;; (native Go `/` truncates toward zero exactly like quot), so keep it native
-  ;; and precisely typed. ANY other operand mix (float, ratio, :number,
-  ;; :unknown, vm.Value) must be computed by rt.QuotValue at runtime — native
-  ;; float `/` does NOT truncate and a native int/float `/` isn't valid Go — so
-  ;; the result is boxed; type it :unknown (-> vm.Value) so lower-go routes it
-  ;; through the helper instead of emitting a wrong native division.
-  (cond
-    (some #(= :bottom %) types)                            :bottom
-    (every? #(or (= % :int) (= % [:const :int 0])) types)  :int
-    :else                                                  :unknown))
-
-(defn- div-op-type [types]
-  ;; clojure.core// is value-dependent: int/int -> Ratio (or Int when exact),
-  ;; any float -> Float (IEEE division). Only all-float operands give a result
-  ;; with a native Go type (:float -> float64, lowered to native `/`); every
-  ;; other mix (int/int Ratio, mixed Float) is boxed and computed by rt.DivValue
-  ;; at runtime, so type it :unknown (-> vm.Value).
-  (cond
-    (some #(= :bottom %) types)                                :bottom
-    (every? #(or (= % :float) (= % [:const :float 0.0])) types) :float
-    :else                                                       :unknown))
+;; numeric-type? / numeric-op-type / quot-op-type / div-op-type moved to
+;; ir.ops: the reified op-types' infer facets (NumericOp/QuotOp/DivOp)
+;; consume them there.
 
 (defn- truthy-type? [t]
   (let [t (normalize-type t)]
@@ -233,8 +184,6 @@
       :else t)))
 
 ;; --- CFG helpers -----------------------------------------------------
-
-(def terminator-ops #{:branch :branch-if :return})
 
 (defn- refine-edge-arg-type [pred-bid target-bid arg-id arg-type f]
   (let [term (ir/block-term pred-bid f)]
@@ -295,66 +244,25 @@
                 preds))
       :bottom)))
 
-(defn- arg-seed [inst f state]
-  ;; Seed sources, in priority order:
-  ;;   1. Type already stored on the load-arg inst (e.g. by the
-  ;;      infer-arg-types backward pass) — strongest signal because it
-  ;;      reflects what callers actually pass.
-  ;;   2. fn-arg-types metadata, if explicitly populated.
-  ;;   3. :unknown.
-  (let [stored    (state-type state inst)
-        arg-types (ir/fn-arg-types f)
-        idx       (ir/aux inst f)]
-    (cond
-      (and (not= stored :unknown)
-           (not= stored :bottom))
-      (normalize-type stored)
-      (and (vector? arg-types)
-           (< (int idx) (count arg-types)))
-      (normalize-type (nth arg-types (int idx)))
-      :else
-      :unknown)))
-
 ;; --- Op-based inference ----------------------------------------------
-
-(def comparison-ops #{:lt :lte :gt :gte :eq})
-(def numeric-ops #{:add :sub :mul :inc :dec})
-(def bitwise-binary-ops
-  #{:bit-and :bit-or :bit-xor :bit-and-not
-    :bit-shift-left :bit-shift-right :unsigned-bit-shift-right})
-(def bitwise-unary-ops #{:bit-not})
-
-(defn- bitwise-op-type [types]
-  (cond
-    (some #(= :bottom %) types) :bottom
-    (every? #(or (= % :int) (= % [:const :int 0])) types) :int
-    :else :unknown))
+;;
+;; Per-op infer rules live on ir.ops op-types (arg-seed became LoadArgOp,
+;; the comparison/numeric/bitwise/quot/div arms became CmpOp/NumericOp/
+;; BitwiseOp/QuotOp/DivOp, ...). The catalog's infer? column
+;; (pkg/ir/ir_ops.lg) names the members; ops/infer-op throws — never
+;; silently nil — if the catalog and its dispatch drift.
 
 (defn infer-one [inst f state]
-  (let [op   (ir/op inst f)
-        refs (ir/refs inst f)
-        ot   (ops/op-type-for op)]
+  (let [op (ir/op inst f)]
     (cond
-      (some? ot)                (ops/infer-op op inst f state)
-      (= op :load-arg)         (arg-seed inst f state)
-      (= op :load-var)         :unknown
-      (= op :load-closed)      :unknown
-      (= op :call)             (or (call-dtype inst f)
-                                   (call-core-type inst f state)
-                                   :unknown)
-      (= op :block-arg)        (normalize-type (state-type state inst))
-      (contains? terminator-ops op) :nil
-      (contains? comparison-ops op) :bool
-      (= op :quot)
-      (quot-op-type (map (fn [r] (state-type state r)) refs))
-      (= op :div)
-      (div-op-type (map (fn [r] (state-type state r)) refs))
-      (contains? bitwise-binary-ops op)
-      (bitwise-op-type (map (fn [r] (state-type state r)) refs))
-      (contains? bitwise-unary-ops op)
-      (bitwise-op-type (map (fn [r] (state-type state r)) refs))
-      (contains? numeric-ops op)
-      (numeric-op-type (map (fn [r] (state-type state r)) refs))
+      (ir/op-infer-facet? op) (ops/infer-op op inst f state)
+      ;; :call is typeinfer-coupled (call-dtype / call-core-type below) and
+      ;; not yet reified — the one remaining legacy arm.
+      (= op :call)            (or (call-dtype inst f)
+                                  (call-core-type inst f state)
+                                  :unknown)
+      ;; Facetless ops (:set-var, :tail-call, :pop, closures, :try, :dot,
+      ;; :def) — no type information tracked.
       :else :unknown)))
 
 ;; --- fixpoint driver -------------------------------------------------

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-da3b35e44ed9b49e8b9138e88f7e1bab665148f30b74af3dbde00966abd043cc
+4871c7a03259af3946da2e6ed53a27436f479de24a4e8b0038a2010efc41ef83

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-4871c7a03259af3946da2e6ed53a27436f479de24a4e8b0038a2010efc41ef83
+db1f436c1e75a4a92f0bdaf3fb0fbe48c0184eaad22d955c1be2faa92fb67f7e

--- a/pkg/rt/ir_bridge_generated.go
+++ b/pkg/rt/ir_bridge_generated.go
@@ -62,6 +62,21 @@ func installIRBridgeBuiltins() {
 		return vm.Boolean(arg0.IsPure()), nil
 	})
 	ns.Def("op-pure?", fn_op_pure_Fn)
+	fn_op_local_carrying_Fn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("ir/op-local-carrying?: expected (OpKw), got %d args", len(vs))
+		}
+		arg0Kw, ok0 := vs[0].(vm.Keyword)
+		if !ok0 {
+			return vm.NIL, fmt.Errorf("ir/op-local-carrying?: arg 0 must be Keyword, got %s", vs[0].Type().Name())
+		}
+		arg0, okOp0 := ir.OpByKeyword(string(arg0Kw))
+		if !okOp0 {
+			return vm.NIL, fmt.Errorf("ir/op-local-carrying?: unknown op %s", string(arg0Kw))
+		}
+		return vm.Boolean(arg0.LocalCarrying()), nil
+	})
+	ns.Def("op-local-carrying?", fn_op_local_carrying_Fn)
 	fn_op_cheap_load_Fn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("ir/op-cheap-load?: expected (OpKw), got %d args", len(vs))

--- a/pkg/rt/ir_bridge_generated.go
+++ b/pkg/rt/ir_bridge_generated.go
@@ -77,6 +77,48 @@ func installIRBridgeBuiltins() {
 		return vm.Boolean(arg0.LocalCarrying()), nil
 	})
 	ns.Def("op-local-carrying?", fn_op_local_carrying_Fn)
+	fn_op_infer_facet_Fn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("ir/op-infer-facet?: expected (OpKw), got %d args", len(vs))
+		}
+		arg0Kw, ok0 := vs[0].(vm.Keyword)
+		if !ok0 {
+			return vm.NIL, fmt.Errorf("ir/op-infer-facet?: arg 0 must be Keyword, got %s", vs[0].Type().Name())
+		}
+		arg0, okOp0 := ir.OpByKeyword(string(arg0Kw))
+		if !okOp0 {
+			return vm.NIL, fmt.Errorf("ir/op-infer-facet?: unknown op %s", string(arg0Kw))
+		}
+		return vm.Boolean(arg0.InferFacet()), nil
+	})
+	ns.Def("op-infer-facet?", fn_op_infer_facet_Fn)
+	fn_op_lower_facet_Fn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("ir/op-lower-facet?: expected (OpKw), got %d args", len(vs))
+		}
+		arg0Kw, ok0 := vs[0].(vm.Keyword)
+		if !ok0 {
+			return vm.NIL, fmt.Errorf("ir/op-lower-facet?: arg 0 must be Keyword, got %s", vs[0].Type().Name())
+		}
+		arg0, okOp0 := ir.OpByKeyword(string(arg0Kw))
+		if !okOp0 {
+			return vm.NIL, fmt.Errorf("ir/op-lower-facet?: unknown op %s", string(arg0Kw))
+		}
+		return vm.Boolean(arg0.LowerFacet()), nil
+	})
+	ns.Def("op-lower-facet?", fn_op_lower_facet_Fn)
+	fn_op_kws_Fn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 0 {
+			return vm.NIL, fmt.Errorf("ir/op-kws: expected (), got %d args", len(vs))
+		}
+		kws := ir.OpKeywords()
+		out := make([]vm.Value, 0, len(kws))
+		for _, k := range kws {
+			out = append(out, vm.Keyword(k))
+		}
+		return vm.NewArrayVector(out), nil
+	})
+	ns.Def("op-kws", fn_op_kws_Fn)
 	fn_op_cheap_load_Fn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("ir/op-cheap-load?: expected (OpKw), got %d args", len(vs))

--- a/scripts/ir-stress-corpus.edn
+++ b/scripts/ir-stress-corpus.edn
@@ -47,6 +47,7 @@
   "pkg/rt/core/ir/lattice.lg"
   "pkg/rt/core/ir/lower_go.lg"
   "pkg/rt/core/ir/lower.lg"
+  "pkg/rt/core/ir/ops.lg"
   "pkg/rt/core/ir/passes.lg"
   "pkg/rt/core/ir/passes/constfold.lg"
   "pkg/rt/core/ir/passes/cse.lg"

--- a/test/ir_ops_catalog.lg
+++ b/test/ir_ops_catalog.lg
@@ -1,0 +1,100 @@
+;; Catalog-driven op dispatch (openspec: catalog-driven-op-dispatch §2/§4).
+;;
+;; The facet columns in pkg/ir/ir_ops.lg (infer?/lower?) are the closed
+;; member set for ir.ops' reified op-types. These tests pin the coherence
+;; contract from three sides:
+;;   1. catalog facet columns == op-registry membership
+;;   2. every infer-facet op actually dispatches through its op-type
+;;   3. facetless ops still infer through the legacy path (no regression)
+;;
+;; The same coherence is enforced at load time by ir.ops itself (a drifted
+;; registry throws during `make generate` / binary boot); this test makes
+;; the contract visible and runnable via the ordinary test suite.
+;; NB: ir.data is required UN-aliased — it interns both the data accessors
+;; (ir/new-fn, ir/add-inst, ...) and the Go bridge primitives
+;; (ir/op-infer-facet?, ir/op-kws, ...) into the native `ir` namespace;
+;; aliasing ir.data as `ir` would shadow the primitives.
+(ns test.ir-ops-catalog
+  (:require
+   [ir.data]
+   [ir.lattice :as lat]
+   [ir.ops :as ops]
+   [ir.passes.typeinfer :as ti]
+   [test :refer :all]))
+
+(deftest catalog-facet-columns-match-registry
+  (testing "ops with a reified facet in the catalog are exactly the op-registry keys"
+    (let [facet-kws  (set (filter (fn [k] (or (ir/op-infer-facet? k)
+                                              (ir/op-lower-facet? k)))
+                                  (ir/op-kws)))
+          registered (set (keys ops/op-registry))]
+      (is (= facet-kws registered)))))
+
+(deftest catalog-enumerates-all-ops
+  (testing "ir/op-kws covers the whole catalog, kebab-cased, invalid first"
+    (let [kws (ir/op-kws)]
+      (is (= :invalid (first kws)))
+      (is (contains? (set kws) :unsigned-bit-shift-right))
+      (is (contains? (set kws) :branch-if))
+      (is (> (count kws) 30)))))
+
+(deftest infer-facet-column-gates-dispatch
+  (testing "infer? column is true exactly for the reified infer arms"
+    (is (ir/op-infer-facet? :const))
+    (is (ir/op-infer-facet? :add))
+    (is (ir/op-infer-facet? :eq))
+    (is (ir/op-infer-facet? :block-arg))
+    ;; :call stays legacy (typeinfer-coupled); :tail-call and :try are facetless.
+    (is (not (ir/op-infer-facet? :call)))
+    (is (not (ir/op-infer-facet? :tail-call)))
+    (is (not (ir/op-infer-facet? :try)))))
+
+(deftest lower-facet-column-gates-dispatch
+  (testing "lower? column is true exactly for the reified lower facets"
+    (is (ir/op-lower-facet? :const))
+    (is (ir/op-lower-facet? :try))
+    (is (not (ir/op-lower-facet? :add)))
+    (is (not (ir/op-lower-facet? :call)))))
+
+(deftest try-lower-impl-registered
+  (testing ":try's lower facet is registered by ir.lower-go (per-layer impl)"
+    ;; Loading ir.lower-go must have registered try-assign-stmts; TryOp
+    ;; throws (naming :try) if lowering runs before registration.
+    (require 'ir.lower-go)
+    (is (some? (get (deref ops/lower-impls) :try)))))
+
+;; --- reified infer rules behave like the legacy arms ------------------
+
+(defn- infer-two-const-op
+  "Build ret = (op c1 c2) in a 1-block fn, run typeinfer, return ret's type."
+  [op c1 c2]
+  (let [f  (ir/new-fn "t" 0 false)
+        a  (ir/add-inst f 0 :const [] c1)
+        b  (ir/add-inst f 0 :const [] c2)
+        r  (ir/add-inst f 0 op [a b] nil)]
+    (ti/typeinfer f)
+    (ir/type-of r f)))
+
+(deftest reified-numeric-infer
+  (testing "NumericOp: int contagion rules survive the move"
+    (is (= :int   (infer-two-const-op :add 1 2)))
+    (is (= :float (infer-two-const-op :add 1 2.5)))
+    (is (= :float (infer-two-const-op :mul 1.5 2.5)))))
+
+(deftest reified-comparison-infer
+  (testing "CmpOp: comparisons infer :bool"
+    (is (= :bool (infer-two-const-op :lt 1 2)))
+    (is (= :bool (infer-two-const-op :eq 1 2)))))
+
+(deftest reified-quot-div-infer
+  (testing "QuotOp/DivOp: int/int quot stays :int; int/int div is boxed"
+    (is (= :int (infer-two-const-op :quot 7 2)))
+    (is (= :unknown (infer-two-const-op :div 7 2)))
+    (is (= :float (infer-two-const-op :div 7.0 2.0)))))
+
+(deftest reified-bitwise-infer
+  (testing "BitwiseOp: all-int operands infer :int"
+    (is (= :int (infer-two-const-op :bit-and 6 3)))
+    (is (= :int (infer-two-const-op :bit-shift-left 1 4)))))
+
+(println "ir_ops_catalog tests defined")


### PR DESCRIPTION
Catalog-driven IR op dispatch: `local-carrying?` as a catalog column (§1), reified infer facets + `:try` lower re-home (§2/§4/§5), and a generated `opByKeywordExact` string switch (§2b).

Benchmark (Apple M3): canonical `OpByKeyword` lookup **−96% time** (57ns → 2.1ns, ~27x) and **alloc-free** (1 → 0), matching TestOpByKeywordCanonicalIsAllocFree; non-canonical falls through to the existing lenient scan.