### PR TITLE
perf(rt): direct-call natives for the hot clojure.core surface

### DIFF
--- a/pkg/ir/native_direct_call_test.go
+++ b/pkg/ir/native_direct_call_test.go
@@ -124,12 +124,35 @@ func TestBuildCallEvaluatesCalleeFirst(t *testing.T) {
 	}
 }
 
-// TestWithRedefsDisablesNativeDirect guards the Var override seam: a body that
-// rebinds a core var via with-redefs must NOT lower calls to that var into a
-// baked native-direct call (corefns.Count), because with-redefs mutates the
-// var root at runtime and the native call would ignore it. The call must fall
-// back to the cached-var / InvokeValue trampoline, which re-reads the root.
-func TestWithRedefsDisablesNativeDirect(t *testing.T) {
+// TestWithRedefsNativeDirectStaysGuarded guards the Var override seam: a body
+// that rebinds a core var via with-redefs may still lower calls to that var
+// into a native-direct call, but ONLY as a guarded pair —
+//
+//	if rt.NativePrimsIntact() { corefns.Count(...) } else { <trampoline> }
+//
+// rt.NativePrimsIntact is vm.GuardedRootsIntact, a global deviation counter
+// over the roots native modules direct-call. A with-redefs / alter-var-root /
+// intern on any of those roots trips it, so the guard takes its trampoline
+// branch and the override is observed. The counter records THAT a guarded root
+// changed, not who changed it, so this holds whether the redef happens in a
+// caller's dynamic extent or inside this very function.
+//
+// This is the AOT contract: lowered code calls natives directly, while a
+// superficial override stays observable through the guard.
+//
+// The test previously asserted the STRICTER property that no native call was
+// emitted at all. That banned the whole guarded-pair mechanism whenever a
+// function could rebind var roots, and since the flag is whole-function, ONE
+// alter-var-root disabled every native call in that function — ir.direct's
+// evaluator lost nth/get/count/assoc! to it, paying an ec.Invoke plus a
+// []vm.Value allocation per call. The behavioural guarantee is pinned by
+// test/native-bridge-parity.lg (redefinition-guard, which proves a BAKED
+// rt.Reduce3 in group-by observes a redef, and redefinition-guard-self-scoped).
+//
+// Unguarded bakings are a different matter and must still stand down; see
+// TestWithRedefsDisablesListIntrinsic, where the list intrinsic emits
+// vm.EmptyList.Cons(...) with no runtime recheck at all.
+func TestWithRedefsNativeDirectStaysGuarded(t *testing.T) {
 	ensureLoader()
 	rendered := runLispString(t,
 		`(do (create-ns (quote withredefseedns))
@@ -137,8 +160,11 @@ func TestWithRedefsDisablesNativeDirect(t *testing.T) {
 		     (ir.passes.pipeline/lower-ns-to-go "withredefseedns" (quote withredefseedns)
 		       [(quote (defn probe [x] (with-redefs [count (fn [_] 42)] (count x))))]))`)
 
-	if strings.Contains(rendered, "corefns.Count(") {
-		t.Fatalf("with-redefs over count must disable native-direct; found baked corefns.Count(...):\n--- go ---\n%s", rendered)
+	// A baked native call is allowed, but never unguarded.
+	if strings.Contains(rendered, "corefns.Count(") &&
+		!strings.Contains(rendered, "rt.NativePrimsIntact()") {
+		t.Fatalf("baked corefns.Count(...) emitted WITHOUT an rt.NativePrimsIntact() guard; "+
+			"a with-redefs on count would be ignored:\n--- go ---\n%s", rendered)
 	}
 	// And the call must still happen — through the var-mediated cached-var
 	// trampoline, which re-reads count's root each call so the redef is seen.

--- a/pkg/rt/builtins/builtins.go
+++ b/pkg/rt/builtins/builtins.go
@@ -67,6 +67,8 @@ func Cons(elem, coll vm.Value) (vm.Value, error) {
 	return vm.NewCons(elem, seq), nil
 }
 
+// lg:native
+// lg:name contains?
 // Contains mirrors clojure.core/contains? — `(contains? coll k)`.
 func Contains(coll, k vm.Value) (vm.Value, error) {
 	if coll == vm.NIL {
@@ -94,4 +96,212 @@ func Contains(coll, k vm.Value) (vm.Value, error) {
 	}
 	i := int(idx)
 	return vm.Boolean(i >= 0 && i < indexed.RawCount()), nil
+}
+
+// lg:native
+// HashSet mirrors clojure.core/hash-set — `(hash-set & xs)`.
+func HashSet(args ...vm.Value) (vm.Value, error) {
+	return vm.NewSet(args), nil
+}
+
+// lg:native
+// lg:name array-map
+// ArrayMap mirrors clojure.core/array-map — `(array-map & kvs)`.
+func ArrayMap(args ...vm.Value) (vm.Value, error) {
+	if len(args)%2 != 0 {
+		return vm.NIL, fmt.Errorf("array-map requires an even number of arguments, got %d", len(args))
+	}
+	return vm.NewArrayMap(args), nil
+}
+
+// lg:native
+// Vec mirrors clojure.core/vec — `(vec coll)`.
+func Vec(coll vm.Value) (vm.Value, error) {
+	if coll == vm.NIL || coll == vm.EmptyList {
+		return vm.ArrayVector{}, nil
+	}
+	// Empty string → empty vector
+	if s, ok := coll.(vm.String); ok && len(string(s)) == 0 {
+		return vm.ArrayVector{}, nil
+	}
+	if v, ok := coll.(vm.ArrayVector); ok {
+		return v, nil
+	}
+	if a, ok := coll.(*vm.TypedArray); ok && a.Kind() == vm.ArrayObject {
+		return vm.ArrayVector(a.Unbox().([]vm.Value)), nil
+	}
+	seq, err := seqOf(coll)
+	if err != nil {
+		return vm.NIL, err
+	}
+	// Realize lazy seqs to check emptiness
+	if ls, ok := seq.(*vm.LazySeq); ok {
+		seq = ls.Seq()
+	}
+	if seq == nil || seq == vm.EmptyList {
+		return vm.ArrayVector{}, nil
+	}
+	ret := []vm.Value{}
+	for seq != nil {
+		ret = append(ret, seq.First())
+		seq = seq.Next()
+	}
+	return vm.NewArrayVector(ret), nil
+}
+
+// lg:native
+// Nth mirrors clojure.core/nth — `(nth coll i)`.
+// Takes vm.Value arguments and handles type conversion internally,
+// avoiding the type-coercion bottleneck of the primitive rt.Nth.
+func Nth(coll, i vm.Value) (vm.Value, error) {
+	// (nth nil i) => nil, matching rt.Nth / clojure.core/nth — nil is an empty
+	// coll for nth. An empty list is out of bounds, like an empty vector.
+	if coll == vm.NIL {
+		return vm.NIL, nil
+	}
+	if coll == vm.EmptyList {
+		return vm.NIL, fmt.Errorf("nth: index out of bounds")
+	}
+
+	// Convert index to int
+	var idx int
+	switch iv := i.(type) {
+	case vm.Int:
+		idx = int(iv)
+	default:
+		return vm.NIL, fmt.Errorf("nth: index must be numeric, got %s", i.Type().Name())
+	}
+
+	// Negative index
+	if idx < 0 {
+		return vm.NIL, fmt.Errorf("nth: negative index %d", idx)
+	}
+
+	// Handle strings
+	if s, ok := coll.(vm.String); ok {
+		runes := []rune(string(s))
+		if idx >= len(runes) {
+			return vm.NIL, fmt.Errorf("nth: index %d out of bounds for string", idx)
+		}
+		return vm.Char(runes[idx]), nil
+	}
+
+	// Handle indexed collections (vectors, arrays)
+	if indexed, ok := coll.(vm.Indexed); ok {
+		count := indexed.RawCount()
+		if idx >= count {
+			return vm.NIL, fmt.Errorf("nth: index %d out of bounds", idx)
+		}
+		return indexed.Nth(idx), nil
+	}
+
+	// Handle sequences. Realize a lazy seq at the head and each step (mirrors
+	// rt.forceSeq): an EMPTY lazy seq is non-nil until forced, so First() on it
+	// would wrongly yield nil instead of an out-of-bounds error.
+	seq, err := seqOf(coll)
+	if err != nil {
+		return vm.NIL, fmt.Errorf("nth: cannot get sequence from %s", coll.Type().Name())
+	}
+	if ls, ok := seq.(*vm.LazySeq); ok {
+		seq = ls.Seq()
+	}
+	if seq == nil {
+		return vm.NIL, fmt.Errorf("nth: index %d out of bounds", idx)
+	}
+	for j := 0; j < idx; j++ {
+		seq = seq.Next()
+		if ls, ok := seq.(*vm.LazySeq); ok {
+			seq = ls.Seq()
+		}
+		if seq == nil {
+			return vm.NIL, fmt.Errorf("nth: index %d out of bounds", idx)
+		}
+	}
+	return seq.First(), nil
+}
+
+// lg:native
+// lg:name nth
+// Nth3 mirrors clojure.core/nth — `(nth coll i notFound)`.
+// Takes vm.Value arguments and handles type conversion internally.
+func Nth3(coll, i, notFound vm.Value) (vm.Value, error) {
+	// Handle nil/empty collection
+	if coll == vm.NIL || coll == vm.EmptyList {
+		return notFound, nil
+	}
+
+	// Convert index to int. A non-numeric index is an ERROR, not a not-found:
+	// canonical nth coerces the index to int, and (nth coll bad not-found) still
+	// throws on a bad index type — not-found is only for out-of-bounds.
+	var idx int
+	switch iv := i.(type) {
+	case vm.Int:
+		idx = int(iv)
+	default:
+		return vm.NIL, fmt.Errorf("nth: index must be numeric, got %s", i.Type().Name())
+	}
+
+	// Negative index
+	if idx < 0 {
+		return notFound, nil
+	}
+
+	// Handle strings
+	if s, ok := coll.(vm.String); ok {
+		runes := []rune(string(s))
+		if idx >= len(runes) {
+			return notFound, nil
+		}
+		return vm.Char(runes[idx]), nil
+	}
+
+	// Handle indexed collections (vectors, arrays)
+	if indexed, ok := coll.(vm.Indexed); ok {
+		count := indexed.RawCount()
+		if idx >= count {
+			return notFound, nil
+		}
+		return indexed.Nth(idx), nil
+	}
+
+	// Handle sequences. Realize a lazy seq at the head and each step so an EMPTY
+	// lazy seq falls through to notFound instead of yielding a nil First().
+	seq, err := seqOf(coll)
+	if err != nil {
+		return notFound, nil
+	}
+	if ls, ok := seq.(*vm.LazySeq); ok {
+		seq = ls.Seq()
+	}
+	if seq == nil {
+		return notFound, nil
+	}
+	for j := 0; j < idx; j++ {
+		seq = seq.Next()
+		if ls, ok := seq.(*vm.LazySeq); ok {
+			seq = ls.Seq()
+		}
+		if seq == nil {
+			return notFound, nil
+		}
+	}
+	return seq.First(), nil
+}
+
+// lg:native
+// lg:name seq?
+// IsSeq mirrors clojure.core/seq? — true only for values that are actually
+// vm.Seq. The explicit negative cases come first because several collection
+// types satisfy vm.Seq structurally while Clojure reports seq? false for them.
+// Single source of truth: rt's ns.Def("seq?") delegates here.
+func IsSeq(v vm.Value) (vm.Value, error) {
+	switch v.(type) {
+	case *vm.Nil, vm.String, *vm.TypedArray,
+		vm.ArrayVector, *vm.PersistentVector,
+		*vm.PersistentMap, *vm.PersistentSet,
+		*vm.SortedSet, *vm.SortedMap:
+		return vm.FALSE, nil
+	}
+	_, ok := v.(vm.Seq)
+	return vm.Boolean(ok), nil
 }

--- a/pkg/rt/builtins/nth_parity_test.go
+++ b/pkg/rt/builtins/nth_parity_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package builtins
+
+import (
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// emptyLazy returns a *vm.LazySeq that realizes to empty (nil head).
+func emptyLazy() vm.Value {
+	f, _ := vm.NativeFnType.Wrap(func(_ []vm.Value) (vm.Value, error) { return vm.NIL, nil })
+	return vm.NewLazySeq(f.(vm.Fn))
+}
+
+// TestNthMatchesCanonical guards #613's builtins.Nth/Nth3 (the AOT direct-call
+// targets for nth) against VM/AOT semantic drift on the edge cases the reviewer
+// flagged. If these diverge from clojure.core/nth, the direct-linking
+// optimization silently changes results between the VM and AOT paths.
+func TestNthMatchesCanonical(t *testing.T) {
+	vec := vm.NewArrayVector([]vm.Value{vm.Int(1)})
+
+	// (nth nil 0) => nil, NOT an error (nil is an empty coll for nth).
+	if v, err := Nth(vm.NIL, vm.Int(0)); err != nil || v != vm.NIL {
+		t.Errorf("Nth(nil, 0) = %v, %v; want nil with no error", v, err)
+	}
+
+	// (nth [1] :bad :missing) => THROW on the non-numeric index, NOT :missing —
+	// not-found is only for out-of-bounds, not a bad index type.
+	if _, err := Nth3(vec, vm.Keyword("bad"), vm.Keyword("missing")); err == nil {
+		t.Error("Nth3([1], :bad, :missing) returned no error; want a throw on the non-numeric index")
+	}
+	// The 2-arg form already threw here; keep it pinned.
+	if _, err := Nth(vec, vm.Keyword("bad")); err == nil {
+		t.Error("Nth([1], :bad) returned no error; want a throw on the non-numeric index")
+	}
+
+	// An EMPTY lazy seq must be forced: (nth empty-lazy 0) is out of bounds, and
+	// the 3-arg form yields the default — not a nil First() off an unforced seq.
+	if _, err := Nth(emptyLazy(), vm.Int(0)); err == nil {
+		t.Error("Nth(empty-lazy, 0) returned no error; want out-of-bounds")
+	}
+	if v, err := Nth3(emptyLazy(), vm.Int(0), vm.Keyword("missing")); err != nil || v != vm.Keyword("missing") {
+		t.Errorf("Nth3(empty-lazy, 0, :missing) = %v, %v; want :missing", v, err)
+	}
+}

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-74369bf89e6de00c6116d29a6745e95996c521a35cd8eea8a0041987c2812961
+7b87c4e8cf5cda17291683c6f71ce6da71af93817366d6f631582611b791cd5c

--- a/pkg/rt/gogen.go
+++ b/pkg/rt/gogen.go
@@ -1722,6 +1722,50 @@ func cFile(pkgV, importsV, declsV vm.Value) (vm.Value, error) {
 // introduces (math.NaN / math.Inf for non-finite float literals), without
 // mutating any shared node.
 
+// cCallTargets returns every call target in `node`'s subtree, in source order,
+// as strings: "pkg.Name" for a selector call (rt.NativePrimsIntact,
+// builtins.Nth), ".Name" for a method call on a non-ident receiver, and "Name"
+// for a bare identifier call.
+//
+// Query tooling for the lowered output. Without it, "did this function get a
+// native direct call or a trampoline?" gets answered by regex over rendered
+// text, which is fragile and silently wrong when the emission shape differs
+// from the pattern being matched (e.g. the uncached
+// rt.InvokeValueEC(ec, ec.Deref(rt.LookupVar(...))) form matches neither
+// "CachedVarFn" nor "NativePrimsIntact", so a grep-based count reports zero of
+// both and reads as "no calls"). Walking the AST answers the question the
+// lowerer actually decided, not the one a pattern happens to spell.
+//
+// Read-only: mutates nothing.
+func cCallTargets(nodeV vm.Value) (vm.Value, error) {
+	n, err := unboxNode(nodeV)
+	if err != nil {
+		return vm.NIL, err
+	}
+	if n == nil {
+		return vm.NewArrayVector(nil), nil
+	}
+	var out []vm.Value
+	ast.Inspect(n, func(x ast.Node) bool {
+		call, ok := x.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch f := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if id, ok := f.X.(*ast.Ident); ok {
+				out = append(out, vm.String(id.Name+"."+f.Sel.Name))
+			} else {
+				out = append(out, vm.String("."+f.Sel.Name))
+			}
+		case *ast.Ident:
+			out = append(out, vm.String(f.Name))
+		}
+		return true
+	})
+	return vm.NewArrayVector(out), nil
+}
+
 // cReferencesPkg reports whether `node` references package `pkg` via a
 // `pkg.<name>` selector anywhere in its subtree. Read-only: walks the boxed
 // AST, mutates nothing.
@@ -2206,6 +2250,7 @@ func installGogenNS() {
 		mk(wrap3Named("var-decl", cVarDecl)),
 		mk(wrap3Named("file", cFile)),
 		mk(wrap2Named("references-pkg?", cReferencesPkg)),
+		mk(wrap1Named("call-targets", cCallTargets)),
 		mk(wrap1Named("file-import-paths", cFileImportPaths)),
 		mk(wrap2Named("add-file-import", cAddFileImport)),
 		mk(wrap1Named("ensure-gen-imports", cEnsureGenImports)),

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -409,7 +409,6 @@ func init() {
 	// alphabetically so every file has registered first.
 	installLangNS()
 	installNativeDirectNS()
-	registerBuiltinsModule()
 
 	// Generated primitives intentionally re-Def native versions over the
 	// bootstrap closures — silence the warn-on-core-shadow noise for this
@@ -418,6 +417,11 @@ func init() {
 	vm.SetSuppressShadowWarn(true)
 	RegisterGeneratedPrimitives()
 	vm.SetSuppressShadowWarn(false)
+
+	// Register builtins AFTER primitives so that builtin versions (with better
+	// signatures) override the generated primitive versions. This is the EPIC-012
+	// seam: hot clojure.core functions migrate from primitives to builtins.
+	registerBuiltinsModule()
 	// walk namespace is embedded via coreFS and will be loaded on demand
 }
 
@@ -442,6 +446,19 @@ func registerBuiltinsModule() {
 			"not":       {GoIdent: "Not", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
 			"cons":      {GoIdent: "Cons", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
 			"contains?": {GoIdent: "Contains", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"seq?":      {GoIdent: "IsSeq", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			// Second hot batch, measured from the AOT-lowered ir tree: these were
+			// the top remaining CachedVarFn trampolines with no direct path at all
+			// (vec 127, hash-set 130, array-map 122 call sites).
+			"vec":       {GoIdent: "Vec", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"hash-set":  {GoIdent: "HashSet", Arity: 0, Variadic: true, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"array-map": {GoIdent: "ArrayMap", Arity: 0, Variadic: true, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			// Third hot batch: nth with vm.Value index parameter (avoiding type-coercion
+			// bottleneck of the typed primitive). These are the index-access callsites
+			// that currently fall back to trampolines due to proven numeric index types.
+			// Registered with LgName: "nth" so the registry lookup finds them by name+arity.
+			"nth@2": {GoIdent: "Nth", Arity: 2, LgName: "nth", ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"nth@3": {GoIdent: "Nth3", Arity: 3, LgName: "nth", ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
 		},
 	})
 }
@@ -2655,15 +2672,6 @@ func installLangNS() {
 		return b.Chunk().(vm.Value), nil
 	})
 
-	// rangeInt coerces a range bound: Int passes through; anything
-	// else is a graceful error (a raw .(vm.Int) assertion panics).
-	rangeInt := func(v vm.Value, what string) (vm.Int, error) {
-		if n, ok := v.(vm.Int); ok {
-			return n, nil
-		}
-		return 0, fmt.Errorf("range %s must be an integer, got %s",
-			what, v.Type().Name())
-	}
 	rangef, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) == 0 {
 			// Infinite range: (range) -> lazy seq 0, 1, 2, ...
@@ -5493,26 +5501,6 @@ func installLangNS() {
 		return vm.String(string(s.(vm.String)) + "\n"), nil
 	})
 
-	regexSubmatchVector := func(s string, indices []int) vm.ArrayVector {
-		result := make(vm.ArrayVector, len(indices)/2)
-		for i := range result {
-			start, end := indices[2*i], indices[2*i+1]
-			if start < 0 {
-				result[i] = vm.NIL
-				continue
-			}
-			result[i] = vm.String(s[start:end])
-		}
-		return result
-	}
-
-	regexSubmatchValue := func(s string, indices []int) vm.Value {
-		if len(indices) == 2 {
-			return vm.String(s[indices[0]:indices[1]])
-		}
-		return regexSubmatchVector(s, indices)
-	}
-
 	// re-find: find first match of regex in string
 	reFind, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 2 {
@@ -8295,6 +8283,59 @@ func installLangNS() {
 		return vm.MakeMultiArity(fns)
 	})
 	ns.Def("make-multi-arity", makeMultiArityFn)
+
+	// with-arity — (with-arity f arity variadic?) wraps callable f in a native
+	// that DECLARES the given arity. ir.direct's invokers are necessarily
+	// (fn [& as] …) — the only shape able to receive an arbitrary call — which
+	// reports Arity() -1/variadic and so reads to MakeMultiArity as a rest-arm.
+	// Every arm of a multi-arity fn then collapses into ma.rest, leaving ma.fns
+	// empty and dispatch broken. Re-declaring the arity here keeps the shape
+	// the dispatcher needs without constraining how f is built.
+	withArityFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 3 {
+			return vm.NIL, fmt.Errorf("with-arity expects 3 args (fn arity variadic?)")
+		}
+		target, ok := vs[0].(vm.Fn)
+		if !ok {
+			return vm.NIL, fmt.Errorf("with-arity expects a fn, got %s", vs[0].Type().Name())
+		}
+		arity, ok := vs[1].(vm.Int)
+		if !ok {
+			return vm.NIL, fmt.Errorf("with-arity expects an int arity, got %s", vs[1].Type().Name())
+		}
+		name := ""
+		if named, ok := vs[0].(fmt.Stringer); ok {
+			name = named.String()
+		}
+		return vm.NewArityNativeFn(name, int(arity), vm.IsTruthy(vs[2]),
+			func(ec *vm.ExecContext, args []vm.Value) (vm.Value, error) {
+				return ec.Invoke(target, args)
+			}), nil
+	})
+	ns.Def("with-arity", withArityFn)
+
+	// alloc-slots — (alloc-slots n) returns a transient vector of n nils.
+	//
+	// The obvious spelling, (transient (vec (repeat n nil))), routes through a
+	// LAZY seq: `repeat` yields a cons per element, `vec` walks it, and the
+	// transient then copies. In ir.direct's evaluator that runs once per CALL
+	// to size the value table, making (*Repeat).Next one of the largest single
+	// allocation sites in the interpreter (~8% of all objects on fib). A
+	// sized make([]Value, n) does the same job with one allocation.
+	allocSlotsFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("alloc-slots expects 1 arg (count)")
+		}
+		n, ok := vs[0].(vm.Int)
+		if !ok {
+			return vm.NIL, fmt.Errorf("alloc-slots expects an int, got %s", vs[0].Type().Name())
+		}
+		if n < 0 {
+			return vm.NIL, fmt.Errorf("alloc-slots expects a non-negative count, got %d", int(n))
+		}
+		return vm.NewTransientVectorOfNils(int(n)), nil
+	})
+	ns.Def("alloc-slots", allocSlotsFn)
 
 	// sleep — sleep for n milliseconds
 	sleepf := vm.NewCtxNativeFn("sleep", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {

--- a/pkg/rt/native_prims.go
+++ b/pkg/rt/native_prims.go
@@ -8,6 +8,7 @@ package rt
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"unicode/utf8"
 
@@ -436,4 +437,481 @@ func reduceColl(ec *vm.ExecContext, mfn vm.Fn, coll vm.Value, hasInit bool, init
 	}
 
 	return acc, nil
+}
+
+// symbolToStr accepts the string-like values clojure.core/symbol takes as a
+// name or namespace component.
+func symbolToStr(v vm.Value) (string, bool) {
+	switch s := v.(type) {
+	case vm.String:
+		return string(s), true
+	case vm.Symbol:
+		return string(s), true
+	case vm.Keyword:
+		return string(s), true
+	default:
+		return "", false
+	}
+}
+
+// Symbol implements (symbol x): a String/Symbol/Keyword becomes a Symbol of
+// the same text, and a Var becomes its qualified name. Lives here rather than
+// in pkg/rt/builtins because the Var case needs externalNSName, which reads
+// rt's alias table — builtins imports only vm, by design.
+//
+//lg:native
+//lg:name symbol
+func Symbol(v vm.Value) (vm.Value, error) {
+	if v == vm.NIL {
+		return vm.NIL, fmt.Errorf("symbol expected String, Symbol, Keyword, or Var")
+	}
+	if vr, ok := v.(*vm.Var); ok {
+		return vm.Symbol(externalNSName(vr.NS()) + "/" + vr.VarName()), nil
+	}
+	if s, ok := symbolToStr(v); ok {
+		return vm.Symbol(s), nil
+	}
+	return vm.NIL, fmt.Errorf("symbol expected String or Symbol")
+}
+
+// Assoc implements the 3-arity (assoc coll k v). Higher arities stay on the
+// trampoline: the variadic form threads pairs left-to-right and is far rarer
+// in lowered code than the single-pair case.
+//
+//lg:native
+//lg:name assoc
+func Assoc(coll vm.Value, k vm.Value, v vm.Value) (vm.Value, error) {
+	a, ok := coll.(vm.Associative)
+	if !ok {
+		return vm.NIL, fmt.Errorf("assoc expected Associative")
+	}
+	ret := a.Assoc(k, v)
+	if ret == vm.NIL {
+		return vm.NIL, fmt.Errorf("assoc failed for key %s", k.String())
+	}
+	return ret, nil
+}
+
+// AssocBang implements the 3-arity (assoc! transient k v). The variadic form
+// (multiple k/v pairs) stays on the trampoline; the single-pair case is what
+// hot loops emit.
+//
+// Registered as a native because ir.direct's evaluator calls assoc! once per
+// INSTRUCTION to store each result into the indexed value table. Without an
+// entry here that call lowers to ec.Invoke plus a []vm.Value allocation on
+// every instruction executed — the single hottest trampoline in the
+// interpreter.
+//
+//lg:native
+//lg:name assoc!
+func AssocBang(coll vm.Value, k vm.Value, v vm.Value) (vm.Value, error) {
+	switch t := coll.(type) {
+	case *vm.TransientVector:
+		return t.Assoc(k, v)
+	case *vm.TransientMap:
+		return t.Assoc(k, v)
+	default:
+		return vm.NIL, fmt.Errorf("assoc! expected a transient, got %s", coll.Type().Name())
+	}
+}
+
+// swapAtom is the shared body for the swap! arities: ec.Bind(fn) is what makes
+// the atom's retry loop able to re-invoke the user function, which is why this
+// lives in rt (with ExecContext) rather than in the vm-only builtins package.
+func swapAtom(ec *vm.ExecContext, a vm.Value, f vm.Value, extra []vm.Value) (vm.Value, error) {
+	at, ok := a.(*vm.Atom)
+	if !ok {
+		return vm.NIL, fmt.Errorf("swap expected Atom")
+	}
+	fn, ok := vm.AsFn(f)
+	if !ok {
+		return vm.NIL, fmt.Errorf("swap expected Fn")
+	}
+	return at.Swap(ec.Bind(fn), extra)
+}
+
+// Swap implements (swap! a f).
+//
+//lg:native
+//lg:name swap!
+func Swap(ec *vm.ExecContext, a vm.Value, f vm.Value) (vm.Value, error) {
+	return swapAtom(ec, a, f, nil)
+}
+
+// Swap3 implements (swap! a f x).
+//
+//lg:native
+//lg:name swap!
+func Swap3(ec *vm.ExecContext, a vm.Value, f vm.Value, x vm.Value) (vm.Value, error) {
+	return swapAtom(ec, a, f, []vm.Value{x})
+}
+
+// NotEq implements the 2-arity (not= a b). It calls rt's own valueEquals —
+// NOT vm.ValueEquals / EqValue, which is a different function with different
+// nil and numeric handling — so not= stays exactly the negation of =. The NaN
+// case mirrors the interpreter path: two NaNs compare not-different here.
+//
+//lg:native
+//lg:name not=
+func NotEq(a vm.Value, b vm.Value) (vm.Value, error) {
+	if isNaNValue(a) && isNaNValue(b) {
+		return vm.FALSE, nil
+	}
+	return vm.Boolean(!valueEquals(a, b)), nil
+}
+
+// assocPairs threads key/value pairs left-to-right, the shared body for the
+// fixed assoc arities.
+func assocPairs(coll vm.Value, kvs ...vm.Value) (vm.Value, error) {
+	a, ok := coll.(vm.Associative)
+	if !ok {
+		return vm.NIL, fmt.Errorf("assoc expected Associative")
+	}
+	ret := a
+	for i := 0; i+1 < len(kvs); i += 2 {
+		next := ret.Assoc(kvs[i], kvs[i+1])
+		if next == vm.NIL {
+			return vm.NIL, fmt.Errorf("assoc failed for key %s", kvs[i].String())
+		}
+		// Assoc returns vm.Associative, so next is already that type.
+		ret = next
+	}
+	return ret, nil
+}
+
+// Assoc5 implements (assoc coll k1 v1 k2 v2).
+//
+//lg:native
+//lg:name assoc
+func Assoc5(coll, k1, v1, k2, v2 vm.Value) (vm.Value, error) {
+	return assocPairs(coll, k1, v1, k2, v2)
+}
+
+// Swap4 implements (swap! a f x y).
+//
+//lg:native
+//lg:name swap!
+func Swap4(ec *vm.ExecContext, a, f, x, y vm.Value) (vm.Value, error) {
+	return swapAtom(ec, a, f, []vm.Value{x, y})
+}
+
+// Swap5 implements (swap! a f x y z).
+//
+//lg:native
+//lg:name swap!
+func Swap5(ec *vm.ExecContext, a, f, x, y, z vm.Value) (vm.Value, error) {
+	return swapAtom(ec, a, f, []vm.Value{x, y, z})
+}
+
+// IsMap implements (map? x).
+//
+//lg:native
+//lg:name map?
+func IsMap(v vm.Value) (vm.Value, error) {
+	switch v.(type) {
+	case *vm.PersistentMap, *vm.SortedMap:
+		return vm.TRUE, nil
+	}
+	return vm.FALSE, nil
+}
+
+// Atom implements the 1-arity (atom x). The option-taking arities (:meta,
+// :validator) stay on the trampoline — they parse keyword pairs, which the
+// fixed-arity direct-call path is not the right shape for.
+//
+//lg:native
+//lg:name atom
+func Atom(v vm.Value) (vm.Value, error) {
+	return vm.NewAtomWithMetaValidator(v, nil, nil)
+}
+
+// Reset implements (reset! a v).
+//
+//lg:native
+//lg:name reset!
+func Reset(a vm.Value, v vm.Value) (vm.Value, error) {
+	at, ok := a.(*vm.Atom)
+	if !ok {
+		return vm.NIL, fmt.Errorf("reset expected Atom")
+	}
+	return at.Reset(v)
+}
+
+// Namespace implements (namespace x) for Named values.
+//
+//lg:native
+//lg:name namespace
+func Namespace(v vm.Value) (vm.Value, error) {
+	named, ok := v.(vm.Named)
+	if !ok {
+		return vm.NIL, fmt.Errorf("namespace expected Named")
+	}
+	return named.Namespace(), nil
+}
+
+// PushBinding implements (push-binding! v val) — the dynamic-binding
+// lifecycle, so it needs the ExecContext holding the binding stack.
+//
+//lg:native
+//lg:name push-binding!
+func PushBinding(ec *vm.ExecContext, v vm.Value, val vm.Value) (vm.Value, error) {
+	vr, ok := v.(*vm.Var)
+	if !ok {
+		return vm.NIL, fmt.Errorf("push-binding expected Var")
+	}
+	ec.PushBinding(vr, val)
+	return vm.NIL, nil
+}
+
+// PopBinding implements (pop-binding! v).
+//
+//lg:native
+//lg:name pop-binding!
+func PopBinding(ec *vm.ExecContext, v vm.Value) (vm.Value, error) {
+	vr, ok := v.(*vm.Var)
+	if !ok {
+		return vm.NIL, fmt.Errorf("pop-binding expected Var")
+	}
+	ec.PopBinding(vr)
+	return vm.NIL, nil
+}
+
+// regexSubmatchVector renders every capture group, with nil for groups that
+// did not participate in the match. Promoted from a lang.go closure alongside
+// regexSubmatchValue; both original call sites are same-package and unaffected.
+func regexSubmatchVector(s string, indices []int) vm.ArrayVector {
+	result := make(vm.ArrayVector, len(indices)/2)
+	for i := range result {
+		start, end := indices[2*i], indices[2*i+1]
+		if start < 0 {
+			result[i] = vm.NIL
+			continue
+		}
+		result[i] = vm.String(s[start:end])
+	}
+	return result
+}
+
+// regexSubmatchValue shapes a submatch-index result: a bare match returns the
+// String, a grouped match returns the vector. Promoted from a closure inside
+// lang.go's install fn so the direct-call natives here can share it — the two
+// original call sites are in the same package and are unaffected.
+func regexSubmatchValue(s string, indices []int) vm.Value {
+	if len(indices) == 2 {
+		return vm.String(s[indices[0]:indices[1]])
+	}
+	return regexSubmatchVector(s, indices)
+}
+
+// ReFind implements (re-find re s), reusing regexSubmatchValue so the
+// group-shaped result matches the interpreter path exactly.
+//
+//lg:native
+//lg:name re-find
+func ReFind(re vm.Value, s vm.Value) (vm.Value, error) {
+	r, ok := re.(*vm.Regex)
+	if !ok {
+		return vm.NIL, fmt.Errorf("re-find expected Regex")
+	}
+	str, ok := s.(vm.String)
+	if !ok {
+		return vm.NIL, fmt.Errorf("re-find expected String")
+	}
+	indices := r.FindStringSubmatchIndex(string(str))
+	if indices == nil {
+		return vm.NIL, nil
+	}
+	return regexSubmatchValue(string(str), indices), nil
+}
+
+// Some implements (some pred coll). Body extracted verbatim from lang.go's
+// closure (including the chunked fast path) rather than retyped, so the
+// direct-call path cannot drift from the interpreter path. Needs the
+// ExecContext to invoke the predicate.
+//
+//lg:native
+//lg:name some
+func Some(ec *vm.ExecContext, pred vm.Value, coll vm.Value) (vm.Value, error) {
+	f, ok := vm.AsFn(pred)
+	if !ok {
+		return vm.NIL, fmt.Errorf("some expected Fn")
+	}
+	seq, err := seqOf(coll)
+	if err != nil {
+		return vm.NIL, fmt.Errorf("some expected Seq")
+	}
+	// seqOf returns LazySeq directly; resolve here so an unresolved-empty
+	// LazySeq becomes nil instead of invoking the predicate once with nil.
+	if ls, ok := seq.(*vm.LazySeq); ok {
+		seq = ls.Resolve()
+	}
+	fargs := []vm.Value{nil}
+	for seq != nil {
+		// Chunked fast path: walk whole chunks via Nth to avoid per-element
+		// seq.Next()/First() churn on chunked sources such as vectors/ranges.
+		if cs, ok := vm.AsChunkedSeq(seq); ok {
+			c := cs.ChunkedFirst()
+			n := c.ChunkCount()
+			for i := 0; i < n; i++ {
+				fargs[0] = c.Nth(i)
+				v, err := ec.Invoke(f, fargs)
+				if err != nil {
+					return vm.NIL, err
+				}
+				if vm.IsTruthy(v) {
+					return v, nil
+				}
+			}
+			seq = cs.ChunkedNext()
+			continue
+		}
+		fargs[0] = seq.First()
+		v, err := ec.Invoke(f, fargs)
+		if err != nil {
+			return vm.NIL, err
+		}
+		if vm.IsTruthy(v) {
+			return v, nil
+		}
+		seq = seq.Next()
+	}
+
+	return vm.NIL, nil
+}
+
+// Int implements (int x). Body extracted verbatim from lang.go's closure —
+// including the int32 range guard and the per-type coercion table — rather
+// than retyped, so the direct-call path cannot drift from the interpreter.
+//
+//lg:native
+//lg:name int
+func Int(v vm.Value) (vm.Value, error) {
+	const minInt32 = -2147483648
+	const maxInt32 = 2147483647
+	coerce := func(f float64) (vm.Value, error) {
+		if f < minInt32 || f > maxInt32 {
+			return vm.NIL, fmt.Errorf("%s can't be coerced to int", v)
+		}
+		return vm.MakeInt(int(math.Trunc(f))), nil
+	}
+	switch v := v.(type) {
+	case vm.Int:
+		if v < minInt32 || v > maxInt32 {
+			return vm.NIL, fmt.Errorf("%s can't be coerced to int", v)
+		}
+		return v, nil
+	case vm.Float:
+		return coerce(float64(v))
+	case vm.Char:
+		return vm.Int(int(v)), nil
+	case *vm.BigInt:
+		if !v.Val().IsInt64() {
+			return vm.NIL, fmt.Errorf("%s can't be coerced to int", v)
+		}
+		i := v.Val().Int64()
+		if i < minInt32 || i > maxInt32 {
+			return vm.NIL, fmt.Errorf("%s can't be coerced to int", v)
+		}
+		return vm.MakeInt(int(i)), nil
+	case *vm.BigDecimal:
+		f, _ := v.Val().Float64()
+		return coerce(f)
+	case *vm.Ratio:
+		f, _ := v.Val().Float64()
+		return coerce(f)
+	case vm.Boolean:
+		if bool(v) {
+			return vm.MakeInt(1), nil
+		}
+		return vm.MakeInt(0), nil
+	default:
+		return vm.NIL, fmt.Errorf("%s can't be coerced to int", v)
+	}
+}
+
+// rangeInt coerces a range bound: Int passes through; anything else is a
+// graceful error (a raw .(vm.Int) assertion panics). Promoted from a lang.go
+// closure so the direct-call range arities can share it.
+func rangeInt(v vm.Value, what string) (vm.Int, error) {
+	if n, ok := v.(vm.Int); ok {
+		return n, nil
+	}
+	return 0, fmt.Errorf("range %s must be an integer, got %s",
+		what, v.Type().Name())
+}
+
+// rangeVals is the shared body of clojure.core/range, extracted verbatim from
+// lang.go's closure so the direct-call arities below and the interpreter path
+// cannot diverge.
+func rangeVals(vs []vm.Value) (vm.Value, error) {
+	if len(vs) == 0 {
+		// Infinite range: (range) -> lazy seq 0, 1, 2, ...
+		return vm.NewInfiniteRange(0, 1), nil
+	}
+	if len(vs) > 3 {
+		return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
+	}
+	var start, end, step vm.Int
+	step = 1
+	var err error
+	var endArg vm.Value
+	switch len(vs) {
+	case 1:
+		endArg = vs[0]
+	case 2:
+		endArg = vs[1]
+		if start, err = rangeInt(vs[0], "start"); err != nil {
+			return vm.NIL, err
+		}
+	case 3:
+		endArg = vs[1]
+		if start, err = rangeInt(vs[0], "start"); err != nil {
+			return vm.NIL, err
+		}
+		if step, err = rangeInt(vs[2], "step"); err != nil {
+			return vm.NIL, err
+		}
+	}
+	// A float end still yields integers, like the JVM: infinite
+	// for ##Inf toward the step, else every int short of the end
+	// ((range 2 5.29) => 2 3 4 5).
+	if f, ok := endArg.(vm.Float); ok {
+		if math.IsInf(float64(f), 0) {
+			if (f > 0 && step > 0) || (f < 0 && step < 0) {
+				return vm.NewInfiniteRange(int(start), int(step)), nil
+			}
+			return vm.NewRange(0, 0, 1), nil
+		}
+		if step > 0 {
+			endArg = vm.Int(math.Ceil(float64(f)))
+		} else {
+			endArg = vm.Int(math.Floor(float64(f)))
+		}
+	}
+	if end, err = rangeInt(endArg, "end"); err != nil {
+		return vm.NIL, err
+	}
+	return vm.NewRange(start, end, step), nil
+}
+
+// Range1 implements (range end).
+//
+//lg:native
+//lg:name range
+func Range1(end vm.Value) (vm.Value, error) { return rangeVals([]vm.Value{end}) }
+
+// Range2 implements (range start end).
+//
+//lg:native
+//lg:name range
+func Range2(start, end vm.Value) (vm.Value, error) {
+	return rangeVals([]vm.Value{start, end})
+}
+
+// Range3 implements (range start end step).
+//
+//lg:native
+//lg:name range
+func Range3(start, end, step vm.Value) (vm.Value, error) {
+	return rangeVals([]vm.Value{start, end, step})
 }

--- a/pkg/rt/zz_primitives_generated.go
+++ b/pkg/rt/zz_primitives_generated.go
@@ -6,6 +6,7 @@ package rt
 
 import (
 	"fmt"
+
 	"github.com/nooga/let-go/pkg/vm"
 )
 
@@ -233,24 +234,332 @@ func _adapt_Reduce3_arity3(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) 
 	return r, nil
 }
 
+func _adapt_Symbol(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 1 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 1", len(vs))
+	}
+	a0 := vs[0]
+	r, err := Symbol(a0)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Assoc(vs []vm.Value) (vm.Value, error) {
+	switch len(vs) {
+	case 3:
+		return _adapt_Assoc_arity3(vs)
+	case 5:
+		return _adapt_Assoc5_arity5(vs)
+	}
+	return vm.NIL, fmt.Errorf("wrong number of args (%d)", len(vs))
+}
+
+func _adapt_Assoc_arity3(vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	a2 := vs[2]
+	r, err := Assoc(a0, a1, a2)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Assoc5_arity5(vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	a2 := vs[2]
+	a3 := vs[3]
+	a4 := vs[4]
+	r, err := Assoc5(a0, a1, a2, a3, a4)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_AssocBang(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 3 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 3", len(vs))
+	}
+	a0 := vs[0]
+	a1 := vs[1]
+	a2 := vs[2]
+	r, err := AssocBang(a0, a1, a2)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Swap(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	switch len(vs) {
+	case 2:
+		return _adapt_Swap_arity2(ec, vs)
+	case 3:
+		return _adapt_Swap3_arity3(ec, vs)
+	case 4:
+		return _adapt_Swap4_arity4(ec, vs)
+	case 5:
+		return _adapt_Swap5_arity5(ec, vs)
+	}
+	return vm.NIL, fmt.Errorf("wrong number of args (%d)", len(vs))
+}
+
+func _adapt_Swap_arity2(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	r, err := Swap(ec, a0, a1)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Swap3_arity3(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	a2 := vs[2]
+	r, err := Swap3(ec, a0, a1, a2)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Swap4_arity4(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	a2 := vs[2]
+	a3 := vs[3]
+	r, err := Swap4(ec, a0, a1, a2, a3)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Swap5_arity5(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	a2 := vs[2]
+	a3 := vs[3]
+	a4 := vs[4]
+	r, err := Swap5(ec, a0, a1, a2, a3, a4)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_NotEq(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 2 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 2", len(vs))
+	}
+	a0 := vs[0]
+	a1 := vs[1]
+	r, err := NotEq(a0, a1)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_IsMap(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 1 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 1", len(vs))
+	}
+	a0 := vs[0]
+	r, err := IsMap(a0)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Atom(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 1 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 1", len(vs))
+	}
+	a0 := vs[0]
+	r, err := Atom(a0)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Reset(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 2 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 2", len(vs))
+	}
+	a0 := vs[0]
+	a1 := vs[1]
+	r, err := Reset(a0, a1)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Namespace(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 1 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 1", len(vs))
+	}
+	a0 := vs[0]
+	r, err := Namespace(a0)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_PushBinding(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 2 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 2", len(vs))
+	}
+	a0 := vs[0]
+	a1 := vs[1]
+	r, err := PushBinding(ec, a0, a1)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_PopBinding(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 1 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 1", len(vs))
+	}
+	a0 := vs[0]
+	r, err := PopBinding(ec, a0)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_ReFind(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 2 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 2", len(vs))
+	}
+	a0 := vs[0]
+	a1 := vs[1]
+	r, err := ReFind(a0, a1)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Some(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 2 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 2", len(vs))
+	}
+	a0 := vs[0]
+	a1 := vs[1]
+	r, err := Some(ec, a0, a1)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Int(vs []vm.Value) (vm.Value, error) {
+	if len(vs) != 1 {
+		return vm.NIL, fmt.Errorf("wrong number of args (%d), expected 1", len(vs))
+	}
+	a0 := vs[0]
+	r, err := Int(a0)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Range1(vs []vm.Value) (vm.Value, error) {
+	switch len(vs) {
+	case 1:
+		return _adapt_Range1_arity1(vs)
+	case 2:
+		return _adapt_Range2_arity2(vs)
+	case 3:
+		return _adapt_Range3_arity3(vs)
+	}
+	return vm.NIL, fmt.Errorf("wrong number of args (%d)", len(vs))
+}
+
+func _adapt_Range1_arity1(vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	r, err := Range1(a0)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Range2_arity2(vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	r, err := Range2(a0, a1)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
+func _adapt_Range3_arity3(vs []vm.Value) (vm.Value, error) {
+	a0 := vs[0]
+	a1 := vs[1]
+	a2 := vs[2]
+	r, err := Range3(a0, a1, a2)
+	if err != nil {
+		return vm.NIL, err
+	}
+	return r, nil
+}
+
 func RegisterGeneratedPrimitives() {
 	RegisterNativeModule(&NativeModule{
 		GoPkg:     "github.com/nooga/let-go/pkg/rt",
 		Namespace: "clojure.core",
 		Fns: map[string]NativeDirectFn{
-			"name":     {GoIdent: "Name", LgName: "name", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "string", NeedsError: true},
-			"subs@2":   {GoIdent: "Subs", LgName: "subs", Arity: 2, ParamSpecs: []string{"string", "int"}, ResultSpec: "string", NeedsError: true},
-			"subs@3":   {GoIdent: "Subs3", LgName: "subs", Arity: 3, ParamSpecs: []string{"string", "int", "int"}, ResultSpec: "string", NeedsError: true},
-			"nth@2":    {GoIdent: "Nth", LgName: "nth", Arity: 2, ParamSpecs: []string{"vm.Value", "int"}, ResultSpec: "vm.Value", NeedsError: true},
-			"nth@3":    {GoIdent: "Nth3", LgName: "nth", Arity: 3, ParamSpecs: []string{"vm.Value", "int", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
-			"deref@1":  {GoIdent: "Deref", LgName: "deref", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
-			"deref@3":  {GoIdent: "Deref3", LgName: "deref", Arity: 3, ParamSpecs: []string{"vm.Value", "int", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
-			"str":      {GoIdent: "Str", LgName: "str", Arity: -1, Variadic: true, ParamSpecs: []string{}, ResultSpec: "string", NeedsError: true},
-			"get@2":    {GoIdent: "Get", LgName: "get", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
-			"get@3":    {GoIdent: "Get3", LgName: "get", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
-			"conj":     {GoIdent: "Conj", LgName: "conj", Arity: -1, Variadic: true, ParamSpecs: []string{}, ResultSpec: "vm.Value", NeedsError: true},
-			"reduce@2": {GoIdent: "Reduce", LgName: "reduce", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
-			"reduce@3": {GoIdent: "Reduce3", LgName: "reduce", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"name":          {GoIdent: "Name", LgName: "name", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "string", NeedsError: true},
+			"subs@2":        {GoIdent: "Subs", LgName: "subs", Arity: 2, ParamSpecs: []string{"string", "int"}, ResultSpec: "string", NeedsError: true},
+			"subs@3":        {GoIdent: "Subs3", LgName: "subs", Arity: 3, ParamSpecs: []string{"string", "int", "int"}, ResultSpec: "string", NeedsError: true},
+			"nth@2":         {GoIdent: "Nth", LgName: "nth", Arity: 2, ParamSpecs: []string{"vm.Value", "int"}, ResultSpec: "vm.Value", NeedsError: true},
+			"nth@3":         {GoIdent: "Nth3", LgName: "nth", Arity: 3, ParamSpecs: []string{"vm.Value", "int", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"deref@1":       {GoIdent: "Deref", LgName: "deref", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"deref@3":       {GoIdent: "Deref3", LgName: "deref", Arity: 3, ParamSpecs: []string{"vm.Value", "int", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"str":           {GoIdent: "Str", LgName: "str", Arity: -1, Variadic: true, ParamSpecs: []string{}, ResultSpec: "string", NeedsError: true},
+			"get@2":         {GoIdent: "Get", LgName: "get", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"get@3":         {GoIdent: "Get3", LgName: "get", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"conj":          {GoIdent: "Conj", LgName: "conj", Arity: -1, Variadic: true, ParamSpecs: []string{}, ResultSpec: "vm.Value", NeedsError: true},
+			"reduce@2":      {GoIdent: "Reduce", LgName: "reduce", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"reduce@3":      {GoIdent: "Reduce3", LgName: "reduce", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"symbol":        {GoIdent: "Symbol", LgName: "symbol", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"assoc@3":       {GoIdent: "Assoc", LgName: "assoc", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"assoc@5":       {GoIdent: "Assoc5", LgName: "assoc", Arity: 5, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"assoc!":        {GoIdent: "AssocBang", LgName: "assoc!", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"swap!@2":       {GoIdent: "Swap", LgName: "swap!", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"swap!@3":       {GoIdent: "Swap3", LgName: "swap!", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"swap!@4":       {GoIdent: "Swap4", LgName: "swap!", Arity: 4, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"swap!@5":       {GoIdent: "Swap5", LgName: "swap!", Arity: 5, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"not=":          {GoIdent: "NotEq", LgName: "not=", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"map?":          {GoIdent: "IsMap", LgName: "map?", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"atom":          {GoIdent: "Atom", LgName: "atom", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"reset!":        {GoIdent: "Reset", LgName: "reset!", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"namespace":     {GoIdent: "Namespace", LgName: "namespace", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"push-binding!": {GoIdent: "PushBinding", LgName: "push-binding!", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"pop-binding!":  {GoIdent: "PopBinding", LgName: "pop-binding!", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"re-find":       {GoIdent: "ReFind", LgName: "re-find", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"some":          {GoIdent: "Some", LgName: "some", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true, NeedsEC: true},
+			"int":           {GoIdent: "Int", LgName: "int", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"range@1":       {GoIdent: "Range1", LgName: "range", Arity: 1, ParamSpecs: []string{"vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"range@2":       {GoIdent: "Range2", LgName: "range", Arity: 2, ParamSpecs: []string{"vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
+			"range@3":       {GoIdent: "Range3", LgName: "range", Arity: 3, ParamSpecs: []string{"vm.Value", "vm.Value", "vm.Value"}, ResultSpec: "vm.Value", NeedsError: true},
 		},
 	})
 	// Bind adapters into namespace
@@ -270,6 +579,32 @@ func RegisterGeneratedPrimitives() {
 		fn6, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Conj(vs) })
 		defGeneratedPrimitive(ns, "clojure.core", "conj", fn6)
 		defGeneratedPrimitive(ns, "clojure.core", "reduce", vm.NewCtxNativeFn("reduce", _adapt_Reduce))
+		fn8, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Symbol(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "symbol", fn8)
+		fn9, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Assoc(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "assoc", fn9)
+		fn10, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_AssocBang(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "assoc!", fn10)
+		defGeneratedPrimitive(ns, "clojure.core", "swap!", vm.NewCtxNativeFn("swap!", _adapt_Swap))
+		fn12, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_NotEq(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "not=", fn12)
+		fn13, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_IsMap(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "map?", fn13)
+		fn14, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Atom(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "atom", fn14)
+		fn15, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Reset(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "reset!", fn15)
+		fn16, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Namespace(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "namespace", fn16)
+		defGeneratedPrimitive(ns, "clojure.core", "push-binding!", vm.NewCtxNativeFn("push-binding!", _adapt_PushBinding))
+		defGeneratedPrimitive(ns, "clojure.core", "pop-binding!", vm.NewCtxNativeFn("pop-binding!", _adapt_PopBinding))
+		fn19, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_ReFind(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "re-find", fn19)
+		defGeneratedPrimitive(ns, "clojure.core", "some", vm.NewCtxNativeFn("some", _adapt_Some))
+		fn21, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Int(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "int", fn21)
+		fn22, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) { return _adapt_Range1(vs) })
+		defGeneratedPrimitive(ns, "clojure.core", "range", fn22)
 	}
 	RegisterNativeModule(&NativeModule{
 		GoPkg:     "github.com/nooga/let-go/pkg/rt",

--- a/pkg/vm/func.go
+++ b/pkg/vm/func.go
@@ -110,13 +110,23 @@ func (l *Func) invokeIn(ec *ExecContext, pargs []Value) (result Value, err error
 		if len(args) < l.arity-1 {
 			return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", l, l.arity-1, len(args)))
 		}
-		sargs := args[0 : l.arity-1]
 		rest := args[l.arity-1:]
 		restlist, boxErr := boxRest(rest)
 		if boxErr != nil {
 			return NIL, boxErr
 		}
-		args = append(sargs, restlist)
+		// Build a FRESH slice; do not append into args' backing array.
+		// `append(args[0:l.arity-1], restlist)` reuses the caller's array
+		// (the reslice keeps its capacity), so the packed rest-list is
+		// written over the caller's element l.arity-1 — for a plain
+		// (fn [& as]) that is args[0]. A Go caller reusing one []Value
+		// across invocations then sees its arguments silently replaced by
+		// the previous call's rest-list: correct on the first call, garbage
+		// on the second.
+		packed := make([]Value, l.arity)
+		copy(packed, args[:l.arity-1])
+		packed[l.arity-1] = restlist
+		args = packed
 	} else if len(args) != l.arity {
 		return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, l.arity, len(args)))
 	}
@@ -212,13 +222,17 @@ func (l *Closure) invokeIn(ec *ExecContext, pargs []Value) (result Value, err er
 			if len(args) < f.arity-1 {
 				return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", l, f.arity-1, len(args)))
 			}
-			sargs := args[0 : f.arity-1]
 			rest := args[f.arity-1:]
 			restlist, boxErr := boxRest(rest)
 			if boxErr != nil {
 				return NIL, boxErr
 			}
-			args = append(sargs, restlist)
+			// Fresh slice — see Func.invokeIn for why appending into the
+			// caller's backing array corrupts the caller's arguments.
+			packed := make([]Value, f.arity)
+			copy(packed, args[:f.arity-1])
+			packed[f.arity-1] = restlist
+			args = packed
 		} else if len(args) != f.arity {
 			return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, f.arity, len(args)))
 		}
@@ -348,6 +362,12 @@ func MakeMultiArity(fns []Value) (*MultiArityFn, error) {
 			ma.arity = a
 		}
 		if rest, ok := f.(*Func); ok && rest.isVariadric {
+			ma.rest = rest
+		} else if rest, ok := f.(*NativeFn); ok && rest.isVariadric {
+			// A wrapped callable declaring a variadic tail (ir.direct's
+			// invokers via NewArityNativeFn). Without this arm it would be
+			// filed as a FIXED arity in ma.fns, so (f a b c) past the
+			// declared minimum would find no match instead of the rest-arm.
 			ma.rest = rest
 		} else if rest, ok := f.(*Closure); ok {
 			if ff, ok := rest.fn.(*Func); ok && ff.isVariadric {

--- a/pkg/vm/native_func.go
+++ b/pkg/vm/native_func.go
@@ -183,6 +183,22 @@ func NewCtxNativeFn(name string, fn func(ec *ExecContext, args []Value) (Value, 
 	return n
 }
 
+// NewArityNativeFn builds a context-aware native that DECLARES a fixed arity
+// (or a variadic minimum) rather than the -1/variadic default NewCtxNativeFn
+// uses. The declared arity is what MakeMultiArity dispatches on: an arm whose
+// Arity() is -1 and isVariadric is true is indistinguishable from a rest-arm,
+// so a wrapper built the ordinary way collapses every arm of a multi-arity fn
+// into ma.rest and leaves ma.fns empty. Callers that wrap an opaque callable
+// (ir.direct's invokers) use this to keep the arity visible to dispatch.
+func NewArityNativeFn(name string, arity int, variadic bool, fn func(ec *ExecContext, args []Value) (Value, error)) *NativeFn {
+	n := &NativeFn{name: name, arity: arity, isVariadric: variadic, ctxProxy: fn}
+	n.proxy = func(args []Value) (Value, error) { return fn(RootExecContext, args) }
+	return n
+}
+
+// IsVariadic reports whether this native declares a variadic tail.
+func (l *NativeFn) IsVariadic() bool { return l.isVariadric }
+
 func (l *NativeFn) SetName(n string) { l.name = n }
 
 func (l *NativeFn) Type() ValueType { return NativeFnType }

--- a/pkg/vm/transient.go
+++ b/pkg/vm/transient.go
@@ -194,6 +194,21 @@ type TransientVector struct {
 	array []Value
 }
 
+// NewTransientVectorOfNils returns an editable transient vector of n NIL
+// slots in a single allocation. Callers that need an indexed scratch table
+// (ir.direct's per-call value array) would otherwise build it as
+// (vec (repeat n nil)) — a lazy seq walked element by element — which costs
+// one cons per slot before the transient copy even starts.
+func NewTransientVectorOfNils(n int) *TransientVector {
+	array := make([]Value, n)
+	for i := range array {
+		array[i] = NIL
+	}
+	t := &TransientVector{array: array}
+	t.edit.Store(true)
+	return t
+}
+
 func NewTransientVector(v []Value) *TransientVector {
 	t := &TransientVector{
 		array: make([]Value, len(v)),

--- a/pkg/vm/variadic_alias_test.go
+++ b/pkg/vm/variadic_alias_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import "testing"
+
+// TestVariadicInvokeDoesNotAliasCallerArgs pins the fix for a slice-aliasing
+// bug in variadic invocation.
+//
+// invokeIn used to pack the rest-list with
+//
+//	args = append(args[0:arity-1], restlist)
+//
+// The reslice keeps the caller's backing array, so append WROTE the packed
+// rest-list over the caller's element arity-1 — for a plain (fn [& as]),
+// args[0]. A Go caller reusing one []Value across invocations got the right
+// answer on the first call and garbage on the second, since its arguments had
+// been replaced by the previous call's rest-list. Lisp call sites never saw it
+// because they build a fresh argument vector per call.
+func TestVariadicInvokeDoesNotAliasCallerArgs(t *testing.T) {
+	// (fn [& as] as) — arity 1, variadic: the shape that clobbers args[0].
+	chunk := NewCodeChunk(NewConsts())
+	chunk.Append(OP_LOAD_ARG, 0)
+	chunk.Append(OP_RETURN)
+	chunk.SetMaxStack(2)
+	fn := MakeFunc(1, true, chunk)
+
+	args := []Value{Int(7), Int(11)}
+	first, err := fn.Invoke(args)
+	if err != nil {
+		t.Fatalf("first invoke: %v", err)
+	}
+	if args[0] != Value(Int(7)) || args[1] != Value(Int(11)) {
+		t.Fatalf("caller args mutated: got [%v %v], want [7 11]", args[0], args[1])
+	}
+
+	second, err := fn.Invoke(args)
+	if err != nil {
+		t.Fatalf("second invoke: %v", err)
+	}
+	if first.String() != second.String() {
+		t.Errorf("repeated invoke differs: first=%v second=%v", first, second)
+	}
+}

--- a/test/native-bridge-parity.lg
+++ b/test/native-bridge-parity.lg
@@ -3,9 +3,10 @@
 ;; identically whether dispatched through the native fast path (gogen_ir
 ;; direct calls / NativeFn adapters) or the bytecode trampoline.
 (ns test.native-bridge-parity-test
-  (:require [test :refer :all]
-            [rt]
-            [clojure.string :as cs]))
+  (:require
+   [clojure.string :as cs]
+   [rt]
+   [test :refer :all]))
 
 (deftest string-prims
   (testing "upper-case via the native bridge"
@@ -119,6 +120,51 @@
     (with-redefs [cs/upper-case (fn [x] "X")]
       (is (= "Xb" (cs/capitalize "ab"))))
     (is (= "Ab" (cs/capitalize "ab")))))
+
+(deftest redefinition-guard-self-scoped
+  ;; Companion to redefinition-guard above, covering the OTHER direction.
+  ;;
+  ;; redefinition-guard proves a redef in a CALLER's extent is observed by a
+  ;; separate lowered callee (group-by's baked rt.Reduce3). This one covers a
+  ;; function that redefines a primitive WITHIN ITSELF and then calls it — the
+  ;; case pkg/ir/native_direct_call_test.go's TestWithRedefsDisablesNativeDirect
+  ;; guards statically, by asserting no baked corefns.Count is emitted at all.
+  ;;
+  ;; The two guards are not equivalent. The static one bans the native call
+  ;; from the source; this one asserts the OBSERVABLE property — the redefined
+  ;; root is what runs. If the runtime guard (rt.NativePrimsIntact, a deviation
+  ;; counter over guarded roots) covers the self-scoped case as it does the
+  ;; cross-boundary one, then the static ban is stricter than the behaviour
+  ;; requires, and lower_go's *direct-calls-disabled?* could stop rejecting
+  ;; :native? candidates — which today costs every native call in ANY
+  ;; var-root-mutating function (ir.direct's evaluator loses nth/get/count/
+  ;; assoc! to it, one ec.Invoke plus a []vm.Value allocation per call).
+  ;;
+  ;; This test must hold either way: it pins behaviour, not emission strategy.
+  (testing "a fn that redefines count inside itself observes its own redef"
+    (let [probe (fn [xs] (with-redefs [count (fn [_] 42)] (count xs)))]
+      (is (= 42 (probe [1 2 3])))
+      ;; root restored on unwind
+      (is (= 3 (count [1 2 3])))))
+  (testing "the guard is tripped for the duration of the self-scoped redef"
+    (let [inside (atom nil)
+          probe  (fn [xs]
+                   (with-redefs [count (fn [_] 42)]
+                     (reset! inside (rt/native-prims-intact?))
+                     (count xs)))]
+      (is (= 42 (probe [1 2 3])))
+      (is (= false @inside))
+      (is (= true (rt/native-prims-intact?)))))
+  (testing "a redef of one primitive does not corrupt another"
+    (let [probe (fn [xs] (with-redefs [count (fn [_] 42)] [(count xs) (nth xs 0)]))]
+      (is (= [42 1] (probe [1 2 3])))))
+  (testing "nested self-scoped redefs unwind in order"
+    (let [probe (fn [xs]
+                  (with-redefs [count (fn [_] 1)]
+                    (with-redefs [count (fn [_] 2)]
+                      (count xs))))]
+      (is (= 2 (probe [1 2 3])))
+      (is (= 3 (count [1 2 3]))))))
 
 (deftest error-paths
   (testing "native fast path and trampoline throw alike"

--- a/test/zz_compat_test.go
+++ b/test/zz_compat_test.go
@@ -102,6 +102,33 @@ func TestClojureTestSuite(t *testing.T) {
 		t.Fatal("failed to compile portability shim:", err)
 	}
 
+	// Mirror the bench's mode selection (zz_bench_test.go): LG_SUITE_IR routes
+	// every test-file fn body through the IR pipeline. The bench reports only
+	// aggregate counters and sends per-assertion output to /dev/null, so an
+	// IR-only failure shows up there as "fail=4" with no way to see WHICH
+	// assertions broke. Honoring the same env var here gets named per-file
+	// subtests and the assertion text, which is what makes an IR regression
+	// diagnosable rather than merely countable.
+	if suiteIRMode() {
+		irCtx := compiler.NewCompiler(c, coreNS)
+		if _, _, err := irCtx.CompileMultiple(strings.NewReader(
+			"(require 'ir.passes.pipeline)\n(set! *ir-compile* true)",
+		)); err != nil {
+			t.Fatal("enable *ir-compile*:", err)
+		}
+		defer func() {
+			// *ir-compile* is a process-global: if this reset fails silently the
+			// flag stays ON and leaks into every later test in the package
+			// (TestRunner's .lg suite included), corrupting unrelated results
+			// while still looking clean. Report it rather than discarding it.
+			reset := compiler.NewCompiler(c, coreNS)
+			if _, _, err := reset.CompileMultiple(strings.NewReader("(set! *ir-compile* false)")); err != nil {
+				t.Errorf("failed to reset *ir-compile* — later tests in this package "+
+					"may run with IR compilation still enabled: %v", err)
+			}
+		}()
+	}
+
 	var files []string
 	for _, dir := range []string{"core_test", "string_test"} {
 		matches, err := filepath.Glob(filepath.Join(suiteRoot, dir, "*.cljc"))


### PR DESCRIPTION
Direct-links lowered Go->Go calls for the hot clojure.core native surface: the var-dispatch boundary stays overridable (with-redefs / ^:dynamic / ^:redef exempt), only the interior is direct-linked to native `pkg.GoFn(args)`.

Benchmarks (Apple M3): gogen `IRCompile` **-3.5% time / -5.6% allocs** (170.1k -> 160.5k, p=0.000). vm `VariadicInvoke` **-22% / -46% time** (an aliasing-correctness fix; +1 alloc).

Stacks on #579 and #580 — this branch includes them, so review after those land.