### PR TITLE
fix(ir/lower-go): compute cross-package :needs-error? under the ns's own deftype/protocol registries

### DIFF
--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -1513,31 +1513,51 @@
    are their own callable name — no `LG_` forwarding wrapper), so a cross-package
    call resolves to `pkg.Conj(ec,…)`. :refs are the cross-ns callees it references
    (same-ns calls filtered — those resolve intra-package with no import)."
-  (binding [*ns* (the-ns ns-sym)
-            ir.passes.typeinfer/*typeinfer-max-drains* nil
-            ;; Same pure map bound in lower-ns-to-go so the registry's :go-name and
-            ;; the emitted decl agree on a collision-resolved export name.
-            lower-go/*export-name-overrides* (lower-go/build-export-name-map forms)]
-    (let [cross   (atom {})
-          results (binding [lower-go/*cross-ns-vars-used* cross]
-                    (lower-defn-forms (order-defn-forms forms)))
-          exports (reduce
-                    (fn [m r]
-                      (let [base (when (:decl r)
-                                   (lower-go/registry-entry-from-result r ns-sym pkg-name))]
-                        (if base
-                          (into m (map (fn [kv]
-                                         [(key kv) (assoc (val kv)
-                                                          :go-pkg  import-path)])
-                                       base))
-                          m)))
-                    {} results)
-          ns-str  (str ns-sym)
-          refs    (reduce (fn [s kv]
-                            (let [k (key kv)]      ; k = [ns-str name-str]
-                              (if (= (first k) ns-str) s (conj s k))))
-                          #{} @cross)]
-      {:exports exports :refs refs})))
+  ;; Derive this ns's OWN deftype/protocol registries (mirrors lower-ns-to-go)
+  ;; and bind them BEFORE lowering computes :needs-error?, so the cross-package
+  ;; effect recorded here matches lower-ns-to-go's emitted signature. Without
+  ;; them, call-error-free? cannot see the ns's protocol methods, so a fn that
+  ;; devirtualizes protocol dispatch (1-value) is recorded as error-producing
+  ;; (2-value) — a cross-package disagreement that miscompiles the caller
+  ;; (`v, callErr = OneValueFn(...)` against a `(vm.Value)` signature).
+  (let [decl-form?  (fn [form]
+                      (and (seq? form)
+                           (contains? #{'defprotocol 'deftype 'defmulti 'defmethod} (first form))))
+        decl-forms  (filterv decl-form? forms)
+        captures    (mapv (fn [form] (binding [*target* :go] (compile-form* form))) decl-forms)
+        protocols   (filterv (fn [c] (= :defprotocol (:decl-kind c))) captures)
+        deftypes    (filterv (fn [c] (= :deftype (:decl-kind c))) captures)
+        protocol-method-set (into #{} (mapcat (fn [p] (map (fn [m] (str (first m))) (:methods p))) protocols))
+        ctors       (into {} (map (fn [dt] [(str "->" (:name dt)) (lower-go/go-export-name (:name dt))]) deftypes))]
+    (binding [*ns* (the-ns ns-sym)
+              ir.passes.typeinfer/*typeinfer-max-drains* nil
+              ;; Same pure map bound in lower-ns-to-go so the registry's :go-name and
+              ;; the emitted decl agree on a collision-resolved export name.
+              lower-go/*export-name-overrides* (lower-go/build-export-name-map forms)
+              lower-go/*deftype-ctors* (when (seq ctors) ctors)
+              lower-go/*protocol-methods* (when (seq protocol-method-set) protocol-method-set)
+              lower-go/*protocol-method-sigs* (let [s (protocol-method-sigs deftypes)]
+                                                (when (seq s) s))]
+      (let [cross   (atom {})
+            results (binding [lower-go/*cross-ns-vars-used* cross]
+                      (lower-defn-forms (order-defn-forms forms)))
+            exports (reduce
+                      (fn [m r]
+                        (let [base (when (:decl r)
+                                     (lower-go/registry-entry-from-result r ns-sym pkg-name))]
+                          (if base
+                            (into m (map (fn [kv]
+                                           [(key kv) (assoc (val kv)
+                                                            :go-pkg  import-path)])
+                                         base))
+                            m)))
+                      {} results)
+            ns-str  (str ns-sym)
+            refs    (reduce (fn [s kv]
+                              (let [k (key kv)]      ; k = [ns-str name-str]
+                                (if (= (first k) ns-str) s (conj s k))))
+                            #{} @cross)]
+        {:exports exports :refs refs}))))
 
 (defn- cross-pkg-owners [global-reg]
   "Internal-ns symbols that OWN at least one cross-package export — i.e. the

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-3e6422d48afd47a710f152282f00679029a1ce7144036d8774eee0831e857d87
+1f9b28d406b0b9ccc62619972dc221218c6a600daa2b3f8564e4ff7376d637ed


### PR DESCRIPTION
`collect-ns-exports` (the phase-0 cross-package registry builder) lowered each ns WITHOUT binding its `*deftype-ctors*`/`*protocol-methods*`/`*protocol-method-sigs*`, so the cross-pkg `:needs-error?` was a pre-devirtualization snapshot that could disagree with lower-ns-to-go's emitted signature — miscompiling a caller as `v, callErr = OneValueFn(...)` against a 1-value `(vm.Value)` signature (the #281 error-effect-across-SCC gap). Bind the same three registries in collect-ns-exports first, so the cross-package effect matches the emission.

Surfaces when deftype/defprotocol forwarding (next PR) devirtualizes `ops.LowerOp`'s protocol calls to error-free `recv.Method` calls. Verified: gogen_ir build clean, ir-stress +9 (2418/2429), deterministic.