### PR TITLE
feat(lgbgen): forward defprotocol/deftype forms to native lowering (deftype-native T9 gap)

### DIFF
--- a/cmd/lgbgen/main.go
+++ b/cmd/lgbgen/main.go
@@ -871,7 +871,7 @@ func runGoTarget(outDir, codeDir string) {
 				fmt.Fprintf(os.Stderr, "%s: read error: %v\n", ns.name, err)
 				os.Exit(1)
 			}
-			if isDefnOnly(form) || isMultimethodForm(form) {
+			if isDefnOnly(form) || isMultimethodForm(form) || isTypeDeclForm(form) {
 				defnForms = append(defnForms, form)
 			}
 		}
@@ -1135,6 +1135,32 @@ func isMultimethodForm(form vm.Value) bool {
 		return false
 	}
 	return string(sym) == "defmulti" || string(sym) == "defmethod"
+}
+
+// isTypeDeclForm returns true for (defprotocol ...) / (deftype ...) forms.
+// They are forwarded to the Go-lowering pipeline so lower-ns-to-go can
+// capture them, emit native decls (interface / struct + constructor +
+// receiver methods), and bind the deftype-ctor + protocol-method registries
+// that let the namespace's own defns type (->T ...) as [:dtype T], lower the
+// constructor to a native call, and devirtualize protocol-method calls on a
+// known-concrete receiver to a direct recv.Method(ec, ...) call. Without
+// this forwarding the registries bind to nil and every such call silently
+// takes the boxed rt.CachedVarFn trampoline (the T9 gap: the .lg capture
+// machinery existed but the driver starved it of the decl forms).
+func isTypeDeclForm(form vm.Value) bool {
+	list, ok := form.(vm.Sequable)
+	if !ok {
+		return false
+	}
+	seq := list.Seq()
+	if seq == nil {
+		return false
+	}
+	sym, ok := seq.First().(vm.Symbol)
+	if !ok {
+		return false
+	}
+	return string(sym) == "defprotocol" || string(sym) == "deftype"
 }
 
 // isSingleArityDefn reports whether a defn/defn- form has exactly one arity.

--- a/pkg/ir/lowered_ops_devirt_test.go
+++ b/pkg/ir/lowered_ops_devirt_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestLoweredOpsDevirtualized guards the lgbgen driver half of the deftype
+// native lowering (T9): lower-ns-to-go captures defprotocol/deftype forms,
+// emits native interface/struct/method decls, and binds the registries that
+// devirtualize (->ConstOp) to a native constructor and (op-infer recv ...)
+// to a direct method call — but only if the driver FORWARDS those forms.
+// cmd/lgbgen's form filter used to keep only defn/defmulti forms, silently
+// starving the machinery: ir.ops lowered with every protocol call as a
+// boxed rt.CachedVarFn trampoline and no type decls at all.
+//
+// Content-based over the lowered --target=go artifact, so a filter regression
+// fails here without re-running lgbgen. That tree (pkg/rt/core_go_lowered/) is
+// gitignored and a clean checkout does not contain it — `go generate ./pkg/rt/`
+// only rebuilds core_compiled.lgb, not the --target=go tree — so this SKIPS
+// when the artifact is absent (the default -short CI lane and fresh clones)
+// rather than failing on ENOENT. It runs wherever the tree has been generated
+// (local dev after `make generate`); the same forwarding regression is also
+// caught in CI by the -tags gogen_ir wire build (undefined symbols) and by
+// check-generated.
+func TestLoweredOpsDevirtualized(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+	loweredOps := filepath.Join(repoRoot, "pkg", "rt", "core_go_lowered", "ir", "ops", "ops.go")
+	b, err := os.ReadFile(loweredOps)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skip("lowered --target=go tree absent (gitignored; run `make generate`); " +
+				"forwarding regressions are covered by the -tags gogen_ir wire build and check-generated")
+		}
+		t.Fatalf("read lowered ir/ops: %v", err)
+	}
+	src := string(b)
+
+	for _, marker := range []string{
+		// deftype decls emitted natively (go-export-name collapses interior
+		// caps: ConstOp -> Constop). #555's ops.lg reifies only :const
+		// (op-registry {:const (->ConstOp)}); further op-types (Tryop, …)
+		// are added as the catalog reifies them — assert the ones present.
+		"type Constop struct",
+		// protocol interface emitted
+		"type Irop interface",
+		// protocol-method call on a known-concrete receiver devirtualized
+		// to a direct method call (any receiver ident, so match loosely)
+		".OpInfer(ec",
+	} {
+		if !strings.Contains(src, marker) {
+			t.Errorf("lowered ir/ops missing %q — defprotocol/deftype forms not forwarded to lower-ns-to-go (lgbgen form filter) or devirtualization regressed", marker)
+		}
+	}
+
+	// The devirtualized arms must not fall back to the boxed trampoline for
+	// the protocol method itself.
+	if strings.Contains(src, `"ir.ops", "op-infer"`) {
+		t.Errorf("lowered ir/ops still dispatches op-infer through rt.CachedVarFn — protocol call not devirtualized")
+	}
+}

--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -1513,31 +1513,51 @@
    are their own callable name — no `LG_` forwarding wrapper), so a cross-package
    call resolves to `pkg.Conj(ec,…)`. :refs are the cross-ns callees it references
    (same-ns calls filtered — those resolve intra-package with no import)."
-  (binding [*ns* (the-ns ns-sym)
-            ir.passes.typeinfer/*typeinfer-max-drains* nil
-            ;; Same pure map bound in lower-ns-to-go so the registry's :go-name and
-            ;; the emitted decl agree on a collision-resolved export name.
-            lower-go/*export-name-overrides* (lower-go/build-export-name-map forms)]
-    (let [cross   (atom {})
-          results (binding [lower-go/*cross-ns-vars-used* cross]
-                    (lower-defn-forms (order-defn-forms forms)))
-          exports (reduce
-                    (fn [m r]
-                      (let [base (when (:decl r)
-                                   (lower-go/registry-entry-from-result r ns-sym pkg-name))]
-                        (if base
-                          (into m (map (fn [kv]
-                                         [(key kv) (assoc (val kv)
-                                                          :go-pkg  import-path)])
-                                       base))
-                          m)))
-                    {} results)
-          ns-str  (str ns-sym)
-          refs    (reduce (fn [s kv]
-                            (let [k (key kv)]      ; k = [ns-str name-str]
-                              (if (= (first k) ns-str) s (conj s k))))
-                          #{} @cross)]
-      {:exports exports :refs refs})))
+  ;; Derive this ns's OWN deftype/protocol registries (mirrors lower-ns-to-go)
+  ;; and bind them BEFORE lowering computes :needs-error?, so the cross-package
+  ;; effect recorded here matches lower-ns-to-go's emitted signature. Without
+  ;; them, call-error-free? cannot see the ns's protocol methods, so a fn that
+  ;; devirtualizes protocol dispatch (1-value) is recorded as error-producing
+  ;; (2-value) — a cross-package disagreement that miscompiles the caller
+  ;; (`v, callErr = OneValueFn(...)` against a `(vm.Value)` signature).
+  (let [decl-form?  (fn [form]
+                      (and (seq? form)
+                           (contains? #{'defprotocol 'deftype 'defmulti 'defmethod} (first form))))
+        decl-forms  (filterv decl-form? forms)
+        captures    (mapv (fn [form] (binding [*target* :go] (compile-form* form))) decl-forms)
+        protocols   (filterv (fn [c] (= :defprotocol (:decl-kind c))) captures)
+        deftypes    (filterv (fn [c] (= :deftype (:decl-kind c))) captures)
+        protocol-method-set (into #{} (mapcat (fn [p] (map (fn [m] (str (first m))) (:methods p))) protocols))
+        ctors       (into {} (map (fn [dt] [(str "->" (:name dt)) (lower-go/go-export-name (:name dt))]) deftypes))]
+    (binding [*ns* (the-ns ns-sym)
+              ir.passes.typeinfer/*typeinfer-max-drains* nil
+              ;; Same pure map bound in lower-ns-to-go so the registry's :go-name and
+              ;; the emitted decl agree on a collision-resolved export name.
+              lower-go/*export-name-overrides* (lower-go/build-export-name-map forms)
+              lower-go/*deftype-ctors* (when (seq ctors) ctors)
+              lower-go/*protocol-methods* (when (seq protocol-method-set) protocol-method-set)
+              lower-go/*protocol-method-sigs* (let [s (protocol-method-sigs deftypes)]
+                                                (when (seq s) s))]
+      (let [cross   (atom {})
+            results (binding [lower-go/*cross-ns-vars-used* cross]
+                      (lower-defn-forms (order-defn-forms forms)))
+            exports (reduce
+                      (fn [m r]
+                        (let [base (when (:decl r)
+                                     (lower-go/registry-entry-from-result r ns-sym pkg-name))]
+                          (if base
+                            (into m (map (fn [kv]
+                                           [(key kv) (assoc (val kv)
+                                                            :go-pkg  import-path)])
+                                         base))
+                            m)))
+                      {} results)
+            ns-str  (str ns-sym)
+            refs    (reduce (fn [s kv]
+                              (let [k (key kv)]      ; k = [ns-str name-str]
+                                (if (= (first k) ns-str) s (conj s k))))
+                            #{} @cross)]
+        {:exports exports :refs refs}))))
 
 (defn- cross-pkg-owners [global-reg]
   "Internal-ns symbols that OWN at least one cross-package export — i.e. the

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-3e6422d48afd47a710f152282f00679029a1ce7144036d8774eee0831e857d87
+1f9b28d406b0b9ccc62619972dc221218c6a600daa2b3f8564e4ff7376d637ed

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-1f9b28d406b0b9ccc62619972dc221218c6a600daa2b3f8564e4ff7376d637ed
+1f730e764961dc0ac23f3565598bd93287900749bc4389b53224582a019b9181


### PR DESCRIPTION
The lgbgen driver forwarded only defn + multimethod forms to lower-ns-to-go, so a namespace's `defprotocol`/`deftype` forms were never captured — the deftype-ctor + protocol-method registries bound to nil and every such call took the boxed `rt.CachedVarFn` trampoline (the T9 gap: the .lg capture machinery existed but the driver starved it of the decl forms). Add `isTypeDeclForm` to the forwarded set.

Depends on the cross-package :needs-error? fix (previous PR) — devirtualizing `ops.LowerOp`'s protocol calls makes it error-free, and without that fix the cross-package caller disagrees. Verified: TestLoweredOpsDevirtualized (Constop/Irop structs, devirtualized .OpInfer), ir-stress +9.