### PR TITLE
perf(vm): reuse frames per bytecode call tree

### DIFF
--- a/pkg/vm/frame_arena_test.go
+++ b/pkg/vm/frame_arena_test.go
@@ -1,0 +1,127 @@
+package vm
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestFrameArena_NestedSelfInvoke(t *testing.T) {
+	// Countdown via OP_INVOKE self-call exercises the arena-threaded path.
+	consts := NewConsts()
+	body := NewCodeChunk(consts)
+	zero := consts.Intern(Int(0))
+	one := consts.Intern(Int(1))
+
+	fn := MakeFunc(1, false, body)
+	fn.SetName("arena-countdown")
+	fnIdx := consts.Intern(fn)
+
+	body.Append(OP_LOAD_ARG)
+	body.Append32(0)
+	body.Append(OP_LOAD_CONST)
+	body.Append32(zero)
+	body.Append(OP_EQ)
+	br := body.Length()
+	body.Append(OP_BRANCH_TRUE)
+	body.Append32(0)
+	body.Append(OP_LOAD_CONST)
+	body.Append32(fnIdx)
+	body.Append(OP_LOAD_ARG)
+	body.Append32(0)
+	body.Append(OP_LOAD_CONST)
+	body.Append32(one)
+	body.Append(OP_SUB)
+	body.Append(OP_INVOKE)
+	body.Append32(1)
+	body.Append(OP_RETURN)
+	ret0 := body.Length()
+	body.Update32(br+1, int32(ret0-br))
+	body.Append(OP_LOAD_CONST)
+	body.Append32(zero)
+	body.Append(OP_RETURN)
+	body.SetMaxStack(8)
+
+	out, err := fn.Invoke([]Value{Int(5)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := out.Unbox().(int); got != 0 {
+		t.Fatalf("got %v, want 0", got)
+	}
+}
+
+func TestFrameArena_ConcurrentTopLevel(t *testing.T) {
+	consts := NewConsts()
+	chunk := NewCodeChunk(consts)
+	chunk.Append(OP_LOAD_ARG)
+	chunk.Append32(0)
+	chunk.Append(OP_RETURN)
+	chunk.SetMaxStack(4)
+	fn := MakeFunc(1, false, chunk)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				out, err := fn.Invoke([]Value{Int(n)})
+				if err != nil {
+					t.Errorf("invoke: %v", err)
+					return
+				}
+				if out.Unbox().(int) != n {
+					t.Errorf("got %v want %d", out, n)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestFrameArena_TopLevelInvokeDoesNotAllocate(t *testing.T) {
+	consts := NewConsts()
+	chunk := NewCodeChunk(consts)
+	chunk.Append(OP_LOAD_ARG)
+	chunk.Append32(0)
+	chunk.Append(OP_RETURN)
+	chunk.SetMaxStack(4)
+	fn := MakeFunc(1, false, chunk)
+	args := []Value{Int(42)}
+
+	var invokeErr error
+	allocs := testing.AllocsPerRun(1000, func() {
+		_, invokeErr = fn.Invoke(args)
+	})
+	if invokeErr != nil {
+		t.Fatal(invokeErr)
+	}
+	if allocs != 0 {
+		t.Fatalf("top-level invoke allocated %.2f objects per call, want 0", allocs)
+	}
+}
+
+func TestFrameArena_ReusesFrames(t *testing.T) {
+	arena := &frameArena{}
+	consts := NewConsts()
+	chunk := NewCodeChunk(consts)
+	chunk.Append(OP_LOAD_CONST)
+	chunk.Append32(consts.Intern(NIL))
+	chunk.Append(OP_RETURN)
+	chunk.SetMaxStack(4)
+
+	f1 := newFrameIn(arena, chunk, nil)
+	ReleaseFrame(f1)
+	if len(arena.free) != 1 {
+		t.Fatalf("expected 1 free frame, got %d", len(arena.free))
+	}
+	f2 := newFrameIn(arena, chunk, nil)
+	if len(arena.free) != 0 {
+		t.Fatalf("expected freelist empty after get, got %d", len(arena.free))
+	}
+	if f1 != f2 {
+		t.Fatal("arena should hand back the same Frame pointer")
+	}
+	ReleaseFrame(f2)
+}

--- a/pkg/vm/func.go
+++ b/pkg/vm/func.go
@@ -103,8 +103,15 @@ func (l *Func) Invoke(pargs []Value) (result Value, err error) {
 
 // invokeIn runs the function with the given ExecContext active in its frame,
 // so dynamic bindings propagate into the call. Invoke is invokeIn against the
-// root context.
+// root context. Top-level entry checks out a call-tree arena so nested
+// bytecode calls can reuse frames without the global pool mutex.
 func (l *Func) invokeIn(ec *ExecContext, pargs []Value) (result Value, err error) {
+	arena := acquireFrameArena()
+	defer releaseFrameArena(arena)
+	return l.invokeInArena(ec, arena, pargs)
+}
+
+func (l *Func) invokeInArena(ec *ExecContext, arena *frameArena, pargs []Value) (result Value, err error) {
 	args := pargs
 	if l.isVariadric {
 		if len(args) < l.arity-1 {
@@ -120,7 +127,7 @@ func (l *Func) invokeIn(ec *ExecContext, pargs []Value) (result Value, err error
 	} else if len(args) != l.arity {
 		return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, l.arity, len(args)))
 	}
-	f := NewFrame(l.chunk, args)
+	f := newFrameIn(arena, l.chunk, args)
 	f.ec = ec
 	result, err = f.Run()
 	ReleaseFrame(f)
@@ -206,6 +213,12 @@ func (l *Closure) Invoke(pargs []Value) (result Value, err error) {
 // so dynamic bindings propagate into the call. Invoke delegates to invokeIn
 // against the root context.
 func (l *Closure) invokeIn(ec *ExecContext, pargs []Value) (result Value, err error) {
+	arena := acquireFrameArena()
+	defer releaseFrameArena(arena)
+	return l.invokeInArena(ec, arena, pargs)
+}
+
+func (l *Closure) invokeInArena(ec *ExecContext, arena *frameArena, pargs []Value) (result Value, err error) {
 	if f, ok := l.fn.(*Func); ok {
 		args := pargs
 		if f.isVariadric {
@@ -222,7 +235,7 @@ func (l *Closure) invokeIn(ec *ExecContext, pargs []Value) (result Value, err er
 		} else if len(args) != f.arity {
 			return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, f.arity, len(args)))
 		}
-		frame := NewFrame(f.chunk, args)
+		frame := newFrameIn(arena, f.chunk, args)
 		frame.closedOvers = l.closedOvers
 		frame.ec = ec
 		result, err = frame.Run()
@@ -246,9 +259,9 @@ func (l *Closure) invokeIn(ec *ExecContext, pargs []Value) (result Value, err er
 				closedOvers: l.closedOvers,
 				fn:          f,
 			}
-			return subClosure.invokeIn(ec, pargs)
+			return subClosure.invokeInArena(ec, arena, pargs)
 		}
-		return ec.Invoke(variant, pargs)
+		return invokeWithArena(ec, arena, variant, pargs)
 	}
 
 	return NIL, NewExecutionError("unsupported closure function type")
@@ -314,14 +327,42 @@ func (l *MultiArityFn) Invoke(pargs []Value) (Value, error) {
 // so dynamic bindings propagate into the selected variant's call. Invoke delegates
 // to invokeIn against the root context.
 func (l *MultiArityFn) invokeIn(ec *ExecContext, pargs []Value) (Value, error) {
+	arena := acquireFrameArena()
+	defer releaseFrameArena(arena)
+	return l.invokeInArena(ec, arena, pargs)
+}
+
+func (l *MultiArityFn) invokeInArena(ec *ExecContext, arena *frameArena, pargs []Value) (Value, error) {
 	le := len(pargs)
 	if f, ok := l.fns[le]; ok {
-		return ec.Invoke(f, pargs)
+		return invokeWithArena(ec, arena, f, pargs)
 	}
 	if l.rest != nil && le >= l.rest.Arity() {
-		return ec.Invoke(l.rest, pargs)
+		return invokeWithArena(ec, arena, l.rest, pargs)
 	}
 	return NIL, NewExecutionError(fmt.Sprintf("function %s doesn't have a %d-arity variant", l, le))
+}
+
+// invokeWithArena is the nested-call entry used by bytecode calls: it keeps the
+// call-tree frameArena so recursive bytecode frames reuse without the global
+// pool mutex. Non-frame callees (natives, protocols, …) fall through to
+// ec.Invoke.
+func invokeWithArena(ec *ExecContext, arena *frameArena, fn Fn, args []Value) (Value, error) {
+	if arena == nil {
+		return ec.orRoot().Invoke(fn, args)
+	}
+	switch f := fn.(type) {
+	case *MetaFn:
+		return invokeWithArena(ec, arena, f.Wrapped(), args)
+	case *Func:
+		return f.invokeInArena(ec, arena, args)
+	case *Closure:
+		return f.invokeInArena(ec, arena, args)
+	case *MultiArityFn:
+		return f.invokeInArena(ec, arena, args)
+	default:
+		return ec.orRoot().Invoke(fn, args)
+	}
 }
 
 func (l *MultiArityFn) String() string {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -385,9 +385,51 @@ type Frame struct {
 	debug       bool
 	handlers    []exHandler  // exception handler stack (nil when unused)
 	ec          *ExecContext // per-execution context (dynamic bindings); nil = none installed
+	arena       *frameArena  // call-tree freelist; nil ⇒ global mutex pool
+	ownedArena  frameArena   // nested-frame batch when this is a top-level root
 }
 
-// Frame reuse via a mutex-guarded LIFO.
+// frameArena is a lock-free LIFO freelist checked out by one top-level invoke
+// and shared with every nested bytecode frame in that call tree. Concurrent
+// top-level invokes each check out their own arena, so there is no
+// cross-goroutine sharing and no mutex on the hot nested-call path.
+//
+// This removes global frame-pool mutex traffic from recursive OP_INVOKE. It
+// does not eliminate the Go-recursive Frame.Run; that remains
+// tracked by #464.
+type frameArena struct {
+	seed *Frame
+	free []*Frame
+}
+
+func (a *frameArena) get() *Frame {
+	if a.seed != nil {
+		f := a.seed
+		a.seed = nil
+		return f
+	}
+	n := len(a.free)
+	if n == 0 {
+		return &Frame{}
+	}
+	f := a.free[n-1]
+	a.free[n-1] = nil
+	a.free = a.free[:n-1]
+	return f
+}
+
+func (a *frameArena) put(f *Frame) {
+	if &f.ownedArena == a {
+		a.seed = f
+		return
+	}
+	if len(a.free) < framePoolCap {
+		a.free = append(a.free, f)
+	}
+}
+
+// Frame reuse via a mutex-guarded LIFO — fallback for NewFrame callers that
+// are not inside an invoke tree (tests, one-shot eval, host entry points).
 //
 // We previously used sync.Pool, but profiling fib(30) showed ~25% of
 // CPU went to pool overhead (sync.(*Pool).Get/Put/pin) because the
@@ -396,6 +438,10 @@ type Frame struct {
 // Get/Put for the common single-goroutine case, and still safe under
 // multi-goroutine workloads (per the async/go macro).
 //
+// Hot bytecode recursion checks this pool out once: Func/Closure.invokeIn
+// threads a frameArena through nested bytecode calls and returns the batch when
+// the top-level invocation completes.
+//
 // The stack is capped at framePoolCap entries — beyond that, frames
 // returned to the pool are dropped and left for GC. This bounds the
 // memory let-go keeps live and matches sync.Pool's eventual-GC behavior.
@@ -403,9 +449,55 @@ type Frame struct {
 const framePoolCap = 256
 
 var (
-	framePoolMu    sync.Mutex
-	framePoolStack []*Frame // LIFO; pop from end
+	framePoolMu        sync.Mutex
+	framePoolStack     []*Frame // standalone NewFrame callers
+	frameArenaRoots    []*Frame // roots retaining their nested-frame batches
+	frameArenaRetained int
 )
+
+// acquireFrameArena checks out a root and its nested-frame batch for one call
+// tree. Keeping the batch embedded in the root preserves nested reuse across
+// top-level calls without an extra arena allocation or per-nested-call locks.
+func acquireFrameArena() *frameArena {
+	framePoolMu.Lock()
+	var root *Frame
+	if n := len(frameArenaRoots); n > 0 {
+		root = frameArenaRoots[n-1]
+		frameArenaRoots[n-1] = nil
+		frameArenaRoots = frameArenaRoots[:n-1]
+		frameArenaRetained -= 1 + len(root.ownedArena.free)
+	} else {
+		root = &Frame{}
+	}
+	framePoolMu.Unlock()
+	arena := &root.ownedArena
+	arena.seed = root
+	return arena
+}
+
+// releaseFrameArena returns the root with its nested-frame batch. Arena-owned
+// frames have a separate global retention cap from standalone NewFrame callers,
+// so neither cache can starve the other and total retained memory stays bounded.
+func releaseFrameArena(arena *frameArena) {
+	framePoolMu.Lock()
+	if arena.seed == nil || len(frameArenaRoots) >= framePoolCap || frameArenaRetained >= framePoolCap {
+		arena.seed = nil
+		clear(arena.free)
+		arena.free = arena.free[:0]
+		framePoolMu.Unlock()
+		return
+	}
+	room := framePoolCap - frameArenaRetained - 1
+	if room < len(arena.free) {
+		clear(arena.free[room:])
+		arena.free = arena.free[:room]
+	}
+	root := arena.seed
+	arena.seed = nil
+	frameArenaRetained += 1 + len(arena.free)
+	frameArenaRoots = append(frameArenaRoots, root)
+	framePoolMu.Unlock()
+}
 
 func acquireFrame() *Frame {
 	framePoolMu.Lock()
@@ -430,8 +522,7 @@ func releaseFrame(f *Frame) {
 	framePoolMu.Unlock()
 }
 
-func NewFrame(code *CodeChunk, args []Value) *Frame {
-	f := acquireFrame()
+func initFrame(f *Frame, code *CodeChunk, args []Value, arena *frameArena) {
 	needed := max(code.maxStack, 4)
 	if cap(f.stack) >= needed {
 		f.stack = f.stack[:needed]
@@ -448,21 +539,47 @@ func NewFrame(code *CodeChunk, args []Value) *Frame {
 	f.sp = 0
 	f.debug = false
 	f.ec = nil
+	f.arena = arena
 	if f.handlers != nil {
 		f.handlers = f.handlers[:0]
 	}
+}
+
+func newFrameIn(arena *frameArena, code *CodeChunk, args []Value) *Frame {
+	var f *Frame
+	if arena != nil {
+		f = arena.get()
+	} else {
+		f = acquireFrame()
+	}
+	initFrame(f, code, args, arena)
 	return f
 }
 
-// ReleaseFrame returns a frame to the pool.
-// We don't clear stack slots — they'll be overwritten on reuse.
-// We only nil out the large reference fields to avoid pinning code/const objects.
-func ReleaseFrame(f *Frame) {
+func NewFrame(code *CodeChunk, args []Value) *Frame {
+	return newFrameIn(nil, code, args)
+}
+
+func clearFrameRefs(f *Frame) {
 	f.args = nil
 	f.closedOvers = nil
 	f.consts = nil
 	f.code = nil
 	f.handlers = nil
+	f.ec = nil
+	f.arena = nil
+}
+
+// ReleaseFrame returns a frame to its arena (lock-free) or the global pool.
+// We don't clear stack slots — they'll be overwritten on reuse.
+// We only nil out the large reference fields to avoid pinning code/const objects.
+func ReleaseFrame(f *Frame) {
+	if a := f.arena; a != nil {
+		clearFrameRefs(f)
+		a.put(f)
+		return
+	}
+	clearFrameRefs(f)
 	releaseFrame(f)
 }
 
@@ -702,7 +819,7 @@ func (f *Frame) Run() (Value, error) {
 				if err != nil {
 					return NIL, NewExecutionError("popping arguments failed").Wrap(err)
 				}
-				out, err = f.ec.Invoke(fn, a)
+				out, err = invokeWithArena(f.ec, f.arena, fn, a)
 				if err != nil {
 					srcInfo := f.code.LookupSource(f.ip)
 					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
@@ -724,7 +841,7 @@ func (f *Frame) Run() (Value, error) {
 				if !ok {
 					return NIL, NewTypeError(fraw, "is not a function", nil)
 				}
-				out, err = f.ec.Invoke(fn, nil)
+				out, err = invokeWithArena(f.ec, f.arena, fn, nil)
 				if err != nil {
 					srcInfo := f.code.LookupSource(f.ip)
 					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)


### PR DESCRIPTION
## Summary

- Keeps a bounded nested-frame batch on each pooled top-level root frame.
- Threads that call-tree arena through `Func`, `Closure`, `MultiArityFn`, and nested `OP_INVOKE` execution.
- Reuses nested bytecode frames without taking the global frame-pool mutex; standalone `NewFrame` callers retain their existing bounded pool.
- Preserves steady-state zero-allocation top-level invocation.
- Adds regression coverage for nested arena-threaded invocation, concurrent top-level invocation, zero-allocation top-level reuse, and frame reuse from the arena freelist.

## Relationship to #618 and #620

This PR is independent and based directly on `main`. It improves generic non-tail `OP_INVOKE` execution without introducing or depending on `OP_CALL_SELF`.

- #618 is complementary: its guarded non-tail self-call can obtain child frames from this arena while retaining #618's borrowed argument slice. That temporary composition was tested below.
- #620 explicitly describes #619 as complementary. General tail-call elimination removes frames for tail calls; this arena reduces the cost of non-tail frames that remain. The eventual #620 resolver should be coordinated with `invokeWithArena` so VM callee dispatch is not duplicated across multiple type switches.

This patch removes frame-pool lock traffic from nested bytecode calls but intentionally leaves `Frame.Run` Go-recursive.

## Shared #618/#619 benchmark status

The first harness correction released the benchmark's top-level `NewFrame`, fixing its allocation accounting, but the benchmark still entered through standalone `NewFrame(...).Run()`. That does not exercise the root call-tree arena that #619 acquires and propagates through normal `Func.Invoke`/`Closure.Invoke` entry. It is nevertheless a real secondary product path used by compiler evaluation, the public API, the resolver, runtime execution, and WASM entry points. The earlier Fibonacci table mixed these two entry-path questions and has been removed pending separately labelled reruns.

#621 fixes the historical standalone-frame lifecycle while preserving its benchmark names, and adds separately labelled `new-frame-run` and `func-invoke` entry modes. The same benchmark-only change is applied to `main`, #618, #619, and the temporary combined build. A strict ABBA/`benchstat` matrix through the explicit entry paths is pending a quiet host.

Two shallow-call screens (five ABBA blocks each, n=10 per side) exposed an entry-path distinction. Through standalone `NewFrame.Run`, #619 was 6.83% slower for direct bytecode calls and 9.98% slower for closure calls (`benchstat` p<0.001 for both; all five paired blocks were slower). Through normal `Func.Invoke`, no difference was established for direct calls (p=0.684) or closures (p=0.190). Bytes/op and allocs/op were unchanged. The standalone slowdown is therefore a real workload risk to investigate, while the normal-entry screen found no regression.

## Validation

- [x] `go test -race ./pkg/vm -count=1`
- [x] `go test ./pkg/bytecode ./pkg/compiler ./pkg/vm ./pkg/rt ./pkg/wasmhost -count=1`
- [x] `make check-generated`
- [x] `make test`
- [x] `BenchmarkFuncInvoke/Direct` and `/Closure`: 0 B/op, 0 allocs/op
- [ ] Repeat the strict-ABBA #618/#619 matrix through normal `Func.Invoke` entry
- [ ] Analyze the fully corrected preserved output with `benchstat`
- [x] Shallow direct/closure A/B for standalone and normal invocation entry
- [ ] Investigate or mitigate the standalone `NewFrame.Run` shallow-call regression
- [ ] Add bytecode-to-native/protocol/multifn dispatch probes
