### PR TITLE
bench(compiler): distinguish execution entry modes

### DIFF
--- a/pkg/compiler/bench_test.go
+++ b/pkg/compiler/bench_test.go
@@ -35,8 +35,7 @@ func benchEval(b *testing.B, src string) {
 	}
 }
 
-// benchExec compiles once, then runs b.N times (execution only).
-func benchExec(b *testing.B, src string) {
+func compileBenchChunk(b *testing.B, src string) *vm.CodeChunk {
 	b.Helper()
 	consts := vm.NewConsts()
 	ctx := NewCompiler(consts, rt.NS(rt.NameCoreNS))
@@ -44,6 +43,14 @@ func benchExec(b *testing.B, src string) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	return chunk
+}
+
+// benchExec compiles once, then executes through the standalone frame entry
+// used by evaluation, API, runtime, resolver, and WASM callers.
+func benchExec(b *testing.B, src string) {
+	b.Helper()
+	chunk := compileBenchChunk(b, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		f := vm.NewFrame(chunk, nil)
@@ -54,6 +61,39 @@ func benchExec(b *testing.B, src string) {
 		}
 	}
 }
+
+// benchFuncInvoke compiles once, wraps the chunk as a zero-argument function,
+// then executes through normal function invocation. Keep this separate from
+// benchExec: the two entry paths have different frame-pool behavior.
+func benchFuncInvoke(b *testing.B, src string) {
+	b.Helper()
+	chunk := compileBenchChunk(b, src)
+	fn := vm.MakeFunc(0, false, chunk)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, runErr := fn.Invoke(nil)
+		if runErr != nil {
+			b.Fatal(runErr)
+		}
+	}
+}
+
+const (
+	benchDirectCallLoop = `
+		(do
+			(defn add1 [x] (+ x 1))
+			(loop [i 0] (if (< i 10000) (do (add1 i) (recur (+ i 1))) i)))`
+	benchClosureCallLoop = `
+		(do
+			(defn make-adder [n] (fn [x] (+ x n)))
+			(let [add5 (make-adder 5)]
+				(loop [i 0] (if (< i 10000) (do (add5 i) (recur (+ i 1))) i))))`
+	benchNonTailFib20 = `
+		(do
+			(defn fib [n]
+				(if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+			(fib 20))`
+)
 
 // ============================================================================
 // Init — core.lg loading: source compilation vs precompiled bytecode
@@ -123,17 +163,10 @@ func BenchmarkArithmetic(b *testing.B) {
 
 func BenchmarkFunctionCalls(b *testing.B) {
 	b.Run("direct-call-loop", func(b *testing.B) {
-		benchExec(b, `
-		(do
-			(defn add1 [x] (+ x 1))
-			(loop [i 0] (if (< i 10000) (do (add1 i) (recur (+ i 1))) i)))`)
+		benchExec(b, benchDirectCallLoop)
 	})
 	b.Run("closure-call-loop", func(b *testing.B) {
-		benchExec(b, `
-		(do
-			(defn make-adder [n] (fn [x] (+ x n)))
-			(let [add5 (make-adder 5)]
-				(loop [i 0] (if (< i 10000) (do (add5 i) (recur (+ i 1))) i))))`)
+		benchExec(b, benchClosureCallLoop)
 	})
 	b.Run("native-call-loop", func(b *testing.B) {
 		benchExec(b, `(loop [i 0] (if (< i 10000) (recur (+ i 1)) i))`)
@@ -212,11 +245,7 @@ func BenchmarkRecursion(b *testing.B) {
 		benchExec(b, `(loop [i 0] (if (< i 10000) (recur (+ i 1)) i))`)
 	})
 	b.Run("non-tail-fib-20", func(b *testing.B) {
-		benchExec(b, `
-		(do
-			(defn fib [n]
-				(if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
-			(fib 20))`)
+		benchExec(b, benchNonTailFib20)
 	})
 	b.Run("mutual-even-odd-1000", func(b *testing.B) {
 		benchExec(b, `
@@ -226,4 +255,28 @@ func BenchmarkRecursion(b *testing.B) {
 			(defn my-odd? [n] (if (= n 0) false (my-even? (- n 1))))
 			(my-even? 1000))`)
 	})
+}
+
+// BenchmarkExecutionEntryModes makes the two real execution entry paths
+// explicit without changing the names or semantics of the existing suite.
+func BenchmarkExecutionEntryModes(b *testing.B) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"direct-call-loop", benchDirectCallLoop},
+		{"closure-call-loop", benchClosureCallLoop},
+		{"non-tail-fib-20", benchNonTailFib20},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("new-frame-run", func(b *testing.B) {
+				benchExec(b, tc.src)
+			})
+			b.Run("func-invoke", func(b *testing.B) {
+				benchFuncInvoke(b, tc.src)
+			})
+		})
+	}
 }

--- a/pkg/compiler/bench_test.go
+++ b/pkg/compiler/bench_test.go
@@ -47,7 +47,11 @@ func benchExec(b *testing.B, src string) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		f := vm.NewFrame(chunk, nil)
-		f.Run()
+		_, runErr := f.Run()
+		vm.ReleaseFrame(f)
+		if runErr != nil {
+			b.Fatal(runErr)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Releases every standalone benchmark frame after execution and reports execution errors instead of discarding them.
- Preserves the existing benchmark names and their `NewFrame(...).Run()` semantics.
- Adds `BenchmarkExecutionEntryModes` with explicitly labelled `new-frame-run` and `func-invoke` variants for shallow direct calls, shallow closure calls, and non-tail Fibonacci.
- Shares the workload sources between the historical benchmarks and the new entry-mode comparison so they cannot drift.

## Why

`benchExec` previously created a top-level frame for every iteration without returning it to the frame pool, and ignored errors from `Frame.Run`. Besides hiding failures, that distorted allocation accounting for changes to `Frame`.

The subsequent #619 investigation also showed that the two public execution entries represent meaningfully different workloads:

- `NewFrame(...).Run()` is used by compiler evaluation, the public API, resolver, runtime, and WASM entry points.
- `Func.Invoke` and `Closure.Invoke` establish the normal function-invocation lifecycle, including #619's call-tree arena.

Replacing the historical benchmark entry wholesale would hide the first workload. This keeps it intact and adds a clearly named comparison for both.

## Benchmark usage

```console
go test ./pkg/compiler -run '^$' \
  -bench '^BenchmarkExecutionEntryModes/' \
  -benchmem -count=1
```

## Validation

- [x] `go test ./...`
- [x] `make test`
- [x] `make check-generated`
- [x] Smoke-tested all six new entry-mode sub-benchmarks with `-benchmem -benchtime=100ms`
