### PR TITLE
feat(bytecode): name capabilities in reject errors and lg -v

### DIFF
--- a/cmd/lg-runtime/main.go
+++ b/cmd/lg-runtime/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/nooga/let-go/pkg/buildmeta"
 	"github.com/nooga/let-go/pkg/bundle"
+	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/rt"
 	"github.com/nooga/let-go/pkg/vm"
 
@@ -142,7 +143,7 @@ func runMain() int {
 
 	flag.Parse()
 	if showVersion {
-		fmt.Printf("lg-runtime %s\n", versionString())
+		fmt.Print(bytecode.FormatVersionReport("lg-runtime", versionString()))
 		return 0
 	}
 	args := flag.Args()

--- a/lg.go
+++ b/lg.go
@@ -437,7 +437,7 @@ func runMain() int {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Printf("lg %s\n", versionString())
+		fmt.Print(bytecode.FormatVersionReport("lg", versionString()))
 		return 0
 	}
 

--- a/pkg/bytecode/bytecode_test.go
+++ b/pkg/bytecode/bytecode_test.go
@@ -1143,11 +1143,16 @@ func TestUnsupportedCapabilityMask(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported capability mask")
 	}
-	if !strings.Contains(err.Error(), "unsupported capability mask") {
-		t.Fatalf("expected 'unsupported capability mask' in error, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "recompile it with a matching lg") {
-		t.Fatalf("expected the recompile hint in error, got: %v", err)
+	msg := err.Error()
+	for _, want := range []string{
+		"unsupported capabilities",
+		"unknown bit 1",
+		"CapOpcodeSet",
+		"recompile the bundle with a matching lg",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected %q in error, got: %v", want, err)
+		}
 	}
 }
 

--- a/pkg/bytecode/capabilities.go
+++ b/pkg/bytecode/capabilities.go
@@ -1,0 +1,121 @@
+package bytecode
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// CapabilityInfo names a known capability bit and the lg release that first
+// accepted it. Keep this in sync when adding bits to the Capability constants
+// in tags.go — the reject path and `lg -v` both read from here.
+type CapabilityInfo struct {
+	Bit   uint32
+	Name  string
+	Since string // semver without leading "v", e.g. "1.12.0"
+}
+
+// KnownCapabilities lists every capability bit this tree knows about, in bit
+// order. SupportedCapabilities is the subset this runtime accepts.
+var KnownCapabilities = []CapabilityInfo{
+	{Bit: CapOpcodeSet, Name: "CapOpcodeSet", Since: "1.12.0"},
+}
+
+// SupportedCapabilities is the capability mask this runtime accepts.
+// Must match the check in readCapabilities.
+const SupportedCapabilities = CapOpcodeSet
+
+// DescribeCapabilities formats a capability mask for humans: named bits as
+// CapName (0x…, since vX.Y.Z), unknown bits as "unknown bit N (0x…)".
+func DescribeCapabilities(mask uint32) string {
+	if mask == 0 {
+		return "(none)"
+	}
+	var parts []string
+	seen := uint32(0)
+	for _, info := range KnownCapabilities {
+		if mask&info.Bit == 0 {
+			continue
+		}
+		seen |= info.Bit
+		parts = append(parts, fmt.Sprintf("%s (0x%x, since v%s)", info.Name, info.Bit, info.Since))
+	}
+	unknown := mask &^ seen
+	for bit := 0; bit < 32 && unknown != 0; bit++ {
+		b := uint32(1) << uint(bit)
+		if unknown&b == 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("unknown bit %d (0x%x)", bit, b))
+		unknown &^= b
+	}
+	return strings.Join(parts, ", ")
+}
+
+// MinVersionForCapabilities returns the highest Since among named bits in
+// mask, or "" when mask has no named capabilities (unknown bits alone).
+func MinVersionForCapabilities(mask uint32) string {
+	var min string
+	for _, info := range KnownCapabilities {
+		if mask&info.Bit == 0 {
+			continue
+		}
+		if min == "" || versionLess(min, info.Since) {
+			min = info.Since
+		}
+	}
+	return min
+}
+
+// versionLess reports whether a < b for dotted numeric semver (no pre-release).
+func versionLess(a, b string) bool {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	n := len(as)
+	if len(bs) > n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		ai, bi := 0, 0
+		if i < len(as) {
+			ai, _ = strconv.Atoi(as[i])
+		}
+		if i < len(bs) {
+			bi, _ = strconv.Atoi(bs[i])
+		}
+		if ai != bi {
+			return ai < bi
+		}
+	}
+	return false
+}
+
+// UnsupportedCapabilityError builds the user-facing reject for a capability
+// mask that asks for bits this runtime does not support.
+func UnsupportedCapabilityError(caps uint32) error {
+	unsupported := caps &^ SupportedCapabilities
+	msg := fmt.Sprintf(
+		"unsupported capabilities: %s (mask 0x%08x); runtime supports: %s (mask 0x%08x)",
+		DescribeCapabilities(unsupported), caps,
+		DescribeCapabilities(SupportedCapabilities), SupportedCapabilities)
+	if min := MinVersionForCapabilities(unsupported); min != "" {
+		msg += fmt.Sprintf("; needs lg >= v%s", min)
+	}
+	msg += " — recompile the bundle with a matching lg or run it on a newer runtime"
+	return errors.New(msg)
+}
+
+// FormatVersionReport returns the multi-line -v/--version body for tool
+// (e.g. "lg" or "lg-runtime") at the given version string.
+func FormatVersionReport(tool, versionStr string) string {
+	count, hash := vm.OpcodeSetSignature()
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s\n", tool, versionStr)
+	fmt.Fprintf(&b, "lgb: format %d\n", FormatVersion)
+	fmt.Fprintf(&b, "capabilities: %s\n", DescribeCapabilities(SupportedCapabilities))
+	fmt.Fprintf(&b, "opcodes: %d (signature %016x)\n", count, hash)
+	return b.String()
+}

--- a/pkg/bytecode/capabilities.go
+++ b/pkg/bytecode/capabilities.go
@@ -99,7 +99,7 @@ func UnsupportedCapabilityError(caps uint32) error {
 	unsupported := caps &^ SupportedCapabilities
 	msg := fmt.Sprintf(
 		"unsupported capabilities: %s (mask 0x%08x); runtime supports: %s (mask 0x%08x)",
-		DescribeCapabilities(unsupported), caps,
+		DescribeCapabilities(unsupported), unsupported,
 		DescribeCapabilities(SupportedCapabilities), SupportedCapabilities)
 	if min := MinVersionForCapabilities(unsupported); min != "" {
 		msg += fmt.Sprintf("; needs lg >= v%s", min)

--- a/pkg/bytecode/capabilities_test.go
+++ b/pkg/bytecode/capabilities_test.go
@@ -1,0 +1,48 @@
+package bytecode
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDescribeCapabilities(t *testing.T) {
+	got := DescribeCapabilities(0)
+	if got != "(none)" {
+		t.Fatalf("empty mask: got %q", got)
+	}
+	got = DescribeCapabilities(CapOpcodeSet)
+	if !strings.Contains(got, "CapOpcodeSet") || !strings.Contains(got, "since v1.12.0") {
+		t.Fatalf("named cap: got %q", got)
+	}
+	got = DescribeCapabilities(0x2)
+	if !strings.Contains(got, "unknown bit 1") {
+		t.Fatalf("unknown bit: got %q", got)
+	}
+}
+
+func TestUnsupportedCapabilityErrorNamedMinVersion(t *testing.T) {
+	// CapOpcodeSet is supported today; synthesize a "named but unsupported"
+	// case by describing a mask that includes only CapOpcodeSet against a
+	// zero support set via MinVersionForCapabilities.
+	if min := MinVersionForCapabilities(CapOpcodeSet); min != "1.12.0" {
+		t.Fatalf("min version: got %q, want 1.12.0", min)
+	}
+	if min := MinVersionForCapabilities(0x2); min != "" {
+		t.Fatalf("unknown-only mask should have no min version, got %q", min)
+	}
+}
+
+func TestFormatVersionReport(t *testing.T) {
+	got := FormatVersionReport("lg", "1.99.0 (deadbee)")
+	for _, want := range []string{
+		"lg 1.99.0 (deadbee)\n",
+		"lgb: format 2\n",
+		"capabilities: CapOpcodeSet",
+		"opcodes:",
+		"signature",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}

--- a/pkg/bytecode/capabilities_test.go
+++ b/pkg/bytecode/capabilities_test.go
@@ -32,6 +32,20 @@ func TestUnsupportedCapabilityErrorNamedMinVersion(t *testing.T) {
 	}
 }
 
+func TestUnsupportedCapabilityErrorMaskIsUnsupportedSubset(t *testing.T) {
+	// A bundle asking for a supported bit (CapOpcodeSet) AND an unknown bit
+	// must report only the unsupported subset in the "unsupported" mask —
+	// not the full requested mask.
+	err := UnsupportedCapabilityError(CapOpcodeSet | 0x2)
+	msg := err.Error()
+	if !strings.Contains(msg, "unsupported capabilities: unknown bit 1 (0x2) (mask 0x00000002)") {
+		t.Fatalf("unsupported section should describe only bit 1 with mask 0x2, got: %s", msg)
+	}
+	if strings.Contains(msg, "mask 0x00000003") {
+		t.Fatalf("unsupported mask must not include the supported bit, got: %s", msg)
+	}
+}
+
 func TestFormatVersionReport(t *testing.T) {
 	got := FormatVersionReport("lg", "1.99.0 (deadbee)")
 	for _, want := range []string{

--- a/pkg/bytecode/decoder.go
+++ b/pkg/bytecode/decoder.go
@@ -198,11 +198,8 @@ func (d *decoder) readCapabilities() error {
 	if err != nil {
 		return fmt.Errorf("reading capability mask: %w", err)
 	}
-	const supportedCaps = CapOpcodeSet
-	if caps&^supportedCaps != 0 {
-		return fmt.Errorf(
-			"unsupported capability mask 0x%08x (supported: 0x%08x) — bundle was produced by a newer lg than this runtime; recompile it with a matching lg or run it on a newer runtime",
-			caps, supportedCaps)
+	if caps&^SupportedCapabilities != 0 {
+		return UnsupportedCapabilityError(caps)
 	}
 	if caps&CapOpcodeSet != 0 {
 		bundleCount, err := d.r.ReadVarint()

--- a/pkg/bytecode/module.go
+++ b/pkg/bytecode/module.go
@@ -8,7 +8,7 @@ type Module struct {
 	Flags   uint16
 	// Capabilities is an optional feature mask. If FlagCapabilities is set in Flags,
 	// a uint32 capability mask follows the header. Bits indicate optional features
-	// the decoder must support. Currently no capability bits are defined (all reserved).
+	// the decoder must support; see KnownCapabilities / CapOpcodeSet.
 	Capabilities uint32
 	Strings      []string
 	Chunks       []*ChunkData


### PR DESCRIPTION
## Summary

Stacked on #608. Addresses the DX follow-up from that review without blocking the hint-only change:

- Capability registry (`CapOpcodeSet` → name + since v1.12.0) so the reject path can name unsupported bits (or `unknown bit N`) and, when the bit is known, surface a minimum lg version
- `lg -v` / `lg-runtime -v` prints LGB format, supported capabilities, and the opcode-set signature

Example reject (bundle asks for bit 1, unsupported today):

```
unsupported capabilities: unknown bit 1 (0x2) (mask 0x00000002); runtime supports: CapOpcodeSet (0x1, since v1.12.0) (mask 0x00000001) — recompile the bundle with a matching lg or run it on a newer runtime
```

Example `-v`:

```
lg 1.12.2 (abc1234)
lgb: format 2
capabilities: CapOpcodeSet (0x1, since v1.12.0)
opcodes: 44 (signature …)
```

Caveat: unknown future bits still cannot report a min version without a wire-format change — that stays out of scope here.

## Test plan

- [x] `go test ./pkg/bytecode/`
- [x] `lg -v` / `lg-runtime -v` show the multi-line report
- [x] Retarget base to `main` after #608 merges


Made with [Cursor](https://cursor.com)