### PR TITLE
feat(cmd): bootprobe + lgbstat — core boot and bundle diagnostics

### DIFF
--- a/cmd/bootprobe/main.go
+++ b/cmd/bootprobe/main.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Matt Parrett <matt.parrett@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+// bootprobe reports where core boot time goes: bundle decode vs definition
+// replay vs everything else, using LoadCoreBundle's OnPhase hooks. It boots
+// compiler-free (same surface as cmd/lg-runtime), so the numbers isolate the
+// runtime boot path.
+//
+// Usage:
+//
+//	bootprobe                              one boot, phase breakdown + counts
+//	bootprobe -decodes 300                 also re-decode the bundle N times
+//	bootprobe -replays 300                 also re-run the core chunk N times
+//	bootprobe -decodes 300 -cpuprofile p   CPU-profile the loop
+//
+// Loops report min/median/max so a quiet-host median is easy to extract;
+// run the binary itself repeatedly to sample process-level variance.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"sort"
+	"time"
+
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+
+	_ "github.com/nooga/let-go/pkg/rt/corefns"
+)
+
+func medianOf(xs []float64) float64 {
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	return s[len(s)/2]
+}
+
+func startProfile(path string) func() {
+	if path == "" {
+		return func() {}
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return pprof.StopCPUProfile
+}
+
+func main() {
+	replays := flag.Int("replays", 0, "re-run the core main chunk N times after boot")
+	decodes := flag.Int("decodes", 0, "re-decode the core bundle N times after boot")
+	cpuprofile := flag.String("cpuprofile", "", "write a CPU profile of the replay/decode loop")
+	flag.Parse()
+
+	var decodeMS, coreMS float64
+	t0 := time.Now()
+	unit, err := rt.LoadCoreBundle(rt.CoreLoadOptions{
+		EagerHybrids: false,
+		OnPhase: func(phase string, since time.Time) {
+			d := float64(time.Since(since).Microseconds()) / 1000
+			switch phase {
+			case "decode-bundle":
+				decodeMS = d
+			case "run-core-chunk":
+				coreMS = d
+			}
+		},
+	})
+	totalMS := float64(time.Since(t0).Microseconds()) / 1000
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "boot failed:", err)
+		os.Exit(1)
+	}
+
+	nses := rt.AllNSes()
+	coreVars, totalVars := 0, 0
+	for name, ns := range nses {
+		totalVars += ns.RegistrySize()
+		if name == rt.NameCoreNS {
+			coreVars = ns.RegistrySize()
+		}
+	}
+
+	fmt.Printf("phases_ms decode=%.3f core_replay=%.3f rest=%.3f total=%.3f\n",
+		decodeMS, coreMS, totalMS-decodeMS-coreMS, totalMS)
+	fmt.Printf("bundle_bytes=%d ns_chunks=%d core_vars=%d total_vars=%d nses=%d\n",
+		len(rt.CoreCompiledLGB), len(unit.NSChunks), coreVars, totalVars, len(nses))
+
+	if *decodes > 0 || *replays > 0 {
+		stop := startProfile(*cpuprofile)
+		defer stop()
+	}
+
+	if *decodes > 0 {
+		ts := make([]float64, 0, *decodes)
+		for i := 0; i < *decodes; i++ {
+			t := time.Now()
+			if _, derr := rt.DecodeExecUnit(rt.CoreCompiledLGB); derr != nil {
+				fmt.Fprintln(os.Stderr, "re-decode failed:", derr)
+				os.Exit(1)
+			}
+			ts = append(ts, float64(time.Since(t).Microseconds())/1000)
+		}
+		sort.Float64s(ts)
+		fmt.Printf("re_decode_ms n=%d min=%.3f median=%.3f max=%.3f\n",
+			*decodes, ts[0], medianOf(ts), ts[len(ts)-1])
+	}
+
+	if *replays > 0 {
+		ts := make([]float64, 0, *replays)
+		for i := 0; i < *replays; i++ {
+			t := time.Now()
+			fr := vm.NewFrame(unit.MainChunk, nil)
+			_, rerr := fr.RunProtected()
+			vm.ReleaseFrame(fr)
+			if rerr != nil {
+				fmt.Fprintln(os.Stderr, "re-replay failed:", rerr)
+				os.Exit(1)
+			}
+			ts = append(ts, float64(time.Since(t).Microseconds())/1000)
+		}
+		sort.Float64s(ts)
+		fmt.Printf("re_replay_ms n=%d min=%.3f median=%.3f max=%.3f\n",
+			*replays, ts[0], medianOf(ts), ts[len(ts)-1])
+	}
+}

--- a/cmd/bootprobe/main.go
+++ b/cmd/bootprobe/main.go
@@ -37,7 +37,11 @@ import (
 func medianOf(xs []float64) float64 {
 	s := append([]float64(nil), xs...)
 	sort.Float64s(s)
-	return s[len(s)/2]
+	mid := len(s) / 2
+	if len(s)%2 == 0 {
+		return (s[mid-1] + s[mid]) / 2
+	}
+	return s[mid]
 }
 
 func startProfile(path string) func() {

--- a/cmd/lgbstat/main.go
+++ b/cmd/lgbstat/main.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Matt Parrett <matt.parrett@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+// lgbstat reports where a .lgb's bytes go. It decodes to the structural
+// Module, tallies contents (chunks, consts by type, string table), attributes
+// chunks to source files via their first source-map entry, and measures the
+// debug sections' weight by ablation: re-encode with a section stripped and
+// diff against the as-is re-encode. Complements scripts/lgbdump.lg, which
+// dumps instructions; this accounts bytes.
+//
+// Usage:
+//
+//	lgbstat <bundle.lgb>
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/nooga/let-go/pkg/bytecode"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func encodedLen(m *bytecode.Module) int {
+	var buf bytes.Buffer
+	if err := bytecode.Encode(&buf, m); err != nil {
+		fmt.Fprintln(os.Stderr, "re-encode failed:", err)
+		os.Exit(1)
+	}
+	return buf.Len()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: lgbstat <bundle.lgb>")
+		os.Exit(2)
+	}
+	data, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	m, err := bytecode.Decode(bytes.NewReader(data))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "decode failed:", err)
+		os.Exit(1)
+	}
+
+	codeInts, smEntries, lvEntries := 0, 0, 0
+	for _, c := range m.Chunks {
+		codeInts += len(c.Code)
+		smEntries += len(c.SourceMap)
+		lvEntries += len(c.LocalVars)
+	}
+	typeCount := map[string]int{}
+	var strs []string
+	for _, v := range m.Consts {
+		typeCount[fmt.Sprintf("%T", v)]++
+		if s, ok := v.(vm.String); ok {
+			strs = append(strs, string(s))
+		}
+	}
+	fmt.Printf("file=%d bytes  chunks=%d  code_int32s=%d  sourcemap_entries=%d  localvar_entries=%d  consts=%d  strings_table=%d\n",
+		len(data), len(m.Chunks), codeInts, smEntries, lvEntries, len(m.Consts), len(m.Strings))
+
+	type kv struct {
+		k string
+		n int
+	}
+	var kvs []kv
+	for k, n := range typeCount {
+		kvs = append(kvs, kv{k, n})
+	}
+	sort.Slice(kvs, func(i, j int) bool { return kvs[i].n > kvs[j].n })
+	fmt.Println("const types:")
+	for _, e := range kvs {
+		fmt.Printf("  %6d  %s\n", e.n, e.k)
+	}
+
+	sort.Slice(strs, func(i, j int) bool { return len(strs[i]) > len(strs[j]) })
+	fmt.Println("largest string consts:")
+	for i := 0; i < 8 && i < len(strs); i++ {
+		s := strings.ReplaceAll(strs[i], "\n", "\\n")
+		if len(s) > 90 {
+			s = s[:90] + "..."
+		}
+		fmt.Printf("  %5d  %q\n", len(strs[i]), s)
+	}
+
+	// String-table accounting is direct: the table is interned against consts,
+	// so ablation-by-blanking would desync the encoder.
+	tableBytes, proseBytes, proseN := 0, 0, 0
+	for _, s := range m.Strings {
+		tableBytes += len(s)
+		if len(s) >= 40 && strings.Contains(s, " ") {
+			proseBytes += len(s)
+			proseN++
+		}
+	}
+	fmt.Printf("string table: %d entries, %d bytes; prose-like (docstrings): %d entries, %d bytes (%.1f%% of file)\n",
+		len(m.Strings), tableBytes, proseN, proseBytes, float64(proseBytes)/float64(len(data))*100)
+
+	base := encodedLen(m)
+	fmt.Printf("re-encoded as-is: %d bytes (file %d)\n", base, len(data))
+
+	saveSM := make([][]bytecode.SourceEntry, len(m.Chunks))
+	saveLV := make([][]bytecode.LocalVarEntry, len(m.Chunks))
+	for i, c := range m.Chunks {
+		saveSM[i], saveLV[i] = c.SourceMap, c.LocalVars
+	}
+	for i := range m.Chunks {
+		m.Chunks[i].SourceMap = nil
+	}
+	noSM := encodedLen(m)
+	for i := range m.Chunks {
+		m.Chunks[i].SourceMap = saveSM[i]
+	}
+	for i := range m.Chunks {
+		m.Chunks[i].LocalVars = nil
+	}
+	noLV := encodedLen(m)
+	for i := range m.Chunks {
+		m.Chunks[i].LocalVars = saveLV[i]
+	}
+	fmt.Printf("ablation: sourcemaps=%d bytes (%.1f%%)  localvars=%d bytes (%.1f%%)\n",
+		base-noSM, float64(base-noSM)/float64(base)*100,
+		base-noLV, float64(base-noLV)/float64(base)*100)
+
+	type acc struct{ chunks, ints, sm int }
+	byFile := map[string]*acc{}
+	for _, c := range m.Chunks {
+		file := "<no-sourcemap>"
+		if len(c.SourceMap) > 0 {
+			file = c.SourceMap[0].File
+		}
+		a := byFile[file]
+		if a == nil {
+			a = &acc{}
+			byFile[file] = a
+		}
+		a.chunks++
+		a.ints += len(c.Code)
+		a.sm += len(c.SourceMap)
+	}
+	var files []string
+	for f := range byFile {
+		files = append(files, f)
+	}
+	sort.Slice(files, func(i, j int) bool { return byFile[files[i]].ints > byFile[files[j]].ints })
+	fmt.Println("per-source-file (chunks / code int32s / sourcemap entries):")
+	for _, f := range files {
+		a := byFile[f]
+		fmt.Printf("  %5d chunks %7d ints %6d sm  %s\n", a.chunks, a.ints, a.sm, f)
+	}
+
+	var nsNames []string
+	for n := range m.NSTable {
+		nsNames = append(nsNames, n)
+	}
+	sort.Strings(nsNames)
+	fmt.Println("NS table:")
+	fmt.Println(" ", strings.Join(nsNames, " "))
+}

--- a/cmd/lgbstat/main.go
+++ b/cmd/lgbstat/main.go
@@ -124,7 +124,12 @@ func main() {
 	for i := range m.Chunks {
 		m.Chunks[i].LocalVars = nil
 	}
+	// Clear the flag too, or the encoder still writes a zero-count varint per
+	// chunk and the ablation under-reports the section by chunks bytes.
+	savedFlags := m.Flags
+	m.Flags &^= bytecode.FlagLocalVars
 	noLV := encodedLen(m)
+	m.Flags = savedFlags
 	for i := range m.Chunks {
 		m.Chunks[i].LocalVars = saveLV[i]
 	}


### PR DESCRIPTION
## Summary

Two small diagnostic commands that came out of assessing what lazy core loading or bundle pruning would buy. Posting them because the numbers they produce reframed that question for me, and they seem worth having in-tree for anyone poking at boot or bundle size.

- `cmd/bootprobe` — phase-timed core boot: decode vs replay vs remainder, via `LoadCoreBundle`'s existing `OnPhase` hooks. Boots compiler-free (same surface as `cmd/lg-runtime`) so it isolates the runtime boot path. Optional `-decodes`/`-replays` loops with `-cpuprofile` for profiling either phase.
- `cmd/lgbstat` — byte composition of a `.lgb`: const-type counts, string-table weight, per-source-file chunk attribution (via each chunk's first source-map entry), and debug-section sizes measured by ablation (re-encode with the section stripped, diff against the as-is re-encode). Complements `scripts/lgbdump.lg`, which dumps instructions; this accounts bytes.

## What they show today

Measured on an M2 (darwin/arm64), quiet-host medians.

Boot: decode of the 264KB core bundle is ~95% of `LoadCoreBundle` (~1.4ms); replaying all 802 core defs is ~0.08ms; and the whole thing is small next to process spawn + Go package init (~5ms; `pkg/rt` native registration is the largest init item per `GODEBUG=inittrace`). So: lazy *replay* has nothing to win; decode cost tracks bundle size; the bigger cold-start item is package init, not the bundle.

Bundle: source maps are 17.3% (45.7KB), localvar debug tables 2.8%, and docstrings 2.1% — a release-stripped bundle is ~20% smaller, which I verified end-to-end (210,882 bytes; boots, rt/vm/compiler suites pass). Per-file attribution also shows ~10% of code int32s under `ir.data:lgbgen-bootstrap`, and 508 VOID consts remain in the pool (#600 stripped VOID instructions; these are the pool slots).

## Notes

- Both build on linux, js/wasm, and plan9; gofmt/vet clean.
- No behavior changes — additive commands only.
- Follow-ups these numbers suggest, each separable: a `-strip` option on `lg -c`/`-b` for release bundles, VOID pool-slot compaction, and lazy native registration.
