### PR TITLE
fix(rt): resolve ns alias in LookupOrRegisterNSNoLoad

### DIFF
--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -686,6 +686,16 @@ func LookupOrRegisterNS(name string) *vm.Namespace {
 }
 
 func LookupOrRegisterNSNoLoad(name string) *vm.Namespace {
+	// Resolve the alias BEFORE touching the registry, as the loading callers do.
+	// Without this, LookupOrRegisterNSNoLoad("clojure.core") registers a DISTINCT
+	// "clojure.core" namespace instead of returning the canonical "core" — so the
+	// generated primitive registrar (RegisterGeneratedPrimitives, which calls this
+	// with "clojure.core"/"clojure.string"/…) Defs into the wrong namespace,
+	// invisible to core.lg's own bootstrap compile. Hand-registered primitives
+	// hid this by also Def'ing into the canonical ns via installLangNS; a primitive
+	// hoisted to //lg:native has ONLY the generated registration, so it must land
+	// in the canonical namespace to resolve.
+	name = resolveNSAlias(name)
 	nsMu.RLock()
 	e := nsRegistry[name]
 	nsMu.RUnlock()


### PR DESCRIPTION
## Problem

`RegisterGeneratedPrimitives` (the lginterop-generated `//lg:native` registrar) Defs primitives via `LookupOrRegisterNSNoLoad("clojure.core")`. Unlike its loading sibling `LookupOrRegisterNS`, that path **never resolved the namespace alias**, so it registered into a *distinct* `clojure.core` namespace instead of the canonical `core`.

Hand-registered primitives masked the bug: they *also* Def into the canonical ns via `installLangNS`, so their canonical binding always existed. But a primitive hoisted to a pure `//lg:native` decl has **only** the generated registration — it landed in the phantom namespace and was invisible to `core.lg`'s own bootstrap compile, which fails with `Can't resolve +`.

## Fix

Resolve the alias as the first step of `LookupOrRegisterNSNoLoad`, matching the loading variant (one line + rationale comment at `pkg/rt/lang.go`).

## Why it matters

This unblocks hoisting the anonymous native closures in `lang.go` into named `//lg:native` primitives — giving them real stack-trace frames and letting them narrow their signatures (e.g. take `ec *vm.ExecContext`) instead of capturing free variables.

## Verification

Proof-hoisted `+ - * /` to `//lg:native` decls and confirmed:
- `make generate` + lgbgen bootstrap: clean
- `make check-generated`: OK on **both** artifacts (bundle + lowered tree)
- `clojure.core` surface: **807 publics, byte-identical** before/after
- arithmetic correct (`(+ 1 2 3) (- 10 3) (* 2 3 4) (/ 12 3)` → `6 7 24 4`)

This PR is the **fix only** — the arith hoist was the test vehicle and is not included. `check-generated` passes with the bundle untouched, since this is a Go-only registration fix.