### PR TITLE
fix(tinygo): stub SameFile for js/wasm in pkg/bundle

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -390,7 +390,7 @@ func collectResourceDir(dir, rootReal, relPrefix string, files map[string][]byte
 		if !info.Mode().IsRegular() {
 			continue // FIFO, device, socket
 		}
-		if exclude != nil && os.SameFile(info, exclude) {
+		if exclude != nil && sameFile(info, exclude) {
 			continue // never embed the bundle's own output file
 		}
 		if _, exists := files[key]; exists {

--- a/pkg/bundle/samefile.go
+++ b/pkg/bundle/samefile.go
@@ -1,0 +1,17 @@
+//go:build !tinygo || (!js && !wasm_unknown)
+
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package bundle
+
+import "os"
+
+// sameFile reports whether fi1 and fi2 describe the same file. Thin wrapper
+// so the TinyGo js/wasm seam can stub the call — TinyGo's os omits SameFile
+// under those GOOSes (types_anyos.go is //go:build !js && !wasm_unknown).
+func sameFile(fi1, fi2 os.FileInfo) bool {
+	return os.SameFile(fi1, fi2)
+}

--- a/pkg/bundle/samefile_tinygo.go
+++ b/pkg/bundle/samefile_tinygo.go
@@ -1,0 +1,19 @@
+//go:build tinygo && (js || wasm_unknown)
+
+/*
+ * Copyright (c) 2021-2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package bundle
+
+import "os"
+
+// TinyGo's js/wasm os has no SameFile. The exclude check only matters for
+// host-side `lg -b` resource collection, which is not the TinyGo wasm
+// payload path — returning false skips the hardlink-robust identity
+// exclude (self-embed of dst under a resource root remains possible only
+// if someone bundles under TinyGo wasm, which we don't).
+func sameFile(_, _ os.FileInfo) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- TinyGo's `os` omits `SameFile` under `js`/`wasm_unknown` (`types_anyos.go` is `!js && !wasm_unknown`), so `pkg/bundle.CollectResources` failed to compile for the TinyGo browser target after #522.
- Route the call through a build-tagged helper: real `os.SameFile` everywhere TinyGo provides it (stock Go, TinyGo wasi/native); `false` on js/wasm where host-side `lg -b` isn't the payload path.

Fast-follow to #522.

## Test plan
- [x] `go test ./pkg/bundle/` green
- [x] `tinygo build -target=wasm` of a probe that imports `pkg/bundle` succeeds
- [x] `tinygo build -target=wasi` of the same probe succeeds (uses real SameFile)


Made with [Cursor](https://cursor.com)