### PR TITLE
chore(make): pin makeplus/makes clone to a SHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,12 @@ M := .cache/makes
 # in this repo. Same rationale as the Clojure toolchain pin in go.yml
 # (unpinned makeplus install → setup-clojure). Bump MAKES-SHA after verifying
 # the new tip; delete .cache/makes first so the next `make` reclones.
+# The trailing `rm -rf` matters: $(shell ...) discards exit status, so without
+# it a failed checkout would leave a valid-looking clone at floating HEAD — the
+# exact thing this pin defends against — and the [ -d ] guard would make that
+# state stick forever. Removing it fails the include loudly and retries next run.
 MAKES-SHA := 7f28494955c20e5a87ca82ae351464842a7236de
-$(shell [ -d '$M' ] || (git clone -q $R '$M' && git -C '$M' -c advice.detachedHead=false checkout -q $(MAKES-SHA)))
+$(shell [ -d '$M' ] || (git clone -q $R '$M' && git -C '$M' -c advice.detachedHead=false checkout -q $(MAKES-SHA)) || rm -rf '$M')
 include $M/init.mk
 # override default Go version with: `make ... GO-VERSION=1.x.y`
 GO-VERSION ?= 1.26.3

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@
 ifneq (,$(or $(if $(shell which go),,1),$(GO-VERSION)))
 R := https://github.com/makeplus/makes
 M := .cache/makes
-$(shell [ -d '$M' ] || git clone -q $R '$M')
+# Pin makeplus/makes so a HEAD change there can't break `make` with no change
+# in this repo. Same rationale as the Clojure toolchain pin in go.yml
+# (unpinned makeplus install → setup-clojure). Bump MAKES-SHA after verifying
+# the new tip; delete .cache/makes first so the next `make` reclones.
+MAKES-SHA := 7f28494955c20e5a87ca82ae351464842a7236de
+$(shell [ -d '$M' ] || (git clone -q $R '$M' && git -C '$M' -c advice.detachedHead=false checkout -q $(MAKES-SHA)))
 include $M/init.mk
 # override default Go version with: `make ... GO-VERSION=1.x.y`
 GO-VERSION ?= 1.26.3


### PR DESCRIPTION
Part of #528 — the unpinned build-time toolchain clone.

When Go is missing from PATH, or `GO-VERSION=…` is set on the command line, the Makefile clones `makeplus/makes` into `.cache/makes` and includes `init.mk` / `go.mk` / `shell.mk` (auto-install Go under `.cache/local/`). That clone was unpinned HEAD. A tip change there can break `make` with no change in this repo — the same failure mode `go.yml` already retired for the Clojure toolchain (unpinned makeplus install → pinned `setup-clojure`).

## Change

- Pin the clone to `MAKES-SHA` (`7f28494955c20e5a87ca82ae351464842a7236de`, `makeplus/makes` tip at open). Fresh clones `git checkout` that SHA.
- A failed clone or checkout removes `.cache/makes`. `$(shell ...)` discards exit status, so without that, a clone that succeeded followed by a checkout that didn't would leave a valid-looking tree at floating HEAD (the state the pin exists to prevent), and the `[ -d ]` guard would make it stick forever.
- An existing `.cache/makes` stays as-is, same as before. Bump the pin by updating `MAKES-SHA` and deleting `.cache/makes` so the next `make` reclones.

Vendoring the three `.mk` files was the other option from the audit; the SHA pin is the smaller diff and matches how we already treat remote tool versions elsewhere. Happy to vendor instead if you'd rather have zero network at Makefile parse time.

## Verification

- `makes` has no self-update: nothing in `init.mk`, `go.mk`, or `shell.mk` fetches or pulls `.cache/makes`, so the detached checkout holds across runs. Without that the pin would be decorative.
- Clone + checkout lands on the pinned SHA, and stays there on a second run.
- With a deliberately bad SHA, the directory is gone afterwards and the `include` fails loudly instead of silently building against tip.
- `make -n build GO-VERSION=1.26.3` parses clean (forces the makeplus path) and resolves `.cache/makes` at the pin. `make -n build` with Go on PATH is unaffected.

Scope note: no CI lane sets `GO-VERSION`, and every lane uses `setup-go`, so this block doesn't execute in CI before or after the change. It's a local-developer path.
