### PR TITLE
ci: run the lginterop round-trip in the expensive e2e lane

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,10 +100,15 @@ jobs:
       # compiles the whole stdlib twice concurrently and is the slow one:
       # ~60-120s on CI, ~200s on a contended local machine. It runs here under a
       # generous ceiling instead of inflating every package's budget.
-      - name: Expensive lowering e2e (determinism, deftype skeleton)
+      # TestLginteropXxh3RoundTrip joins them: it is -short-gated too (it builds
+      # lg), so it matched no lane and went unrun — long enough to go red on main
+      # unnoticed. It regenerates interop_xxh3.go and byte-compares, which is what
+      # now enforces the //go:build !tinygo constraint since the hand-tag guard
+      # (TestInteropXxh3KeepsTinygoBuildTag) was retired.
+      - name: Expensive lowering e2e (determinism, deftype skeleton, lginterop round-trip)
         # No -short here so the testing.Short()-gated heavyweight e2e tests run
         # full; the fast `make test` loop passes -short to skip them.
-        run: go test -v -timeout 600s ./test/e2e/ -run 'TestLoweringDeterminism|TestDeftypeSkeletonNativeLowering'
+        run: go test -v -timeout 600s ./test/e2e/ -run 'TestLoweringDeterminism|TestDeftypeSkeletonNativeLowering|TestLginteropXxh3RoundTrip'
 
   # Race-detector pass over the packages that hold cross-goroutine state:
   # the VM's shared runtime structures and the rt layer. Motivated by #464 —


### PR DESCRIPTION
Stacked on #630 — merge that first. Base retargets to `main` once it lands.

`TestLginteropXxh3RoundTrip` regenerates `pkg/rt/interop_xxh3.go` and byte-compares it against the committed file. It is `-short`-gated because it builds `lg`, so the two fast lanes skip it — and the one non-short e2e lane pins `-run` to `TestLoweringDeterminism|TestDeftypeSkeletonNativeLowering`, so it matched no lane at all and never ran in CI.

It had gone red on `main` in the meantime, unobserved: the emitter produces 897 bytes against a 1297-byte committed file. The difference is the hand-added `//go:build !tinygo` block. #630 makes `lginterop` emit that constraint, which is what turns the test green again — so this only becomes mergeable on top of it.

That byte-comparison also matters more than it used to. #630 retires `TestInteropXxh3KeepsTinygoBuildTag`, the cheap `pkg/rt` test that asserted the tag was still on line 1, because the tag is no longer hand-added. The round-trip test is now the only thing enforcing the constraint, and until this change nothing ran it.

## Change

One line: add `TestLginteropXxh3RoundTrip` to the expensive-e2e lane's `-run` filter, plus a comment recording why it belongs there.

## Verification

- The exact lane command passes locally: determinism, deftype skeleton, and the round-trip, `ok` in 184s against the lane's 600s ceiling. The round-trip itself accounts for 1.9s of that.
- Confirmed the gap empirically rather than by reading the workflow: the round-trip test SKIPs under `-short`, and the retired hand-tag test PASSes under `-short` (so it did run, in three lanes including `-race`).
- Checked all nine workflow files. There are eight `go test` invocations, all in `go.yml`, and none of them reached this test.
