### PR TITLE
fix(ir): give function-level recur its own op and lower it to OP_RECUR_FN

### DIFF
--- a/pkg/ir/ir_ops.lg
+++ b/pkg/ir/ir_ops.lg
@@ -125,7 +125,18 @@
     ;; the bytecode defCompiler does), EXCEPT gogen must INTERN the var at
     ;; runtime (rt.InternVar) rather than look it up. .Refs[0] = var (Const
     ;; aux=*vm.Var), optional .Refs[1] = value. stack-in -1: 1 or 2 refs.
-    ["Def"       -1  1 false false nil                false true  false false "Def"        ".Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)"]])
+    ["Def"       -1  1 false false nil                false true  false false "Def"        ".Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)"]
+
+    ;; Function-level `recur`: rebind this function's parameters and
+    ;; re-enter it. Distinct from TailCall, which is a CALL — it carries a
+    ;; callee in Refs[0] and can dispatch anywhere. RecurFn carries only the
+    ;; replacement arguments and statically re-enters the executing function,
+    ;; which is why it maps to OP_RECUR_FN (pops argc args, resets ip/sp) and
+    ;; not OP_TAIL_CALL (resolves a callee via f.nth(argc), which a
+    ;; callee-less terminator does not supply). infer? is false for the same
+    ;; reason as TailCall: it infers :unknown via the default rather than
+    ;; joining typeinfer's terminator-ops set.
+    ["RecurFn"   -1  0 false true  OP_RECUR_FN        false false false false "RecurFn"    "function-level recur back-edge; .Refs = replacement args (no callee), .Aux = argc int"]])
 
 (g/check-spec ops)
 

--- a/pkg/ir/lisp_inline_test.go
+++ b/pkg/ir/lisp_inline_test.go
@@ -301,3 +301,39 @@ func TestDevirtualizesMultiBlockClosureCall(t *testing.T) {
 		t.Fatalf("multi-block capturing closure call should be devirtualized (no InvokeValueEC/BoxNativeFn):\n%s", src)
 	}
 }
+
+// TestInlineRejectsFunctionLevelRecurCallee pins the second spelling of
+// self-recursion. self-recursive? only spots a :load-var of the callee's own
+// name; a function-level `recur` re-enters through the terminator instead, so
+// without has-recur-fn? the callee looks inlineable.
+//
+// Splicing it is a miscompile, and the arity-mismatched case shows why: the
+// cloned :recur-fn rebinds parameter slots BY INDEX, so a 1-arg callee inlined
+// into a 2-arg caller writes the caller's a0 while the loop body reads a1. The
+// counter never advances and Usec2 spins forever. Guarded, the call survives as
+// a call (nooga/let-go#638).
+func TestInlineRejectsFunctionLevelRecurCallee(t *testing.T) {
+	ensureLoader()
+	v := runLispExpr(t, `(do (create-ns (quote inlinerecurz))
+	     (binding [*ns* (the-ns (quote inlinerecurz))]
+	       (eval (quote (defn cnt [n] (if (< n 0) 0 (recur (dec n))))))
+	       (eval (quote (defn usec2 [p q] (cnt q)))))
+	     (binding [ir.passes.inline/*enable-inline* true]
+	       (ir.passes.pipeline/lower-ns-to-go "inlinerecurz" (quote inlinerecurz)
+	         [(quote (defn cnt [n] (if (< n 0) 0 (recur (dec n)))))
+	          (quote (defn usec2 [p q] (cnt q)))])))`)
+	rendered, ok := v.Unbox().(string)
+	if !ok {
+		t.Fatalf("expected rendered Go string, got %T", v.Unbox())
+	}
+	// Definition plus a surviving call site.
+	if got := strings.Count(rendered, "Cnt("); got != 2 {
+		t.Errorf("expected Cnt to appear twice (definition + un-inlined call), got %d:\n%s",
+			got, rendered)
+	}
+	// The back-edge must stay inside Cnt: Usec2 gets no loop of its own.
+	usec := rendered[strings.Index(rendered, "func Usec2("):]
+	if strings.Contains(usec, "func_entry") {
+		t.Errorf("recur back-edge was spliced into the caller:\n%s", usec)
+	}
+}

--- a/pkg/ir/lisp_inline_test.go
+++ b/pkg/ir/lisp_inline_test.go
@@ -332,7 +332,11 @@ func TestInlineRejectsFunctionLevelRecurCallee(t *testing.T) {
 			got, rendered)
 	}
 	// The back-edge must stay inside Cnt: Usec2 gets no loop of its own.
-	usec := rendered[strings.Index(rendered, "func Usec2("):]
+	at := strings.Index(rendered, "func Usec2(")
+	if at < 0 {
+		t.Fatalf("no func Usec2( in rendered output:\n%s", rendered)
+	}
+	usec := rendered[at:]
 	if strings.Contains(usec, "func_entry") {
 		t.Errorf("recur back-edge was spliced into the caller:\n%s", usec)
 	}

--- a/pkg/ir/op_generated.go
+++ b/pkg/ir/op_generated.go
@@ -65,6 +65,7 @@ const (
 	OpTry         // .Refs[0] = body closure; then optional handler closure (binds the caught value), then optional finally closure; .Aux = {:has-handler bool :has-finally bool}. lower? -> TryOp delegates to try-assign-stmts (registered by ir.lower-go)
 	OpDot         // .Refs[0] = obj; .Aux = field symbol; Go struct field selector obj.field (gogen_ir path only)
 	OpDef         // .Refs[0] = var (Const aux=*vm.Var), optional .Refs[1] = value; interns + returns the var (2-ref also sets root)
+	OpRecurFn     // function-level recur back-edge; .Refs = replacement args (no callee), .Aux = argc int
 )
 
 // opInfo describes an Op's structural metadata.
@@ -118,6 +119,7 @@ var opTable = [...]opInfo{
 	OpTry:                   {"Try", -1, 1, false, false, true, false, true},
 	OpDot:                   {"Dot", 1, 1, false, false, true, false, false},
 	OpDef:                   {"Def", -1, 1, false, false, true, false, false},
+	OpRecurFn:               {"RecurFn", -1, 0, false, true, false, false, false},
 }
 
 // String returns the op's display name (or "Op?" for an unknown op).
@@ -251,6 +253,8 @@ func irOpToBytecode(op Op) int32 {
 		return vm.OP_MAKE_CLOSURE
 	case OpPushClosed:
 		return vm.OP_PUSH_CLOSEDOVER
+	case OpRecurFn:
+		return vm.OP_RECUR_FN
 	default:
 		return vm.OP_NOOP
 	}
@@ -322,12 +326,14 @@ func bytecodeToIROp(op int32) Op {
 		return OpMakeClosure
 	case vm.OP_PUSH_CLOSEDOVER:
 		return OpPushClosed
+	case vm.OP_RECUR_FN:
+		return OpRecurFn
 	default:
 		return OpInvalid
 	}
 }
 
-var opKeywordNames = []string{"invalid", "const", "load-arg", "load-var", "load-closed", "block-arg", "set-var", "call", "tail-call", "add", "sub", "mul", "bit-and", "bit-or", "bit-xor", "bit-and-not", "bit-shift-left", "bit-shift-right", "unsigned-bit-shift-right", "quot", "div", "lt", "lte", "gt", "gte", "eq", "inc", "dec", "bit-not", "pop", "return", "branch", "branch-if", "make-closure", "push-closed", "try", "dot", "def"}
+var opKeywordNames = []string{"invalid", "const", "load-arg", "load-var", "load-closed", "block-arg", "set-var", "call", "tail-call", "add", "sub", "mul", "bit-and", "bit-or", "bit-xor", "bit-and-not", "bit-shift-left", "bit-shift-right", "unsigned-bit-shift-right", "quot", "div", "lt", "lte", "gt", "gte", "eq", "inc", "dec", "bit-not", "pop", "return", "branch", "branch-if", "make-closure", "push-closed", "try", "dot", "def", "recur-fn"}
 
 // OpKeywords returns every catalogued op as its kebab-case keyword name, in Op order.
 func OpKeywords() []string { return opKeywordNames }
@@ -410,6 +416,8 @@ func opByKeywordExact(name string) (Op, bool) {
 		return OpDot, true
 	case "def":
 		return OpDef, true
+	case "recur-fn":
+		return OpRecurFn, true
 	default:
 		return OpInvalid, false
 	}

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -1221,16 +1221,27 @@
       ;; Function-level recur: emit :recur-fn.
       (let [arg-syms (get @ctx :fn-arg-syms)]
         (if arg-syms
-          (let [arg-ids (mapv (fn [a] (build-form a ctx)) (rest form))
-                cur     (ctx-block ctx)]
-            ;; :recur-fn refs are just the new arg values (self-recursive,
-            ;; no fn ref needed) — which is exactly why this is NOT :tail-call.
-            ;; :tail-call is a call: Refs[0] is a callee and the bytecode
-            ;; lowering emits OP_TAIL_CALL, which resolves that callee off the
-            ;; stack. Emitting it here handed OP_TAIL_CALL a callee-less stack
-            ;; and it read an argument instead (nooga/let-go#638).
-            (ir/add-terminator! f cur :recur-fn arg-ids (count arg-ids))
-            TERMINATED)
+          (let [recur-args (rest form)]
+            ;; Arity has to match the enclosing fn. OP_RECUR_FN restarts the
+            ;; frame with whatever count it is handed, so a mismatch rebinds
+            ;; the wrong params and the call spins instead of failing — the
+            ;; non-IR compiler rejects this at compile time, and the two paths
+            ;; must agree. Checked before building the args so a rejected form
+            ;; leaves no half-built blocks behind.
+            (when (not= (count recur-args) (count arg-syms))
+              (throw (str "ir/build: recur argument count must match function "
+                          "argument count (got " (count recur-args)
+                          ", need " (count arg-syms) ")")))
+            (let [arg-ids (mapv (fn [a] (build-form a ctx)) recur-args)
+                  cur     (ctx-block ctx)]
+              ;; :recur-fn refs are just the new arg values (self-recursive,
+              ;; no fn ref needed) — which is exactly why this is NOT :tail-call.
+              ;; :tail-call is a call: Refs[0] is a callee and the bytecode
+              ;; lowering emits OP_TAIL_CALL, which resolves that callee off the
+              ;; stack. Emitting it here handed OP_TAIL_CALL a callee-less stack
+              ;; and it read an argument instead (nooga/let-go#638).
+              (ir/add-terminator! f cur :recur-fn arg-ids (count arg-ids))
+              TERMINATED))
           (throw "recur outside of loop or function"))))))
 
 ;; --- destructuring helpers ------------------------------------------------

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -1193,7 +1193,7 @@
   (build-loop form ctx))
 
 (defn build-recur [form ctx]
-  "recur emits Branch back to the current loop header, or :tail-call for
+  "recur emits Branch back to the current loop header, or :recur-fn for
    function-level recursion.
 
    Subtle: ctx-block must be re-read AFTER building the recur args, not
@@ -1218,14 +1218,18 @@
         (ir/add-terminator! f cur :branch [] bt)
         (ir/add-pred! f header cur)
         TERMINATED)
-      ;; Function-level recur: emit :tail-call.
+      ;; Function-level recur: emit :recur-fn.
       (let [arg-syms (get @ctx :fn-arg-syms)]
         (if arg-syms
           (let [arg-ids (mapv (fn [a] (build-form a ctx)) (rest form))
                 cur     (ctx-block ctx)]
-            ;; :tail-call refs are just the new arg values (self-recursive,
-            ;; no fn ref needed).
-            (ir/add-terminator! f cur :tail-call arg-ids (count arg-ids))
+            ;; :recur-fn refs are just the new arg values (self-recursive,
+            ;; no fn ref needed) — which is exactly why this is NOT :tail-call.
+            ;; :tail-call is a call: Refs[0] is a callee and the bytecode
+            ;; lowering emits OP_TAIL_CALL, which resolves that callee off the
+            ;; stack. Emitting it here handed OP_TAIL_CALL a callee-less stack
+            ;; and it read an argument instead (nooga/let-go#638).
+            (ir/add-terminator! f cur :recur-fn arg-ids (count arg-ids))
             TERMINATED)
           (throw "recur outside of loop or function"))))))
 
@@ -1407,7 +1411,7 @@
   (let [inner     (ir/new-fn (str name-sym) (count args-vec) variadic?)
         entry     (ir/entry-block inner)
         inner-ctx (new-context inner)]
-    ;; Stash arg symbols so build-recur can emit :tail-call at function level.
+    ;; Stash arg symbols so build-recur can emit :recur-fn at function level.
     (reset! inner-ctx (assoc @inner-ctx :fn-arg-syms (vec args-vec)))
     (loop [i 0]
       (when (< i (count args-vec))
@@ -1538,7 +1542,7 @@
             f          (ir/new-fn (str name-sym) arity variadic?)
             entry-blk  (ir/entry-block f)
             ctx        (new-context f)]
-        ;; Stash arg symbols so build-recur can emit :tail-call at function level.
+        ;; Stash arg symbols so build-recur can emit :recur-fn at function level.
         (reset! ctx (assoc @ctx :fn-arg-syms (vec flat-args)))
         (loop [i 0]
           (when (< i arity)

--- a/pkg/rt/core/ir/dump.lg
+++ b/pkg/rt/core/ir/dump.lg
@@ -24,7 +24,7 @@
    [ir.data]
    [string :as str]))
 
-(def terminator-ops #{:tail-call :return :branch :branch-if})
+(def terminator-ops #{:tail-call :recur-fn :return :branch :branch-if})
 
 (defn op-display-name [op-kw]
   "Convert an ir op keyword (e.g. :branch-if, :load-arg) to its

--- a/pkg/rt/core/ir/lower.lg
+++ b/pkg/rt/core/ir/lower.lg
@@ -526,6 +526,14 @@
       (emit-with-arg! l nid :tail-call (int aux))
       ;; TAIL_CALL is a true terminator; no SP tracking needed past this.
 
+      :recur-fn
+      ;; Function-level recur. lower-block! has materialized the replacement
+      ;; args to the top of the stack, which is what OP_RECUR_FN consumes
+      ;; (mult(0, argc), then ip/sp reset). It is NOT OP_TAIL_CALL: that
+      ;; opcode resolves a callee at f.nth(argc), and this terminator carries
+      ;; no callee.
+      (emit-with-arg! l nid :recur-fn (int aux))
+
       :return
       (emit! l nid :return)
 

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -5,7 +5,7 @@
 ;;   - strict mode: unsupported ops/shapes throw
 ;;   - bridge mode: unsupported functions fall back at whole-function granularity
 ;;   - supported ops: const, load-arg, block-arg, add/sub/mul, bitwise int ops,
-;;     lt/lte/gt/gte/eq, inc/dec, return, branch, branch-if, tail-call
+;;     lt/lte/gt/gte/eq, inc/dec, return, branch, branch-if, recur-fn
 ;;   - control flow lowers from block-parameter SSA to mutable locals plus labels/gotos
 
 (ns ir.lower-go
@@ -40,7 +40,7 @@
 (declare function-needs-error?)
 (declare function-needs-rt?)
 (declare function-needs-vm?)
-(declare function-needs-tail-call?)
+(declare function-needs-recur-fn?)
 (declare return-ref-ids)
 (declare function-return-spec)
 (declare const-param-of)
@@ -49,7 +49,7 @@
 (declare param-go-spec)
 
 ;; --- closure-local arg naming -----------------------------------------------
-;; A lowered fn names its parameters arg0/arg1/… and (for tail-call fns) its
+;; A lowered fn names its parameters arg0/arg1/… and (for recur-fn fns) its
 ;; mutable locals a0/a1/… and rest slot args0. An inline closure (lower-fn-lit)
 ;; is lowered with the SAME scheme, but its captured values (:load-closed) are
 ;; spliced in as the ENCLOSING scope's identifiers (e.g. arg0). A closure
@@ -64,11 +64,11 @@
 (def ^:dynamic *closure-arg-prefix* nil)
 
 (defn- go-arg-name [base i]
-  ;; base is "arg" (immutable Go param) or "a" (tail-call mutable local).
+  ;; base is "arg" (immutable Go param) or "a" (recur-fn mutable local).
   (str (or *closure-arg-prefix* "") base i))
 
 (defn- go-args-name [base]
-  ;; variadic rest slot: "args" (param/rest read) or "args0" (tail-call local).
+  ;; variadic rest slot: "args" (param/rest read) or "args0" (recur-fn local).
   (str (or *closure-arg-prefix* "") base))
 
 (defn- unsupported [mode msg]
@@ -813,11 +813,11 @@
 
           (= op :load-arg)
           (if (and (ir/fn-variadic? f) (= aux (dec (ir/fn-arity f))))
-            (let [rest-var (go-args-name (if (function-needs-tail-call? f) "args0" "args"))]
+            (let [rest-var (go-args-name (if (function-needs-recur-fn? f) "args0" "args"))]
               (gogen/call
                 (gogen/field-sel (gogen/ident "rt") "BoxRestArgs")
                 [(gogen/ident rest-var)]))
-            (gogen/ident (go-arg-name (if (function-needs-tail-call? f) "a" "arg") aux)))
+            (gogen/ident (go-arg-name (if (function-needs-recur-fn? f) "a" "arg") aux)))
 
           (= op :load-var)
           ;; In a function with a set! the var is materialised into a one-time
@@ -1312,13 +1312,13 @@
     (when assigns
       (conj assigns (gogen/goto-stmt (label-name (ir/branch-target-target bt)))))))
 
-(defn- tail-call-arg-expr [f closed-exprs nid i variadic-slot?]
-  "Expression assigned to recur loop-slot i (`a<i>`) at a tail-call back-edge.
+(defn- recur-fn-arg-expr [f closed-exprs nid i variadic-slot?]
+  "Expression assigned to recur loop-slot i (`a<i>`) at a recur-fn back-edge.
    Coerces the arg to the SLOT's type (param-go-spec) instead of unconditionally
    boxing to vm.Value: a native slot (int/float64/…) whose arg already has that
    type gets the raw expr (`a0 = v4`, no box); box/unbox only across a genuine
    vm.Value boundary. The variadic rest slot (args0 []vm.Value) still boxes.
-   Shared by BOTH tail-call emitters (lower-terminator + the structured :tail
+   Shared by BOTH recur-fn emitters (lower-terminator + the structured :tail
    case) so they can't diverge — the divergence that left the back-edge boxing
    an int slot after the loop-local was fixed to int."
   (if variadic-slot?
@@ -1374,7 +1374,7 @@
           (when (and cond-expr true-stmts false-stmts)
             [(gogen/if-stmt nil cond-expr true-stmts false-stmts)])))
 
-      (= op :tail-call)
+      (= op :recur-fn)
       (let [tail-args refs
             fixed-arity (if (ir/fn-variadic? f) (dec (ir/fn-arity f)) (ir/fn-arity f))
             assigns (loop [i 0 remaining tail-args out []]
@@ -1382,7 +1382,7 @@
                         out
                         (let [nid            (first remaining)
                               variadic-slot? (and (ir/fn-variadic? f) (= i fixed-arity))
-                              val-expr       (tail-call-arg-expr f closed-exprs nid i variadic-slot?)
+                              val-expr       (recur-fn-arg-expr f closed-exprs nid i variadic-slot?)
                               lhs (if variadic-slot?
                                     (gogen/ident (go-args-name "args0"))
                                     (gogen/ident (go-arg-name "a" i)))]
@@ -2604,7 +2604,7 @@
         (some (fn [nid] (= "vm.Value" (go-type-spec (ir/type-of nid f)))) ret-ids)
         (some function-needs-vm? (nested-template-fns f)))))
 
-(defn- function-needs-tail-call? [f]
+(defn- function-needs-recur-fn? [f]
   ;; Blocks with no terminator (e.g. unreachable dead blocks left by build)
   ;; return nil from block-term; `(ir/op nil f)` would fail. Skip them.
   (loop [blocks (ir/blocks f)]
@@ -2614,16 +2614,16 @@
       (let [term (ir/block-term (first blocks) f)]
         (cond
           (nil? term) (recur (rest blocks))
-          (= :tail-call (ir/op term f)) true
+          (= :recur-fn (ir/op term f)) true
           :else (recur (rest blocks)))))))
 
 (defn- param-inferred-type [f i]
-  "Lattice type inferred for parameter i — for a tail-call fn this IS the
+  "Lattice type inferred for parameter i — for a recur-fn fn this IS the
    loop-carried type, since typeinfer's fixpoint folds every recur back-edge arg
    into the entry LoadArg. Priority: load-arg inst inference > explicit
    fn-arg-types metadata > :unknown. The single source of truth for a param's
    type, shared by params-for (the Go param decl `arg<i>`), arg-local-decls (its
-   mutable tail-call loop-local `a<i>`), and the tail-call back-edge assignment —
+   mutable recur-fn loop-local `a<i>`), and the recur-fn back-edge assignment —
    so the three can never diverge. That divergence was the bug: params-for learned
    to specialize `arg<i>` to a native type (int/float64) from the indexed IR type,
    but the loop-local + back-edge stayed hardcoded vm.Value, producing Go that
@@ -2640,7 +2640,7 @@
   (or (go-type-spec (param-inferred-type f i)) "vm.Value"))
 
 (defn- arg-local-decls [f]
-  "For tail-call fns, declare mutable locals (a0, a1, ...) that shadow the
+  "For recur-fn fns, declare mutable locals (a0, a1, ...) that shadow the
    immutable Go params, plus init assignments (a0 = arg0, ...). Each loop-local
    takes its param's inferred Go type (param-go-spec), NOT a hardcoded vm.Value —
    so `a<i> = arg<i>` and the body's native uses of `a<i>` agree.
@@ -3055,7 +3055,7 @@
         (let [bid (first args)]
           (when-let [inst-stmts (block-inst-stmts f closed-exprs bid)]
             (when-let [term (ir/block-term bid f)]
-              (when (= :tail-call (ir/op term f))
+              (when (= :recur-fn (ir/op term f))
                 (let [tail-args (ir/refs term f)
                       fixed-arity (if (ir/fn-variadic? f) (dec (ir/fn-arity f)) (ir/fn-arity f))
                       assigns (loop [i 0 remaining tail-args out []]
@@ -3063,7 +3063,7 @@
                                   out
                                   (let [nid            (first remaining)
                                         variadic-slot? (and (ir/fn-variadic? f) (= i fixed-arity))
-                                        val-expr       (tail-call-arg-expr f closed-exprs nid i variadic-slot?)
+                                        val-expr       (recur-fn-arg-expr f closed-exprs nid i variadic-slot?)
                                         lhs (if variadic-slot?
                                               (gogen/ident (go-args-name "args0"))
                                               (gogen/ident (go-arg-name "a" i)))]
@@ -3144,7 +3144,7 @@
    (binding [*call-err-used* (atom false)
              *typed-call-temps* (atom [])]
      (let [needs-error?     (function-needs-error? f)
-           needs-tail-call? (function-needs-tail-call? f)
+           needs-recur-fn? (function-needs-recur-fn? f)
            ;; Build the body FIRST (inside the *call-err-used* binding) so we
            ;; know whether it actually references callErr before deciding to
            ;; declare it. Structured path: build.lg emits reducible CFGs, so try
@@ -3201,12 +3201,12 @@
                                 (conj acc (gogen/var-decl nm (gogen/type go-type) nil)))
                               decls1
                               (distinct @*typed-call-temps*))
-               [arg-decls arg-inits] (if needs-tail-call?
+               [arg-decls arg-inits] (if needs-recur-fn?
                                        (arg-local-decls f)
                                        [[] []])
                decls  (into decls1 arg-decls)
                entry-label [(gogen/label-stmt "func_entry" nil)]
-               base (if needs-tail-call?
+               base (if needs-recur-fn?
                       (vec (concat decls arg-inits entry-label))
                       decls)]
            (into base body-stmts)))))))

--- a/pkg/rt/core/ir/passes/inline.lg
+++ b/pkg/rt/core/ir/passes/inline.lg
@@ -62,13 +62,27 @@
                     (ir/block-insts bid f)))
             (ir/blocks f)))))
 
+(defn- has-recur-fn? [f]
+  "True if any block ends in :recur-fn — a function-level `recur` back-edge.
+   self-recursive? cannot see this: a function-level recur re-enters via the
+   terminator, with no :load-var of the fn's own name to spot. Splicing such a
+   callee into a caller would clone the back-edge, which then re-enters the
+   CALLER (nooga/let-go#638)."
+  (boolean
+    (some (fn [bid]
+            (let [term (ir/block-term bid f)]
+              (and term (= :recur-fn (ir/op term f)))))
+          (ir/blocks f))))
+
 (defn inline-eligible? [callee-f]
   "True when callee-f is eligible for inlining:
    - does not rebind var roots (checked via mutability analysis)
-   - is not self-recursive
+   - is not self-recursive, by either spelling: a :load-var self-call
+     (self-recursive?) or a function-level recur (has-recur-fn?)
    - contains <= max-inline-insts instructions"
   (and (not (mut/rebinds-var-roots? callee-f))
        (not (self-recursive? callee-f))
+       (not (has-recur-fn? callee-f))
        (<= (inst-count callee-f) max-inline-insts)))
 
 (defn call-head-var [f call-nid]
@@ -302,8 +316,10 @@
                 (ir/add-pred! f (ir/branch-target-target ft) nb))
 
               :else
-              ;; Defensive: any other terminator (e.g. :tail-call — no block
-              ;; targets) clones with refs remapped and aux carried verbatim.
+              ;; Defensive: any other terminator (e.g. :tail-call/:recur-fn —
+              ;; no block targets) clones with refs remapped and aux carried
+              ;; verbatim. inline-eligible? refuses :recur-fn callees, so a
+              ;; back-edge cannot reach here and re-enter the CALLER.
               (ir/add-terminator! f nb top
                 (mapv (fn [r] (get @nid-map r r)) (ir/refs term callee-f))
                 (ir/aux term callee-f)))))

--- a/pkg/rt/core/ir/passes/liveness.lg
+++ b/pkg/rt/core/ir/passes/liveness.lg
@@ -179,7 +179,7 @@
       (let [term (ir/block-term bid f)]
         (when term
           (let [op (ir/op term f)]
-            (when (or (= op :return) (= op :branch-if) (= op :tail-call))
+            (when (or (= op :return) (= op :branch-if) (= op :tail-call) (= op :recur-fn))
               (doseq [r (ir/refs term f)] (seed r))))))
       (doseq [nid (ir/block-insts bid f)]
         (when (= :call (ir/op nid f))

--- a/pkg/rt/core/ir/passes/purity.lg
+++ b/pkg/rt/core/ir/passes/purity.lg
@@ -66,8 +66,13 @@
 (def pure-terminator-ops
   "Terminator ops that are themselves side-effect-free (control flow /
    dataflow only). A block whose terminator is in this set can be
-   pure-block? if all its body Insts are pure."
-  #{:branch :branch-if :return})
+   pure-block? if all its body Insts are pure.
+
+   :recur-fn belongs here for the same reason :branch does — a
+   function-level recur is a back-edge that rebinds args and jumps, with
+   no effect of its own. Omitting it would keep LICM and the other
+   pure-block passes off every recur-fn loop."
+  #{:branch :branch-if :return :recur-fn})
 
 (defn pure-terminator-op?
   [op]

--- a/pkg/rt/core/ir/passes/typeinfer.lg
+++ b/pkg/rt/core/ir/passes/typeinfer.lg
@@ -261,8 +261,8 @@
       (= op :call)            (or (call-dtype inst f)
                                   (call-core-type inst f state)
                                   :unknown)
-      ;; Facetless ops (:set-var, :tail-call, :pop, closures, :try, :dot,
-      ;; :def) — no type information tracked.
+      ;; Facetless ops (:set-var, :tail-call, :recur-fn, :pop, closures, :try,
+      ;; :dot, :def) — no type information tracked.
       :else :unknown)))
 
 ;; --- fixpoint driver -------------------------------------------------

--- a/pkg/rt/core/ir/structurize.lg
+++ b/pkg/rt/core/ir/structurize.lg
@@ -9,7 +9,8 @@
 ;; target-INDEPENDENT control tree:
 ;;
 ;;   [:return    bid]                 block bid's terminator is :return
-;;   [:tail      bid]                 terminator is :tail-call
+;;   [:tail      bid]                 terminator is :recur-fn (function-level
+;;                                    recur back-edge)
 ;;   [:seq       bid edge next]       :branch; edge = branch-target, then `next`
 ;;   [:if        bid tt et then else cont]
 ;;                                    :branch-if; tt/et = the true/false
@@ -208,7 +209,7 @@
         op   (ir/op term f)]
     (cond
       (= op :return)    [:return b]
-      (= op :tail-call) [:tail b]
+      (= op :recur-fn)  [:tail b]
 
       (= op :branch)
       (let [edge (ir/aux term f)]

--- a/pkg/rt/core/ir/structurize.lg
+++ b/pkg/rt/core/ir/structurize.lg
@@ -211,6 +211,14 @@
       (= op :return)    [:return b]
       (= op :recur-fn)  [:tail b]
 
+      ;; build.lg no longer emits :tail-call — function-level recur is
+      ;; :recur-fn now. Without this arm a stray one would land in the
+      ;; :else fallback below and degrade to an unstructured :goto, which
+      ;; is a silent miscompile risk rather than a visible regression.
+      (= op :tail-call)
+      (throw (str "ir/structurize: unexpected :tail-call terminator in block "
+                  b " — build.lg emits :recur-fn for function-level recur"))
+
       (= op :branch)
       (let [edge (ir/aux term f)]
         [:seq b edge (edge->node f ctx edge stop)])

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-d62e01c7a9d36f27beb45cdd0ccffacca211078a391a92ab195fe00f09846acb
+e0876236eff2ad2d40708cabe4cd1f426144f950eb0c57d099b24d63755e2cd1

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-c1c6e3a30352271dd54c0c20ff0ba88096771d8ad2d6df48b39655beeac4a7dc
+db508d93800e65183d91fc94ee9861ef54c50b7be8d9c23a6d4703d4a5c8af9a

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-db508d93800e65183d91fc94ee9861ef54c50b7be8d9c23a6d4703d4a5c8af9a
+d62e01c7a9d36f27beb45cdd0ccffacca211078a391a92ab195fe00f09846acb

--- a/test/ir_compile_loop_test.lg
+++ b/test/ir_compile_loop_test.lg
@@ -145,3 +145,44 @@
 (deftest ir-compile-fn-level-recur-deep
   (testing "the back-edge is a jump, so depth is unbounded"
     (is (= 499999500000 (ir-fnrecur-3 0 0 1000000)))))
+
+;; --- function-level recur: arity mismatch --------------------------------
+;; build-recur emitted :recur-fn with whatever argument count it was handed.
+;; OP_RECUR_FN accepts that count and restarts the frame, so `(defn f [x]
+;; (recur))` compiled clean and then spun forever instead of failing. The
+;; bytecode compiler has always rejected it ("recur argument count must match
+;; function argument count"); the IR path has to agree.
+;;
+;; These assert through *ir-compile-strict* on purpose. Under the default
+;; fallback a rejected form is re-compiled by the bytecode compiler, which
+;; throws for its own reasons — so a default-mode assertion would stay green
+;; even if the IR check were removed, and would prove it by hanging. Strict
+;; mode fails at the IR builder, which is the thing under test.
+(def fnrecur-under-arity '(defn fnrecur-under-probe [x] (recur)))
+(def fnrecur-over-arity  '(defn fnrecur-over-probe [x] (recur 1 2)))
+
+(deftest ir-compile-fn-recur-arity-mismatch-rejected
+  (testing "too few recur args are rejected at the IR builder"
+    (is (= :threw
+           (binding [*ir-compile* true *ir-compile-strict* true]
+             (try (eval fnrecur-under-arity) :no-throw (catch _ :threw))))))
+  (testing "too many recur args are rejected at the IR builder"
+    (is (= :threw
+           (binding [*ir-compile* true *ir-compile-strict* true]
+             (try (eval fnrecur-over-arity) :no-throw (catch _ :threw)))))))
+
+(deftest ir-compile-fn-recur-arity-mismatch-names-the-counts
+  (testing "the throw identifies the arity mismatch, not some later failure"
+    (let [msg (binding [*ir-compile* true *ir-compile-strict* true]
+                (try (eval fnrecur-under-arity) "" (catch e (str e))))]
+      (is (>= (index-of msg "recur argument count") 0))
+      (is (>= (index-of msg "got 0") 0))
+      (is (>= (index-of msg "need 1") 0)))))
+
+(deftest ir-compile-fn-recur-matching-arity-still-compiles
+  (testing "a correct-arity function-level recur is unaffected by the check"
+    (is (= :ok
+           (binding [*ir-compile* true *ir-compile-strict* true]
+             (try (eval '(defn fnrecur-ok-probe [n] (if (< n 0) :done (recur (dec n)))))
+                  :ok (catch _ :threw)))))
+    (is (= :done (eval '(fnrecur-ok-probe 3))))))

--- a/test/ir_compile_loop_test.lg
+++ b/test/ir_compile_loop_test.lg
@@ -103,6 +103,9 @@
   (if (< n 0) (+ (* 100 a) (* 10 b) c) (recur b c a (dec n))))
 ;; recur in the OTHER arm, so the back-edge is not the fall-through branch.
 (defn ir-fnrecur-else [i n] (if (>= i n) i (recur (inc i) n)))
+;; Variadic: the back-edge has to rebind the packed rest slot, not just the
+;; fixed params. recur passes the rest as one seq, so the arity is 2 here.
+(defn ir-fnrecur-var [n & xs] (if (< n 0) (apply + xs) (recur (dec n) (cons n xs))))
 
 (set! *ir-compile* false)
 
@@ -114,6 +117,7 @@
 (defn bc-fnrecur-rot [a b c n]
   (if (< n 0) (+ (* 100 a) (* 10 b) c) (recur b c a (dec n))))
 (defn bc-fnrecur-else [i n] (if (>= i n) i (recur (inc i) n)))
+(defn bc-fnrecur-var [n & xs] (if (< n 0) (apply + xs) (recur (dec n) (cons n xs))))
 
 (deftest ir-compile-fn-level-recur-arities
   (testing "a taken function-level recur runs and matches the bytecode backend"
@@ -141,6 +145,16 @@
   (testing "the back-edge works from either arm of the if"
     (is (= (bc-fnrecur-else 0 4) (ir-fnrecur-else 0 4)))
     (is (= 4 (ir-fnrecur-else 0 4)))))
+
+(deftest ir-compile-fn-level-recur-variadic
+  (testing "a variadic function-level recur rebinds the packed rest slot"
+    (is (= (bc-fnrecur-var 3) (ir-fnrecur-var 3)))
+    (is (= (bc-fnrecur-var 2 10) (ir-fnrecur-var 2 10)))
+    (is (= 6 (ir-fnrecur-var 3)))
+    (is (= 13 (ir-fnrecur-var 2 10))))
+  (testing "an untaken variadic back-edge still returns"
+    (is (= (bc-fnrecur-var -1) (ir-fnrecur-var -1)))
+    (is (= 0 (ir-fnrecur-var -1)))))
 
 (deftest ir-compile-fn-level-recur-deep
   (testing "the back-edge is a jump, so depth is unbounded"

--- a/test/ir_compile_loop_test.lg
+++ b/test/ir_compile_loop_test.lg
@@ -1,6 +1,14 @@
 ;; Tests for *ir-compile* path with loop/recur forms
 ;; Covers the bytecode compilation of loop/recur, including direct loops,
 ;; loops inside returned closures, and loops with binding shadowing.
+;;
+;; The second half covers FUNCTION-LEVEL recur — `(defn f [..] .. (recur ..))`
+;; with no enclosing loop*. It has its own terminator (:recur-fn) and its own
+;; opcode (OP_RECUR_FN); before #638 it was emitted as :tail-call/OP_TAIL_CALL,
+;; which resolves a callee this terminator does not carry, so a taken back-edge
+;; read an argument as the callee (arity 3: "Int is not a function") or indexed
+;; below the frame base (arity 1 and 2: index out of range). Each case is
+;; asserted against a bytecode-compiled twin so the two backends have to agree.
 (ns test.ir-compile-loop-test
   (:require
    [ir.passes.pipeline]
@@ -79,3 +87,61 @@
   (testing "nested loop/recur under *ir-compile* true"
     ;; outer: i=0 < 3 → result is the inner loop's value, which runs j to m.
     (is (= 5 (ir-nested-loop 3 5)))))
+
+;; --- function-level recur (#638) -----------------------------------------
+;; Arity matters: OP_TAIL_CALL resolved its callee at f.nth(argc), so the slot
+;; it landed on — and therefore the failure mode — moved with the arity. All
+;; three are pinned.
+
+(set! *ir-compile* true)
+
+(defn ir-fnrecur-1 [n] (if (< n 0) :done (recur (dec n))))
+(defn ir-fnrecur-2 [s n] (if (< n 0) s (recur (inc s) (dec n))))
+(defn ir-fnrecur-3 [i s n] (if (< i n) (recur (inc i) (+ s i) n) s))
+;; Permuted args: the back-edge rebinds slots out of order.
+(defn ir-fnrecur-rot [a b c n]
+  (if (< n 0) (+ (* 100 a) (* 10 b) c) (recur b c a (dec n))))
+;; recur in the OTHER arm, so the back-edge is not the fall-through branch.
+(defn ir-fnrecur-else [i n] (if (>= i n) i (recur (inc i) n)))
+
+(set! *ir-compile* false)
+
+;; Bytecode-compiled twins. Same source, plain compiler — the reference the
+;; IR path has to match.
+(defn bc-fnrecur-1 [n] (if (< n 0) :done (recur (dec n))))
+(defn bc-fnrecur-2 [s n] (if (< n 0) s (recur (inc s) (dec n))))
+(defn bc-fnrecur-3 [i s n] (if (< i n) (recur (inc i) (+ s i) n) s))
+(defn bc-fnrecur-rot [a b c n]
+  (if (< n 0) (+ (* 100 a) (* 10 b) c) (recur b c a (dec n))))
+(defn bc-fnrecur-else [i n] (if (>= i n) i (recur (inc i) n)))
+
+(deftest ir-compile-fn-level-recur-arities
+  (testing "a taken function-level recur runs and matches the bytecode backend"
+    (is (= (bc-fnrecur-1 3) (ir-fnrecur-1 3)))
+    (is (= (bc-fnrecur-2 0 3) (ir-fnrecur-2 0 3)))
+    (is (= (bc-fnrecur-3 0 0 4) (ir-fnrecur-3 0 0 4)))
+    ;; and the values themselves, so a twin that broke the same way still fails
+    (is (= :done (ir-fnrecur-1 3)))
+    (is (= 4 (ir-fnrecur-2 0 3)))
+    (is (= 6 (ir-fnrecur-3 0 0 4)))))
+
+(deftest ir-compile-fn-level-recur-untaken
+  (testing "a function-level recur whose back-edge is never taken still returns"
+    (is (= 0 (ir-fnrecur-3 5 0 5)))
+    (is (= :done (ir-fnrecur-1 -1)))))
+
+(deftest ir-compile-fn-level-recur-permuted-args
+  (testing "a back-edge that permutes its arguments rebinds all slots at once"
+    (is (= (bc-fnrecur-rot 1 2 3 0) (ir-fnrecur-rot 1 2 3 0)))
+    (is (= (bc-fnrecur-rot 1 2 3 1) (ir-fnrecur-rot 1 2 3 1)))
+    (is (= 231 (ir-fnrecur-rot 1 2 3 0)))
+    (is (= 312 (ir-fnrecur-rot 1 2 3 1)))))
+
+(deftest ir-compile-fn-level-recur-else-arm
+  (testing "the back-edge works from either arm of the if"
+    (is (= (bc-fnrecur-else 0 4) (ir-fnrecur-else 0 4)))
+    (is (= 4 (ir-fnrecur-else 0 4)))))
+
+(deftest ir-compile-fn-level-recur-deep
+  (testing "the back-edge is a jump, so depth is unbounded"
+    (is (= 499999500000 (ir-fnrecur-3 0 0 1000000)))))

--- a/test/structurize_test.lg
+++ b/test/structurize_test.lg
@@ -50,6 +50,13 @@
                          (if (> y 100) :big (if (> y 10) :med :small))))
    '(defn loop-if [n] (loop [i 0 t 0]
                         (if (< i n) (recur (inc i) (if (even? i) (+ t i) t)) t)))
+   ;; Function-level recur (no enclosing loop*) — its own terminator
+   ;; (:recur-fn), so it needs its own corpus row. The corpus covered only the
+   ;; loop* spelling, which is how a structurize arm that matched the old
+   ;; terminator kept passing while every function-level recur silently
+   ;; dropped to the goto+label emitter (#638).
+   '(defn fnrecur [i n] (if (< i n) (recur (inc i) n) i))
+   '(defn fnrecur-let [i n] (let [j (inc i)] (if (< j n) (recur j n) j)))
    ;; lambda-bearing: the OUTER fn's control flow must structure cleanly.
    ;; (each nested fn is a separate IR Function, structurized independently)
    '(defn adder [x] (fn [y] (+ x y)))


### PR DESCRIPTION
Closes #638.

A function-level `recur` — `(defn f [..] .. (recur ..))` with no enclosing `loop*` — crashed under `*ir-compile*` the moment the back-edge was taken. Arity 3 gave `Int is not a function`; arities 1 and 2 gave `index out of range [-1]`.

`build-recur` emitted a `:tail-call` terminator carrying only the replacement arguments, and `lower.lg` maps `:tail-call` to `OP_TAIL_CALL`, which resolves its callee at `f.nth(argc)`. With no callee pushed, that read an argument or indexed below the frame base, which is also why the failure mode moved with the arity.

`OP_RECUR_FN` is the opcode for this shape and has been there all along: it pops `argc` arguments, copies them into `f.args`, and resets `ip`/`sp`. `recurCompiler` emits it for the same source. Only the IR path diverged.

## The fix

Split the two spellings that were sharing one keyword. `:tail-call` is a call: `Refs[0]` is a callee, it can dispatch anywhere, and it is what bytecode lifting decodes `OP_TAIL_CALL` into. `:recur-fn` carries only arguments and statically re-enters the executing function. Conflating them is what let a callee-less terminator reach a callee-resolving opcode.

This is not the silent bytecode fallback. Lowering reported success and emitted bad bytecode, so neither the fallback nor `*ir-compile-strict*` saw anything wrong.

## Consumers that move with the terminator

**structurize.** `structure-straight` matched `:tail-call`, so without updating it every function-level recur stops structuring and drops to the goto+label emitter — `sumr` goes from 1 goto/1 label to 4/4 — and under `LG_STRICT_STRUCTURED` the function is refused outright and falls back to bytecode. Updated, it structures as before and the rendered Go for these shapes is unchanged.

**liveness.** `:recur-fn` refs have to be seeded, or the back-edge arguments are dead-code eliminated.

**lower_go.** Its two back-edge emitters key on the new op, and the private helpers follow the name (`function-needs-recur-fn?`, `recur-fn-arg-expr`).

## A second defect with the same root

`inline-eligible?` recognized only recursion that goes through a `:load-var` of the callee's own name. A function-level recur re-enters through the terminator and never loads its own name, so such a callee read as inlineable.

Splicing it is a miscompile: the cloned back-edge rebinds parameter slots by index against the *caller's* frame, so a 1-arg callee inlined into a 2-arg caller writes the caller's `a0` while the loop body reads `a1`, and the caller spins forever. Latent behind `*enable-inline*`, which is opt-in, but wrong whenever it is on.

## Test gaps that kept this alive

`test/ir_compile_loop_test.lg` covered only the `loop*` spelling. `structurize_test.lg`'s corpus describes itself as "every shape build.lg can emit" while omitting function-level recur. An arm matching the old terminator kept passing in both. Both corpora now carry it.

## Validation

- `make test`, `go test ./pkg/...`, `make check-generated`: green
- gofmt clean; `GOOS=linux`, `GOOS=js GOARCH=wasm`, and `GOOS=plan9 GOARCH=amd64` all build
- New coverage: arities 1 through 3, permuted arguments, recur in either `if` arm, an untaken back-edge, and a million-deep run, each asserted against a bytecode-compiled twin as well as expected values
- Red-checked: reverting the terminator alone makes the `*ir-compile*` tests error, and reverting the structurize arm alone makes the two new corpus rows report 1 goto fallback each
- The inline miscompile was reproduced on a pre-guard build before the guard was written
