### PR TITLE
vm: make direct bytecode calls non-recursive with an explicit frame chain

### DIFF
--- a/pkg/vm/explicit_frame_test.go
+++ b/pkg/vm/explicit_frame_test.go
@@ -1,6 +1,9 @@
 package vm
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func testBytecodeFnReturningArg(consts *Consts, arity int) *Func {
 	chunk := NewCodeChunk(consts)
@@ -22,7 +25,18 @@ func testInvokeZeroChunk(consts *Consts, fn Fn) *CodeChunk {
 	return chunk
 }
 
-func TestChildFrameForSelectsMultiArityAndPreservesCaptures(t *testing.T) {
+func testTailCallZeroChunk(consts *Consts, fn Fn) *CodeChunk {
+	chunk := NewCodeChunk(consts)
+	chunk.Append(OP_LOAD_CONST)
+	chunk.Append32(consts.Intern(fn))
+	chunk.Append(OP_TAIL_CALL)
+	chunk.Append32(0)
+	chunk.Append(OP_RETURN)
+	chunk.SetMaxStack(4)
+	return chunk
+}
+
+func TestResolveBytecodeCallSelectsMultiArityAndPreservesCaptures(t *testing.T) {
 	consts := NewConsts()
 	oneArg := testBytecodeFnReturningArg(consts, 1)
 	twoArg := testBytecodeFnReturningArg(consts, 2)
@@ -31,28 +45,161 @@ func TestChildFrameForSelectsMultiArityAndPreservesCaptures(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	child, err := childFrameFor(NewMetaFn(multi, NIL), []Value{Int(7)}, RootExecContext)
+	target, direct, err := resolveBytecodeCall(NewMetaFn(multi, NIL), []Value{Int(7)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if child == nil || child.code != oneArg.chunk {
+	if !direct || target.fn.chunk != oneArg.chunk {
 		t.Fatal("metadata-wrapped multi-arity call did not select its bytecode variant")
 	}
-	ReleaseFrame(child)
 
 	captures := []Value{Int(99)}
 	closure := &Closure{fn: multi, closedOvers: captures}
-	child, err = childFrameFor(closure, []Value{Int(7), Int(8)}, RootExecContext)
+	target, direct, err = resolveBytecodeCall(closure, []Value{Int(7), Int(8)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if child == nil || child.code != twoArg.chunk {
+	if !direct || target.fn.chunk != twoArg.chunk {
 		t.Fatal("closure over multi-arity function did not select its bytecode variant")
 	}
-	if len(child.closedOvers) != 1 || child.closedOvers[0] != captures[0] {
-		t.Fatalf("closure captures were not preserved: got %v, want %v", child.closedOvers, captures)
+	if len(target.closedOvers) != 1 || target.closedOvers[0] != captures[0] {
+		t.Fatalf("closure captures were not preserved: got %v, want %v", target.closedOvers, captures)
 	}
-	ReleaseFrame(child)
+}
+
+func TestResolveBytecodeCallVariadicPackingDoesNotMutateBorrowedArgs(t *testing.T) {
+	consts := NewConsts()
+	variadic := MakeFunc(2, true, testBytecodeFnReturningArg(consts, 2).chunk)
+	borrowed := []Value{Int(7), Int(11), Int(13)}
+
+	target, direct, err := resolveBytecodeCall(variadic, borrowed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !direct {
+		t.Fatal("variadic bytecode function was not resolved")
+	}
+	if borrowed[0] != Value(Int(7)) || borrowed[1] != Value(Int(11)) || borrowed[2] != Value(Int(13)) {
+		t.Fatalf("resolver mutated borrowed args: got %v", borrowed)
+	}
+	if len(target.args) != 2 || target.args[0] != Value(Int(7)) {
+		t.Fatalf("unexpected packed args: %v", target.args)
+	}
+	if target.args[1].String() != "(11 13)" {
+		t.Fatalf("unexpected packed rest args: %v", target.args[1])
+	}
+}
+
+func TestInstallBytecodeCallOwnsBorrowedArgs(t *testing.T) {
+	consts := NewConsts()
+	targetFn := testBytecodeFnReturningArg(consts, 2)
+	frame := NewFrame(testBytecodeFnReturningArg(consts, 0).chunk, nil)
+	frame.stack[0] = Int(7)
+	frame.stack[1] = Int(11)
+	frame.sp = 2
+
+	target, direct, err := resolveBytecodeCall(targetFn, frame.stack[:2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !direct {
+		t.Fatal("fixed-arity bytecode function was not resolved")
+	}
+	installBytecodeCall(frame, target)
+	frame.stack[0] = Int(99)
+	if frame.args[0] != Value(Int(7)) || frame.args[1] != Value(Int(11)) {
+		t.Fatalf("tail transition retained operand-stack-backed args: %v", frame.args)
+	}
+	ReleaseFrame(frame)
+}
+
+func TestSuspendedCallArityValidatesContinuation(t *testing.T) {
+	valid := NewCodeChunk(NewConsts())
+	valid.Append(OP_INVOKE)
+	valid.Append32(1)
+	valid.SetMaxStack(4)
+	frame := NewFrame(valid, nil)
+	frame.sp = 2
+	if arity, err := suspendedCallArity(frame); err != nil || arity != 1 {
+		t.Fatalf("valid continuation: arity=%d err=%v", arity, err)
+	}
+
+	tests := []struct {
+		name  string
+		code  []int32
+		ip    int
+		sp    int
+		match string
+	}{
+		{name: "negative ip", code: []int32{OP_INVOKE, 0}, ip: -1, sp: 1, match: "out of bounds"},
+		{name: "ip past end", code: []int32{OP_INVOKE, 0}, ip: 2, sp: 1, match: "out of bounds"},
+		{name: "missing arity", code: []int32{OP_INVOKE}, ip: 0, sp: 1, match: "missing arity"},
+		{name: "wrong opcode", code: []int32{OP_NOOP, 0}, ip: 0, sp: 1, match: "NOOP"},
+		{name: "invalid stack depth", code: []int32{OP_INVOKE, 0}, ip: 0, sp: 5, match: "stack depth 5 is out of bounds"},
+		{name: "negative arity", code: []int32{OP_INVOKE, -1}, ip: 0, sp: 1, match: "arity -1"},
+		{name: "arity exceeds stack", code: []int32{OP_TAIL_CALL, 2}, ip: 0, sp: 2, match: "exceeds stack depth"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk := NewCodeChunk(NewConsts())
+			chunk.Append(tt.code...)
+			chunk.SetMaxStack(4)
+			candidate := NewFrame(chunk, nil)
+			candidate.ip = tt.ip
+			candidate.sp = tt.sp
+			_, err := suspendedCallArity(candidate)
+			if err == nil || !strings.Contains(err.Error(), tt.match) {
+				t.Fatalf("got %v, want error containing %q", err, tt.match)
+			}
+			ReleaseFrame(candidate)
+		})
+	}
+	ReleaseFrame(frame)
+}
+
+func TestTailCallClosureArityErrorMatchesInvokeAndIsCatchable(t *testing.T) {
+	consts := NewConsts()
+	closure := &Closure{fn: testBytecodeFnReturningArg(consts, 1)}
+
+	run := func(chunk *CodeChunk) error {
+		frame := NewFrame(chunk, nil)
+		frame.ec = RootExecContext
+		_, err := frame.Run()
+		ReleaseFrame(frame)
+		return err
+	}
+	invokeErr := run(testInvokeZeroChunk(consts, closure))
+	tailErr := run(testTailCallZeroChunk(consts, closure))
+	if invokeErr == nil || tailErr == nil {
+		t.Fatalf("expected arity errors: invoke=%v tail=%v", invokeErr, tailErr)
+	}
+	if got, want := innermostMessage(tailErr), innermostMessage(invokeErr); got != want {
+		t.Fatalf("tail-call arity error differs from invoke: got %q, want %q", got, want)
+	}
+
+	catching := NewCodeChunk(consts)
+	catching.Append(OP_TRY_PUSH)
+	catching.Append32(9) // catch at the final OP_RETURN
+	catching.Append32(0)
+	catching.Append(OP_LOAD_CONST)
+	catching.Append32(consts.Intern(closure))
+	catching.Append(OP_TAIL_CALL)
+	catching.Append32(0)
+	catching.Append(OP_TRY_POP)
+	catching.Append(OP_RETURN)
+	catching.Append(OP_RETURN)
+	catching.SetMaxStack(4)
+	frame := NewFrame(catching, nil)
+	frame.ec = RootExecContext
+	result, err := frame.Run()
+	ReleaseFrame(frame)
+	if err != nil {
+		t.Fatalf("caught tail-call arity error escaped: %v", err)
+	}
+	ex, ok := result.(*ExInfo)
+	if !ok || !strings.Contains(ex.Message(), "expected 1 args, got 0") {
+		t.Fatalf("unexpected caught value: %v", result)
+	}
 }
 
 func TestDescendedFrameLifecycle(t *testing.T) {
@@ -91,6 +238,51 @@ func TestDescendedFrameLifecycle(t *testing.T) {
 	parentChunk = testInvokeZeroChunk(consts, child)
 
 	root := NewFrame(parentChunk, nil)
+	root.ec = RootExecContext
+	if _, err := root.Run(); err != nil {
+		t.Fatal(err)
+	}
+	ReleaseFrame(root)
+
+	attrMu.Lock()
+	defer attrMu.Unlock()
+	if len(attrStack) != 0 {
+		t.Fatalf("allocation attribution stack leaked %d frame(s)", len(attrStack))
+	}
+}
+
+func TestZeroArityClosureTailCallDescendsInDispatchLoop(t *testing.T) {
+	oldAllocAttr := allocAttrEnabled
+	allocAttrEnabled = true
+	attrMu.Lock()
+	oldAttrStack := attrStack
+	attrStack = nil
+	attrMu.Unlock()
+	t.Cleanup(func() {
+		attrMu.Lock()
+		attrStack = oldAttrStack
+		attrMu.Unlock()
+		allocAttrEnabled = oldAllocAttr
+	})
+
+	consts := NewConsts()
+	checkerValue, err := NativeFnType.Wrap(func(_ []Value) (Value, error) {
+		attrMu.Lock()
+		defer attrMu.Unlock()
+		if len(attrStack) != 2 {
+			return NIL, NewExecutionError("zero-arity tail call did not enter exactly one child frame")
+		}
+		if attrStack[1].parent != attrStack[0] {
+			return NIL, NewExecutionError("zero-arity closure re-entered Frame.Run instead of linking its parent")
+		}
+		return Int(1), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	childChunk := testInvokeZeroChunk(consts, checkerValue.(Fn))
+	closure := &Closure{fn: MakeFunc(0, false, childChunk)}
+	root := NewFrame(testTailCallZeroChunk(consts, closure), nil)
 	root.ec = RootExecContext
 	if _, err := root.Run(); err != nil {
 		t.Fatal(err)

--- a/pkg/vm/explicit_frame_test.go
+++ b/pkg/vm/explicit_frame_test.go
@@ -1,0 +1,191 @@
+package vm
+
+import "testing"
+
+func testBytecodeFnReturningArg(consts *Consts, arity int) *Func {
+	chunk := NewCodeChunk(consts)
+	chunk.Append(OP_LOAD_ARG)
+	chunk.Append32(0)
+	chunk.Append(OP_RETURN)
+	chunk.SetMaxStack(4)
+	return MakeFunc(arity, false, chunk)
+}
+
+func testInvokeZeroChunk(consts *Consts, fn Fn) *CodeChunk {
+	chunk := NewCodeChunk(consts)
+	chunk.Append(OP_LOAD_CONST)
+	chunk.Append32(consts.Intern(fn))
+	chunk.Append(OP_INVOKE)
+	chunk.Append32(0)
+	chunk.Append(OP_RETURN)
+	chunk.SetMaxStack(4)
+	return chunk
+}
+
+func TestChildFrameForSelectsMultiArityAndPreservesCaptures(t *testing.T) {
+	consts := NewConsts()
+	oneArg := testBytecodeFnReturningArg(consts, 1)
+	twoArg := testBytecodeFnReturningArg(consts, 2)
+	multi, err := MakeMultiArity([]Value{oneArg, twoArg})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	child, err := childFrameFor(NewMetaFn(multi, NIL), []Value{Int(7)}, RootExecContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if child == nil || child.code != oneArg.chunk {
+		t.Fatal("metadata-wrapped multi-arity call did not select its bytecode variant")
+	}
+	ReleaseFrame(child)
+
+	captures := []Value{Int(99)}
+	closure := &Closure{fn: multi, closedOvers: captures}
+	child, err = childFrameFor(closure, []Value{Int(7), Int(8)}, RootExecContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if child == nil || child.code != twoArg.chunk {
+		t.Fatal("closure over multi-arity function did not select its bytecode variant")
+	}
+	if len(child.closedOvers) != 1 || child.closedOvers[0] != captures[0] {
+		t.Fatalf("closure captures were not preserved: got %v, want %v", child.closedOvers, captures)
+	}
+	ReleaseFrame(child)
+}
+
+func TestDescendedFrameLifecycle(t *testing.T) {
+	oldAllocAttr := allocAttrEnabled
+	allocAttrEnabled = true
+	attrMu.Lock()
+	oldAttrStack := attrStack
+	attrStack = nil
+	attrMu.Unlock()
+	t.Cleanup(func() {
+		attrMu.Lock()
+		attrStack = oldAttrStack
+		attrMu.Unlock()
+		allocAttrEnabled = oldAllocAttr
+	})
+
+	consts := NewConsts()
+	var parentChunk, childChunk *CodeChunk
+	checkerValue, err := NativeFnType.Wrap(func(_ []Value) (Value, error) {
+		attrMu.Lock()
+		defer attrMu.Unlock()
+		if len(attrStack) != 2 {
+			return NIL, NewExecutionError("allocation attribution stack did not include parent and child")
+		}
+		if attrStack[0].code != parentChunk || attrStack[1].code != childChunk {
+			return NIL, NewExecutionError("allocation attribution stack has the wrong frame order")
+		}
+		return Int(1), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checker := checkerValue.(Fn)
+	childChunk = testInvokeZeroChunk(consts, checker)
+	child := MakeFunc(0, false, childChunk)
+	parentChunk = testInvokeZeroChunk(consts, child)
+
+	root := NewFrame(parentChunk, nil)
+	root.ec = RootExecContext
+	if _, err := root.Run(); err != nil {
+		t.Fatal(err)
+	}
+	ReleaseFrame(root)
+
+	attrMu.Lock()
+	defer attrMu.Unlock()
+	if len(attrStack) != 0 {
+		t.Fatalf("allocation attribution stack leaked %d frame(s)", len(attrStack))
+	}
+}
+
+func TestOpcodeProfileSeparatesDescendedFrames(t *testing.T) {
+	ResetProfile()
+	ProfilingEnabled.Store(true)
+	t.Cleanup(func() {
+		ProfilingEnabled.Store(false)
+		ResetProfile()
+	})
+
+	consts := NewConsts()
+	childChunk := NewCodeChunk(consts)
+	childChunk.Append(OP_LOAD_CONST)
+	childChunk.Append32(consts.Intern(NIL))
+	childChunk.Append(OP_RETURN)
+	childChunk.SetMaxStack(4)
+	parentChunk := testInvokeZeroChunk(consts, MakeFunc(0, false, childChunk))
+
+	root := NewFrame(parentChunk, nil)
+	root.ec = RootExecContext
+	if _, err := root.Run(); err != nil {
+		t.Fatal(err)
+	}
+	ReleaseFrame(root)
+
+	var initialLoads, crossFrameLoads, invokeReturns uint64
+	for _, pair := range PairSnapshot() {
+		switch {
+		case pair.Prev == 0 && pair.Curr == uint8(OP_LOAD_CONST):
+			initialLoads = pair.Count
+		case pair.Prev == uint8(OP_INVOKE) && pair.Curr == uint8(OP_LOAD_CONST):
+			crossFrameLoads = pair.Count
+		case pair.Prev == uint8(OP_INVOKE) && pair.Curr == uint8(OP_RETURN):
+			invokeReturns = pair.Count
+		}
+	}
+	if initialLoads != 2 {
+		t.Fatalf("first opcode was not reset for both frames: got %d initial LOAD_CONST pairs", initialLoads)
+	}
+	if crossFrameLoads != 0 {
+		t.Fatalf("profiler joined parent OP_INVOKE to child LOAD_CONST %d time(s)", crossFrameLoads)
+	}
+	if invokeReturns != 1 {
+		t.Fatalf("parent profiler state was not restored: got %d INVOKE→RETURN pairs", invokeReturns)
+	}
+}
+
+func TestDescendedErrorReleasesChildFrame(t *testing.T) {
+	framePoolMu.Lock()
+	oldPool := framePoolStack
+	framePoolStack = nil
+	framePoolMu.Unlock()
+	t.Cleanup(func() {
+		framePoolMu.Lock()
+		clear(framePoolStack)
+		framePoolStack = oldPool
+		framePoolMu.Unlock()
+	})
+
+	consts := NewConsts()
+	badChunk := NewCodeChunk(consts)
+	badChunk.Append(OP_LOAD_ARG)
+	badChunk.Append32(0)
+	badChunk.Append(OP_RETURN)
+	badChunk.SetMaxStack(4)
+	parentChunk := testInvokeZeroChunk(consts, MakeFunc(0, false, badChunk))
+
+	root := NewFrame(parentChunk, nil)
+	root.ec = RootExecContext
+	if _, err := root.Run(); err == nil {
+		t.Fatal("expected descended child to fail")
+	}
+	if root.parent != nil {
+		t.Fatal("root retained a parent link after failed descent")
+	}
+
+	framePoolMu.Lock()
+	pooled := append([]*Frame(nil), framePoolStack...)
+	framePoolMu.Unlock()
+	if len(pooled) != 1 {
+		t.Fatalf("failed child was not returned exactly once: pool has %d frames", len(pooled))
+	}
+	if pooled[0].parent != nil || pooled[0].code != nil || pooled[0].args != nil {
+		t.Fatal("failed child retained execution references after pooling")
+	}
+	ReleaseFrame(root)
+}

--- a/pkg/vm/func.go
+++ b/pkg/vm/func.go
@@ -97,6 +97,76 @@ func boxRest(rest []Value) (Value, error) {
 	return ListType.Box(rest)
 }
 
+// bytecodeCallTarget is the resolved, frame-independent description of a
+// directly executable bytecode call. Frame allocation and same-frame tail
+// replacement are deliberately separate transitions so this resolver can be
+// shared with the constant-space tail-call work in #620.
+type bytecodeCallTarget struct {
+	fn          *Func
+	args        []Value
+	closedOvers []Value
+}
+
+// resolveBytecodeCall unwraps metadata, selects multi-arity variants,
+// preserves closure captures, validates arity, and packs variadic arguments.
+// It returns false for callables that must continue through ExecContext.Invoke.
+//
+// Fixed-arity args may still borrow the caller's operand stack. A transition
+// that reuses that same frame must copy them into frame-owned storage before
+// resetting the operand stack. Variadic packing always returns a fresh slice.
+func resolveBytecodeCall(fn Fn, args []Value) (bytecodeCallTarget, bool, error) {
+	display := fn
+	var closedOvers []Value
+	for {
+		switch t := fn.(type) {
+		case *MetaFn:
+			fn = t.Wrapped()
+		case *MultiArityFn:
+			variant, err := t.variantFor(display, len(args))
+			if err != nil {
+				return bytecodeCallTarget{}, false, err
+			}
+			fn = variant
+		case *Closure:
+			closedOvers = t.closedOvers
+			fn = t.fn
+		case *Func:
+			prepared := args
+			if t.isVariadric {
+				if len(prepared) < t.arity-1 {
+					return bytecodeCallTarget{}, false, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", display, t.arity-1, len(prepared)))
+				}
+				restlist, boxErr := boxRest(prepared[t.arity-1:])
+				if boxErr != nil {
+					return bytecodeCallTarget{}, false, boxErr
+				}
+				// Never append into prepared: it may be a window into the
+				// caller's operand stack or a host-owned argument slice.
+				packed := make([]Value, t.arity)
+				copy(packed, prepared[:t.arity-1])
+				packed[t.arity-1] = restlist
+				prepared = packed
+			} else if len(prepared) != t.arity {
+				return bytecodeCallTarget{}, false, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", display, t.arity, len(prepared)))
+			}
+			return bytecodeCallTarget{
+				fn:          t,
+				args:        prepared,
+				closedOvers: closedOvers,
+			}, true, nil
+		default:
+			return bytecodeCallTarget{}, false, nil
+		}
+	}
+}
+
+func runBytecodeCallTarget(ec *ExecContext, target bytecodeCallTarget) (Value, error) {
+	f := newFrameForBytecodeCall(target, ec)
+	result, err := f.Run()
+	ReleaseFrame(f)
+	return result, err
+}
+
 func (l *Func) Invoke(pargs []Value) (result Value, err error) {
 	return l.invokeIn(RootExecContext, pargs)
 }
@@ -105,36 +175,14 @@ func (l *Func) Invoke(pargs []Value) (result Value, err error) {
 // so dynamic bindings propagate into the call. Invoke is invokeIn against the
 // root context.
 func (l *Func) invokeIn(ec *ExecContext, pargs []Value) (result Value, err error) {
-	args := pargs
-	if l.isVariadric {
-		if len(args) < l.arity-1 {
-			return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", l, l.arity-1, len(args)))
-		}
-		rest := args[l.arity-1:]
-		restlist, boxErr := boxRest(rest)
-		if boxErr != nil {
-			return NIL, boxErr
-		}
-		// Build a FRESH slice; do not append into args' backing array.
-		// `append(args[0:l.arity-1], restlist)` reuses the caller's array
-		// (the reslice keeps its capacity), so the packed rest-list is
-		// written over the caller's element l.arity-1 — for a plain
-		// (fn [& as]) that is args[0]. A Go caller reusing one []Value
-		// across invocations then sees its arguments silently replaced by
-		// the previous call's rest-list: correct on the first call, garbage
-		// on the second.
-		packed := make([]Value, l.arity)
-		copy(packed, args[:l.arity-1])
-		packed[l.arity-1] = restlist
-		args = packed
-	} else if len(args) != l.arity {
-		return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, l.arity, len(args)))
+	target, ok, err := resolveBytecodeCall(l, pargs)
+	if err != nil {
+		return NIL, err
 	}
-	f := NewFrame(l.chunk, args)
-	f.ec = ec
-	result, err = f.Run()
-	ReleaseFrame(f)
-	return result, err
+	if !ok {
+		return NIL, NewExecutionError("unsupported function type")
+	}
+	return runBytecodeCallTarget(ec, target)
 }
 
 func (l *Func) String() string {
@@ -216,51 +264,18 @@ func (l *Closure) Invoke(pargs []Value) (result Value, err error) {
 // so dynamic bindings propagate into the call. Invoke delegates to invokeIn
 // against the root context.
 func (l *Closure) invokeIn(ec *ExecContext, pargs []Value) (result Value, err error) {
-	if f, ok := l.fn.(*Func); ok {
-		args := pargs
-		if f.isVariadric {
-			if len(args) < f.arity-1 {
-				return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", l, f.arity-1, len(args)))
-			}
-			rest := args[f.arity-1:]
-			restlist, boxErr := boxRest(rest)
-			if boxErr != nil {
-				return NIL, boxErr
-			}
-			// Fresh slice — see Func.invokeIn for why appending into the
-			// caller's backing array corrupts the caller's arguments.
-			packed := make([]Value, f.arity)
-			copy(packed, args[:f.arity-1])
-			packed[f.arity-1] = restlist
-			args = packed
-		} else if len(args) != f.arity {
-			return NIL, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", l, f.arity, len(args)))
-		}
-		frame := NewFrame(f.chunk, args)
-		frame.closedOvers = l.closedOvers
-		frame.ec = ec
-		result, err = frame.Run()
-		ReleaseFrame(frame)
-		return result, err
+	target, ok, err := resolveBytecodeCall(l, pargs)
+	if err != nil {
+		return NIL, err
+	}
+	if ok {
+		return runBytecodeCallTarget(ec, target)
 	}
 
 	if mfn, ok := l.fn.(*MultiArityFn); ok {
-		le := len(pargs)
-		var variant Fn
-		if f, ok := mfn.fns[le]; ok {
-			variant = f
-		} else if mfn.rest != nil && le >= mfn.rest.Arity() {
-			variant = mfn.rest
-		} else {
-			return NIL, NewExecutionError(fmt.Sprintf("function %s doesn't have a %d-arity variant", l, le))
-		}
-
-		if f, ok := variant.(*Func); ok {
-			subClosure := &Closure{
-				closedOvers: l.closedOvers,
-				fn:          f,
-			}
-			return subClosure.invokeIn(ec, pargs)
+		variant, variantErr := mfn.variantFor(l, len(pargs))
+		if variantErr != nil {
+			return NIL, variantErr
 		}
 		return ec.Invoke(variant, pargs)
 	}
@@ -324,18 +339,25 @@ func (l *MultiArityFn) Invoke(pargs []Value) (Value, error) {
 	return l.invokeIn(RootExecContext, pargs)
 }
 
+func (l *MultiArityFn) variantFor(display Fn, arity int) (Fn, error) {
+	if f, ok := l.fns[arity]; ok {
+		return f, nil
+	}
+	if l.rest != nil && arity >= l.rest.Arity() {
+		return l.rest, nil
+	}
+	return nil, NewExecutionError(fmt.Sprintf("function %s doesn't have a %d-arity variant", display, arity))
+}
+
 // invokeIn runs the multi-arity function with the given ExecContext active,
 // so dynamic bindings propagate into the selected variant's call. Invoke delegates
 // to invokeIn against the root context.
 func (l *MultiArityFn) invokeIn(ec *ExecContext, pargs []Value) (Value, error) {
-	le := len(pargs)
-	if f, ok := l.fns[le]; ok {
-		return ec.Invoke(f, pargs)
+	variant, err := l.variantFor(l, len(pargs))
+	if err != nil {
+		return NIL, err
 	}
-	if l.rest != nil && le >= l.rest.Arity() {
-		return ec.Invoke(l.rest, pargs)
-	}
-	return NIL, NewExecutionError(fmt.Sprintf("function %s doesn't have a %d-arity variant", l, le))
+	return ec.Invoke(variant, pargs)
 }
 
 func (l *MultiArityFn) String() string {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -385,6 +385,9 @@ type Frame struct {
 	debug       bool
 	handlers    []exHandler  // exception handler stack (nil when unused)
 	ec          *ExecContext // per-execution context (dynamic bindings); nil = none installed
+	// chain is maintained only on the root frame of a Run: the suspended
+	// parents of the frame currently executing.
+	chain []*Frame
 }
 
 // Frame reuse via a mutex-guarded LIFO.
@@ -464,6 +467,55 @@ func ReleaseFrame(f *Frame) {
 	f.code = nil
 	f.handlers = nil
 	releaseFrame(f)
+}
+
+// childFrameFor builds a frame for a callee the dispatch loop can descend
+// into directly — a *Func, or a *Closure wrapping one. It returns (nil, nil)
+// for everything else (natives, multi-arity, multimethods, protocols), which
+// the caller routes through ec.Invoke as before.
+//
+// Arity checking and variadic packing mirror Func.invokeIn / Closure.invokeIn.
+// args may alias the caller's operand stack: the parent frame is suspended
+// underneath the child and never writes above its own sp while the child
+// runs, which is the same aliasing the nested-Run path relies on today.
+func childFrameFor(fn Fn, args []Value, ec *ExecContext) (*Frame, error) {
+	var base *Func
+	var closedOvers []Value
+	switch t := fn.(type) {
+	case *Func:
+		base = t
+	case *Closure:
+		inner, ok := t.fn.(*Func)
+		if !ok {
+			return nil, nil
+		}
+		base = inner
+		closedOvers = t.closedOvers
+	default:
+		return nil, nil
+	}
+	a := args
+	if base.isVariadric {
+		if len(a) < base.arity-1 {
+			return nil, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", base, base.arity-1, len(a)))
+		}
+		restlist, boxErr := boxRest(a[base.arity-1:])
+		if boxErr != nil {
+			return nil, boxErr
+		}
+		// Fresh slice — appending into the caller's backing array corrupts
+		// the caller's arguments (see Func.invokeIn).
+		packed := make([]Value, base.arity)
+		copy(packed, a[:base.arity-1])
+		packed[base.arity-1] = restlist
+		a = packed
+	} else if len(a) != base.arity {
+		return nil, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", base, base.arity, len(a)))
+	}
+	child := NewFrame(base.chunk, a)
+	child.closedOvers = closedOvers
+	child.ec = ec
+	return child, nil
 }
 
 func NewDebugFrame(code *CodeChunk, args []Value) *Frame {
@@ -618,7 +670,52 @@ func (f *Frame) RunProtected() (result Value, err error) {
 	return f.Run()
 }
 
+// wrapCallSite attributes err to the call currently under f.ip. The callee is
+// still on f's operand stack (the call opcodes peek rather than pop), so the
+// name is recoverable without extra bookkeeping.
+func wrapCallSite(f *Frame, err error) error {
+	srcInfo := f.code.LookupSource(f.ip)
+	name := "fn"
+	arity := int(f.code.code[f.ip+1])
+	if fraw, e := f.nth(arity); e == nil {
+		if fn, ok := AsFn(fraw); ok {
+			name = fnName(fn)
+		}
+	}
+	return NewExecutionError(fmt.Sprintf("calling %s", name)).WithSource(srcInfo).Wrap(err)
+}
+
+// Run executes this frame to completion. runLoop descends into let-go callees
+// within its own dispatch loop, so the Go stack stays flat; Run re-enters it
+// only to resume after an error has been routed to a handler further out.
 func (f *Frame) Run() (Value, error) {
+	f.chain = nil
+	cur := f
+	for {
+		v, err := cur.runLoop(f)
+		if err == nil {
+			return v, nil
+		}
+		// The erroring frame already declined the error inside runLoop. Walk
+		// out through its suspended parents offering it to each.
+		handled := false
+		for len(f.chain) > 0 {
+			parent := f.chain[len(f.chain)-1]
+			f.chain = f.chain[:len(f.chain)-1]
+			err = wrapCallSite(parent, err)
+			if parent.handleError(err) {
+				cur = parent
+				handled = true
+				break
+			}
+		}
+		if !handled {
+			return NIL, err
+		}
+	}
+}
+
+func (f *Frame) runLoop(root *Frame) (Value, error) {
 	if allocAttrEnabled {
 		attrPushFrame(f)
 		defer attrPopFrame()
@@ -684,7 +781,26 @@ func (f *Frame) Run() (Value, error) {
 			if err != nil {
 				return NIL, NewExecutionError("return failed").Wrap(err)
 			}
-			return v, nil
+			if len(root.chain) == 0 {
+				return v, nil
+			}
+			parent := root.chain[len(root.chain)-1]
+			root.chain = root.chain[:len(root.chain)-1]
+			if f != root {
+				ReleaseFrame(f)
+			}
+			f = parent
+			if op := f.code.code[f.ip] & 0xff; op != OP_INVOKE && op != OP_TAIL_CALL {
+				panic(fmt.Sprintf("PROBE: parent ip %d holds %s, not a call opcode", f.ip, OpcodeToString(f.code.code[f.ip])))
+			}
+			callArity := int(f.code.code[f.ip+1])
+			if e := f.drop(callArity + 1); e != nil {
+				return NIL, NewExecutionError("cleaning stack after call").Wrap(e)
+			}
+			if e := f.push(v); e != nil {
+				return NIL, NewExecutionError("pushing return value failed").Wrap(e)
+			}
+			f.ip += 2
 
 		case OP_INVOKE:
 			arity := f.code.code[f.ip+1]
@@ -702,6 +818,21 @@ func (f *Frame) Run() (Value, error) {
 				if err != nil {
 					return NIL, NewExecutionError("popping arguments failed").Wrap(err)
 				}
+				// PROBE: direct let-go callee — descend in this loop.
+				child, cerr := childFrameFor(fn, a, f.ec)
+				if cerr != nil {
+					srcInfo := f.code.LookupSource(f.ip)
+					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(cerr)
+					if f.handleError(wrapped) {
+						continue
+					}
+					return NIL, wrapped
+				}
+				if child != nil {
+					root.chain = append(root.chain, f)
+					f = child
+					continue
+				}
 				out, err = f.ec.Invoke(fn, a)
 				if err != nil {
 					srcInfo := f.code.LookupSource(f.ip)
@@ -716,13 +847,32 @@ func (f *Frame) Run() (Value, error) {
 					return NIL, NewExecutionError("cleaning stack after call").Wrap(err)
 				}
 			} else {
-				fraw, err := f.pop()
+				// PROBE: peek rather than pop, so the callee slot is still
+				// there for the uniform drop(arity+1) on return.
+				fraw, err := f.nth(0)
 				if err != nil {
 					return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
 				}
 				fn, ok := AsFn(fraw)
 				if !ok {
 					return NIL, NewTypeError(fraw, "is not a function", nil)
+				}
+				child, cerr := childFrameFor(fn, nil, f.ec)
+				if cerr != nil {
+					srcInfo := f.code.LookupSource(f.ip)
+					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(cerr)
+					if f.handleError(wrapped) {
+						continue
+					}
+					return NIL, wrapped
+				}
+				if child != nil {
+					root.chain = append(root.chain, f)
+					f = child
+					continue
+				}
+				if _, perr := f.pop(); perr != nil {
+					return NIL, NewExecutionError("invoke instruction failed").Wrap(perr)
 				}
 				out, err = f.ec.Invoke(fn, nil)
 				if err != nil {
@@ -757,6 +907,18 @@ func (f *Frame) Run() (Value, error) {
 					return NIL, NewExecutionError("popping arguments failed").Wrap(err)
 				}
 				if _, ok := fn.(*Func); !ok {
+					// PROBE: a *Closure tail call can't reuse this frame (the
+					// closedOvers differ), but it can descend in-loop instead
+					// of recursing. Not constant-space — that's #620's job —
+					// but heap-bounded rather than Go-stack-bounded. The
+					// compiler still emits OP_RETURN after OP_TAIL_CALL, so
+					// the ordinary return path lands on it and returns.
+					child, cerr := childFrameFor(fn, a, f.ec)
+					if cerr == nil && child != nil {
+						root.chain = append(root.chain, f)
+						f = child
+						continue
+					}
 					out, err = f.ec.Invoke(fn, a)
 					if err != nil {
 						srcInfo := f.code.LookupSource(f.ip)
@@ -766,10 +928,17 @@ func (f *Frame) Run() (Value, error) {
 						}
 						return NIL, wrapped
 					}
-					// TAIL_CALL is terminal: builtin's result is this
-					// frame's result. (The compiler still emits RETURN
-					// after TAIL_CALL but it's now dead code.)
-					return out, nil
+					// TAIL_CALL is terminal: the builtin's result is this
+					// frame's result. Land it on the compiler-emitted RETURN
+					// so the chain pop stays in one place.
+					if e := f.drop(int(arity) + 1); e != nil {
+						return NIL, NewExecutionError("cleaning stack after call").Wrap(e)
+					}
+					if e := f.push(out); e != nil {
+						return NIL, NewExecutionError("pushing return value failed").Wrap(e)
+					}
+					f.ip += 2
+					continue
 				} else {
 					ff := fn.(*Func)
 					// Package variadic args for direct frame reuse
@@ -825,9 +994,12 @@ func (f *Frame) Run() (Value, error) {
 						}
 						return NIL, wrapped
 					}
-					// TAIL_CALL is terminal: builtin's result is this
-					// frame's result.
-					return out, nil
+					// TAIL_CALL is terminal — same as above.
+					if e := f.push(out); e != nil {
+						return NIL, NewExecutionError("pushing return value failed").Wrap(e)
+					}
+					f.ip += 2
+					continue
 				} else {
 					ff := fn.(*Func)
 					// Package the (nil) rest binding for variadic

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -375,6 +375,7 @@ type exHandler struct {
 type Frame struct {
 	stack       []Value
 	args        []Value
+	argbuf      []Value // frame-owned arguments used by same-frame tail replacement
 	closedOvers []Value
 	argc        int
 	consts      *Consts
@@ -442,6 +443,7 @@ func NewFrame(code *CodeChunk, args []Value) *Frame {
 		f.stack = make([]Value, needed)
 	}
 	f.args = args
+	f.argbuf = f.argbuf[:0]
 	f.argc = len(args)
 	f.closedOvers = nil
 	f.consts = code.consts
@@ -465,6 +467,8 @@ func NewFrame(code *CodeChunk, args []Value) *Frame {
 // We only nil out the large reference fields to avoid pinning code/const objects.
 func ReleaseFrame(f *Frame) {
 	f.args = nil
+	clear(f.argbuf)
+	f.argbuf = nil
 	f.closedOvers = nil
 	f.consts = nil
 	f.code = nil
@@ -474,68 +478,44 @@ func ReleaseFrame(f *Frame) {
 	releaseFrame(f)
 }
 
-// childFrameFor builds a frame for a bytecode callee the dispatch loop can
-// descend into directly. It unwraps metadata, selects multi-arity variants,
-// and preserves closure captures before preparing the concrete *Func frame.
-// It returns (nil, nil) for natives, multimethods, protocols, and other
-// callables that must continue through ec.Invoke.
-//
-// Arity checking and variadic packing mirror Func.invokeIn / Closure.invokeIn.
-// args may alias the caller's operand stack: the parent frame is suspended
-// underneath the child and never writes above its own sp while the child
-// runs, which is the same aliasing the nested-Run path relies on today.
-func childFrameFor(fn Fn, args []Value, ec *ExecContext) (*Frame, error) {
-	var base *Func
-	var closedOvers []Value
-	for {
-		switch t := fn.(type) {
-		case *MetaFn:
-			fn = t.Wrapped()
-		case *MultiArityFn:
-			le := len(args)
-			if variant, ok := t.fns[le]; ok {
-				fn = variant
-				continue
-			}
-			if t.rest != nil && le >= t.rest.Arity() {
-				fn = t.rest
-				continue
-			}
-			return nil, NewExecutionError(fmt.Sprintf("function %s doesn't have a %d-arity variant", t, le))
-		case *Closure:
-			closedOvers = t.closedOvers
-			fn = t.fn
-		case *Func:
-			base = t
-		default:
-			return nil, nil
-		}
-		if base != nil {
-			break
-		}
-	}
-	a := args
-	if base.isVariadric {
-		if len(a) < base.arity-1 {
-			return nil, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", base, base.arity-1, len(a)))
-		}
-		restlist, boxErr := boxRest(a[base.arity-1:])
-		if boxErr != nil {
-			return nil, boxErr
-		}
-		// Fresh slice — appending into the caller's backing array corrupts
-		// the caller's arguments (see Func.invokeIn).
-		packed := make([]Value, base.arity)
-		copy(packed, a[:base.arity-1])
-		packed[base.arity-1] = restlist
-		a = packed
-	} else if len(a) != base.arity {
-		return nil, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", base, base.arity, len(a)))
-	}
-	child := NewFrame(base.chunk, a)
-	child.closedOvers = closedOvers
+// newFrameForBytecodeCall is the non-tail transition for a prepared bytecode
+// target. Fixed-arity target.args may borrow the suspended parent's operand
+// stack; that is safe for a child frame because the parent does not resume
+// until the child has completed.
+func newFrameForBytecodeCall(target bytecodeCallTarget, ec *ExecContext) *Frame {
+	child := NewFrame(target.fn.chunk, target.args)
+	child.closedOvers = target.closedOvers
 	child.ec = ec
-	return child, nil
+	return child
+}
+
+// installBytecodeCall is the same-frame transition used by the existing
+// direct-*Func tail-call path. target.args may be a window into f.stack, so
+// copy it into the frame-owned buffer before resetting or reusing that stack.
+func installBytecodeCall(f *Frame, target bytecodeCallTarget) {
+	argc := len(target.args)
+	if cap(f.argbuf) < argc {
+		f.argbuf = make([]Value, argc)
+	} else {
+		clear(f.argbuf)
+		f.argbuf = f.argbuf[:argc]
+	}
+	copy(f.argbuf, target.args)
+
+	f.args = f.argbuf
+	f.argc = argc
+	f.closedOvers = target.closedOvers
+	f.code = target.fn.chunk
+	f.consts = f.code.consts
+	f.constsc = f.code.consts.count()
+	f.ip = 0
+	f.sp = 0
+	needed := max(f.code.maxStack, 4)
+	if cap(f.stack) < needed {
+		f.stack = make([]Value, needed)
+	} else {
+		f.stack = f.stack[:needed]
+	}
 }
 
 func NewDebugFrame(code *CodeChunk, args []Value) *Frame {
@@ -690,17 +670,46 @@ func (f *Frame) RunProtected() (result Value, err error) {
 	return f.Run()
 }
 
+// suspendedCallArity validates the continuation stored in a suspended parent.
+// Returning an error here is preferable to either panicking or trusting corrupt
+// bytecode and silently dropping an arbitrary number of operand-stack values.
+func suspendedCallArity(f *Frame) (int, *ExecutionError) {
+	if f == nil || f.code == nil {
+		return 0, NewExecutionError("invalid suspended call: missing frame code")
+	}
+	if f.ip < 0 || f.ip >= len(f.code.code) {
+		return 0, NewExecutionError(fmt.Sprintf("invalid suspended call: instruction pointer %d is out of bounds", f.ip))
+	}
+	if f.ip+1 >= len(f.code.code) {
+		return 0, NewExecutionError(fmt.Sprintf("invalid suspended call at %d: missing arity operand", f.ip))
+	}
+	if f.sp < 0 || f.sp > len(f.stack) {
+		return 0, NewExecutionError(fmt.Sprintf("invalid suspended call at %d: stack depth %d is out of bounds", f.ip, f.sp))
+	}
+	op := f.code.code[f.ip] & 0xff
+	if op != OP_INVOKE && op != OP_TAIL_CALL {
+		return 0, NewExecutionError(fmt.Sprintf("invalid suspended call at %d: found %s", f.ip, OpcodeToString(f.code.code[f.ip])))
+	}
+	arity := int(f.code.code[f.ip+1])
+	if arity < 0 || arity+1 > f.sp {
+		return 0, NewExecutionError(fmt.Sprintf("invalid suspended call at %d: arity %d exceeds stack depth %d", f.ip, arity, f.sp))
+	}
+	return arity, nil
+}
+
 // wrapCallSite attributes err to the call currently under f.ip. The callee is
 // still on f's operand stack (the call opcodes peek rather than pop), so the
 // name is recoverable without extra bookkeeping.
 func wrapCallSite(f *Frame, err error) error {
+	arity, siteErr := suspendedCallArity(f)
+	if siteErr != nil {
+		return NewExecutionError(siteErr.message).Wrap(err)
+	}
 	srcInfo := f.code.LookupSource(f.ip)
 	name := "fn"
-	arity := int(f.code.code[f.ip+1])
-	if fraw, e := f.nth(arity); e == nil {
-		if fn, ok := AsFn(fraw); ok {
-			name = fnName(fn)
-		}
+	calleeIndex := f.sp - 1 - arity
+	if fn, ok := AsFn(f.stack[calleeIndex]); ok {
+		name = fnName(fn)
 	}
 	return NewExecutionError(fmt.Sprintf("calling %s", name)).WithSource(srcInfo).Wrap(err)
 }
@@ -728,9 +737,9 @@ func enterFrame(f *Frame) {
 		fmt.Print("run", f.args, "\n")
 		f.code.Debug()
 	}
-	// Profiler state belongs to the logical frame so suspending a parent and
-	// running a child neither joins their opcode pairs nor loses the parent's
-	// previous opcode when it resumes.
+	// The newly entered frame starts a fresh opcode-pair sequence at zero.
+	// Suspended parents retain prevOp on their own Frame, so resuming records
+	// the next parent-local pair; cross-frame pairs are intentionally omitted.
 	f.prevOp = 0
 	f.profileOn = ProfilingEnabled.Load()
 }
@@ -874,10 +883,13 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 			ReleaseFrame(child)
 			f = parent
 			state.current = f
-			if op := f.code.code[f.ip] & 0xff; op != OP_INVOKE && op != OP_TAIL_CALL {
-				panic(fmt.Sprintf("PROBE: parent ip %d holds %s, not a call opcode", f.ip, OpcodeToString(f.code.code[f.ip])))
+			callArity, callErr := suspendedCallArity(f)
+			if callErr != nil {
+				if f.handleError(callErr) {
+					continue
+				}
+				return NIL, callErr
 			}
-			callArity := int(f.code.code[f.ip+1])
 			if e := f.drop(callArity + 1); e != nil {
 				return NIL, NewExecutionError("cleaning stack after call").Wrap(e)
 			}
@@ -902,8 +914,7 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 				if err != nil {
 					return NIL, NewExecutionError("popping arguments failed").Wrap(err)
 				}
-				// PROBE: direct let-go callee — descend in this loop.
-				child, cerr := childFrameFor(fn, a, f.ec)
+				target, direct, cerr := resolveBytecodeCall(fn, a)
 				if cerr != nil {
 					srcInfo := f.code.LookupSource(f.ip)
 					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(cerr)
@@ -912,7 +923,8 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 					}
 					return NIL, wrapped
 				}
-				if child != nil {
+				if direct {
+					child := newFrameForBytecodeCall(target, f.ec)
 					child.parent = f
 					f = child
 					state.current = f
@@ -933,8 +945,8 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 					return NIL, NewExecutionError("cleaning stack after call").Wrap(err)
 				}
 			} else {
-				// PROBE: peek rather than pop, so the callee slot is still
-				// there for the uniform drop(arity+1) on return.
+				// Peek rather than pop, so the callee slot remains for the
+				// uniform drop(arity+1) when a descended child returns.
 				fraw, err := f.nth(0)
 				if err != nil {
 					return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
@@ -943,7 +955,7 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 				if !ok {
 					return NIL, NewTypeError(fraw, "is not a function", nil)
 				}
-				child, cerr := childFrameFor(fn, nil, f.ec)
+				target, direct, cerr := resolveBytecodeCall(fn, nil)
 				if cerr != nil {
 					srcInfo := f.code.LookupSource(f.ip)
 					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(cerr)
@@ -952,7 +964,8 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 					}
 					return NIL, wrapped
 				}
-				if child != nil {
+				if direct {
+					child := newFrameForBytecodeCall(target, f.ec)
 					child.parent = f
 					f = child
 					state.current = f
@@ -980,142 +993,69 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 
 		case OP_TAIL_CALL:
 			arity := f.code.code[f.ip+1]
-			var out Value
+			// Keep the callee on the operand stack when descending so the
+			// return path can use one drop(arity+1) protocol for every arity.
+			fraw, err := f.nth(int(arity))
+			if err != nil {
+				return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
+			}
+			fn, ok := AsFn(fraw)
+			if !ok {
+				return NIL, NewTypeError(fraw, "is not a function", nil)
+			}
+			var a []Value
 			if arity > 0 {
-				fraw, err := f.nth(int(arity))
-				if err != nil {
-					return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
-				}
-				fn, ok := AsFn(fraw)
-				if !ok {
-					return NIL, NewTypeError(fraw, "is not a function", nil)
-				}
-				a, err := f.mult(0, int(arity))
+				a, err = f.mult(0, int(arity))
 				if err != nil {
 					return NIL, NewExecutionError("popping arguments failed").Wrap(err)
 				}
-				if _, ok := fn.(*Func); !ok {
-					// PROBE: a *Closure tail call can't reuse this frame (the
-					// closedOvers differ), but it can descend in-loop instead
-					// of recursing. Not constant-space — that's #620's job —
-					// but heap-bounded rather than Go-stack-bounded. The
-					// compiler still emits OP_RETURN after OP_TAIL_CALL, so
-					// the ordinary return path lands on it and returns.
-					child, cerr := childFrameFor(fn, a, f.ec)
-					if cerr == nil && child != nil {
-						child.parent = f
-						f = child
-						state.current = f
-						enterFrame(f)
-						continue
-					}
-					out, err = f.ec.Invoke(fn, a)
-					if err != nil {
-						srcInfo := f.code.LookupSource(f.ip)
-						wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
-						if f.handleError(wrapped) {
-							continue
-						}
-						return NIL, wrapped
-					}
-					// TAIL_CALL is terminal: the builtin's result is this
-					// frame's result. Land it on the compiler-emitted RETURN
-					// so the chain pop stays in one place.
-					if e := f.drop(int(arity) + 1); e != nil {
-						return NIL, NewExecutionError("cleaning stack after call").Wrap(e)
-					}
-					if e := f.push(out); e != nil {
-						return NIL, NewExecutionError("pushing return value failed").Wrap(e)
-					}
-					f.ip += 2
-					continue
-				} else {
-					ff := fn.(*Func)
-					// Package variadic args for direct frame reuse
-					if ff.isVariadric {
-						if len(a) < ff.arity-1 {
-							return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", ff, ff.arity-1, len(a)))
-						}
-						sargs := a[0 : ff.arity-1]
-						rest := a[ff.arity-1:]
-						restlist, boxErr := boxRest(rest)
-						if boxErr != nil {
-							return NIL, boxErr
-						}
-						a = append(sargs, restlist)
-					}
-					f.code = ff.chunk
-					f.consts = f.code.consts
-					f.constsc = f.code.consts.count()
-					f.ip = 0
-					f.sp = 0
-					if len(f.stack) < f.code.maxStack {
-						f.stack = make([]Value, f.code.maxStack)
-						f.args = a
-						f.argc = len(a)
-					} else {
-						la := len(a)
-						if la <= f.argc {
-							copy(f.args, a)
-						} else {
-							f.args = make([]Value, la)
-							copy(f.args, a)
-						}
-						f.argc = len(a)
-					}
-					continue
-				}
-			} else {
-				fraw, err := f.pop()
-				if err != nil {
-					return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
-				}
-				fn, ok := AsFn(fraw)
-				if !ok {
-					return NIL, NewTypeError(fraw, "is not a function", nil)
-				}
-				if _, ok := fn.(*Func); !ok {
-					out, err = f.ec.Invoke(fn, nil)
-					if err != nil {
-						srcInfo := f.code.LookupSource(f.ip)
-						wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
-						if f.handleError(wrapped) {
-							continue
-						}
-						return NIL, wrapped
-					}
-					// TAIL_CALL is terminal — same as above.
-					if e := f.push(out); e != nil {
-						return NIL, NewExecutionError("pushing return value failed").Wrap(e)
-					}
-					f.ip += 2
-					continue
-				} else {
-					ff := fn.(*Func)
-					// Package the (nil) rest binding for variadic
-					// functions, exactly like the arity > 0 path above;
-					// without it the reused frame runs LOAD_ARG against
-					// zero args.
-					var a []Value
-					if ff.isVariadric {
-						if ff.arity > 1 {
-							return NIL, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got 0", ff, ff.arity-1))
-						}
-						a = []Value{NIL}
-					}
-					f.code = ff.chunk
-					f.consts = f.code.consts
-					f.constsc = f.code.consts.count()
-					f.ip = 0
-					f.sp = 0
-					if len(f.stack) < f.code.maxStack {
-						f.stack = make([]Value, f.code.maxStack)
-					}
-					f.args = a
-					f.argc = len(a)
-					continue
-				}
 			}
+
+			target, direct, resolveErr := resolveBytecodeCall(fn, a)
+			if resolveErr != nil {
+				srcInfo := f.code.LookupSource(f.ip)
+				wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(resolveErr)
+				if f.handleError(wrapped) {
+					continue
+				}
+				return NIL, wrapped
+			}
+			if direct {
+				if _, reuse := fn.(*Func); reuse {
+					installBytecodeCall(f, target)
+					continue
+				}
+				// Closure, multi-arity, and metadata-wrapped bytecode
+				// callees descend without re-entering Frame.Run. #620 will
+				// move these targets onto the same-frame transition.
+				child := newFrameForBytecodeCall(target, f.ec)
+				child.parent = f
+				f = child
+				state.current = f
+				enterFrame(f)
+				continue
+			}
+
+			out, err := f.ec.Invoke(fn, a)
+			if err != nil {
+				srcInfo := f.code.LookupSource(f.ip)
+				wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
+				if f.handleError(wrapped) {
+					continue
+				}
+				return NIL, wrapped
+			}
+			// A native/non-bytecode tail call is terminal. Land its result
+			// on the compiler-emitted RETURN so frame-chain unwind remains
+			// centralized in OP_RETURN.
+			if e := f.drop(int(arity) + 1); e != nil {
+				return NIL, NewExecutionError("cleaning stack after call").Wrap(e)
+			}
+			if e := f.push(out); e != nil {
+				return NIL, NewExecutionError("pushing return value failed").Wrap(e)
+			}
+			f.ip += 2
+			continue
 
 		case OP_BRANCH_TRUE:
 			offset := f.code.code[f.ip+1]

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -385,9 +385,9 @@ type Frame struct {
 	debug       bool
 	handlers    []exHandler  // exception handler stack (nil when unused)
 	ec          *ExecContext // per-execution context (dynamic bindings); nil = none installed
-	// chain is maintained only on the root frame of a Run: the suspended
-	// parents of the frame currently executing.
-	chain []*Frame
+	parent      *Frame       // suspended caller while the dispatch loop runs this frame
+	prevOp      uint8        // opcode profiler state, preserved while this frame is suspended
+	profileOn   bool         // profiler gate sampled at frame entry
 }
 
 // Frame reuse via a mutex-guarded LIFO.
@@ -451,6 +451,9 @@ func NewFrame(code *CodeChunk, args []Value) *Frame {
 	f.sp = 0
 	f.debug = false
 	f.ec = nil
+	f.parent = nil
+	f.prevOp = 0
+	f.profileOn = false
 	if f.handlers != nil {
 		f.handlers = f.handlers[:0]
 	}
@@ -466,13 +469,16 @@ func ReleaseFrame(f *Frame) {
 	f.consts = nil
 	f.code = nil
 	f.handlers = nil
+	f.ec = nil
+	f.parent = nil
 	releaseFrame(f)
 }
 
-// childFrameFor builds a frame for a callee the dispatch loop can descend
-// into directly — a *Func, or a *Closure wrapping one. It returns (nil, nil)
-// for everything else (natives, multi-arity, multimethods, protocols), which
-// the caller routes through ec.Invoke as before.
+// childFrameFor builds a frame for a bytecode callee the dispatch loop can
+// descend into directly. It unwraps metadata, selects multi-arity variants,
+// and preserves closure captures before preparing the concrete *Func frame.
+// It returns (nil, nil) for natives, multimethods, protocols, and other
+// callables that must continue through ec.Invoke.
 //
 // Arity checking and variadic packing mirror Func.invokeIn / Closure.invokeIn.
 // args may alias the caller's operand stack: the parent frame is suspended
@@ -481,18 +487,32 @@ func ReleaseFrame(f *Frame) {
 func childFrameFor(fn Fn, args []Value, ec *ExecContext) (*Frame, error) {
 	var base *Func
 	var closedOvers []Value
-	switch t := fn.(type) {
-	case *Func:
-		base = t
-	case *Closure:
-		inner, ok := t.fn.(*Func)
-		if !ok {
+	for {
+		switch t := fn.(type) {
+		case *MetaFn:
+			fn = t.Wrapped()
+		case *MultiArityFn:
+			le := len(args)
+			if variant, ok := t.fns[le]; ok {
+				fn = variant
+				continue
+			}
+			if t.rest != nil && le >= t.rest.Arity() {
+				fn = t.rest
+				continue
+			}
+			return nil, NewExecutionError(fmt.Sprintf("function %s doesn't have a %d-arity variant", t, le))
+		case *Closure:
+			closedOvers = t.closedOvers
+			fn = t.fn
+		case *Func:
+			base = t
+		default:
 			return nil, nil
 		}
-		base = inner
-		closedOvers = t.closedOvers
-	default:
-		return nil, nil
+		if base != nil {
+			break
+		}
 	}
 	a := args
 	if base.isVariadric {
@@ -685,40 +705,14 @@ func wrapCallSite(f *Frame, err error) error {
 	return NewExecutionError(fmt.Sprintf("calling %s", name)).WithSource(srcInfo).Wrap(err)
 }
 
-// Run executes this frame to completion. runLoop descends into let-go callees
-// within its own dispatch loop, so the Go stack stays flat; Run re-enters it
-// only to resume after an error has been routed to a handler further out.
-func (f *Frame) Run() (Value, error) {
-	f.chain = nil
-	cur := f
-	for {
-		v, err := cur.runLoop(f)
-		if err == nil {
-			return v, nil
-		}
-		// The erroring frame already declined the error inside runLoop. Walk
-		// out through its suspended parents offering it to each.
-		handled := false
-		for len(f.chain) > 0 {
-			parent := f.chain[len(f.chain)-1]
-			f.chain = f.chain[:len(f.chain)-1]
-			err = wrapCallSite(parent, err)
-			if parent.handleError(err) {
-				cur = parent
-				handled = true
-				break
-			}
-		}
-		if !handled {
-			return NIL, err
-		}
-	}
+type frameRunState struct {
+	root    *Frame
+	current *Frame
 }
 
-func (f *Frame) runLoop(root *Frame) (Value, error) {
+func enterFrame(f *Frame) {
 	if allocAttrEnabled {
 		attrPushFrame(f)
-		defer attrPopFrame()
 	}
 	// Dynamically-scoped tracing (*lg-trace*). Coarse gate first: TraceArmed is
 	// false until *lg-trace* is first set truthy, so the precise per-frame Deref
@@ -734,21 +728,110 @@ func (f *Frame) runLoop(root *Frame) (Value, error) {
 		fmt.Print("run", f.args, "\n")
 		f.code.Debug()
 	}
-	// Profiler state: previous opcode byte (0 at frame entry). Only
-	// touched when ProfilingEnabled — the load is a single atomic
-	// branch per opcode, well-predicted in the disabled case.
-	var prevOp uint8
-	profileOn := ProfilingEnabled.Load()
+	// Profiler state belongs to the logical frame so suspending a parent and
+	// running a child neither joins their opcode pairs nor loses the parent's
+	// previous opcode when it resumes.
+	f.prevOp = 0
+	f.profileOn = ProfilingEnabled.Load()
+}
+
+func leaveFrame(_ *Frame) {
+	if allocAttrEnabled {
+		attrPopFrame()
+	}
+}
+
+// releaseFailedFrames drops the current failed frame and each unhandled
+// suspended parent. The root is owned by Run's caller and is never pooled here.
+// It returns the first parent whose handler accepts err, or nil if none does.
+func releaseFailedFrames(state *frameRunState, err error) (*Frame, error) {
+	failed := state.current
+	parent := failed.parent
+	failed.parent = nil
+	if failed != state.root {
+		ReleaseFrame(failed)
+	}
+	for parent != nil {
+		next := parent.parent
+		err = wrapCallSite(parent, err)
+		if parent.handleError(err) {
+			state.current = parent
+			return parent, err
+		}
+		leaveFrame(parent)
+		parent.parent = nil
+		if parent != state.root {
+			ReleaseFrame(parent)
+		}
+		parent = next
+	}
+	return nil, err
+}
+
+func releasePanickedFrames(state *frameRunState) {
+	failed := state.current
+	parent := failed.parent
+	failed.parent = nil
+	if failed != state.root {
+		ReleaseFrame(failed)
+	}
+	for parent != nil {
+		next := parent.parent
+		leaveFrame(parent)
+		parent.parent = nil
+		if parent != state.root {
+			ReleaseFrame(parent)
+		}
+		parent = next
+	}
+}
+
+// Run executes this frame to completion. runLoop descends into bytecode
+// callees within one dispatch loop, keeping the Go stack flat. A parent link
+// on each live frame carries the suspended call chain without a retained slice.
+func (f *Frame) Run() (result Value, resultErr error) {
+	f.parent = nil
+	state := frameRunState{root: f, current: f}
+	entering := true
+	defer func() {
+		if r := recover(); r != nil {
+			// runLoop's defer already left the current frame. Balance and release
+			// every suspended child-owned frame before preserving the panic.
+			releasePanickedFrames(&state)
+			panic(r)
+		}
+	}()
+	for {
+		result, resultErr = state.current.runLoop(&state, entering)
+		entering = false
+		if resultErr == nil {
+			return result, nil
+		}
+		var resumed *Frame
+		resumed, resultErr = releaseFailedFrames(&state, resultErr)
+		if resumed == nil {
+			return NIL, resultErr
+		}
+	}
+}
+
+func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
+	if entering {
+		enterFrame(f)
+	}
+	// f changes as the loop descends and returns. On a final return or error,
+	// leave whichever logical frame is current; suspended parents remain active.
+	defer func() { leaveFrame(f) }()
 	for {
 		inst := f.code.code[f.ip]
 		if f.debug {
 			f.stackDbg()
 			fmt.Println("#", f.ip, OpcodeToString(inst))
 		}
-		if profileOn {
+		if f.profileOn {
 			currOp := uint8(inst & 0xff)
-			RecordOpcode(prevOp, currOp)
-			prevOp = currOp
+			RecordOpcode(f.prevOp, currOp)
+			f.prevOp = currOp
 		}
 		switch inst & 0xff {
 		case OP_NOOP:
@@ -781,15 +864,16 @@ func (f *Frame) runLoop(root *Frame) (Value, error) {
 			if err != nil {
 				return NIL, NewExecutionError("return failed").Wrap(err)
 			}
-			if len(root.chain) == 0 {
+			if f.parent == nil {
 				return v, nil
 			}
-			parent := root.chain[len(root.chain)-1]
-			root.chain = root.chain[:len(root.chain)-1]
-			if f != root {
-				ReleaseFrame(f)
-			}
+			child := f
+			parent := child.parent
+			child.parent = nil
+			leaveFrame(child)
+			ReleaseFrame(child)
 			f = parent
+			state.current = f
 			if op := f.code.code[f.ip] & 0xff; op != OP_INVOKE && op != OP_TAIL_CALL {
 				panic(fmt.Sprintf("PROBE: parent ip %d holds %s, not a call opcode", f.ip, OpcodeToString(f.code.code[f.ip])))
 			}
@@ -829,8 +913,10 @@ func (f *Frame) runLoop(root *Frame) (Value, error) {
 					return NIL, wrapped
 				}
 				if child != nil {
-					root.chain = append(root.chain, f)
+					child.parent = f
 					f = child
+					state.current = f
+					enterFrame(f)
 					continue
 				}
 				out, err = f.ec.Invoke(fn, a)
@@ -867,8 +953,10 @@ func (f *Frame) runLoop(root *Frame) (Value, error) {
 					return NIL, wrapped
 				}
 				if child != nil {
-					root.chain = append(root.chain, f)
+					child.parent = f
 					f = child
+					state.current = f
+					enterFrame(f)
 					continue
 				}
 				if _, perr := f.pop(); perr != nil {
@@ -915,8 +1003,10 @@ func (f *Frame) runLoop(root *Frame) (Value, error) {
 					// the ordinary return path lands on it and returns.
 					child, cerr := childFrameFor(fn, a, f.ec)
 					if cerr == nil && child != nil {
-						root.chain = append(root.chain, f)
+						child.parent = f
 						f = child
+						state.current = f
+						enterFrame(f)
 						continue
 					}
 					out, err = f.ec.Invoke(fn, a)


### PR DESCRIPTION
## Summary

This PR makes contiguous direct bytecode-call spans non-recursive in Go by running child `Frame`s inside one interpreter dispatch loop.

- Replaces the implicit `Frame.Run` → `ec.Invoke` → `Frame.Run` call chain with explicit parent links between live heap frames.
- Descends directly through `MetaFn`, `Func`, `Closure`, and `MultiArityFn` bytecode callees while preserving arity checks, variadic packing, and closure captures.
- Routes normal returns and errors through the explicit chain, releasing completed and failed child frames.
- Preserves logical frame entry/exit behavior for `*lg-trace*`, opcode and opcode-pair profiling, and allocation-attribution shadow stacks.
- Adds focused regressions for multi-arity selection, captures, lifecycle ordering, profiler boundaries, and error-path frame release.

This is the implementation prototype discussed in #644. It intentionally does **not** close that issue yet; the resource-budget and native-callback boundaries below remain design work.

## Why

Every ordinary non-tail bytecode call currently reaches a nested `Frame.Run` through `ec.Invoke`. Deep recursion therefore grows the Go stack until the runtime aborts the process with `fatal error: stack overflow`. That abort is not a let-go `ExecutionError`, cannot be caught by `try`, and takes down an embedding host.

Frames are already heap objects. The missing state is the parent-child link currently represented by the Go call stack. This patch makes that link explicit and lets one dispatch loop descend and return without recursively entering Go.

## Observed depth

- The original single-arity non-tail and capturing-closure repros run to 10M levels without Go-stack growth.
- The corrected multi-arity repro now completes at 1M levels; the first prototype still overflowed because `MultiArityFn` fell back to `ec.Invoke`.
- Nested catch/finally propagation remains intact.

The claim is deliberately scoped to contiguous bytecode-call spans. A native builtin that calls back into let-go can still start another Go-stack segment.

## Corrected throughput measurements

Fresh stripped binaries from `dc316a0c` and this branch, using the preserved interleaved ABBA harness:

| workload | rounds | A/A median (range) | branch vs baseline |
|---|---:|---:|---:|
| `fib(32)` | 25 | -0.25% (-12.78, +6.77) | **-4.25%** (-13.22, +0.45) |
| `reduce`/`map` | 25 | +0.35% (-6.98, +5.92) | **+4.22%** (-2.70, +11.61) |
| `loop`/`recur` control | 12 | +1.15% (-3.43, +9.11) | -5.08% (-18.22, +7.89) |

Lower is faster. `fib` favored the branch in 23/25 paired rounds; `reduce`/`map` favored baseline in 24/25. The call-free control is too noisy to interpret. This is therefore workload-dependent, not a blanket throughput win.

## Validation

- [x] `go test -count=1 -timeout 60s ./...`
- [x] `go test -race ./pkg/vm -count=1`
- [x] Existing `TestLgTraceOutputAndPropagation`
- [x] Existing transduce allocation ratchet
- [x] 1M-level multi-arity repro
- [x] Nested catch/finally repro
- [x] Focused lifecycle, profiler, capture, and failed-frame-release tests

## Why this remains draft

- **Resource budget:** non-tail depth becomes linear heap growth. A configurable live-frame or execution budget is still needed to turn runaway recursion into a catchable `ExecutionError` rather than a possible heap OOM.
- **Native callback boundary:** builtins such as `reduce` that synchronously call back into let-go can still accumulate Go-stack segments under alternating recursion. Removing that boundary requires a resumable native-call protocol, CPS across the builtin surface, or an equivalent continuation mechanism.
- **Shared resolver:** #620 tail-frame reuse and this non-tail descent need one callee-preparation/frame-transition seam. This prototype proves the runtime shape but still duplicates some preparation logic from `Func`/`Closure` invocation.
- **Performance:** the corrected collection workload regresses 4.22% and needs profiling before a merge-ready disposition.
- **#618 interaction:** #618's current `OP_CALL_SELF` path enters `child.Run()` recursively, so it does not compose with this design as written. Its remaining static-callee shortcut should be evaluated inside this explicit descent path rather than merged unchanged.

## Relationship to CPS

CPS remains a legitimate broader compiler/backend strategy. Go would still need continuation applications lowered to jumps, a trampoline, or an explicit abstract machine; after defunctionalization that runtime state resembles this frame chain. This draft is the smaller runtime experiment needed to address `Frame.Run` recursion without first replacing the compiler IR.
