### PR TITLE
perf(ir/lower): tail-call fusion — :return of a single-use :call → TAIL_CALL

### DIFF
--- a/pkg/rt/core/ir/lower.lg
+++ b/pkg/rt/core/ir/lower.lg
@@ -795,7 +795,32 @@
         (when (= term-op :branch-if)
           (let [cond-ref (first (ir/refs term f))]
             (when (deferrable-branch-if-cond? l term cond-ref)
-              cond-ref)))]
+              cond-ref)))
+        ;; Tail-call fusion: a :return whose value is a single-use :call
+        ;; that is this block's last live inst lowers as TAIL_CALL (frame
+        ;; reuse) instead of INVOKE+RETURN — mirroring the plain bytecode
+        ;; compiler's tail-position emission. Safe w.r.t. try: the IR
+        ;; models try bodies as inner closures referenced by a :try inst,
+        ;; so a fusable :call is never inside a guarded region of this
+        ;; frame.
+        fused-tail-call
+        (when (= term-op :return)
+          (let [r (first (ir/refs term f))]
+            (when (and r
+                       (= :call (ir/op r f))
+                       (= 1 (use-count-of l r))
+                       (let [uses (:uses @l)
+                             us   (when (< r (count uses)) (nth uses r))]
+                         (and us
+                              (not (ir/uses-empty? us))
+                              (= term (ir/uses-first us))))
+                       ;; Must be the last live inst of THIS block so
+                       ;; skipping it in the body walk reorders nothing.
+                       (let [remaining (drop-while (fn [x] (not= x r)) insts)]
+                         (and (seq remaining)
+                              (every? (fn [x] (= :invalid (ir/op x f)))
+                                      (rest remaining)))))
+              r)))]
     ;; Block-args are pre-placed by predecessors. Entry block has none.
     (set-stack-sp! l (count params))
     (loop [i 0]
@@ -816,6 +841,8 @@
           (doseq [r (ir/refs nid f)] (decrement-use! l r))
           ;; Deferred cond (emitted after branch-target args).
           (and deferred-cond (= nid deferred-cond)) nil
+          ;; Tail-call-fused call (emitted as part of the terminator).
+          (and fused-tail-call (= nid fused-tail-call)) nil
           ;; Cheap-load deferral: skip body emission when not body-emit-cheap.
           ;; Only set!-TARGET :load-vars are excluded — those must be
           ;; materialized once so two loads can't straddle the set! and read
@@ -865,6 +892,18 @@
                   (materialize-refs! l term-refs)))))
           ;; 3. Emit BRANCH_FALSE.
           (lower-node! l term))
+        fused-tail-call
+        ;; Fused tail call: put the call's fn+args on top, emit TAIL_CALL
+        ;; argc. The RETURN after it is dead (the VM treats TAIL_CALL as
+        ;; terminal) but kept for parity with the plain compiler's shape.
+        (let [crefs (ir/refs fused-tail-call f)]
+          (if (refs-at-top-last-use? l crefs)
+            (consume-refs-in-place! l crefs)
+            (materialize-refs! l crefs))
+          (decrement-use! l fused-tail-call)
+          (emit-with-arg! l fused-tail-call :tail-call
+                          (int (ir/aux fused-tail-call f)))
+          (emit! l term :return))
         :else
         (let [term-refs (ir/refs term f)]
           ;; Direct Refs (return value, branch's empty refs, call's fn+args).

--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -62,7 +62,7 @@ pkg/rt/core_compiled.lgb pkg/rt/core/ir/dominance.lg generator 628f963434f65c2d9
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/dump.lg generator 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/form_heads.lg generator 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lattice.lg generator a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg generator 21248f3560d118f62101af26b4e1204b6ba61f3ebd129e47c8b229b3eac5c0e8
+pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg generator c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower_go.lg generator c668b95929339d8eeaf4023b0e2edf907c14e2690a8b0af37fbb017817133b1e
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/ops.lg generator 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/passes.lg generator ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169
@@ -287,7 +287,7 @@ pkg/rt/core_compiled.lgb pkg/rt/core/ir/dominance.lg input 628f963434f65c2d93827
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/dump.lg input 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/form_heads.lg input 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lattice.lg input a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg input 21248f3560d118f62101af26b4e1204b6ba61f3ebd129e47c8b229b3eac5c0e8
+pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg input c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower_go.lg input c668b95929339d8eeaf4023b0e2edf907c14e2690a8b0af37fbb017817133b1e
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/ops.lg input 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/passes.lg input ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169
@@ -376,7 +376,7 @@ pkg/rt/core_go_lowered/ pkg/rt/core/ir/dominance.lg generator 628f963434f65c2d93
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/dump.lg generator 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/form_heads.lg generator 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lattice.lg generator a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg generator 21248f3560d118f62101af26b4e1204b6ba61f3ebd129e47c8b229b3eac5c0e8
+pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg generator c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower_go.lg generator c668b95929339d8eeaf4023b0e2edf907c14e2690a8b0af37fbb017817133b1e
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/ops.lg generator 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/passes.lg generator ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169
@@ -601,7 +601,7 @@ pkg/rt/core_go_lowered/ pkg/rt/core/ir/dominance.lg input 628f963434f65c2d938273
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/dump.lg input 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/form_heads.lg input 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lattice.lg input a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg input 21248f3560d118f62101af26b4e1204b6ba61f3ebd129e47c8b229b3eac5c0e8
+pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg input c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower_go.lg input c668b95929339d8eeaf4023b0e2edf907c14e2690a8b0af37fbb017817133b1e
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/ops.lg input 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/passes.lg input ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-56f4d9bb82ad965450d82c72e84b2bab7823a3cc8f048e0c6b6555cbd20747d7
+3a91b3580af61ea92a8c8f82fa17e7f1aa8c0812fcc4003b6fbc8473b7991c71

--- a/test/ir_tailcall_fusion.lg
+++ b/test/ir_tailcall_fusion.lg
@@ -11,6 +11,9 @@
 (ns test.ir-tailcall-fusion-test
   (:require
    [disasm :as d]
+   [ir.build]
+   [ir.data :as ir]
+   [ir.lower :as lower]
    [ir.passes.pipeline]
    [test :refer :all]))
 
@@ -88,6 +91,17 @@
 (defn- count-op [f op]
   (count (filter (fn [o] (= o op)) (ops-of f))))
 
+(defn- nids-with-op [f wanted]
+  (filter (fn [nid] (= wanted (ir/op nid f)))
+          (mapcat (fn [bid] (ir/block-insts bid f)) (ir/blocks f))))
+
+(def guarded-tail-source-ir
+  (ir.build/build-fn
+   '(defn guarded-tail-source-ir []
+      (try
+        (identity :ok)
+        (catch _ :caught)))))
+
 (deftest ir-tailcall-fusion-bytecode-shape
   (testing "tail call through a let-bound function"
     ;; Direct self-recursion is lowered through :recur-fn before this pass.
@@ -95,6 +109,23 @@
     ;; exercises this fusion specifically.
     (is (pos? (count-op tail-in-let-ir :TAIL_CALL)))
     (is (zero? (count-op tail-in-let-ir :INVOKE)))))
+
+(deftest ir-tailcall-fusion-try-frame-isolation
+  (testing "the guarded frame owns :try while its body call lives in an inner fn"
+    (let [try-nids      (nids-with-op guarded-tail-source-ir :try)
+          try-nid       (first try-nids)
+          body-ref      (first (ir/refs try-nid guarded-tail-source-ir))
+          body-template (ir/aux body-ref guarded-tail-source-ir)
+          body-fn       (:fn body-template)
+          body-ops      (ops-of (lower/lower body-fn))]
+      (is (= 1 (count try-nids)))
+      (is (= true (:has-handler (ir/aux try-nid guarded-tail-source-ir))))
+      (is (zero? (count (nids-with-op guarded-tail-source-ir :call))))
+      (is (= :const (ir/op body-ref guarded-tail-source-ir)))
+      (is (= :fn-template (:kind body-template)))
+      (is (= 1 (count (nids-with-op body-fn :call))))
+      (is (pos? (count (filter (fn [op] (= :TAIL_CALL op)) body-ops))))
+      (is (zero? (count (filter (fn [op] (= :INVOKE op)) body-ops)))))))
 
 (deftest ir-tailcall-fusion-parity
   (testing "tail-call fusion: simple self-recursion"

--- a/test/ir_tailcall_fusion.lg
+++ b/test/ir_tailcall_fusion.lg
@@ -1,0 +1,123 @@
+;; Test: tail-call fusion parity (#625 fix 4)
+;;
+;; The tail-call fusion fix ensures that :return of a single-use :call lowers
+;; as TAIL_CALL (frame reuse) instead of INVOKE+RETURN. This mirrors the plain
+;; bytecode compiler's tail-position emission and saves a stack frame per call,
+;; mirroring TCO behavior where applicable.
+;;
+;; The test constructs functions with tail calls in various forms and verifies
+;; that the IR-compiled and bytecode-compiled versions produce identical results.
+;; Tail calls are calls that are the last expression in their function.
+(ns test.ir-tailcall-fusion-test
+  (:require
+   [disasm :as d]
+   [ir.passes.pipeline]
+   [test :refer :all]))
+
+;; Bytecode path: simple recursive tail call
+(defn countdown-bytecode [n]
+  (if (<= n 0)
+    :done
+    (countdown-bytecode (dec n))))
+
+;; IR-compile path: should match bytecode
+(set! *ir-compile* true)
+(set! *ir-compile-strict* true)
+
+(defn countdown-ir [n]
+  (if (<= n 0)
+    :done
+    (countdown-ir (dec n))))
+
+(set! *ir-compile-strict* false)
+(set! *ir-compile* false)
+
+;; Another shape: tail call in conditional (if true branch is a tail call)
+(defn tail-in-if-bytecode [n]
+  (if (< n 0)
+    :negative
+    (tail-in-if-bytecode (dec n))))  ; tail call in true branch
+
+(set! *ir-compile* true)
+(set! *ir-compile-strict* true)
+
+(defn tail-in-if-ir [n]
+  (if (< n 0)
+    :negative
+    (tail-in-if-ir (dec n))))
+
+(set! *ir-compile-strict* false)
+(set! *ir-compile* false)
+
+;; Accumulator-passing style (APS): tail recursion
+(defn sum-aps-bytecode [n acc]
+  (if (= n 0)
+    acc
+    (sum-aps-bytecode (dec n) (+ acc n))))
+
+(set! *ir-compile* true)
+(set! *ir-compile-strict* true)
+
+(defn sum-aps-ir [n acc]
+  (if (= n 0)
+    acc
+    (sum-aps-ir (dec n) (+ acc n))))
+
+(set! *ir-compile-strict* false)
+(set! *ir-compile* false)
+
+;; Tail call within a let binding
+(defn tail-in-let-bytecode [n]
+  (let [f countdown-bytecode]
+    (f n)))
+
+(set! *ir-compile* true)
+(set! *ir-compile-strict* true)
+
+(defn tail-in-let-ir [n]
+  (let [f countdown-ir]
+    (f n)))
+
+(set! *ir-compile-strict* false)
+(set! *ir-compile* false)
+
+(defn- ops-of [f]
+  "Opcode keywords of f's chunk, in order."
+  (map first (d/disassemble-resolved f)))
+
+(defn- count-op [f op]
+  (count (filter (fn [o] (= o op)) (ops-of f))))
+
+(deftest ir-tailcall-fusion-bytecode-shape
+  (testing "tail call through a let-bound function"
+    ;; Direct self-recursion is lowered through :recur-fn before this pass.
+    ;; The let-bound call remains a :call in return position and therefore
+    ;; exercises this fusion specifically.
+    (is (pos? (count-op tail-in-let-ir :TAIL_CALL)))
+    (is (zero? (count-op tail-in-let-ir :INVOKE)))))
+
+(deftest ir-tailcall-fusion-parity
+  (testing "tail-call fusion: simple self-recursion"
+    ;; Both compiler paths emit TAIL_CALL for this tail position.
+    ;; They should produce the same result (and not overflow the stack on deep recursion)
+    (is (= (countdown-bytecode 10) (countdown-ir 10)))
+    (is (= :done (countdown-ir 10)))
+    (is (= (countdown-bytecode 50) (countdown-ir 50)))
+    (is (= :done (countdown-ir 50))))
+  (testing "tail-call fusion: tail call in if branch"
+    ;; The true branch of the if is a tail call
+    (is (= (tail-in-if-bytecode 0) (tail-in-if-ir 0)))
+    (is (= (tail-in-if-bytecode -1) (tail-in-if-ir -1)))
+    (is (= :negative (tail-in-if-ir -1))))
+  (testing "tail-call fusion: accumulator-passing style"
+    ;; Classic tail-recursive pattern
+    (is (= (sum-aps-bytecode 10 0) (sum-aps-ir 10 0)))
+    (is (= 55 (sum-aps-ir 10 0)))  ; 1+2+...+10
+    (is (= (sum-aps-bytecode 100 0) (sum-aps-ir 100 0)))
+    (is (= 5050 (sum-aps-ir 100 0)))
+    (is (= (sum-aps-bytecode 1000 0) (sum-aps-ir 1000 0)))
+    (is (= 500500 (sum-aps-ir 1000 0))))
+  (testing "tail-call fusion: tail call within let binding"
+    ;; f is bound to the countdown function, then called in tail position
+    (is (= (tail-in-let-bytecode 10) (tail-in-let-ir 10)))
+    (is (= :done (tail-in-let-ir 10)))))


### PR DESCRIPTION
## Summary
Tail-call fusion emits `TAIL_CALL` for a single-use `:call` in return position, enabling frame reuse.

## Test coverage
- `test/ir_tailcall_fusion.lg`: bytecode/IR parity, opcode falsifier, and try-frame isolation coverage

## Base
Rebased directly onto `main` at `a759f8655eb8`.

## Verification
- `make generate` twice: byte-identical `generated.sums`, `generated.manifest`, and `core_compiled.lgb`
- `make check-generated`: passed
- `go test ./pkg/ir ./test`: passed
- `make ir-stress-gate`: passed; 2505/2516 native-lowering fixtures, 11 known baseline failures
- Push gates: compiled-output guard, Go tests, compatibility suite, and IR stress ratchet passed

## Bench ratchet
`make bench-ratchet` ran in the exclusive benchmark lane on the candidate and on `main@a759f8655eb8` using Apple M3 / Go 1.26.5. Both runs returned exit 2 against the Go 1.26.3 baseline with the same two benchmark groups over budget.

Candidate vs main control wall time:
- compiler init: 1.98 ms vs 2.02 ms (-2.0%)
- IR compile, bytecode: 20.4 ms vs 20.9 ms (-2.4%)
- IR compile, gogen_ir: 14.4 ms vs 14.6 ms (-1.4%)

Reported deterministic candidate-minus-main deltas:
- compiler: 0 allocs/op, -3 bytes/op
- IR compile, bytecode: 0 allocs/op
- IR compile, gogen_ir: +46 allocs/op, -5,349 bytes/op
