### PR TITLE
perf(ir): retain *runtime-defn-ir-cache* for only the current ns

### DIFF
--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -635,10 +635,20 @@
               _          (swap! built assoc :private? private?)
               ;; Stash the built IR (pre-optimize) so later same-ns defns can
               ;; seed the inline registry from this one. Opt-in: only when
-              ;; *enable-inline* is bound true.
+              ;; *enable-inline* is bound true. Retention is single-ns: the
+              ;; registry seeds same-ns only, so entries for other (already
+              ;; loaded) namespaces are dead weight — retaining them across a
+              ;; whole corpus load measurably raises live heap and GC mark
+              ;; cost per cycle. A require mid-file switches the cache to the
+              ;; dependency's ns and back, which at worst drops seed entries
+              ;; for defns that preceded the require (requires normally come
+              ;; first, and a lost seed only forfeits an inline opportunity).
               _          (when ir.passes.inline/*enable-inline*
-                           (swap! *runtime-defn-ir-cache*
-                                  assoc-in [(str (ns-name *ns*)) (str name-sym)] built))]
+                           (let [ns-str (str (ns-name *ns*))]
+                             (swap! *runtime-defn-ir-cache*
+                                    (fn [c]
+                                      {ns-str (assoc (get c ns-str {})
+                                                     (str name-sym) built)}))))]
           ;; Target-specific orchestration (lambda-lift for :go, fold-outline for
           ;; :bytecode) wraps the actual lowering — but the lowering itself is
           ;; DELEGATED to the `lowerings` strategy registry via *target* (#387's

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-e540bb6d152533dbbbbad4b0320d2791c1ba98656e5ca60cc3ec89a67b62a4be
+d4343b5f89a3d636b273089e2944bd8e27f596975f2eff3dd67b685d5f378623

--- a/test/ir_runtime_defn_ir_cache_test.lg
+++ b/test/ir_runtime_defn_ir_cache_test.lg
@@ -1,0 +1,51 @@
+;; *runtime-defn-ir-cache* single-ns retention (#650).
+;;
+;; When *enable-inline* is on, the IR pipeline stashes each defn's built
+;; (pre-optimize) IR so a later same-ns defn can seed its inline registry from
+;; it. The registry only ever seeds SAME-ns, so entries for other, already-loaded
+;; namespaces are dead weight — across a whole-corpus load they raise live heap
+;; and per-cycle GC mark cost for no benefit.
+;;
+;; The retention change makes each seed REPLACE the cache with a single-key map
+;; {current-ns {...}} instead of assoc-in-ing into an ever-growing multi-ns map.
+;; Two invariants pin that: same-ns defns still accumulate (the assoc within the
+;; ns is preserved), and the first seed in a new ns evicts every prior ns. The
+;; eviction assertion is the load-bearing one — the pre-change `assoc-in` code
+;; kept the foreign entry, so it would fail here.
+(ns test.ir-runtime-defn-ir-cache-test
+  (:require
+   [ir.passes.pipeline]
+   [ir.passes.inline]
+   [test :refer :all]))
+
+(def cache ir.passes.pipeline/*runtime-defn-ir-cache*)
+
+(deftest cache-accumulates-within-one-ns
+  (testing "same-ns defns both retained under a single top-level key"
+    (reset! cache {})
+    (binding [*ir-compile* true ir.passes.inline/*enable-inline* true]
+      (eval '(defn cache-fn-a [x] (inc x)))
+      (eval '(defn cache-fn-b [x] (dec x))))
+    (let [c @cache]
+      ;; exactly one ns retained (the current one) — never a growing multi-ns map
+      (is (= 1 (count c)))
+      ;; and the second defn did not evict the first within that ns
+      (let [entries (val (first c))]
+        (is (contains? entries "cache-fn-a"))
+        (is (contains? entries "cache-fn-b"))))))
+
+(deftest cache-evicts-prior-ns-on-next-seed
+  (testing "seeding in the current ns drops entries stashed for any other ns"
+    ;; Pre-seed a stale entry for a DIFFERENT ns, then compile one defn in the
+    ;; current ns. The retention change replaces the whole map with
+    ;; {current-ns ...}, so the foreign entry must be gone — that eviction is
+    ;; the memory win. The pre-change assoc-in would keep it (count would be 2).
+    (reset! cache {"some.other.ns" {"stale" :junk}})
+    (binding [*ir-compile* true ir.passes.inline/*enable-inline* true]
+      (eval '(defn cache-fn-c [x] (inc x))))
+    (let [c @cache]
+      (is (= 1 (count c)))
+      (is (not (contains? c "some.other.ns")))
+      (is (contains? (val (first c)) "cache-fn-c"))))
+  ;; leave the shared atom clean for tests that run after this file
+  (reset! cache {}))


### PR DESCRIPTION
## Summary
IR pipeline cache retention: retain *runtime-defn-ir-cache* for only the current namespace.

When *enable-inline* is on, the cache stashes each defn's built IR for same-ns inline registry seeding. The registry only seeds same-ns, so entries for other namespaces are dead weight. This change makes each seed replace the cache with a single-key map `{current-ns {...}}` instead of accumulating across all loaded namespaces.

## Decomposition Note
This PR has been decomposed per reviewer feedback:
- **compile-def-fn-value** (def+name* IR seam) → moved to #647
- **Test files** (ir_blockarg_cond.lg, ir_junk_agreement.lg, ir_and_cond_rpo.lg) → moved to #648

**This PR now contains the cache-window retention change only** — the isolated performance improvement for same-ns inline caching.

## Base & Merge Order
Base: `main@upstream`
Merge order: 4th (lands after #648, #649, #647 in stack)

## Verification
- ✓ Build: `go build ./...` passes
- ✓ Tests: `go test ./pkg/ir` passes
- ✓ Generated: `make check-generated` passes
