### PR TITLE
fix(aot): register a boxed override for typed-return fns (#554)

### DIFF
--- a/benchmark/aot/src/bench/loop-recur.lg
+++ b/benchmark/aot/src/bench/loop-recur.lg
@@ -1,15 +1,14 @@
 ;; Tight loop with tail-call recursion — AOT fixture (same workload as ../loop-recur.clj)
 ;;
-;; The loop lives in its own defn: lowered it becomes a fully typed native
-;; (func(ec) int), which the emitter does not register as an override on its
-;; own; `run` wraps it with a boxed signature so the override registers and
-;; dispatches into the native loop via an intra-ns direct call.
+;; The loop lives directly in `run`: it lowers to a fully typed native
+;; (func(ec) int), which registers as an override because the wrapper boxes the
+;; typed return (#554). Before that, a typed signature registered nothing, and
+;; the fixture had to keep the loop in a separate defn behind a boxed `run` to
+;; get native dispatch at all.
 (ns bench.loop-recur)
 
-(defn sum-loop []
+(defn run []
   (loop [i 0 acc 0]
     (if (< i 1000000)
       (recur (inc i) (+ acc i))
       acc)))
-
-(defn run [] (sum-loop))

--- a/pkg/ir/lisp_typed_directcall_test.go
+++ b/pkg/ir/lisp_typed_directcall_test.go
@@ -14,7 +14,10 @@ package ir_test
 
 import (
 	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
 )
 
 func TestLowerNsInlinesTypedSibling(t *testing.T) {
@@ -29,7 +32,11 @@ func TestLowerNsInlinesTypedSibling(t *testing.T) {
 		       (ir.passes.pipeline/lower-ns-to-go "typedres" (quote typedres)
 		         [(quote (defn callee [x] (= x 1)))
 		          (quote (defn caller [y] (callee y)))])))`)
-	src := v.String()
+	vs, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go source string, got %T", v)
+	}
+	src := string(vs)
 
 	// callee still lowers as its own bool-returning fn (public → PascalCase per #371).
 	if !regexp.MustCompile(`func Callee\(ec \*vm\.ExecContext, [a-z0-9_]+ vm\.Value\) bool`).MatchString(src) {
@@ -42,11 +49,26 @@ func TestLowerNsInlinesTypedSibling(t *testing.T) {
 	if !regexp.MustCompile(`func Caller\(ec[^}]*rt\.EqValue`).MatchString(src) {
 		t.Fatalf("expected Caller to carry callee's inlined body (rt.EqValue):\n%s", src)
 	}
-	// No call or trampoline to Callee: `Callee(` appears only in its own definition.
-	if n := len(regexp.MustCompile(`Callee\(`).FindAllString(src, -1)); n != 1 {
-		t.Fatalf("expected Callee( once (its definition only), got %d — caller did not inline:\n%s", n, src)
+	// No call to Callee from Caller's body — the actual inlining invariant.
+	// Scoped to Caller rather than counting `Callee(` across the file: since
+	// #554 a typed (bool) return also registers a boxed override, so the file
+	// legitimately contains `vm.Boolean(Callee(ec, args[0]))` in the init() map.
+	callerBody := regexp.MustCompile(`(?s)func Caller\(ec.*?\n\}`).FindString(src)
+	if callerBody == "" {
+		t.Fatalf("could not isolate Caller's body:\n%s", src)
+	}
+	if strings.Contains(callerBody, "Callee(") {
+		t.Fatalf("Caller still calls Callee — it did not inline:\n%s", callerBody)
 	}
 	if regexp.MustCompile(`InvokeValue\([^\n]*"callee"|CachedVarFn\([^\n]*"callee"`).MatchString(src) {
 		t.Fatalf("caller must NOT trampoline to callee after inlining:\n%s", src)
+	}
+	// Both fns return bool, so both register a boxed override (#554). Before
+	// that they lowered and then registered nothing, leaving the native code
+	// unreachable from a dynamic call.
+	for _, name := range []string{"callee", "caller"} {
+		if !regexp.MustCompile(`"` + name + `":\s*__gogen_wrap`).MatchString(src) {
+			t.Fatalf("expected %q to register a boxed override (#554):\n%s", name, src)
+		}
 	}
 }

--- a/pkg/ir/lisp_typed_return_override_test.go
+++ b/pkg/ir/lisp_typed_return_override_test.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// #554: a fn whose body lowers to a fully typed signature — the canonical case
+// being a loop that infers an int result, `func SumLoop(ec) int` — used to
+// register no override at all, because override-uniform-value? demanded
+// vm.Value in AND out. The lowered code was emitted and then never reached: the
+// var kept its bytecode fn, so every dynamic call ran the VM.
+//
+// Measured on benchmark/gloat/loop-recur.clj, where the loop sits inside -main:
+// the AOT binary ran at 60.0ms against the VM's 60.5ms (no benefit at all),
+// while the same program with a boxed return ran 6.9ms — 8.7x, from lowering
+// that was already happening.
+func TestTypedReturnRegistersBoxedOverride(t *testing.T) {
+	ensureLoader()
+
+	v := runLispExpr(t, `(do (create-ns (quote tret))
+      (ir.passes.pipeline/lower-ns-to-go "tret" (quote tret)
+        [(quote (defn sum-loop [] (loop [i 0 acc 0] (if (< i 1000000) (recur (inc i) (+ acc i)) acc))))]))`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go source string, got %T", v)
+	}
+	src := string(s)
+
+	// Precondition: the body really did lower to a typed int return. If this
+	// stops holding the test is no longer exercising #554.
+	if !regexp.MustCompile(`func SumLoop\(ec \*vm\.ExecContext\) int`).MatchString(src) {
+		t.Fatalf("expected a typed `func SumLoop(ec *vm.ExecContext) int`:\n%s", src)
+	}
+
+	// The fix: it registers, and the wrapper boxes the typed result.
+	if !strings.Contains(src, "RegisterGoOverrides") {
+		t.Fatalf("typed-return fn emitted no init()/RegisterGoOverrides — it is unreachable as an override:\n%s", src)
+	}
+	if !regexp.MustCompile(`"sum-loop":\s*__gogen_wrap`).MatchString(src) {
+		t.Fatalf("sum-loop is NOT in the override map:\n%s", src)
+	}
+	if !strings.Contains(src, "return vm.Int(SumLoop(ec)), nil") {
+		t.Fatalf("expected the wrapper to box the typed return as vm.Int:\n%s", src)
+	}
+}
+
+// The return side is lifted; the PARAM side deliberately is not. Unboxing an
+// arg needs a proof that the runtime value really is that primitive — the
+// direct-call path gets that at the call site (coerce-arg-to-type), a dynamic
+// override boundary does not. A typed PARAM must therefore still stay off the
+// override path rather than registering a wrapper that would mis-assert.
+func TestTypedParamStillSkipsOverride(t *testing.T) {
+	ensureLoader()
+
+	v := runLispExpr(t, `(do (create-ns (quote tparam))
+      (ir.passes.pipeline/lower-ns-to-go "tparam" (quote tparam)
+        [(quote (defn twice [^long n] (* 2 n)))]))`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go source string, got %T", v)
+	}
+	src := string(s)
+
+	// Precondition: a typed PARAM really was emitted.
+	if !regexp.MustCompile(`func Twice\(ec \*vm\.ExecContext, arg0 int\)`).MatchString(src) {
+		t.Fatalf("expected a typed param `func Twice(ec *vm.ExecContext, arg0 int)`:\n%s", src)
+	}
+	if regexp.MustCompile(`"twice":\s*__gogen_wrap`).MatchString(src) {
+		t.Fatalf("typed-PARAM fn registered an override; the wrapper cannot soundly unbox args[i]:\n%s", src)
+	}
+}

--- a/pkg/ir/lisp_typed_return_override_test.go
+++ b/pkg/ir/lisp_typed_return_override_test.go
@@ -79,3 +79,42 @@ func TestTypedParamStillSkipsOverride(t *testing.T) {
 		t.Fatalf("typed-PARAM fn registered an override; the wrapper cannot soundly unbox args[i]:\n%s", src)
 	}
 }
+
+// Multi-arity sibling of TestTypedReturnRegistersBoxedOverride. Both arities of
+// `choose` return bool, so before #554's multi-arity arm the whole fn was
+// disqualified from override registration (multi-arity-override-groups required
+// every arity to be uniformly vm.Value) and emitted no init() at all — the two
+// native helpers were unreachable from a dynamic call.
+func TestTypedReturnRegistersMultiArityOverride(t *testing.T) {
+	ensureLoader()
+
+	v := runLispExpr(t, `(do (create-ns (quote tmulti))
+      (ir.passes.pipeline/lower-ns-to-go "tmulti" (quote tmulti)
+        [(quote (defn choose ([x] (= x 1)) ([x y] (= x y))))]))`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go source string, got %T", v)
+	}
+	src := string(s)
+
+	// Precondition: both arities lowered with typed bool returns.
+	for _, want := range []string{"func Choose_1(", "func Choose_2("} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("expected %s in the lowered output:\n%s", want, src)
+		}
+	}
+	if !regexp.MustCompile(`func Choose_1\([^)]*\) bool`).MatchString(src) {
+		t.Fatalf("expected Choose_1 to return a typed bool:\n%s", src)
+	}
+
+	// The fix: one combined adapter registered under the bare name, with each
+	// typed arm boxed independently.
+	if !regexp.MustCompile(`"choose":\s*__gogen_wrap`).MatchString(src) {
+		t.Fatalf("multi-arity typed-return fn is NOT registered (#554):\n%s", src)
+	}
+	for _, want := range []string{"vm.Boolean(Choose_1(ec, args[0]))", "vm.Boolean(Choose_2(ec, args[0], args[1]))"} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("expected each arm boxed — missing %q:\n%s", want, src)
+		}
+	}
+}

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -3311,6 +3311,30 @@
        (= "vm.Value" (function-return-spec f))
        (every? (fn [s] (= "vm.Value" s)) (function-param-specs f))))
 
+(def ^:private boxable-return-specs
+  ;; Return specs the override wrapper can lift back to vm.Value with a single
+  ;; constructor. Deliberately mirrors box-as-value's type set — anything it
+  ;; can't box must stay off the override path.
+  #{"bool" "int" "float64" "string" "vm.Char"})
+
+(defn- override-boxable-return? [f]
+  ;; True iff a TYPED RETURN is the only thing keeping this fn off the override
+  ;; path: params are already uniformly vm.Value (so args[i] flow straight in,
+  ;; no unboxing needed) and the result is a primitive the wrapper can box.
+  ;;
+  ;; #554: without this, a fn whose body lowers perfectly — the canonical case
+  ;; being a loop that infers an int result, `func SumLoop(ec) int` — registers
+  ;; no override at all, so every dynamic (var) call to it stays on bytecode and
+  ;; the lowered code is dead. Measured at 8.7x on benchmark/gloat/loop-recur.clj.
+  ;;
+  ;; Params are NOT coerced here on purpose. Unboxing an arg requires knowing the
+  ;; runtime value really is that primitive, which the direct-call path proves at
+  ;; the call site (coerce-arg-to-type) but a dynamic override boundary cannot.
+  ;; Typed params therefore remain ineligible; only the return side is lifted.
+  (and (not (ir/fn-variadic? f))
+       (contains? boxable-return-specs (function-return-spec f))
+       (every? (fn [s] (= "vm.Value" s)) (function-param-specs f))))
+
 (defn- override-coercible? [f]
   ;; True iff the lowered Go signature is a DIRECT-CALL target: non-variadic and
   ;; every param/result spec is one the call site can coerce soundly
@@ -3443,6 +3467,11 @@
        :arity (ir/fn-arity f)
        :needs-error? needs-error?
        :override-eligible? (override-uniform-value? f)
+       ;; Uniform params but a typed RETURN: the wrapper boxes the result and
+       ;; registers anyway (#554). Separate flag so the wrapper emitter knows to
+       ;; wrap, and so :override-eligible? keeps meaning "adaptable with no
+       ;; coercion at all".
+       :override-boxable-return? (override-boxable-return? f)
        ;; :direct-callable? + the actual typed specs feed the direct-call
        ;; REGISTRY (registry-entry-from-result), separate from :override-eligible?
        ;; which feeds the NativeFn override wrapper. A typed sibling (e.g.

--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -963,7 +963,8 @@
    __gogen_wrap/NewCtxNativeFn) so the dynamic var path stays multi-arity AND is
    context-aware — the caller's ec is threaded into each helper (a
    MakeNativeMultiArity value can't, being built at package load with no ec).
-   Only used when every arity is override-eligible (uniform vm.Value)."
+   Every arity is adaptable: uniform vm.Value, or a typed return this boxes
+   per-arm (#554)."
   (let [fn-name  (:fn-name (first arities))
         args-id  (gogen/ident "args")
         len-call (gogen/call (gogen/ident "len") [args-id])
@@ -976,9 +977,17 @@
                                    (range arity))
                 inner-call   (gogen/call (gogen/ident go-name)
                                          (into [(gogen/ident "ec")] arg-exprs))
-                ret-stmt     (if needs-error?
-                               (gogen/return-stmt [inner-call])
-                               (gogen/return-stmt [inner-call (gogen/ident "nil")]))]
+                ;; Each arm boxes independently: arities are admitted per-arm,
+                ;; so one may return vm.Value while another returns a typed
+                ;; primitive that needs lifting (#554).
+                ret-stmt     (cond
+                               (:override-boxable-return? r)
+                               (gogen/return-stmt
+                                 [(box-return-expr (:result-spec r) inner-call)
+                                  (gogen/ident "nil")])
+                               needs-error? (gogen/return-stmt [inner-call])
+                               :else (gogen/return-stmt
+                                       [inner-call (gogen/ident "nil")]))]
             (gogen/case-clause [(gogen/int-lit arity)] [ret-stmt])))
         cases    (mapv arm->case arities)
         msg      (str fn-name ": wrong number of arguments %d")
@@ -1077,21 +1086,26 @@
 (defn- multi-arity-override-groups [valid-results]
   "Group the multi-arity per-arity results by bare :fn-name for ONE combined
    override adapter each. Only emit the override when EVERY arity is
-   :override-eligible? (uniform vm.Value) — a typed arity can't be called with
-   boxed args[i] from the dynamic dispatch adapter. When any arity is typed the
-   whole fn's dynamic (var) path stays on bytecode; the per-arity STATIC direct
-   calls still go native (registry-entry-from-result gates on the broader
-   :direct-callable?, coercing typed args at the call site). Returns a sorted vec
-   of [fn-name (sorted-by-arity results)] pairs for deterministic emission."
+   adaptable — uniform vm.Value, or (#554) uniform vm.Value params with a
+   boxable typed return, which the wrapper lifts per-arm. A typed-PARAM arity
+   still disqualifies the whole fn: it can't be called with boxed args[i] from
+   the dynamic dispatch adapter. In that case the fn's dynamic (var) path stays
+   on bytecode; the per-arity STATIC direct calls still go native
+   (registry-entry-from-result gates on the broader :direct-callable?, coercing
+   typed args at the call site). Returns a sorted vec of
+   [fn-name (sorted-by-arity results)] pairs for deterministic emission."
   (let [by-name (reduce (fn [m r]
                           (if (:multi-arity? r)
                             (update m (:fn-name r) (fnil conj []) r)
                             m))
-                        {} valid-results)]
+                        {} valid-results)
+        adaptable? (fn [r] (or (:override-eligible? r)
+                               (and (:override-boxable-return? r)
+                                    (not (:needs-error? r)))))]
     (vec
       (keep (fn [nm]
               (let [arities (sort-by :arity (get by-name nm))]
-                (when (every? :override-eligible? arities)
+                (when (every? adaptable? arities)
                   [nm arities])))
             (sort (keys by-name))))))
 

--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -889,10 +889,30 @@
   ;; fns are registered — the strict fixed-arity wrapper can't represent an
   ;; &-rest tail.
 
+(defn- box-return-expr [spec expr]
+  "Lift a typed return expression back to vm.Value with the matching vm
+   constructor. Mirrors lower_go.lg's box-as-value / boxable-return-specs; a
+   spec outside that set returns expr unchanged (the caller gates on
+   :override-boxable-return?, so that case shouldn't arise)."
+  (cond
+    (= spec "bool")    (gogen/call (gogen/field-sel (gogen/ident "vm") "Boolean") [expr])
+    (= spec "int")     (gogen/call (gogen/field-sel (gogen/ident "vm") "Int") [expr])
+    (= spec "float64") (gogen/call (gogen/field-sel (gogen/ident "vm") "Float") [expr])
+    (= spec "string")  (gogen/call (gogen/field-sel (gogen/ident "vm") "String") [expr])
+    ;; vm.Char already implements vm.Value — usable as-is.
+    (= spec "vm.Char") expr
+    :else              expr))
+
 (defn- override-wrapper-fn-lit [entry]
   "Build the per-defn `func(args []vm.Value) (vm.Value, error)` adapter:
    arity-check, then call the generated typed fn, supplying `, nil` when
-   the typed fn doesn't itself return an error."
+   the typed fn doesn't itself return an error.
+
+   When the lowered fn has a TYPED return (:override-boxable-return?, #554) the
+   result is boxed on the way out: `return vm.Int(Foo(ec, args[0])), nil`. That
+   case is always error-free — override-entries only admits a boxable return
+   when :needs-error? is false, because a body that can error carries its result
+   as vm.Value and so never presents a typed return in the first place."
   (let [arity        (:arity entry)
         go-name      (:go-name entry)
         fn-name      (:fn-name entry)
@@ -918,9 +938,17 @@
         ;; caller's context (matching the bytecode path) rather than the root.
         inner-call   (gogen/call (gogen/ident go-name)
                                  (into [(gogen/ident "ec")] arg-exprs))
-        ret-stmt     (if needs-error?
-                       (gogen/return-stmt [inner-call])
-                       (gogen/return-stmt [inner-call (gogen/ident "nil")]))]
+        boxed?       (:override-boxable-return? entry)
+        ret-spec     (:result-spec entry)
+        ret-stmt     (cond
+                       ;; Typed return (#554): box it. Error-free by
+                       ;; construction — see the docstring.
+                       boxed?       (gogen/return-stmt
+                                      [(box-return-expr ret-spec inner-call)
+                                       (gogen/ident "nil")])
+                       needs-error? (gogen/return-stmt [inner-call])
+                       :else        (gogen/return-stmt
+                                      [inner-call (gogen/ident "nil")]))]
     (gogen/func-lit
       [(gogen/param "ec" (gogen/type "*vm.ExecContext"))
        (gogen/param "args" (gogen/type "[]vm.Value"))]
@@ -1031,12 +1059,19 @@
 (defn- override-entries [valid-results]
   "Lowered results eligible for SINGLE-arity override registration: single-arity
    fns (carry :fn-name) whose Go signature is uniformly vm.Value, so the
-   fixed-arity wrapper adapts them without boxing/unboxing. Typed and
-   variadic fns are flagged :override-eligible? false and stay on bytecode.
+   fixed-arity wrapper adapts them without boxing/unboxing — plus (#554) those
+   whose params are uniform but whose RETURN is a boxable primitive, where the
+   wrapper boxes the result on the way out. Typed-PARAM and variadic fns are
+   still excluded and stay on bytecode: unboxing an arg needs a proof about the
+   runtime value that a dynamic override boundary doesn't have.
    Multi-arity arities (:multi-arity?) are EXCLUDED here — they'd each register a
    colliding single-arity wrapper under the same bare :fn-name; the whole fn gets
    one multi-arity override adapter instead (multi-arity-override-groups)."
-  (filterv (fn [r] (and (:fn-name r) (:override-eligible? r) (not (:multi-arity? r))))
+  (filterv (fn [r] (and (:fn-name r)
+                        (or (:override-eligible? r)
+                            (and (:override-boxable-return? r)
+                                 (not (:needs-error? r))))
+                        (not (:multi-arity? r))))
            valid-results))
 
 (defn- multi-arity-override-groups [valid-results]

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-c363f088eba259d5e755ab31f27a94072f693e1ae80aa6ff11c4dd26dd5f3704
+a210bcd910f540e79b5ec050d4708d92d429e5954804758c328f7cabe97b7267


### PR DESCRIPTION
## Summary

A fn that lowers to a fully typed signature registered no override at all, so the lowered Go was emitted and then never reached — the var kept its bytecode fn and every dynamic call ran the VM. `override-uniform-value?` demanded `vm.Value` in *and* out; a typed return failed it.

This admits the case where the params are already uniform `vm.Value` and only the return is typed, and boxes the result in the wrapper:

```go
return vm.Int(SumLoop(ec)), nil
```

Closes #554.

## Why it matters

The canonical shape is a loop whose result infers to `int`, which is what `benchmark/gloat/loop-recur.clj` is — the loop sits directly in `-main`, so there is no inner fn to register and nothing dispatches. Measured on darwin/arm64, gloat v0.1.62 `-E lglvm`, let-go v1.12.2, hyperfine 3 warmup / 10 runs:

| leg | mean |
|---|---|
| VM (`lg loop-recur.clj`) | 60.5 ms ± 0.7 |
| AOT, as gloat builds it today | 60.0 ms ± 0.7 |
| AOT, same program with a boxed return | 6.9 ms ± 1.5 |

8.7x, from lowering that was already happening.

fib doesn't hit this because `fib` is its own registerable fn: the VM runs `-main` as bytecode, calls `fib`, and that first call enters the native island where the recursion stays. loop-recur has no inner fn, so the entry's registration is the only door in.

This is also the shape external comparisons compile. cljgo's published AOT table has let-go's loop-recur at 37.3 ms against a 36.6 ms VM leg — the same null result on their hardware.

Multi-arity fns need the same treatment and get it here: `multi-arity-override-groups` required *every* arity to be uniform `vm.Value`, so `(defn choose ([x] (= x 1)) ([x y] (= x y)))` emitted `Choose_1`/`Choose_2` returning `bool` and no `init()` at all. Each arm boxes independently, since one arm may return `vm.Value` while another returns a primitive.

## The two judgement calls

**Params are deliberately not coerced.** Only the return side is lifted. Unboxing an arg needs a proof that the runtime value really is that primitive; the direct-call path gets that at the call site (`coerce-arg-to-type` only direct-calls a typed param when the arg is proven that type, else falls back), but a dynamic override boundary has no such proof. A typed *param* therefore still stays on bytecode, and `TestTypedParamStillSkipsOverride` pins that.

**Typed return plus error looks unreachable, so the wrapper stays single-branch.** A body containing a call that can error carries its result as `vm.Value`, so it never presents a typed return; I found no shape that produces the pair. `override-entries` gates on `(not (:needs-error? r))` to state that rather than emit a two-value branch nothing exercises.

## Fixture cleanup

`benchmark/aot/src/bench/loop-recur.lg` kept the loop in a separate `defn` behind a boxed `run` purely to work around this — its header comment said so. The loop moves back into `run`, and `build.lg`'s native-dispatch check (which fails the build if any fixture silently falls back to bytecode) still passes on all 7 fixtures. The row also got faster, 10.15x over the VM against 6.58x with the indirection.

## Test plan

- [x] `go test -short -timeout 60s ./... -skip TestClojureTestSuite`
- [x] `make test` and `make build`
- [x] `bash benchmark/run.sh loop-recur` — `aot-build: OK (all 7 fixtures dispatch native)`
- [x] `gofmt -l`; `GOOS=linux`, `GOOS=js/wasm`, `GOOS=plan9/amd64` builds
- [x] CI green

`TestLowerNsInlinesTypedSibling` needed a follow-up commit. Its callee returns `bool`, so it now registers a boxed override, and the test proved inlining by counting `Callee(` across the whole file — the new wrapper made that 2. The inlining was still correct; the assertion moved into `Caller`'s body, where the invariant actually lives.

