### PR TITLE
fix(ir): treat a return-hinted arity vector as one arity (#598)

### DIFF
--- a/pkg/ir/lisp_return_hint_arity_test.go
+++ b/pkg/ir/lisp_return_hint_arity_test.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+// #598: `(defn f ^long [n] …)` — the idiomatic return-hint position — reads as
+// `(defn f (with-meta [n] {:tag …}) …)`. The lowering pipeline split single- from
+// multi-arity on a bare `vector?` test, so the hinted form fell through to the
+// multi-arity arm, threw, and was demoted to a warning: the fn silently vanished
+// from the lowered package and the program ran on the VM instead. These tests
+// assert the hinted form lowers, that the spellings which already worked still
+// do, and that real multi-arity is still routed as multi-arity.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// Intern the defn before lowering it: build resolves same-ns call targets
+// through the namespace, so a self-recursive fn is an unresolved symbol
+// otherwise. (lisp_defmulti_native_test.go does the same for its multimethod.)
+func lowerForms(t *testing.T, pkg string, forms string) string {
+	t.Helper()
+	runLispExpr(t, `(do `+forms+`)`)
+	v := runLispExpr(t, `(ir.passes.pipeline/lower-ns-to-go "`+pkg+`" (quote core) (quote [`+forms+`]))`)
+	s, ok := v.(vm.String)
+	if !ok {
+		t.Fatalf("expected rendered Go string, got %T: %v", v, v)
+	}
+	return string(s)
+}
+
+func TestReturnHintedArityLowers(t *testing.T) {
+	ensureLoader()
+
+	rendered := lowerForms(t, "rhpkg",
+		`(defn rhfib ^long [^long n] (if (< n 2) n (+ (rhfib (- n 1)) (rhfib (- n 2)))))`)
+
+	if !strings.Contains(rendered, "func Rhfib(") {
+		t.Fatalf("return-hinted defn did not lower to a native fn; rendered:\n%s", rendered)
+	}
+	// The param hint still has to survive the unwrap — a lowered fn taking
+	// vm.Value would mean the arity vector reached build-fn stripped of its
+	// element metadata.
+	if !strings.Contains(rendered, "arg0 int") {
+		t.Errorf("expected an unboxed int param on the lowered fn; rendered:\n%s", rendered)
+	}
+}
+
+// The spellings the issue reported as already working. They route through the
+// same branch, so a fix that only special-cased the broken one would show up here.
+func TestUnhintedAndAlternateHintSpellingsStillLower(t *testing.T) {
+	ensureLoader()
+
+	cases := []struct {
+		name  string
+		form  string
+		wantF string
+	}{
+		{"no hint", `(defn rhplain [^long n] (+ n 1))`, "func Rhplain("},
+		{"param hint only", `(defn rhparam [^long n] (* n 2))`, "func Rhparam("},
+		{"hint on the name", `(defn ^long rhname [^long n] (- n 1))`, "func Rhname("},
+		// Wrapped in an arity list, so it takes the multi-arity path and gets
+		// that path's per-arity name (`_1`) rather than a bare `Rhwrapped`.
+		{"hint on a wrapped arity vector", `(defn rhwrapped (^long [^long n] (+ n 3)))`, "func Rhwrapped_1("},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rendered := lowerForms(t, "rhpkg", tc.form)
+			if !strings.Contains(rendered, tc.wantF) {
+				t.Fatalf("%s did not lower; rendered:\n%s", tc.name, rendered)
+			}
+		})
+	}
+}
+
+// Guard the other direction: widening the single-arity predicate must not
+// swallow a genuine multi-arity defn, whose first form is a list too.
+func TestRealMultiArityStillRoutesAsMultiArity(t *testing.T) {
+	ensureLoader()
+
+	rendered := lowerForms(t, "rhpkg", `(defn rhmulti ([a] a) ([a b] (+ a b)))`)
+
+	// Multi-arity lowers to per-arity fns, never to a single `func Rhmulti(`
+	// carrying one signature — that would mean it took the single-arity arm and
+	// dropped an arity on the floor.
+	if strings.Contains(rendered, "func Rhmulti(ec *vm.ExecContext, arg0 vm.Value) (vm.Value, error)") {
+		t.Fatalf("multi-arity defn collapsed to a single arity; rendered:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Rhmulti") {
+		t.Fatalf("multi-arity defn vanished from the lowered package; rendered:\n%s", rendered)
+	}
+}

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -1355,12 +1355,16 @@
          :variadic? variadic?
          :arg-tags final-arg-tags}))))
 
-(defn- return-hinted-arity-vector? [form]
+;; Public because the lowering pipeline needs the same test: the reader
+;; reifies `(defn f ^long [n] …)` as `(defn f (with-meta [n] {:tag …}) …)`,
+;; so every place that distinguishes single- from multi-arity by `vector?`
+;; has to know this shape is still one arity. See #598.
+(defn return-hinted-arity-vector? [form]
   (and (seq? form)
        (= 'with-meta (first form))
        (vector? (second form))))
 
-(defn- unwrap-arity-vector [form]
+(defn unwrap-arity-vector [form]
   (if (return-hinted-arity-vector? form)
     (second form)
     form))

--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -616,7 +616,14 @@
           has-doc?    (string? maybe-doc)
           first-form  (if has-doc? (nth form 3) maybe-doc)
           go-target?  (= *target* :go)]
-      (if (vector? first-form)
+      ;; A return-hinted arity vector is still ONE arity. `^long [n]` reads as
+      ;; the list (with-meta [n] {:tag …}), which fails `vector?` and used to
+      ;; fall through to the multi-arity arm, where `with-meta` was taken for an
+      ;; args vector and threw — caught per-fn and demoted to a warning, so the
+      ;; fn silently vanished from the lowered package (#598). args-vec keeps
+      ;; the hinted form: ir.build/build-fn unwraps it and reads the :tag.
+      (if (or (vector? first-form)
+              (ir.build/return-hinted-arity-vector? first-form))
         ;; Single arity
         (let [args-vec   first-form
               body-forms (map expand-all (drop (if has-doc? 4 3) form))
@@ -781,6 +788,11 @@
                           maybe-doc)]
       (cond
         (vector? args-or-arity) [name-str (count args-or-arity)]
+        ;; Before the (list? …) arm: a return-hinted vector is a list, but it
+        ;; is one arity, and calling it :multi would let a hinted defn dedupe
+        ;; against an unhinted same-name one of the same real arity (#598).
+        (ir.build/return-hinted-arity-vector? args-or-arity)
+        [name-str (count (ir.build/unwrap-arity-vector args-or-arity))]
         (list? args-or-arity)   [name-str :multi]
         :else                   nil))))
 
@@ -1188,11 +1200,16 @@
             (recur (rest remaining) out)))))))
 
 (defn- single-arity-defn-form? [form]
-  "True for (defn name [params...] body...) — the shape inline can splice."
+  "True for (defn name [params...] body...) — the shape inline can splice.
+   A return-hinted `^long [params...]` counts: it reads as a with-meta list
+   but is still one arity, and excluding it left hinted fns permanently
+   un-spliceable (#598)."
   (and (seq? form)
        (= 'defn (first form))
        (symbol? (second form))
-       (vector? (nth form 2 nil))))
+       (let [a (nth form 2 nil)]
+         (or (vector? a)
+             (ir.build/return-hinted-arity-vector? a)))))
 
 (defn- build-inline-registry
   "Build the per-namespace inline callee registry: each single-arity defn in

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-031b3c41c8f5ff3e2084e0629cb1227ae34de5bdb7bc95d6b35e238fe5731695
+276d15f47313666b6deea5828014599dbe6eb195f1fe22ffea3462d00fdda4ae

--- a/test/e2e/gold_dynvar_test.go
+++ b/test/e2e/gold_dynvar_test.go
@@ -43,6 +43,8 @@ import (
 //     transducer application, with-out-str) when the binding lives in a child
 //     ExecContext (inside a future). A context-free Fn.Invoke at any of those
 //     sites resolves the var against the root context and breaks every scenario.
+//   - return_hint_metadata.cljc: reader metadata on the idiomatic
+//     (defn f ^long [^long n] ...) spelling, plus execution of the hinted fn.
 //
 // The scripts deliberately stay inside the subset where let-go and Clojure
 // agree. let-go is intentionally MORE PERMISSIVE than Clojure in two spots the
@@ -54,6 +56,7 @@ const (
 	dynvarThreadsScript   = "test/gold/dynvar_threads.cljc"
 	nsThreadsScript       = "test/gold/ns_threads.cljc"
 	dynvarCallbacksScript = "test/gold/dynvar_callbacks.cljc"
+	returnHintMetaScript  = "test/gold/return_hint_metadata.cljc"
 )
 
 // rederiveGoldEnv, when set to "1", makes the gold tests re-derive their .out
@@ -63,6 +66,9 @@ const rederiveGoldEnv = "LETGO_GOLD_REDERIVE"
 func TestGoldDynvarThreadsMatchesClojure(t *testing.T)   { checkGold(t, dynvarThreadsScript) }
 func TestGoldNsThreadsMatchesClojure(t *testing.T)       { checkGold(t, nsThreadsScript) }
 func TestGoldDynvarCallbacksMatchesClojure(t *testing.T) { checkGold(t, dynvarCallbacksScript) }
+func TestGoldReturnHintMetadataMatchesClojure(t *testing.T) {
+	checkGold(t, returnHintMetaScript)
+}
 
 // goldPath maps a .cljc script to its committed expected-output file:
 // test/gold/foo.cljc -> test/gold/foo.out.

--- a/test/gogen/return_hint_metadata.lg
+++ b/test/gogen/return_hint_metadata.lg
@@ -1,0 +1,25 @@
+;; Native-lowering oracle for reader metadata on the idiomatic return-hint
+;; position. The same behavior is pinned against live JVM Clojure by
+;; test/gold/return_hint_metadata.cljc. The trampoline runs `run` under both the
+;; bytecode VM and generated Go, and also verifies that `run` dispatches to the
+;; native override rather than silently falling back to bytecode.
+(ns examples.return-hint-metadata)
+
+(def return-hinted-source "(defn hinted ^long [^long n] n)")
+
+(defn reader-metadata []
+  (let [arity (nth (read-string return-hinted-source) 2)]
+    ;; JVM Clojure attaches reader metadata directly. let-go preserves the
+    ;; reader form as (with-meta value metadata), so normalize both shapes.
+    (if (vector? arity)
+      [(meta arity) (meta (first arity))]
+      (let [arg        (first (second arity))
+            arity-meta (nth arity 2)
+            arg-meta   (nth arg 2)]
+        [(assoc arity-meta :tag (second (:tag arity-meta)))
+         (assoc arg-meta :tag (second (:tag arg-meta)))]))))
+
+(defn hinted ^long [^long n] n)
+
+(defn run ^Object []
+  [(hinted 7) (reader-metadata)])

--- a/test/gold/return_hint_metadata.cljc
+++ b/test/gold/return_hint_metadata.cljc
@@ -1,0 +1,23 @@
+(ns test.gold.return-hint-metadata)
+
+(def return-hinted-source "(defn hinted ^long [^long n] n)")
+
+(defn reader-metadata []
+  (let [arity (nth (read-string return-hinted-source) 2)]
+    ;; JVM Clojure attaches reader metadata directly. let-go preserves the
+    ;; reader form as (with-meta value metadata), so normalize both shapes to
+    ;; the same metadata maps before comparing their behavior.
+    (if (vector? arity)
+      [(meta arity) (meta (first arity))]
+      (let [arg        (first (second arity))
+            arity-meta (nth arity 2)
+            arg-meta   (nth arg 2)]
+        [(assoc arity-meta :tag (second (:tag arity-meta)))
+         (assoc arg-meta :tag (second (:tag arg-meta)))]))))
+
+(defn hinted ^long [^long n] n)
+
+(defn run ^Object []
+  [(hinted 7) (reader-metadata)])
+
+(println (pr-str (run)))

--- a/test/gold/return_hint_metadata.out
+++ b/test/gold/return_hint_metadata.out
@@ -1,0 +1,1 @@
+[7 [{:tag long} {:tag long}]]


### PR DESCRIPTION
Closes #598.

## The bug

The reader reifies `(defn f ^long [n] …)` — the idiomatic Clojure position for a return hint — as `(defn f (with-meta [n] {:tag (quote long)}) …)`. The lowering pipeline split single- from multi-arity on a bare `vector?` test, so that list fell through to the multi-arity arm, where `with-meta` got taken for an args vector and threw "seq expected Seqable" inside `expand-fn-args`.

The throw is caught per-fn and demoted to a `WARNING`, so the function vanished from the lowered package and the program kept running on the VM. Adding the hint that is supposed to make code faster turned native lowering off.

Repro from the issue, on `cb99d7c5`:

```
$ ./lg scripts/lg-compile out fibv fib.lg
WARNING: lowering failed for fib: … "seq expected Seqable" …
```

`fib` is absent from the generated Go. After this change the same input emits `func Fib(ec *vm.ExecContext, arg0 int) (vm.Value, error)`.

## The fix

`ir/build.lg` already had the right predicate for this shape — #484/#489 fixed the same syntax at the compiler layer, which is why the hinted form compiles and runs correctly on the VM. It was private. This promotes `return-hinted-arity-vector?` and `unwrap-arity-vector` and uses them at the three places in `pipeline.lg` that tell arities apart by `vector?`:

- **The `compile-form*` arity branch** — the one that dropped the function.
`args-vec` keeps the hinted form rather than unwrapping it here, because `build-fn` already unwraps it. To be precise about what this does not do: the `:tag` is dropped by `unwrap-arity-vector` and read by nothing today, so the hint still has no effect on the return type. Consuming it is #599.
- **`defn-key`** — a hinted single-arity defn was keyed `:multi`, so it could
dedupe against an unhinted same-name defn of the same real arity.
- **`single-arity-defn-form?`** — the inline-registry gate, where the
consequence was milder: hinted fns were permanently un-spliceable.

## Tests

`pkg/ir/lisp_return_hint_arity_test.go` asserts the hinted form lowers and keeps its unboxed `int` param. It also pins the three spellings the issue reported as already working, so a narrower fix that special-cased only the broken one fails. A third test pins that a real multi-arity defn still routes as multi-arity, since the widened predicate must not swallow it.

One correction to the issue while writing those: I listed `(defn fib (^long [^long n] …))` as lowering correctly, which it does, but it lowers as `Fib_1` via the multi-arity path rather than as a bare `Fib`. The test expects that name.

## Scope

The lowering half only. Returns still come back boxed, which is #599. I checked whether the wrapped-arity spelling already unboxes its return; it does not. Recursive `fib` yields `(vm.Value, error)` in both spellings, so there is nothing in that path to reuse for #599.

## Checks

`gofmt` and `go vet` clean. `go test ./pkg/...` and `./test/...` both pass. Cross-builds pass for linux/amd64, js/wasm, plan9/amd64, and wasip1/wasm. `pkg/rt/generated.sums` is updated from `make generate`; `core_compiled.lgb` is byte-identical, since the IR namespaces load from embedded source rather than the bundle.
