### PR TITLE
feat(ir): seed self-recursive calls from a declared return type (#599)

### DIFF
--- a/pkg/ir/lisp_declared_return_test.go
+++ b/pkg/ir/lisp_declared_return_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Marcin Gasperowicz <xnooga@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package ir_test
+
+// #599: a self-recursive integer fn used to lower with unboxed params but a
+// boxed return — `(vm.Value, error)` plus `rt.AddValue` for the addition —
+// because the self-call typed as :unknown and poisoned the numeric chain. A
+// declared return type (`(defn f ^long [n] …)`) seeds the self-call, after
+// which the existing typed-result machinery carries native ints all the way
+// through. These tests pin the resulting shape, that it stays opt-in, and that
+// the seed does not leak across function boundaries.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeclaredReturnTypeUnboxesSelfRecursion(t *testing.T) {
+	ensureLoader()
+
+	rendered := lowerForms(t, "drpkg",
+		`(defn drfib ^long [^long n] (if (< n 2) n (+ (drfib (- n 1)) (drfib (- n 2)))))`)
+
+	if !strings.Contains(rendered, "func Drfib(ec *vm.ExecContext, arg0 int) (int, error)") {
+		t.Fatalf("expected a natively-typed int return; rendered:\n%s", rendered)
+	}
+	// The payoff: generic boxed addition is gone in favour of int + int.
+	if strings.Contains(rendered, "rt.AddValue") {
+		t.Errorf("addition still dispatches through rt.AddValue; rendered:\n%s", rendered)
+	}
+}
+
+// Opt-in: without a hint nothing changes, so the whole corpus of unhinted code
+// lowers exactly as before.
+func TestUnhintedRecursionStillBoxes(t *testing.T) {
+	ensureLoader()
+
+	rendered := lowerForms(t, "drpkg",
+		`(defn drplain [^long n] (if (< n 2) n (+ (drplain (- n 1)) (drplain (- n 2)))))`)
+
+	if strings.Contains(rendered, "func Drplain(ec *vm.ExecContext, arg0 int) (int, error)") {
+		t.Fatalf("unhinted fn typed its return without a declaration; rendered:\n%s", rendered)
+	}
+}
+
+// The seed is restricted to self-calls. A declaration the body contradicts must
+// not reach a *caller's* inference: before that restriction, drcaller returned
+// (int, error) and assigned vm.String(...) into an int temp, which does not
+// compile. drliar itself is free to lower honestly as string.
+func TestContradictoryHintDoesNotCorruptCallers(t *testing.T) {
+	ensureLoader()
+
+	rendered := lowerForms(t, "drpkg",
+		`(defn drliar ^long [n] "not-an-int") (defn drcaller [n] (drliar n))`)
+
+	if strings.Contains(rendered, "func Drcaller(ec *vm.ExecContext, arg0 vm.Value) (int, error)") {
+		t.Fatalf("callee's contradictory hint leaked into the caller's return type; rendered:\n%s", rendered)
+	}
+	// The give-away statement from the broken version: a string boxed into an
+	// int-typed temp.
+	for _, bad := range []string{"var v2 int\n\tv2 = vm.String("} {
+		if strings.Contains(rendered, bad) {
+			t.Fatalf("string result assigned to an int temp; rendered:\n%s", rendered)
+		}
+	}
+}
+
+// A float hint takes the same path, so the mechanism is not int-specific.
+func TestDeclaredFloatReturnType(t *testing.T) {
+	ensureLoader()
+
+	rendered := lowerForms(t, "drpkg",
+		`(defn drdec ^double [^double x] (if (< x 1.0) x (drdec (- x 1.0))))`)
+
+	if !strings.Contains(rendered, "func Drdec(ec *vm.ExecContext, arg0 float64) (float64, error)") {
+		t.Fatalf("expected a natively-typed float64 return; rendered:\n%s", rendered)
+	}
+}

--- a/pkg/rt/core/ir/build.lg
+++ b/pkg/rt/core/ir/build.lg
@@ -1532,6 +1532,17 @@
         forms (if (map? (first forms)) (next forms) forms)]
     [(first forms) (rest forms)]))
 
+(defn declared-return-type [form]
+  "The lattice type declared by a defn's return hint — `(defn f ^long [n] …)`
+   — or nil when there is no hint, or the hint is not one lowering has a native
+   type for. Reuses the same tag decoding as param hints, so the two positions
+   accept exactly the same set (^long/^int → :int, ^double/^float → :float).
+   Public so the lowering pipeline can seed typeinfer with it (#599); the tag
+   itself lives on the arity vector's metadata, which unwrap-arity-vector drops."
+  (let [raw-args (nth (parse-defn-args-body form) 0)]
+    (when (return-hinted-arity-vector? raw-args)
+      (tag->arg-type (hinted-tag raw-args)))))
+
 (defn build-fn [defn-form]
   "Build an IR Function from a (defn name [args] body...) or
    multi-arity (defn name ([args] body...) ([args2] body2...)) form.

--- a/pkg/rt/core/ir/lower_go.lg
+++ b/pkg/rt/core/ir/lower_go.lg
@@ -1722,6 +1722,20 @@
 (defn- register-typed-call-temp! [name go-type]
   (when *typed-call-temps* (swap! *typed-call-temps* conj [name go-type])))
 
+(defn- typed-result-assign
+  "Assign a typed call's result to the call node's temp, boxing only when that
+   temp is a vm.Value. Every typed result used to be boxed here unconditionally,
+   which was right while a lowered callee's result could only ever land in a
+   vm.Value temp. With declared return types (#599) the temp can itself be
+   natively typed — `(+ (fib …) (fib …))` gives both call nodes an :int temp —
+   and boxing into it emits `arg__4 = vm.Int(tr8)` against a `var arg__4 int`,
+   which is a Go type error. A nil/:unknown temp spec never matches, so anything
+   we cannot type still takes the boxing path."
+  [f nid target res-expr result-spec]
+  (if (= (go-type-spec (ir/type-of nid f)) result-spec)
+    (gogen/assign "=" target res-expr)
+    (gogen/assign "=" target (box-result-from-type res-expr result-spec))))
+
 (defn- emit-call-stmts [f assign-target invoke-expr]
   "Build the [assign err-check] statement pair shared by both call paths.
    assign-target is either a gogen ident (used? case) or '_'; invoke-expr
@@ -1770,11 +1784,11 @@
       ;; assign + err-check path.
       (and (= result-spec "vm.Value") (:needs-error? entry))
       (emit-call-stmts f target raw-call)
-      ;; Typed result + no error: result := <call>; target = vm.<Box>(result)
+      ;; Typed result + no error: target = <call>, boxed only if the temp is
+      ;; a vm.Value (see typed-result-assign).
       (and (not (:needs-error? entry))
            (not= result-spec "vm.Value"))
-      (let [boxed (box-result-from-type raw-call result-spec)]
-        [(gogen/assign "=" target boxed)])
+      [(typed-result-assign f nid target raw-call result-spec)]
       ;; Typed result + error: tr<nid>, te<nid> = <call>; if err return;
       ;; target = vm.<Box>(tr<nid>). The intermediate result+err vars are
       ;; FUNCTION-scoped (registered via register-typed-call-temp! and
@@ -1801,8 +1815,7 @@
                                      (gogen/binary "!=" err-id (gogen/ident "nil"))
                                      [(gogen/return-stmt [zero-expr err-id])]
                                      nil)
-            boxed (box-result-from-type res-id result-spec)
-            box-assign (gogen/assign "=" target boxed)]
+            box-assign (typed-result-assign f nid target res-id result-spec)]
         [assign err-check box-assign])
       ;; vm.Value result, no error: target = <call>
       (= result-spec "vm.Value")

--- a/pkg/rt/core/ir/passes/pipeline.lg
+++ b/pkg/rt/core/ir/passes/pipeline.lg
@@ -1269,6 +1269,16 @@
         ;; protocol-method calls on a known-concrete receiver to recv.M().
         protocol-method-set (into #{} (mapcat (fn [p] (map (fn [m] (str (first m))) (:methods p))) protocols))
         ctor-types  (into {} (map (fn [dt] [(str "->" (:name dt)) (:name dt)]) deftypes))
+        ;; Declared return types for this namespace's own defns, so a call to a
+        ;; hinted sibling (self-recursion included) types from the declaration
+        ;; instead of collapsing to :unknown (#599).
+        ret-types   (into {} (keep (fn [form]
+                                     (when (and (seq? form)
+                                                (contains? #{'defn 'defn-} (first form))
+                                                (symbol? (nth form 1 nil)))
+                                       (when-let [t (ir.build/declared-return-type form)]
+                                         [(str (unwrap-name (nth form 1))) t])))
+                                   defn-forms0))
         ctors       (into {} (map (fn [dt] [(str "->" (:name dt)) (lower-go/go-export-name (:name dt))]) deftypes))
         vm-import   {:path "github.com/nooga/let-go/pkg/vm" :alias "vm"}
         rt-import   {:path "github.com/nooga/let-go/pkg/rt" :alias "rt"}
@@ -1280,6 +1290,7 @@
                                                    {})
               ir.passes.typeinfer/*typeinfer-max-drains* nil
               ir.passes.typeinfer/*deftype-ctor-types* (when (seq ctor-types) ctor-types)
+              ir.passes.typeinfer/*declared-return-types* (when (seq ret-types) ret-types)
               lower-go/*deftype-ctors* (when (seq ctors) ctors)
               lower-go/*protocol-methods* (when (seq protocol-method-set) protocol-method-set)
               ;; Resolve non-injective PascalCase export collisions deterministically;

--- a/pkg/rt/core/ir/passes/typeinfer.lg
+++ b/pkg/rt/core/ir/passes/typeinfer.lg
@@ -62,6 +62,40 @@
                   tsym  (get *deftype-ctor-types* vname)]
               (when tsym [:dtype tsym]))))))))
 
+;; Bind to a map {fn-name-string -> lattice-type} around a typeinfer call so a
+;; SELF-recursive call to a fn with a declared return type — `(defn f ^long [n]
+;; …)` — is typed from that declaration. Without it the self-call is :unknown,
+;; which poisons the whole numeric chain: fib's `(+ (fib …) (fib …))` sees two
+;; unknown operands, stays boxed, and the fn's own return type never resolves
+;; either (#599). Same shape and cost profile as *deftype-ctor-types* — nil
+;; disables it.
+;;
+;; SELF-calls only, deliberately. A non-recursive fn's return type already falls
+;; out of its body, so the declaration adds nothing there; and seeding calls to
+;; OTHER fns means a declaration the callee's body contradicts corrupts the
+;; caller — `(defn liar ^long [n] "s")` lowers honestly to `string`, but a
+;; caller seeded with :int emits `v2 = vm.String(Liar(…))` into an `int` temp.
+;; Restricted to self-calls, an inconsistent hint can only produce a type the
+;; declaring fn's own body already joins, so the fallout stays local and shows
+;; up as that fn declining to type its return.
+;;
+;; Trusting the declaration otherwise mirrors #357's treatment of param hints:
+;; the hint is authoritative and the boundary coerces.
+(def ^:dynamic *declared-return-types* nil)
+
+(defn- call-declared-type
+  "If a :call inst is a SELF-call to the fn being inferred and that fn declared
+   a return type, return it; otherwise nil."
+  [inst f]
+  (when *declared-return-types*
+    (let [refs (ir/refs inst f)]
+      (when (seq refs)
+        (let [callee (first refs)]
+          (when (= :load-var (ir/op callee f))
+            (let [callee-name (name (symbol (ir/aux callee f)))]
+              (when (= callee-name (str (ir/fn-name f)))
+                (get *declared-return-types* callee-name)))))))))
+
 (defn- load-var-ns+name [nid f]
   (when (= :load-var (ir/op nid f))
     (let [sym (symbol (ir/aux nid f))]
@@ -258,7 +292,10 @@
       (ir/op-infer-facet? op) (ops/infer-op op inst f state)
       ;; :call is typeinfer-coupled (call-dtype / call-core-type below) and
       ;; not yet reified — the one remaining legacy arm.
-      (= op :call)            (or (call-dtype inst f)
+      ;; call-declared-type first: an explicit ^long/^double on the callee is a
+      ;; declaration, so it outranks the structural guesses below.
+      (= op :call)            (or (call-declared-type inst f)
+                                  (call-dtype inst f)
                                   (call-core-type inst f state)
                                   :unknown)
       ;; Facetless ops (:set-var, :tail-call, :recur-fn, :pop, closures, :try,

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Content digest of all .lg + lgbgen sources that feed the .lgb
 # bundle and the lowered Go tree. The genmanifest staleness test
 # fails if this no longer matches the sources on disk.
-e0876236eff2ad2d40708cabe4cd1f426144f950eb0c57d099b24d63755e2cd1
+c363f088eba259d5e755ab31f27a94072f693e1ae80aa6ff11c4dd26dd5f3704


### PR DESCRIPTION
Closes #599. **Stacked on #661** (`wt/fix-598-return-hint`) — review that first; the idiomatic `^long` spelling does not reach lowering without it.

Because it targets a branch rather than `main`, the workflows do not fire and the check list here is empty apart from skipped jobs. Everything in Checks below was run locally; CI will cover it once #661 merges and this retargets.

## The cause is upstream of codegen

A self-recursive integer fn lowered with unboxed params but a boxed return: `func Fib(ec, arg0 int) (vm.Value, error)`, with the addition dispatching through `rt.AddValue`. That looked like a codegen gap, but it is an inference one. The self-call node types as `:unknown`, so `(+ (fib …) (fib …))` sees two unknown operands, stays boxed, and the function's own return type never resolves either. Nothing downstream can recover from that.

A return hint breaks the cycle. `(defn fib ^long [^long n] …)` seeds the self-call with the declared type, and the typed-result machinery that already exists carries it the rest of the way:

```go
func Fib(ec *vm.ExecContext, arg0 int) (int, error) {
	...
	if v2 {
		v15 = arg0
	} else {
		tr8, te8 = Fib(ec, arg__3)
		...
		v15 = arg__4 + arg__7
	}
	return v15, nil
}
```

## Numbers

In-process, darwin/arm64, fib(27), all three arms in one process, 4 repeats:

| arm | median ns/op | |
|---|---|---|
| boxed (before) | 1,998,000 | |
| typed (after) | 725,000 | 2.76× faster |
| hand-written Go | 624,000 | the typed lowering is 1.16× off, was ~3× |

The residual over pure Go is the `ec` param and the `(T, error)` result — #281's `callErr` threading, as the issue anticipated.

One caveat on the method: the machine was not idle (load ~5), so treat the absolute figures as soft. The three arms ran back to back in one process and the ratios held across all four repeats, which is the claim I would stand on. Process-level timing on this machine produced nonsense — "lowered beats hand-written Go" — which is a good reminder that a result contradicting the mechanism means the harness is wrong, not the code.

## Three pieces

- **`ir/build.lg`** gains `declared-return-type`, decoding the tag the reader
leaves on the arity vector's metadata. `unwrap-arity-vector` drops that metadata, so before this nothing read it — #598 only stopped the hinted form from vanishing, it did not give the hint meaning.
- **`typeinfer`** types a `:call` from that declaration, ahead of the
structural guesses, since an explicit hint outranks them.
- **`lower_go`** boxes a typed call's result only when the receiving temp is a
`vm.Value`. It boxed unconditionally before, which was right while a callee's result could only ever land in a `vm.Value` temp. Now the temp can itself be natively typed, and boxing into it emits `arg__4 = vm.Int(tr8)` against `var arg__4 int`, which does not compile.

## Why self-calls only

This restriction is load-bearing, not conservatism. Seeding calls to *other* functions lets a declaration the callee's body contradicts corrupt the caller. `(defn liar ^long [n] "not-an-int")` lowers honestly to `string`, but a caller seeded with `:int` emitted:

```go
func Caller(ec *vm.ExecContext, arg0 vm.Value) (int, error) {
	var v2 int
	v2 = vm.String(Liar(ec, arg0))   // does not compile
```

I hit that while building this. Restricted to self-calls, an inconsistent hint can only produce a type the declaring function's own body already joins, so the fallout stays local and shows up as that function declining to type its return. There is a test for it.

A non-recursive function's return type already falls out of its body, so the declaration adds nothing there — self-recursion is exactly the gap.

## Blast radius

Opt-in. No defn in `pkg/rt/core` carries a return hint, so the core lowering is untouched: `make check-selfhost` reports the native re-lowering fixpoint still byte-identical, and `make gogen-diff` passes.

## Checks

`gofmt` and `go vet` clean. `go test ./pkg/...` and `./test/...` pass. Cross-builds pass for linux/amd64, js/wasm, plan9/amd64, and wasip1/wasm. Four new tests cover the typed self-recursion, the unhinted case still boxing, the contradictory-hint containment, and a `^double` variant so the mechanism is not int-specific.
