### PR TITLE
build: single-source Go toolchain via go.mod toolchain directive

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       # Use the official action: it installs a cached, prebuilt golangci-lint
@@ -56,7 +56,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Race-detector tests (pkg/vm, pkg/rt)
@@ -144,7 +144,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build for GOOS=wasip1
@@ -161,7 +161,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build runtime-only without net/http
@@ -190,7 +190,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Install TinyGo
@@ -222,7 +222,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -287,7 +287,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: make gogen-diff
@@ -304,7 +304,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: make check-generated

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
             echo "perf-data branch does not exist yet; charts will be empty."
           fi
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build WASM

--- a/.github/workflows/perf-pr-repeat.yml
+++ b/.github/workflows/perf-pr-repeat.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -82,7 +82,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/perf-wasm.yml
+++ b/.github/workflows/perf-wasm.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,21 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # Guard the single-source Go version pin. go.mod owns it (the Makefile
+      # derives GO-VERSION from it; CI uses `go-version-file: go.mod`), so
+      # mise.toml carries no `go` entry. Absent passes silently; re-adding one
+      # is allowed only while it agrees with go.mod, so the two can never
+      # disagree unnoticed the way Makefile/mise.toml did before #677.
+      # Runs when either file is staged; stdlib-only Python.
+      - id: check-mise-go-sync
+        name: mise.toml Go pin agrees with go.mod
+        description: Reject a mise.toml go entry that disagrees with go.mod's version
+        entry: python3 scripts/check_mise_go_sync.py
+        language: system
+        files: ^(mise\.toml|go\.mod)$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # Frontmatter maintenance for docs/**/*.md: stub on missing,
       # bump `last-verified:` on staged docs. Never touches
       # `human-verified:` or any human-authored field. Stdlib-only

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,18 @@ M := .cache/makes
 MAKES-SHA := 7f28494955c20e5a87ca82ae351464842a7236de
 $(shell [ -d '$M' ] || (git clone -q $R '$M' && git -C '$M' -c advice.detachedHead=false checkout -q $(MAKES-SHA)) || rm -rf '$M')
 include $M/init.mk
-# go.mod's toolchain directive is the single repository-owned Go version pin.
-# Override only for an explicit one-off bootstrap: `make ... GO-VERSION=1.x.y`.
+# go.mod is the single repository-owned Go version pin: prefer the toolchain
+# directive; `go mod tidy` erases it when it equals the go directive, so fall
+# back to a full-patch go directive. Anything weaker fails loudly rather than
+# guessing. Override only for an explicit one-off bootstrap:
+# `make ... GO-VERSION=1.x.y`.
 GO-VERSION ?= $(shell sed -n 's/^toolchain go//p' go.mod)
+ifeq ($(strip $(GO-VERSION)),)
+GO-VERSION := $(shell sed -n 's/^go \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$$/\1/p' go.mod)
+endif
+ifeq ($(strip $(GO-VERSION)),)
+$(error cannot derive GO-VERSION: go.mod needs 'toolchain goX.Y.Z' or a full 'go X.Y.Z' directive)
+endif
 include $M/go.mk
 include $M/shell.mk
 endif

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ M := .cache/makes
 MAKES-SHA := 7f28494955c20e5a87ca82ae351464842a7236de
 $(shell [ -d '$M' ] || (git clone -q $R '$M' && git -C '$M' -c advice.detachedHead=false checkout -q $(MAKES-SHA)) || rm -rf '$M')
 include $M/init.mk
-# override default Go version with: `make ... GO-VERSION=1.x.y`
-GO-VERSION ?= 1.26.3
+# go.mod's toolchain directive is the single repository-owned Go version pin.
+# Override only for an explicit one-off bootstrap: `make ... GO-VERSION=1.x.y`.
+GO-VERSION ?= $(shell sed -n 's/^toolchain go//p' go.mod)
 include $M/go.mk
 include $M/shell.mk
 endif

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/nooga/let-go
 
 go 1.26
+toolchain go1.26.5
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,2 @@
 [tools]
-go = "1.26.3"
 opencode = "latest"

--- a/scripts/check_mise_go_sync.py
+++ b/scripts/check_mise_go_sync.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Fail if mise.toml pins a Go version that disagrees with go.mod.
+
+go.mod is the single repository-owned Go version pin: the Makefile derives
+GO-VERSION from it and every CI job uses `go-version-file: go.mod`. mise.toml
+therefore carries no `go` entry — a second pin is a copy that drifts, which is
+exactly what happened before this was single-sourced (Makefile said 1.26.3,
+mise.toml said 1.26.5, go.mod said neither).
+
+Deleting the pin is the intended state and passes silently. Re-adding one is
+allowed but must agree with go.mod, so the two can never disagree unnoticed:
+
+  * no `go` entry in mise.toml            -> pass (the normal state)
+  * `go` matches go.mod                   -> pass
+  * `go` disagrees with go.mod            -> fail, naming both values
+  * go.mod states only major.minor        -> a mise patch release under that
+                                             minor is accepted, since go.mod
+                                             does not pin a patch to match
+
+Stdlib-only, like the other hooks here. Run with no arguments; any filenames
+passed by pre-commit are ignored, because the answer depends on both files
+regardless of which one was staged.
+"""
+
+import os
+import re
+import sys
+
+TOOLCHAIN = re.compile(r"^toolchain\s+go(\d+\.\d+(?:\.\d+)?)\s*$", re.M)
+GO_DIRECTIVE = re.compile(r"^go\s+(\d+\.\d+(?:\.\d+)?)\s*$", re.M)
+# [tools] entry, e.g.  go = "1.26.5"  /  go = '1.26'  /  go = "1.26.5"  # note
+MISE_GO = re.compile(r"""^\s*go\s*=\s*["']([^"']+)["']""", re.M)
+
+
+def repo_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except FileNotFoundError:
+        return ""
+
+
+def gomod_version(text: str) -> tuple[str, str] | tuple[None, None]:
+    """Authoritative version and the directive it came from."""
+    m = TOOLCHAIN.search(text)
+    if m:
+        return m.group(1), "toolchain"
+    m = GO_DIRECTIVE.search(text)
+    if m:
+        return m.group(1), "go"
+    return None, None
+
+
+def mise_go_version(text: str) -> str | None:
+    m = MISE_GO.search(text)
+    return m.group(1) if m else None
+
+
+def compatible(mise: str, gomod: str) -> bool:
+    if mise == gomod:
+        return True
+    # go.mod pins only major.minor: accept any patch release of that minor.
+    if gomod.count(".") == 1 and mise.startswith(gomod + "."):
+        return True
+    return False
+
+
+def check(gomod_text: str, mise_text: str) -> list[str]:
+    mise = mise_go_version(mise_text)
+    if mise is None:
+        return []
+    gomod, directive = gomod_version(gomod_text)
+    if gomod is None:
+        return [
+            "mise.toml pins go = \"%s\" but go.mod declares no Go version to check it "
+            "against (expected a `toolchain goX.Y.Z` or `go X.Y.Z` directive)." % mise
+        ]
+    if compatible(mise, gomod):
+        return []
+    return [
+        'mise.toml pins go = "%s" but go.mod\'s %s directive says %s.' % (mise, directive, gomod),
+        "go.mod is the single source for the Go version: the Makefile derives GO-VERSION",
+        "from it and CI uses `go-version-file: go.mod`.",
+        "Fix by deleting the `go` line from mise.toml (preferred), or by making it match.",
+    ]
+
+
+def main(argv: list[str]) -> int:
+    root = repo_root()
+    problems = check(read(os.path.join(root, "go.mod")), read(os.path.join(root, "mise.toml")))
+    if not problems:
+        return 0
+    print("Go version pins disagree:", file=sys.stderr)
+    for line in problems:
+        print("  " + line, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Make Go 1.26.5 the repository authority across CI, local tooling, and bootstrap paths, preventing version skew and malformed fallback downloads.

## What changed

- Pin `toolchain go1.26.5` in `go.mod` as the version authority.
- Remove the competing hard-coded Go pin from `mise.toml`.
- Derive Make bootstrap version from `go.mod`.
- Fall back only to a full-patch `go X.Y.Z` directive.
- Fail loudly when neither directive provides an exact version.

## Evidence

- `make test`: 242 Clojure files, 6,311 assertions, zero failures/skips.
- `make check-generated`, `go vet ./...`, and pinned lint passed.
- No-host bootstrap selected `go1.26.5.darwin-arm64.tar.gz`.
- Full-patch fallback passed; minor-only and missing-version mutants failed loudly.
- Restoring the prior Makefile reproduced an empty version and malformed archive URL.

## Migration note

A machine that ran golangci-lint under the old toolchain may carry a stale analysis cache. Run `golangci-lint cache clean` once if untouched files report a Go version mismatch.
