### PR TITLE
ci(tinygo): pin wasmtime and verify it landed on PATH

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -203,10 +203,17 @@ jobs:
         run: |
           wget -q https://github.com/tinygo-org/tinygo/releases/download/v0.41.1/tinygo_0.41.1_amd64.deb
           sudo dpkg -i tinygo_0.41.1_amd64.deb
+      # Pinned like TinyGo above. Unpinned, install.sh resolves "latest" by
+      # sed-ing tag_name out of an unauthenticated GitHub API response; when
+      # that call is rate-limited the sed yields a literal `{`, the download
+      # 404s, and the script still exits 0 — so the job died two steps later
+      # at `wasmtime run` with `command not found` (#682).
       - name: Install wasmtime
         run: |
-          curl -sSf https://wasmtime.dev/install.sh | bash
+          curl -sSf https://wasmtime.dev/install.sh | bash -s -- --version v47.0.3
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+      - name: Verify wasmtime is on PATH
+        run: wasmtime --version
       - name: Build runtime-only for TinyGo WASI
         run: tinygo build -target=wasi -o /tmp/lg-ro-tinygo.wasm ./cmd/lg-runtime
       - name: Boot past the reflect shim (must not trap)


### PR DESCRIPTION
`tinygo-wasi-build` could fail on a PR that touched nothing related to TinyGo, and blame the wrong step while doing it. #682 has the full trace; the short version is that `install.sh` resolves "latest" by sed-ing `tag_name` out of an unauthenticated GitHub API response. When that call is rate-limited the sed yields a literal `{`, the download 404s, and the script still exits 0. The install step stayed green, and the job died two steps later at `wasmtime run` with `command not found` — attributed to `Boot past the reflect shim (must not trap)`, which reads as a real TinyGo regression.

Two changes, both in the `tinygo-wasi-build` job:

- **Pin the version.** `--version v47.0.3` sends the installer down its specific-version branch, which never calls the GitHub API, so the failure mode is gone rather than reported better. This also matches `Install TinyGo` directly above, which has always pinned (`v0.41.1`).
- **Verify after install.** `wasmtime --version` as its own step, since `GITHUB_PATH` only affects later steps. A bad install now fails at the install, not two steps downstream.

Verified the pinned path end to end: the installer takes `--version` and downloads that archive with no API call, and the `v47.0.3` linux asset the workflow fetches returns 200.

v47.0.3 is current as of 2026-07-31. Pinning does mean someone bumps it eventually; that seems right for a job whose purpose is proving our TinyGo build boots past the reflect shim, not tracking wasmtime releases. If you want tip coverage it belongs in a scheduled job, not a per-PR gate that can go red on an unrelated PR.
