### PR TITLE
feat(rt): add os/rename and os/delete-tree

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -145,7 +145,7 @@ pkg/rt/core_compiled.lgb pkg/rt/native_prims.go generator eb0246a1c8565285c8b3fb
 pkg/rt/core_compiled.lgb pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_compiled.lgb pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_compiled.lgb pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/core_compiled.lgb pkg/rt/os.go generator 490bc7b243bd60c6f05ac8fa3d405e1a42da91627048717f6a3f001ac9ffa3fc
+pkg/rt/core_compiled.lgb pkg/rt/os.go generator 720d5964ae9cf671770d56b7a62050fdc1e2115fba419458333093f3cdff31d7
 pkg/rt/core_compiled.lgb pkg/rt/os_tinygo.go generator 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/core_compiled.lgb pkg/rt/parallel.go generator 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/core_compiled.lgb pkg/rt/pods.go generator 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3
@@ -459,7 +459,7 @@ pkg/rt/core_go_lowered/ pkg/rt/native_prims.go generator eb0246a1c8565285c8b3fb3
 pkg/rt/core_go_lowered/ pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_go_lowered/ pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_go_lowered/ pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/core_go_lowered/ pkg/rt/os.go generator 490bc7b243bd60c6f05ac8fa3d405e1a42da91627048717f6a3f001ac9ffa3fc
+pkg/rt/core_go_lowered/ pkg/rt/os.go generator 720d5964ae9cf671770d56b7a62050fdc1e2115fba419458333093f3cdff31d7
 pkg/rt/core_go_lowered/ pkg/rt/os_tinygo.go generator 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/core_go_lowered/ pkg/rt/parallel.go generator 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/core_go_lowered/ pkg/rt/pods.go generator 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3
@@ -704,7 +704,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/native_prims.go input eb0246a1c8565285c
 pkg/rt/zz_primitives_generated.go pkg/rt/native_prims_lifecycle.go input 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/zz_primitives_generated.go pkg/rt/net.go input 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/zz_primitives_generated.go pkg/rt/net_wasm.go input e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/zz_primitives_generated.go pkg/rt/os.go input 490bc7b243bd60c6f05ac8fa3d405e1a42da91627048717f6a3f001ac9ffa3fc
+pkg/rt/zz_primitives_generated.go pkg/rt/os.go input 720d5964ae9cf671770d56b7a62050fdc1e2115fba419458333093f3cdff31d7
 pkg/rt/zz_primitives_generated.go pkg/rt/os_tinygo.go input 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/zz_primitives_generated.go pkg/rt/parallel.go input 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/zz_primitives_generated.go pkg/rt/pods.go input 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-3a91b3580af61ea92a8c8f82fa17e7f1aa8c0812fcc4003b6fbc8473b7991c71
+9044993e44b17c22f8545a256fee076d92d873abb52c135a04b5b65153484273

--- a/pkg/rt/os.go
+++ b/pkg/rt/os.go
@@ -287,6 +287,63 @@ func installOsNS() {
 		return vs[1], nil
 	}))
 
+	// os/rename — (os/rename old-path new-path) → new-path
+	//
+	// Renames old-path to new-path through rename(2), which is atomic within
+	// a filesystem: a concurrent reader sees either the old state or the new
+	// one, never a half-written file. Writing to a temporary name and
+	// renaming into place is the usual way to publish a file safely.
+	//
+	// A rename across filesystems fails rather than falling back to
+	// copy-then-delete. The fallback is what callers reach for this instead
+	// of, so silently substituting it would remove the only property that
+	// distinguishes it from spit.
+	ns.Def("rename", mustWrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 2 {
+			return vm.NIL, fmt.Errorf("os/rename expects 2 args")
+		}
+		from, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("os/rename expected String path")
+		}
+		to, ok := vs[1].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("os/rename expected String destination")
+		}
+		if err := os.Rename(string(from), string(to)); err != nil {
+			return vm.NIL, err
+		}
+		return vs[1], nil
+	}))
+
+	// os/delete-tree — (os/delete-tree path) → nil
+	//
+	// Removes path and everything beneath it. The recursive form of
+	// delete-file, which removes a single entry and fails on a non-empty
+	// directory.
+	//
+	// Unlike delete-file, removing something already absent succeeds: the
+	// post-state the caller asked for is the one that holds. An empty path
+	// is refused, because it is never a thing a caller means to delete and
+	// RemoveAll treats it as a silent no-op, which hides the unset variable
+	// that produced it.
+	ns.Def("delete-tree", mustWrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("os/delete-tree expects 1 arg")
+		}
+		path, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("os/delete-tree expected String path")
+		}
+		if path == "" {
+			return vm.NIL, fmt.Errorf("os/delete-tree refuses an empty path")
+		}
+		if err := os.RemoveAll(string(path)); err != nil {
+			return vm.NIL, err
+		}
+		return vm.NIL, nil
+	}))
+
 	// os/os-name — (os/os-name) → "linux", "darwin", "windows", ...
 	ns.Def("os-name", mustWrap(func(vs []vm.Value) (vm.Value, error) {
 		return vm.String(runtime.GOOS), nil

--- a/pkg/rt/os.go
+++ b/pkg/rt/os.go
@@ -318,15 +318,33 @@ func installOsNS() {
 
 	// os/delete-tree — (os/delete-tree path) → nil
 	//
-	// Removes path and everything beneath it. The recursive form of
+	// Removes path and everything beneath it: the recursive form of
 	// delete-file, which removes a single entry and fails on a non-empty
 	// directory.
 	//
-	// Unlike delete-file, removing something already absent succeeds: the
-	// post-state the caller asked for is the one that holds. An empty path
-	// is refused, because it is never a thing a caller means to delete and
-	// RemoveAll treats it as a silent no-op, which hides the unset variable
-	// that produced it.
+	// syscall/rm-rf is the same RemoveAll call and predates this. It lives
+	// in a namespace built for container setup, beside clone, pivot-root
+	// and seccomp, which is not where a caller doing ordinary filesystem
+	// work looks. This is the os-namespace spelling, and it is the one that
+	// carries the guards below.
+	//
+	// Three behaviours worth knowing, all inherited from RemoveAll:
+	//
+	//   - Removing something already absent succeeds. The post-state the
+	//     caller asked for is the one that holds. delete-file errors here.
+	//   - Symlinks are unlinked, never followed, so a link inside the tree
+	//     pointing outside it does not take the target down with it.
+	//   - By the same rule, a path that is *itself* a symlink to a
+	//     directory loses only the link; the directory it names keeps its
+	//     contents. Callers wanting the target gone should canonicalize
+	//     first.
+	//
+	// An empty path is refused: RemoveAll treats "" as a silent no-op,
+	// which hides the unset variable that produced it. The filesystem root
+	// is refused for the same reason and a worse outcome — (str nil) is ""
+	// in lg, so a caller building "$root/$name" with root unset produces
+	// "/name", one level below the root it never meant to touch. RemoveAll
+	// already rejects "." itself.
 	ns.Def("delete-tree", mustWrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("os/delete-tree expects 1 arg")
@@ -336,7 +354,12 @@ func installOsNS() {
 			return vm.NIL, fmt.Errorf("os/delete-tree expected String path")
 		}
 		if path == "" {
-			return vm.NIL, fmt.Errorf("os/delete-tree refuses an empty path")
+			return vm.NIL, fmt.Errorf("os/delete-tree expected a non-empty path")
+		}
+		// Dir(p) == p exactly at a volume root: "/" on unix, "C:\" and "\"
+		// on Windows. Cheaper and more portable than matching separators.
+		if cleaned := filepath.Clean(string(path)); filepath.Dir(cleaned) == cleaned {
+			return vm.NIL, fmt.Errorf("os/delete-tree refused the filesystem root %q", cleaned)
 		}
 		if err := os.RemoveAll(string(path)); err != nil {
 			return vm.NIL, err

--- a/pkg/rt/os_fs_test.go
+++ b/pkg/rt/os_fs_test.go
@@ -72,8 +72,10 @@ func TestOsRenameMovesAFile(t *testing.T) {
 	}
 }
 
-// The publish-by-rename pattern is the reason this native exists: the
-// destination must go from old content to new with nothing in between.
+// The publish-by-rename pattern is the reason this native exists. This
+// checks the end state only — a torn intermediate is not observable from
+// here — so it pins that the destination ends up holding the new content
+// with no leftover source.
 func TestOsRenameReplacesAnExistingFile(t *testing.T) {
 	tmp := t.TempDir()
 	staged := filepath.Join(tmp, "staged")
@@ -113,6 +115,9 @@ func TestOsRenameReportsAMissingSource(t *testing.T) {
 
 func TestOsRenameRejectsBadArgs(t *testing.T) {
 	tmp := t.TempDir()
+	if _, err := osFn(t, "rename").Invoke(nil); err == nil {
+		t.Error("rename with no args succeeded, want an error")
+	}
 	if _, err := callOsFn(t, "rename", filepath.Join(tmp, "a")); err == nil {
 		t.Error("rename with 1 arg succeeded, want an error")
 	}
@@ -164,18 +169,63 @@ func TestOsDeleteTreeSucceedsWhenAlreadyAbsent(t *testing.T) {
 	}
 }
 
-func TestOsDeleteTreeLeavesSiblingsAlone(t *testing.T) {
+// The containment property worth pinning: a symlink inside the doomed tree
+// pointing out of it must be unlinked, not followed. Two unrelated sibling
+// directories would prove nothing, since no implementation could conflate
+// them.
+func TestOsDeleteTreeUnlinksSymlinksRatherThanFollowingThem(t *testing.T) {
 	tmp := t.TempDir()
 	doomed := filepath.Join(tmp, "doomed")
-	keep := filepath.Join(tmp, "keep")
+	outside := filepath.Join(tmp, "outside")
 	writeFileAt(t, filepath.Join(doomed, "x.txt"), "x")
-	writeFileAt(t, filepath.Join(keep, "y.txt"), "y")
+	writeFileAt(t, filepath.Join(outside, "keep.txt"), "keep")
+	if err := os.Symlink(outside, filepath.Join(doomed, "escape")); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
 
 	if _, err := callOsFn(t, "delete-tree", doomed); err != nil {
 		t.Fatalf("delete-tree: %v", err)
 	}
-	if body := readFile(t, filepath.Join(keep, "y.txt")); body != "y" {
-		t.Errorf("sibling holds %q, want %q", body, "y")
+	if _, err := os.Stat(doomed); !os.IsNotExist(err) {
+		t.Errorf("doomed tree survived, stat err = %v", err)
+	}
+	if body := readFile(t, filepath.Join(outside, "keep.txt")); body != "keep" {
+		t.Errorf("the symlink was followed out of the tree; outside holds %q", body)
+	}
+}
+
+// The corollary, and the surprising half: when the path itself is a symlink
+// to a directory, only the link goes. Documented on the native because
+// "removes path and everything beneath it" does not lead a caller to expect
+// it.
+func TestOsDeleteTreeOnASymlinkRemovesOnlyTheLink(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "target")
+	writeFileAt(t, filepath.Join(target, "t.txt"), "t")
+	link := filepath.Join(tmp, "linkdir")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	if _, err := callOsFn(t, "delete-tree", link); err != nil {
+		t.Fatalf("delete-tree: %v", err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Errorf("link survived, lstat err = %v", err)
+	}
+	if body := readFile(t, filepath.Join(target, "t.txt")); body != "t" {
+		t.Errorf("the link's target lost its contents; holds %q", body)
+	}
+}
+
+// The empty-path guard exists to catch an unset variable. "/" is the same
+// mistake with a worse outcome, and in lg (str nil) is "", so "$root/$name"
+// with root unset yields "/name" rather than "".
+func TestOsDeleteTreeRefusesTheFilesystemRoot(t *testing.T) {
+	for _, p := range []string{"/", "//", "/.."} {
+		if _, err := callOsFn(t, "delete-tree", p); err == nil {
+			t.Errorf("delete-tree(%q) succeeded, want an error", p)
+		}
 	}
 }
 

--- a/pkg/rt/os_fs_test.go
+++ b/pkg/rt/os_fs_test.go
@@ -1,0 +1,197 @@
+//go:build !tinygo
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// osFn resolves a registered native from the os namespace.
+func osFn(t *testing.T, name string) vm.Fn {
+	t.Helper()
+	v := NS("os").Lookup(vm.Symbol(name))
+	if v == nil || v == vm.NIL {
+		t.Fatalf("os/%s not found", name)
+	}
+	if vr, ok := v.(*vm.Var); ok {
+		v = vr.Deref()
+	}
+	fn, ok := v.(vm.Fn)
+	if !ok {
+		t.Fatalf("os/%s is not an Fn, got %T", name, v)
+	}
+	return fn
+}
+
+func callOsFn(t *testing.T, name string, args ...string) (vm.Value, error) {
+	t.Helper()
+	vs := make([]vm.Value, len(args))
+	for i, a := range args {
+		vs[i] = vm.String(a)
+	}
+	return osFn(t, name).Invoke(vs)
+}
+
+func writeFileAt(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestOsRenameMovesAFile(t *testing.T) {
+	tmp := t.TempDir()
+	from := filepath.Join(tmp, "before.txt")
+	to := filepath.Join(tmp, "after.txt")
+	writeFileAt(t, from, "payload")
+
+	got, err := callOsFn(t, "rename", from, to)
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if want := vm.String(to); got != want {
+		t.Errorf("rename returned %v, want %v", got, want)
+	}
+	if body := readFile(t, to); body != "payload" {
+		t.Errorf("destination holds %q, want %q", body, "payload")
+	}
+	if _, err := os.Stat(from); !os.IsNotExist(err) {
+		t.Errorf("source still present after rename, stat err = %v", err)
+	}
+}
+
+// The publish-by-rename pattern is the reason this native exists: the
+// destination must go from old content to new with nothing in between.
+func TestOsRenameReplacesAnExistingFile(t *testing.T) {
+	tmp := t.TempDir()
+	staged := filepath.Join(tmp, "staged")
+	live := filepath.Join(tmp, "live")
+	writeFileAt(t, staged, "new")
+	writeFileAt(t, live, "old")
+
+	if _, err := callOsFn(t, "rename", staged, live); err != nil {
+		t.Fatalf("rename over existing: %v", err)
+	}
+	if body := readFile(t, live); body != "new" {
+		t.Errorf("live holds %q, want %q", body, "new")
+	}
+}
+
+func TestOsRenameMovesADirectoryWithContents(t *testing.T) {
+	tmp := t.TempDir()
+	from := filepath.Join(tmp, "tree")
+	to := filepath.Join(tmp, "moved")
+	writeFileAt(t, filepath.Join(from, "nested", "leaf.txt"), "leaf")
+
+	if _, err := callOsFn(t, "rename", from, to); err != nil {
+		t.Fatalf("rename dir: %v", err)
+	}
+	if body := readFile(t, filepath.Join(to, "nested", "leaf.txt")); body != "leaf" {
+		t.Errorf("moved leaf holds %q, want %q", body, "leaf")
+	}
+}
+
+func TestOsRenameReportsAMissingSource(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := callOsFn(t, "rename", filepath.Join(tmp, "absent"), filepath.Join(tmp, "dest"))
+	if err == nil {
+		t.Fatal("renaming a missing source succeeded, want an error")
+	}
+}
+
+func TestOsRenameRejectsBadArgs(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := callOsFn(t, "rename", filepath.Join(tmp, "a")); err == nil {
+		t.Error("rename with 1 arg succeeded, want an error")
+	}
+	if _, err := osFn(t, "rename").Invoke([]vm.Value{vm.Int(1), vm.String(tmp)}); err == nil {
+		t.Error("rename with a non-String source succeeded, want an error")
+	}
+	if _, err := osFn(t, "rename").Invoke([]vm.Value{vm.String(tmp), vm.Int(1)}); err == nil {
+		t.Error("rename with a non-String destination succeeded, want an error")
+	}
+}
+
+func TestOsDeleteTreeRemovesRecursively(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	writeFileAt(t, filepath.Join(root, "top.txt"), "top")
+	writeFileAt(t, filepath.Join(root, "a", "b", "deep.txt"), "deep")
+
+	got, err := callOsFn(t, "delete-tree", root)
+	if err != nil {
+		t.Fatalf("delete-tree: %v", err)
+	}
+	if got != vm.NIL {
+		t.Errorf("delete-tree returned %v, want nil", got)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Errorf("tree still present, stat err = %v", err)
+	}
+}
+
+func TestOsDeleteTreeRemovesASingleFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "lone.txt")
+	writeFileAt(t, path, "x")
+
+	if _, err := callOsFn(t, "delete-tree", path); err != nil {
+		t.Fatalf("delete-tree on a file: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file still present, stat err = %v", err)
+	}
+}
+
+// Absent-is-success is the documented divergence from delete-file, which
+// fails on a missing path. Pinned so it can't drift back silently.
+func TestOsDeleteTreeSucceedsWhenAlreadyAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := callOsFn(t, "delete-tree", filepath.Join(tmp, "never-existed")); err != nil {
+		t.Errorf("delete-tree on an absent path returned %v, want nil", err)
+	}
+}
+
+func TestOsDeleteTreeLeavesSiblingsAlone(t *testing.T) {
+	tmp := t.TempDir()
+	doomed := filepath.Join(tmp, "doomed")
+	keep := filepath.Join(tmp, "keep")
+	writeFileAt(t, filepath.Join(doomed, "x.txt"), "x")
+	writeFileAt(t, filepath.Join(keep, "y.txt"), "y")
+
+	if _, err := callOsFn(t, "delete-tree", doomed); err != nil {
+		t.Fatalf("delete-tree: %v", err)
+	}
+	if body := readFile(t, filepath.Join(keep, "y.txt")); body != "y" {
+		t.Errorf("sibling holds %q, want %q", body, "y")
+	}
+}
+
+// RemoveAll("") is a silent no-op in Go. Returning an error instead turns
+// an unset path variable into a failure the caller can see.
+func TestOsDeleteTreeRefusesAnEmptyPath(t *testing.T) {
+	if _, err := callOsFn(t, "delete-tree", ""); err == nil {
+		t.Error("delete-tree on an empty path succeeded, want an error")
+	}
+}
+
+func TestOsDeleteTreeRejectsBadArgs(t *testing.T) {
+	if _, err := osFn(t, "delete-tree").Invoke(nil); err == nil {
+		t.Error("delete-tree with no args succeeded, want an error")
+	}
+	if _, err := osFn(t, "delete-tree").Invoke([]vm.Value{vm.Int(1)}); err == nil {
+		t.Error("delete-tree with a non-String path succeeded, want an error")
+	}
+}

--- a/test/os_fs_test.lg
+++ b/test/os_fs_test.lg
@@ -1,0 +1,72 @@
+;; os/rename and os/delete-tree from lg.
+;;
+;; The argument and error paths are covered in pkg/rt/os_fs_test.go, which
+;; can reach the natives directly. This file checks the shape a caller sees:
+;; what each returns, and that the effect happened on disk.
+(ns test.os-fs-test
+  (:require [test :refer :all]))
+
+(def root "/tmp/let-go-os-fs-test")
+
+(defn- setup []
+  ;; delete-tree tolerates an absent path, so this doubles as the check
+  ;; that a rerun after a failed run starts clean.
+  (os/delete-tree root)
+  (mkdir root))
+
+(deftest rename-publishes-a-file-atomically
+  (setup)
+  (let [staged (str root "/config.json.tmp")
+        live (str root "/config.json")]
+    (spit staged "{\"v\":2}")
+    (spit live "{\"v\":1}")
+
+    (testing "returns the destination path"
+      (is (= live (os/rename staged live))))
+
+    (testing "the destination holds the new content"
+      (is (= "{\"v\":2}" (slurp live))))
+
+    (testing "the source is gone"
+      (is (not (file-exists? staged)))))
+  (os/delete-tree root))
+
+(deftest rename-moves-a-directory
+  (setup)
+  (let [from (str root "/tree")
+        to (str root "/moved")]
+    (mkdir (str from "/nested"))
+    (spit (str from "/nested/leaf.txt") "leaf")
+
+    (os/rename from to)
+    (testing "contents come along"
+      (is (= "leaf" (slurp (str to "/nested/leaf.txt")))))
+    (testing "the old path is gone"
+      (is (not (file-exists? from)))))
+  (os/delete-tree root))
+
+(deftest delete-tree-removes-a-populated-directory
+  (setup)
+  (mkdir (str root "/a/b"))
+  (spit (str root "/a/b/deep.txt") "deep")
+  (spit (str root "/a/top.txt") "top")
+
+  (testing "returns nil"
+    (is (nil? (os/delete-tree (str root "/a")))))
+
+  (testing "the whole subtree is gone"
+    (is (not (file-exists? (str root "/a"))))
+    (is (not (file-exists? (str root "/a/b/deep.txt")))))
+  (os/delete-tree root))
+
+(deftest delete-tree-tolerates-an-absent-path
+  ;; delete-file throws here; this is the documented divergence.
+  (testing "removing what is not there is not an error"
+    (is (nil? (os/delete-tree (str root "/never-existed"))))))
+
+(deftest delete-tree-refuses-an-empty-path
+  ;; let-go has no thrown? — use try/catch directly.
+  (testing "an empty path throws rather than silently doing nothing"
+    (is (= :threw (try (os/delete-tree "")
+                       :no-throw
+                       (catch _ :threw))))))


### PR DESCRIPTION
Two filesystem primitives that had no equivalent in the runtime.

**`os/rename`** wraps `rename(2)`. Nothing did, so publishing a file meant `spit` and a window in which a reader could observe it half-written. Staging to a temporary name and renaming into place closes that window, and rename is the only call that gives it.

**`os/delete-tree`** is the recursive form of `delete-file`, which removes a single entry and fails on a non-empty directory. `test/os_unzip_test.lg` in this repo unwinds its fixture with five `delete-file` calls in dependency order, which is the shape this replaces.

A correction to what I wrote on #688: a recursive delete does already exist, as `syscall/rm-rf`, and I missed it. It is the same `RemoveAll` call. The argument for a second spelling is placement rather than capability — `syscall` is the container-setup namespace, sitting beside `clone`, `pivot-root`, `chroot` and `seccomp`, which is not where someone doing ordinary filesystem work looks, and `os` is now where `rename` and `unzip` live. If you'd rather have one, the alternative is to leave `syscall/rm-rf` as the only spelling and drop this half of the PR; `os/rename` has no equivalent anywhere and stands either way.

Both came out of surveying let-go against Grenadine's host contract (#688). Of the slots still unfilled, these were the two that were plain missing functions rather than design questions; @abogoyavlensky confirmed they weren't working on them.

## Behavior worth agreeing on

**`os/rename` fails across filesystems** rather than falling back to copy-then-delete. The fallback is the thing a caller reaches for this *instead of*, so substituting it silently would remove the only property separating the call from `spit`. An `EXDEV` error is the honest answer.

**`os/delete-tree` succeeds when the path is already absent.** The post-state the caller asked for is the one that holds. This diverges from `delete-file`, which throws, so it's pinned by a test in both suites rather than left to be rediscovered.

**Symlinks are unlinked, never followed.** A link inside the tree pointing outside it does not take the target down. By the same rule a path that is *itself* a symlink to a directory loses only the link, and the directory keeps its contents — worth documenting because "removes path and everything beneath it" does not suggest it. Both are now tested.

**An empty path and the filesystem root are refused.** `os.RemoveAll("")` is a silent no-op in Go, which hides the unset variable that produced it. The root is the same mistake with a worse outcome: `(str nil)` is `""` in lg, so a caller building `"$root/$name"` with `root` unset gets `"/name"`, one level below the root and past an empty-string check. The root test is `Dir(p) == p` after `Clean`, which holds exactly at a volume root on unix and Windows alike.

## Placement

Both go in the `os` namespace rather than core, following `os/unzip` from #688. Core is the always-loaded surface and there's active work to shrink it; these are host effects and belong beside the other host effects.

The TinyGo `os` namespace is a deliberate three-function subset (`exit`, `getenv`, `args`) and gains neither, matching how `os/unzip` was added.

## Verification

- `pkg/rt/os_fs_test.go` — 13 tests covering the effect on disk, replacing an existing destination, moving a populated directory, symlink containment in both directions, absent-source, empty-path and root errors, and the argument guards.
- `test/os_fs_test.lg` — the same surface from lg, checking what each call returns and that siblings survive.
- `go test -short ./...` — 21 packages, no failures.
- Builds clean for `linux/amd64`, `js/wasm`, `wasip1/wasm`, `plan9/amd64`, and `darwin/arm64`. `windows/amd64` fails in `pkg/rt/term.go` on `unix.SIGWINCH`, which reproduces on `main` at `aeac42d4` and is untouched by this change.

No generated artifacts change: the `os` namespace is registered from Go, so there's no `generated.sums` regen the way #690 needed one.
