### PR TITLE
feat(rt): add os/absolute-path and os/canonical-path

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -145,7 +145,7 @@ pkg/rt/core_compiled.lgb pkg/rt/native_prims.go generator eb0246a1c8565285c8b3fb
 pkg/rt/core_compiled.lgb pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_compiled.lgb pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_compiled.lgb pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/core_compiled.lgb pkg/rt/os.go generator 720d5964ae9cf671770d56b7a62050fdc1e2115fba419458333093f3cdff31d7
+pkg/rt/core_compiled.lgb pkg/rt/os.go generator 444077d3727b8a18f5c78672883953d090c4b56d381064158e27aae370dec71d
 pkg/rt/core_compiled.lgb pkg/rt/os_tinygo.go generator 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/core_compiled.lgb pkg/rt/parallel.go generator 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/core_compiled.lgb pkg/rt/pods.go generator 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3
@@ -459,7 +459,7 @@ pkg/rt/core_go_lowered/ pkg/rt/native_prims.go generator eb0246a1c8565285c8b3fb3
 pkg/rt/core_go_lowered/ pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_go_lowered/ pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_go_lowered/ pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/core_go_lowered/ pkg/rt/os.go generator 720d5964ae9cf671770d56b7a62050fdc1e2115fba419458333093f3cdff31d7
+pkg/rt/core_go_lowered/ pkg/rt/os.go generator 444077d3727b8a18f5c78672883953d090c4b56d381064158e27aae370dec71d
 pkg/rt/core_go_lowered/ pkg/rt/os_tinygo.go generator 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/core_go_lowered/ pkg/rt/parallel.go generator 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/core_go_lowered/ pkg/rt/pods.go generator 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3
@@ -704,7 +704,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/native_prims.go input eb0246a1c8565285c
 pkg/rt/zz_primitives_generated.go pkg/rt/native_prims_lifecycle.go input 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/zz_primitives_generated.go pkg/rt/net.go input 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/zz_primitives_generated.go pkg/rt/net_wasm.go input e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/zz_primitives_generated.go pkg/rt/os.go input 720d5964ae9cf671770d56b7a62050fdc1e2115fba419458333093f3cdff31d7
+pkg/rt/zz_primitives_generated.go pkg/rt/os.go input 444077d3727b8a18f5c78672883953d090c4b56d381064158e27aae370dec71d
 pkg/rt/zz_primitives_generated.go pkg/rt/os_tinygo.go input 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/zz_primitives_generated.go pkg/rt/parallel.go input 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/zz_primitives_generated.go pkg/rt/pods.go input 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-9044993e44b17c22f8545a256fee076d92d873abb52c135a04b5b65153484273
+9a9f67ede417733eafe258455cf9f4e16df7e594d5d5d400b55244caadd7df61

--- a/pkg/rt/os.go
+++ b/pkg/rt/os.go
@@ -367,6 +367,55 @@ func installOsNS() {
 		return vm.NIL, nil
 	}))
 
+	// os/absolute-path — (os/absolute-path path) → "/abs/path"
+	//
+	// Resolves path against the process working directory and cleans it.
+	// Purely lexical: it does not touch the filesystem, so the path need not
+	// exist, and any symlink in it stays a symlink.
+	ns.Def("absolute-path", mustWrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("os/absolute-path expects 1 arg")
+		}
+		path, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("os/absolute-path expected String path")
+		}
+		abs, err := filepath.Abs(string(path))
+		if err != nil {
+			return vm.NIL, err
+		}
+		return vm.String(abs), nil
+	}))
+
+	// os/canonical-path — (os/canonical-path path) → "/real/path"
+	//
+	// The absolute path with every symlink resolved, so two names for one
+	// file produce one string. That is what makes it the form to compare or
+	// use as a key, and it is why this reads the filesystem where
+	// absolute-path does not: a symlink can only be followed by looking.
+	//
+	// A path that does not exist is an error rather than a cleaned-up
+	// guess. Callers wanting a name for a file they are about to create
+	// want absolute-path.
+	ns.Def("canonical-path", mustWrap(func(vs []vm.Value) (vm.Value, error) {
+		if len(vs) != 1 {
+			return vm.NIL, fmt.Errorf("os/canonical-path expects 1 arg")
+		}
+		path, ok := vs[0].(vm.String)
+		if !ok {
+			return vm.NIL, fmt.Errorf("os/canonical-path expected String path")
+		}
+		abs, err := filepath.Abs(string(path))
+		if err != nil {
+			return vm.NIL, err
+		}
+		real, err := filepath.EvalSymlinks(abs)
+		if err != nil {
+			return vm.NIL, err
+		}
+		return vm.String(real), nil
+	}))
+
 	// os/os-name — (os/os-name) → "linux", "darwin", "windows", ...
 	ns.Def("os-name", mustWrap(func(vs []vm.Value) (vm.Value, error) {
 		return vm.String(runtime.GOOS), nil

--- a/pkg/rt/os.go
+++ b/pkg/rt/os.go
@@ -370,8 +370,14 @@ func installOsNS() {
 	// os/absolute-path — (os/absolute-path path) → "/abs/path"
 	//
 	// Resolves path against the process working directory and cleans it.
-	// Purely lexical: it does not touch the filesystem, so the path need not
-	// exist, and any symlink in it stays a symlink.
+	// Lexical with respect to the argument: the path itself is never looked
+	// up, so it need not exist and any symlink in it stays a symlink. (The
+	// process cwd is read, which is why this can still fail — os.Getwd
+	// errors when the working directory has been removed.)
+	//
+	// An empty path is refused rather than quietly meaning the cwd, on the
+	// same reasoning as delete-tree: it is what an unset variable looks
+	// like, and returning a plausible answer hides it.
 	ns.Def("absolute-path", mustWrap(func(vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, fmt.Errorf("os/absolute-path expects 1 arg")
@@ -379,6 +385,9 @@ func installOsNS() {
 		path, ok := vs[0].(vm.String)
 		if !ok {
 			return vm.NIL, fmt.Errorf("os/absolute-path expected String path")
+		}
+		if path == "" {
+			return vm.NIL, fmt.Errorf("os/absolute-path expected a non-empty path")
 		}
 		abs, err := filepath.Abs(string(path))
 		if err != nil {
@@ -405,15 +414,23 @@ func installOsNS() {
 		if !ok {
 			return vm.NIL, fmt.Errorf("os/canonical-path expected String path")
 		}
-		abs, err := filepath.Abs(string(path))
+		if path == "" {
+			return vm.NIL, fmt.Errorf("os/canonical-path expected a non-empty path")
+		}
+		// Resolve before absolutizing. filepath.Abs cleans lexically, which
+		// collapses ".." against the *link's* parent instead of the
+		// target's — so Abs-then-EvalSymlinks reports ENOENT for a path the
+		// kernel opens fine. EvalSymlinks walks a relative path against the
+		// cwd itself, so doing it first costs nothing.
+		real, err := filepath.EvalSymlinks(string(path))
 		if err != nil {
 			return vm.NIL, err
 		}
-		real, err := filepath.EvalSymlinks(abs)
+		abs, err := filepath.Abs(real)
 		if err != nil {
 			return vm.NIL, err
 		}
-		return vm.String(real), nil
+		return vm.String(abs), nil
 	}))
 
 	// os/os-name — (os/os-name) → "linux", "darwin", "windows", ...

--- a/pkg/rt/os_paths_test.go
+++ b/pkg/rt/os_paths_test.go
@@ -1,0 +1,142 @@
+//go:build !tinygo
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func TestOsAbsolutePathResolvesAgainstCwd(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	got, err := callOsFn(t, "absolute-path", "relative/leaf.txt")
+	if err != nil {
+		t.Fatalf("absolute-path: %v", err)
+	}
+	if want := vm.String(filepath.Join(cwd, "relative/leaf.txt")); got != want {
+		t.Errorf("absolute-path = %v, want %v", got, want)
+	}
+}
+
+func TestOsAbsolutePathCleansTraversal(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	got, err := callOsFn(t, "absolute-path", "a/b/../c")
+	if err != nil {
+		t.Fatalf("absolute-path: %v", err)
+	}
+	if want := vm.String(filepath.Join(cwd, "a/c")); got != want {
+		t.Errorf("absolute-path = %v, want %v", got, want)
+	}
+}
+
+func TestOsAbsolutePathLeavesAnAbsolutePathAlone(t *testing.T) {
+	tmp := t.TempDir()
+	got, err := callOsFn(t, "absolute-path", tmp)
+	if err != nil {
+		t.Fatalf("absolute-path: %v", err)
+	}
+	if want := vm.String(tmp); got != want {
+		t.Errorf("absolute-path = %v, want %v", got, want)
+	}
+}
+
+// absolute-path is lexical, so it must not require the path to exist.
+func TestOsAbsolutePathAcceptsAMissingPath(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := callOsFn(t, "absolute-path", filepath.Join(tmp, "not-created-yet")); err != nil {
+		t.Errorf("absolute-path on a missing path returned %v, want nil", err)
+	}
+}
+
+func TestOsCanonicalPathResolvesASymlink(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "target.txt")
+	writeFileAt(t, target, "x")
+	link := filepath.Join(tmp, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	got, err := callOsFn(t, "canonical-path", link)
+	if err != nil {
+		t.Fatalf("canonical-path: %v", err)
+	}
+	// t.TempDir can itself sit under a symlink (/var → /private/var on
+	// darwin), so compare against the resolved target rather than target.
+	wantReal, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("evalsymlinks: %v", err)
+	}
+	if want := vm.String(wantReal); got != want {
+		t.Errorf("canonical-path = %v, want %v", got, want)
+	}
+}
+
+// Two names for one file must canonicalize to one string — the property
+// that makes this the form to compare or key on.
+func TestOsCanonicalPathCollapsesTwoNamesForOneFile(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "real.txt")
+	writeFileAt(t, target, "x")
+	link := filepath.Join(tmp, "alias.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	viaLink, err := callOsFn(t, "canonical-path", link)
+	if err != nil {
+		t.Fatalf("canonical-path via link: %v", err)
+	}
+	viaReal, err := callOsFn(t, "canonical-path", target)
+	if err != nil {
+		t.Fatalf("canonical-path via target: %v", err)
+	}
+	if viaLink != viaReal {
+		t.Errorf("link canonicalized to %v, target to %v; want one string", viaLink, viaReal)
+	}
+}
+
+func TestOsCanonicalPathAcceptsARelativePath(t *testing.T) {
+	got, err := callOsFn(t, "canonical-path", ".")
+	if err != nil {
+		t.Fatalf("canonical-path: %v", err)
+	}
+	if s, ok := got.(vm.String); !ok || !strings.HasPrefix(string(s), "/") {
+		t.Errorf("canonical-path(\".\") = %v, want an absolute path", got)
+	}
+}
+
+// The documented divergence from absolute-path: canonicalizing requires
+// looking at the filesystem, so a missing path has no answer.
+func TestOsCanonicalPathReportsAMissingPath(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := callOsFn(t, "canonical-path", filepath.Join(tmp, "absent")); err == nil {
+		t.Error("canonical-path on a missing path succeeded, want an error")
+	}
+}
+
+func TestOsPathFnsRejectBadArgs(t *testing.T) {
+	for _, name := range []string{"absolute-path", "canonical-path"} {
+		if _, err := osFn(t, name).Invoke(nil); err == nil {
+			t.Errorf("os/%s with no args succeeded, want an error", name)
+		}
+		if _, err := osFn(t, name).Invoke([]vm.Value{vm.Int(1)}); err == nil {
+			t.Errorf("os/%s with a non-String path succeeded, want an error", name)
+		}
+	}
+}

--- a/pkg/rt/os_paths_test.go
+++ b/pkg/rt/os_paths_test.go
@@ -130,6 +130,83 @@ func TestOsCanonicalPathReportsAMissingPath(t *testing.T) {
 	}
 }
 
+// Regression: filepath.Abs cleans ".." lexically, against the *link's*
+// parent rather than the target's. Absolutizing first therefore throws away
+// the answer and reports ENOENT for a path the kernel opens fine, so the
+// resolution has to happen before the cleaning.
+//
+// The path is built by concatenation, not filepath.Join — Join cleans too,
+// which would destroy the case before the native ever saw it.
+func TestOsCanonicalPathResolvesDotDotAfterASymlink(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "a"), 0o755); err != nil {
+		t.Fatalf("mkdir a: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "b", "c"), 0o755); err != nil {
+		t.Fatalf("mkdir b/c: %v", err)
+	}
+	// Sits one level above what the link points at, so it is reachable only
+	// if ".." is applied after the link is followed.
+	writeFileAt(t, filepath.Join(tmp, "b", "target.txt"), "x")
+	if err := os.Symlink(filepath.Join(tmp, "b", "c"), filepath.Join(tmp, "a", "link")); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	input := tmp + "/a/link/../target.txt"
+	if _, err := os.Stat(input); err != nil {
+		t.Fatalf("fixture is wrong, the kernel cannot open %s: %v", input, err)
+	}
+
+	got, err := callOsFn(t, "canonical-path", input)
+	if err != nil {
+		t.Fatalf("canonical-path on a path the kernel opens: %v", err)
+	}
+	wantReal, err := filepath.EvalSymlinks(filepath.Join(tmp, "b", "target.txt"))
+	if err != nil {
+		t.Fatalf("evalsymlinks: %v", err)
+	}
+	if want := vm.String(wantReal); got != want {
+		t.Errorf("canonical-path = %v, want %v", got, want)
+	}
+}
+
+// The distinction the two functions exist to draw: absolute-path must leave
+// a symlink alone where canonical-path resolves it.
+func TestOsAbsolutePathLeavesSymlinksUnresolved(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "target.txt")
+	writeFileAt(t, target, "x")
+	link := filepath.Join(tmp, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	abs, err := callOsFn(t, "absolute-path", link)
+	if err != nil {
+		t.Fatalf("absolute-path: %v", err)
+	}
+	if want := vm.String(link); abs != want {
+		t.Errorf("absolute-path = %v, want the link itself %v", abs, want)
+	}
+	canon, err := callOsFn(t, "canonical-path", link)
+	if err != nil {
+		t.Fatalf("canonical-path: %v", err)
+	}
+	if abs == canon {
+		t.Errorf("absolute-path and canonical-path both returned %v; the symlink was resolved by both", abs)
+	}
+}
+
+// Same reasoning as delete-tree's: an empty path is what an unset variable
+// looks like, and filepath.Abs("") quietly answers with the cwd.
+func TestOsPathFnsRefuseAnEmptyPath(t *testing.T) {
+	for _, name := range []string{"absolute-path", "canonical-path"} {
+		if _, err := callOsFn(t, name, ""); err == nil {
+			t.Errorf("os/%s on an empty path succeeded, want an error", name)
+		}
+	}
+}
+
 func TestOsPathFnsRejectBadArgs(t *testing.T) {
 	for _, name := range []string{"absolute-path", "canonical-path"} {
 		if _, err := osFn(t, name).Invoke(nil); err == nil {

--- a/test/os_paths_test.lg
+++ b/test/os_paths_test.lg
@@ -1,0 +1,42 @@
+;; os/absolute-path and os/canonical-path from lg.
+;;
+;; Argument and error paths are covered in pkg/rt/os_paths_test.go. This
+;; file checks the shape a caller sees, and the one distinction that
+;; matters when picking between them: absolute-path is lexical and works on
+;; a path that does not exist, canonical-path reads the filesystem and does
+;; not.
+(ns test.os-paths-test
+  (:require [test :refer :all]))
+
+(def root "/tmp/let-go-os-paths-test")
+
+(deftest absolute-path-is-lexical
+  (testing "an absolute path comes back unchanged"
+    (is (= "/tmp" (os/absolute-path "/tmp"))))
+
+  (testing "traversal is cleaned away"
+    (is (= "/tmp/c" (os/absolute-path "/tmp/a/../c"))))
+
+  (testing "a path that does not exist still resolves"
+    (is (= "/tmp/definitely-not-here" (os/absolute-path "/tmp/definitely-not-here")))))
+
+(deftest canonical-path-resolves-to-one-name
+  (os/delete-tree root)
+  (mkdir root)
+  (spit (str root "/real.txt") "x")
+
+  (testing "a relative path becomes absolute"
+    (is (= (os/canonical-path root) (os/canonical-path (str root "/.")))))
+
+  (testing "traversal collapses to the same file"
+    (is (= (os/canonical-path (str root "/real.txt"))
+           (os/canonical-path (str root "/../let-go-os-paths-test/real.txt")))))
+
+  (os/delete-tree root))
+
+(deftest canonical-path-needs-the-path-to-exist
+  ;; let-go has no thrown? — use try/catch directly.
+  (testing "a missing path throws where absolute-path would not"
+    (is (= :threw (try (os/canonical-path "/tmp/let-go-no-such-path-here")
+                       :no-throw
+                       (catch _ :threw))))))

--- a/test/os_paths_test.lg
+++ b/test/os_paths_test.lg
@@ -20,19 +20,22 @@
   (testing "a path that does not exist still resolves"
     (is (= "/tmp/definitely-not-here" (os/absolute-path "/tmp/definitely-not-here")))))
 
-(deftest canonical-path-resolves-to-one-name
-  (os/delete-tree root)
-  (mkdir root)
-  (spit (str root "/real.txt") "x")
+(deftest canonical-path-makes-a-relative-path-absolute
+  ;; Symlink resolution is covered in pkg/rt/os_paths_test.go, which can
+  ;; create links. What lg can check without them is the half that needs the
+  ;; process cwd: a genuinely relative input has to come back absolute, and
+  ;; equal to what os/cwd reports.
+  (testing "a relative input resolves against the working directory"
+    (let [here (os/canonical-path ".")]
+      (is (= "/" (subs here 0 1)))
+      (is (= (os/canonical-path (os/cwd)) here)))))
 
-  (testing "a relative path becomes absolute"
-    (is (= (os/canonical-path root) (os/canonical-path (str root "/.")))))
-
-  (testing "traversal collapses to the same file"
-    (is (= (os/canonical-path (str root "/real.txt"))
-           (os/canonical-path (str root "/../let-go-os-paths-test/real.txt")))))
-
-  (os/delete-tree root))
+(deftest path-fns-refuse-an-empty-path
+  ;; (str nil) is "" in lg, so this is what an unset variable looks like.
+  ;; filepath.Abs would quietly answer with the cwd.
+  (testing "both refuse rather than resolving to the working directory"
+    (is (= :threw (try (os/absolute-path "") :no-throw (catch _ :threw))))
+    (is (= :threw (try (os/canonical-path "") :no-throw (catch _ :threw))))))
 
 (deftest canonical-path-needs-the-path-to-exist
   ;; let-go has no thrown? — use try/catch directly.


### PR DESCRIPTION
Stacked on #698; review that first. The delta here is the two path functions.

let-go has no path namespace, so nothing resolves a relative path and nothing collapses two names for one file into a single string. Both are slots in Grenadine's host contract (#688).

## Why two functions and not one normalize

They answer different questions, and merging them would force every caller to accept the stricter one.

**`os/absolute-path` is lexical with respect to its argument.** It resolves against the working directory and cleans traversal without looking the path up, so it answers for a path that does not exist yet. That is what a caller naming a file it is about to create needs, and a symlink in the path stays a symlink. It does read the process cwd, so it is not free of filesystem access and can fail when the working directory has been removed.

**`os/canonical-path` also resolves symlinks.** Following a link can only be done by looking, so this one requires the path to exist. In exchange it gives a string that compares and keys correctly: two names for one file produce one answer, which is the property that makes it the right form for a cache key or an identity check.

A missing path is an error from `canonical-path` rather than a cleaned-up guess, since there is no honest answer. Both refuse an empty path, matching `os/delete-tree` on the parent branch: `filepath.Abs("")` answers with the cwd, so an unset variable would produce a plausible path instead of an error.

## Resolution order

`canonical-path` resolves symlinks *before* absolutizing, and the order is load-bearing. `filepath.Abs` cleans `..` lexically, so absolutizing first collapses `..` against the link's parent rather than the target's. With `a/link` → `b/c`, the input `a/link/../target.txt` becomes `a/target.txt` and errors, where the answer is `b/target.txt`. The first draft of this PR had it the wrong way round and reported `ENOENT` for a path the kernel opens fine; there is a regression test, and it builds its path by concatenation because `filepath.Join` would clean the case away before the native saw it.

## Placement

Both go in `os` beside `rename` and `delete-tree` rather than opening a `path` namespace for two functions. If the surface grows to `join`, `basename`, and `dirname`, a `path` namespace becomes the better home and these should move with it. Happy to start that namespace here instead if you'd rather set the shape now.

## Verification

- `pkg/rt/os_paths_test.go` — 12 tests: resolution against cwd, traversal cleaning, an already-absolute path, symlink resolution, two names collapsing to one string, the missing-path divergence between the two, argument guards, the `..`-after-symlink regression, and that `absolute-path` leaves a symlink unresolved where `canonical-path` resolves it. The symlink cases skip where the platform refuses symlinks, and compare against an `EvalSymlinks` of the target rather than the raw path, since `t.TempDir` itself sits under a symlink on darwin.
- `test/os_paths_test.lg` — the same surface from lg, including the lexical-vs-filesystem distinction.
- Builds clean for `linux/amd64`, `js/wasm`, `wasip1/wasm`, and `plan9/amd64`.

One caveat on browser `js/wasm`: Go's `wasm_exec.js` shim throws `ENOSYS` from `process.cwd()` and `fs.lstat()`, so `absolute-path` fails on relative input there and `canonical-path` fails on any input. That matches `os/cwd`, `os/ls` and `os/stat`, which are already dead on that target, so it is not a regression — but unlike them these two carry doc comments making unconditional promises, and I can add a caveat if you'd rather they said so. `wasip1` and `plan9` are both fine: wasip1 tracks a real cwd and has working `Lstat`, and plan9 implements `evalSymlinks` as `Lstat` plus `Clean`.

## Still open from the contract survey

`:bytes->utf8` and `:byte-count` are left out because they need a decision rather than a function. Bytes are `vm.String` today (`read-bytes` returns one), so `bytes->utf8` is identity and the real question is whether an invalid-UTF-8 check belongs on it. `byte-count` is a genuine gap — `count` is rune-based, so `(count "héllo")` is 5 where the byte length is 6, and lg has no way to ask for the latter. Where it belongs is the open part: `count`'s neighbours are in core, which there is active work to shrink.
