### PR TITLE
vm: drop leaveFrame's unused *Frame parameter to unpin f from memory

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -744,7 +744,11 @@ func enterFrame(f *Frame) {
 	f.profileOn = ProfilingEnabled.Load()
 }
 
-func leaveFrame(_ *Frame) {
+// leaveFrame takes no frame on purpose. attrPopFrame pops the shadow stack by
+// position, so the frame was never read. Restoring the parameter would put a
+// *Frame back into runLoop's deferred call and reintroduce the by-ref capture
+// of f described at that defer.
+func leaveFrame() {
 	if allocAttrEnabled {
 		attrPopFrame()
 	}
@@ -767,7 +771,7 @@ func releaseFailedFrames(state *frameRunState, err error) (*Frame, error) {
 			state.current = parent
 			return parent, err
 		}
-		leaveFrame(parent)
+		leaveFrame()
 		parent.parent = nil
 		if parent != state.root {
 			ReleaseFrame(parent)
@@ -786,7 +790,7 @@ func releasePanickedFrames(state *frameRunState) {
 	}
 	for parent != nil {
 		next := parent.parent
-		leaveFrame(parent)
+		leaveFrame()
 		parent.parent = nil
 		if parent != state.root {
 			ReleaseFrame(parent)
@@ -828,9 +832,12 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 	if entering {
 		enterFrame(f)
 	}
-	// f changes as the loop descends and returns. On a final return or error,
-	// leave whichever logical frame is current; suspended parents remain active.
-	defer func() { leaveFrame(f) }()
+	// Balances the enterFrame above on a final return or error; suspended
+	// parents remain active and are released by releaseFailedFrames /
+	// releasePanickedFrames. Deliberately not a closure: capturing f here
+	// would pin the dispatch loop's hottest pointer to memory for an argument
+	// leaveFrame does not take.
+	defer leaveFrame()
 	for {
 		inst := f.code.code[f.ip]
 		if f.debug {
@@ -879,7 +886,7 @@ func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
 			child := f
 			parent := child.parent
 			child.parent = nil
-			leaveFrame(child)
+			leaveFrame()
 			ReleaseFrame(child)
 			f = parent
 			state.current = f


### PR DESCRIPTION
`leaveFrame` never read its `*Frame`. `attrPopFrame` pops the alloc-attribution shadow stack by position, so the parameter was inert. But `runLoop` passed it from a deferred closure, and `f` is also reassigned as the dispatch loop descends into callees and returns to parents, so capturing it forced the compiler to box the interpreter's hottest pointer:

```
$ go build -gcflags='-m -m' ./pkg/vm
pkg/vm/vm.go:827:7: (*Frame).runLoop capturing by ref: f (addr=false assign=true width=8)
```

`assign=true` is the operative half. Every `f.ip`, `f.sp` and `f.code.code[f.ip]` in the dispatch loop reads through an indirection, to supply an argument the callee discards.

Dropping the parameter lets the defer be a direct call. The capture is gone from escape analysis after the change, and no call site loses information, since none of the four was passing anything that got read.

## Why the parameter is now documented as absent

`defer leaveFrame(f)` and `defer func() { leaveFrame(f) }()` are not equivalent: deferred arguments evaluate at defer time, which is the entry frame, while the closure evaluates at return time, which is whichever frame is current. Today that difference is unobservable because the argument is unused. It stops being unobservable the moment someone gives the parameter meaning, so both the defer and `leaveFrame` itself now carry a comment saying why there is no frame to pass.

## On performance

This came out of measuring #700's entry-boundary cost, and the honest summary is that the effect is not demonstrated. Locally on an M2, `(some #(> % 999998) (range 1000000))` under hyperfine (3 warmup, 20 runs) gave order-dependent results — `main` 1.03 ± 0.03x faster with A first, this change 1.07 ± 0.09x faster with B first — and the `pkg/vm` micros ran at ±20–30% σ with no family reaching significance. That is thermal, not signal.

So judge this one on the dead parameter and the removed capture; any number would be a bonus. I would run it through the `perf-repeat` EPYC lane to see whether the indirection shows up on quieter hardware, and will label it unless you would rather not spend the lane time.

One related note for #700: the ~2% previously attributed to gating this defer cannot have come from the capture. Gating a defer whose body still references `f` keeps the by-ref capture, so that measurement was moving something else.

## Verification

- `capturing by ref` line absent from `go build -gcflags='-m -m' ./pkg/vm`
- `go test ./pkg/vm ./pkg/rt ./test/...` green, including `TestGogenAOTDiff`
- builds clean for `linux/amd64`, `js/wasm`, `plan9/amd64`, `wasip1/wasm`
