### PR TITLE
test: pin apply*'s no-mutation property end to end

### DIFF
--- a/test/apply_rest_aliasing_test.lg
+++ b/test/apply_rest_aliasing_test.lg
@@ -32,9 +32,13 @@
 ;; --- characterization, not a guard -----------------------------------------
 ;; Public `apply` was never exposed to this bug and still passes against the
 ;; pre-fix code, so these assertions do not guard the fix. They are here to
-;; record why the two spellings differ: for 2+ args `apply` reaches apply*
-;; through list*/spread, which allocates a fresh seq, so the caller's storage
-;; is never the backing array. Only the raw apply* hands it straight through.
+;; record why the two spellings differ: apply* aliases the caller's storage
+;; only when it is handed an ArrayVector (pkg/rt/lang.go), and no `apply` arity
+;; hands it one. The 2-arg arity passes (seq args), a seq view over the vector
+;; (pkg/rt/core/core.lg); the 3+-arg arities pass a list*/spread cons chain.
+;; Both reach apply*'s seq branch, which copies the arguments into a fresh
+;; slice via appendSeqValues. Only the raw apply* hands the vector straight
+;; through.
 ;; If a future change makes `apply` alias its argument, these start failing —
 ;; which is the point of writing them down rather than assuming the coverage.
 

--- a/test/apply_rest_aliasing_test.lg
+++ b/test/apply_rest_aliasing_test.lg
@@ -1,0 +1,47 @@
+;; apply* must not mutate the collection its args came from.
+;;
+;; Reported on #620 (point 5, 2026-07-22): rest-arg packing appended into the
+;; caller's storage, so the source vector came back with its second element
+;; overwritten by the rest list — (let [v [1 2 3]] [(apply* f v) v]) gave
+;; [(2 3) [1 (2 3) 3]] instead of [(2 3) [1 2 3]].
+;;
+;; #645 fixed it in resolveBytecodeCall, which now packs into a fresh slice,
+;; and pinned the resolver-level invariant in
+;; pkg/vm/explicit_frame_test.go::TestResolveBytecodeCallVariadicPackingDoesNotMutateBorrowedArgs.
+;; This file adds the end-to-end spelling the original report used, because
+;; that unit test pins the resolver rather than the route into it, and #620
+;; Phase 3 rewrites the route.
+
+(ns test.apply-rest-aliasing-test
+  (:require [test :refer :all]))
+
+;; A *bytecode* fn with a rest param is required. The packing path under test
+;; is reached only for bytecode callees, so a native like + would not exercise
+;; it.
+(defn take-rest [x & xs] xs)
+
+;; --- the regression guard --------------------------------------------------
+;; Verified to fail against the pre-fix `append(prepared[:arity-1], restlist)`:
+;; v comes back as [1 (2 3) 3].
+
+(deftest apply-star-does-not-mutate-the-source-vector
+  (let [v [1 2 3]]
+    (is (= '(2 3) (apply* take-rest v)))
+    (is (= [1 2 3] v) "apply* must not write into the vector it read args from")))
+
+;; --- characterization, not a guard -----------------------------------------
+;; Public `apply` was never exposed to this bug and still passes against the
+;; pre-fix code, so these assertions do not guard the fix. They are here to
+;; record why the two spellings differ: for 2+ args `apply` reaches apply*
+;; through list*/spread, which allocates a fresh seq, so the caller's storage
+;; is never the backing array. Only the raw apply* hands it straight through.
+;; If a future change makes `apply` alias its argument, these start failing —
+;; which is the point of writing them down rather than assuming the coverage.
+
+(deftest apply-reaches-apply-star-through-a-fresh-seq
+  (let [v [1 2 3]]
+    (is (= '(2 3) (apply take-rest v)))
+    (is (= [1 2 3] v)))
+  (let [v [2 3]]
+    (is (= '(2 3) (apply take-rest 1 v)))
+    (is (= [2 3] v))))


### PR DESCRIPTION
Point 5 of my 2026-07-22 comment on #620 reported that applying a variadic bytecode fn to a vector handed the vector back mutated, because rest packing appended into the caller's storage:

```clojure
(let [v [1 2 3]] [(apply* (fn [x & xs] xs) v) v])
;; 2026-07-22: [(2 3) [1 (2 3) 3]]
```

#645 fixed that in `resolveBytecodeCall` and pinned the invariant where the fix lives, in `TestResolveBytecodeCallVariadicPackingDoesNotMutateBorrowedArgs`. I said on #620 that no test pinned it, which was wrong — I searched for `apply*` in the test files and the guard does not mention `apply*` anywhere. Correcting that separately on the issue.

What is genuinely uncovered is the route into the resolver. The existing test calls `resolveBytecodeCall` directly, so nothing asserts that `apply*` reaches it, and #620 Phase 3 rewrites exactly that route while proposing a borrowed-argument rule. This adds the end-to-end spelling the original report used.

## The guard is verified in both directions

Against the pre-fix `append(prepared[:t.arity-1], restlist)` it fails with `v` = `[1 (2 3) 3]`; on `main` it passes. A test that passes either way would not be a ratchet.

## Public `apply` was never exposed to this

`apply*` aliases the caller's storage only when it is handed an `ArrayVector` — the one branch in its `pkg/rt/lang.go` body that passes `vs[1]` to `ec.Invoke` unchanged — and no `apply` arity hands it one. The 2-arg arity passes `(seq args)`, a seq view over the vector (`apply` in `pkg/rt/core/core.lg`); the 3+-arg arities pass a `list*` / `spread` cons chain. Both reach `apply*`'s seq branch, which copies the arguments into a fresh slice via `appendSeqValues`. Only the raw `apply*` hands the vector straight through.

That means the `apply` assertions pass against the pre-fix code as well. Rather than delete them or let them read as coverage they do not provide, the file groups them under a heading that says they are characterization, with the reason. If a later change makes `apply` alias its argument, they start failing, which is the argument for writing them down instead of assuming.

Thanks to @nnunley for catching this. The earlier wording attributed all of it to `list*` / `spread`, which does not cover the 2-arg arity the first characterization assertion exercises. The test file's comment block carried the same claim and is fixed too.

## Placement

`test/apply_rest_aliasing_test.lg`, picked up by `TestRunner`'s `.lg` walk. If you would rather this rode the Phase 3 branch than land ahead of it, say so and I will close this — the offer on #620 was to keep it off that branch, not to insist.
