### PR TITLE
probe(vm): comment-only control for the repeat A/B noise floor

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -744,6 +744,11 @@ func enterFrame(f *Frame) {
 	f.profileOn = ProfilingEnabled.Load()
 }
 
+// MEASUREMENT CONTROL — DO NOT MERGE.
+// This comment is the entire diff. It exists to push a functionally identical
+// build through the repeat A/B lane, so the deltas that come back are the
+// harness's own noise floor rather than any property of a change. Sibling of
+// #706, same base, same lane, same label. See the PR description.
 func leaveFrame(_ *Frame) {
 	if allocAttrEnabled {
 		attrPopFrame()


### PR DESCRIPTION
**Measurement control. Do not merge.** Closing it once the numbers land, same as #691.

The entire diff is a comment. The point is to push a build with *identical machine code* through the repeat A/B lane, so whatever deltas come back are the lane's own noise at N=7 rather than a property of any change.

## The code really is identical

Worth checking rather than assuming, since the whole value of the control rests on it. Built base and head with `-trimpath` and compared:

- `go tool nm`: 12907 symbols in both, at identical addresses — same layout, nothing moved.
- `__text` section: `0x338184` bytes in both.
- The binaries do differ, but only near the start of the file: the Go build ID hashes the source bytes, and a comment is a source byte.

So this holds code *and* placement constant, which is what makes any reported delta attributable to the harness and the runner alone.

## Why now

#706 is a semantically inert change — it deletes a `*Frame` parameter that was never read. On this lane it measured `SeqIteration/List/01000` +8.30% and `FrameDispatch` +4.97%, each consistent across all seven cycles, alongside −0.75% on `FuncInvoke/Direct`. I could not tell from that run whether those are real or whether the lane can produce numbers that size on its own, and that is not a question #706 should have to answer.

It is also the measurement #705 §1 is about. The 5% ratchet budget has never been checked against a measured floor, and #564 already found byte-identical binaries landing 3.7% and 1.1% apart on two packages.

## Reading the result

- **Swings of the same order as #706's** (five to eight percent on those families) — the lane's floor at N=7 is far above the 5% budget on memory-bound families. #706's numbers carry no information, and the budget needs per-family or per-tier calibration before it can gate anything.
- **Flat, say within one or two percent** — the lane is trustworthy at N=7, and #706's swings are a property of its binary. That would not yet say *which* property: this control holds layout constant, so it cannot distinguish code placement from a changed inlining or register-allocation decision. Separating those needs a second control that perturbs placement without changing semantics, which is only worth building if this one comes back flat.

Either way the number is worth having, and it belongs on #705 rather than buried in a PR thread. I will post it there too.
