### PR TITLE
fix(vm,repl): stop tab completion crashing on the cyclic refer graph

### DIFF
--- a/lg_repl.go
+++ b/lg_repl.go
@@ -48,10 +48,19 @@ func (c *completer) Do(line []rune, pos int) (newLine [][]rune, length int) {
 	prefix := string(head[start:])
 
 	symbols := rt.FuzzyNamespacedSymbolLookup(c.ctx.CurrentNS(), vm.Symbol(prefix))
+
+	// readline INSERTS the candidate at the cursor, so a candidate has to be the
+	// part not typed yet — returning whole symbols turns "ns-unm<tab>" into
+	// "ns-unmns-unmap". Candidates come back unqualified (the lookup resolves the
+	// ns segment of the prefix and matches on the name), so the typed part to
+	// strip is the name segment, not the whole word. length is the same segment's
+	// rune count: readline echoes that many runes ahead of each candidate when it
+	// lists them.
+	_, namePrefix, _ := vm.Symbol(prefix).NamespacedRaw()
 	for _, s := range symbols {
-		newLine = append(newLine, []rune(string(s)+" "))
+		newLine = append(newLine, []rune(strings.TrimPrefix(string(s), string(namePrefix))+" "))
 	}
-	length = pos - start
+	length = len([]rune(string(namePrefix)))
 	return
 }
 

--- a/lg_repl.go
+++ b/lg_repl.go
@@ -12,57 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode"
 
 	"github.com/chzyer/readline"
 	"github.com/nooga/let-go/pkg/compiler"
-	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/complete"
 	"github.com/nooga/let-go/pkg/vm"
 )
-
-func isCompletionTerminator(r rune) bool {
-	switch r {
-	case '(', ')', '[', ']', '{', '}', '"', '\\', '\'', '@', '`', '~', ';', '#':
-		return true
-	}
-	return unicode.IsSpace(r)
-}
-
-// completer implements readline's AutoCompleter interface.
-// readline passes line as []rune and pos as a rune index; we stay in runes
-// throughout so non-ASCII input and mid-line cursors are handled correctly.
-type completer struct {
-	ctx *compiler.Context
-}
-
-func (c *completer) Do(line []rune, pos int) (newLine [][]rune, length int) {
-	if pos > len(line) {
-		pos = len(line)
-	}
-	head := line[:pos]
-
-	start := pos
-	for start > 0 && !isCompletionTerminator(head[start-1]) {
-		start--
-	}
-	prefix := string(head[start:])
-
-	symbols := rt.FuzzyNamespacedSymbolLookup(c.ctx.CurrentNS(), vm.Symbol(prefix))
-
-	// readline INSERTS the candidate at the cursor, so a candidate has to be the
-	// part not typed yet — returning whole symbols turns "ns-unm<tab>" into
-	// "ns-unmns-unmap". Candidates come back unqualified (the lookup resolves the
-	// ns segment of the prefix and matches on the name), so the typed part to
-	// strip is the name segment, not the whole word. length is the same segment's
-	// rune count: readline echoes that many runes ahead of each candidate when it
-	// lists them.
-	_, namePrefix, _ := vm.Symbol(prefix).NamespacedRaw()
-	for _, s := range symbols {
-		newLine = append(newLine, []rune(strings.TrimPrefix(string(s), string(namePrefix))+" "))
-	}
-	length = len([]rune(string(namePrefix)))
-	return
-}
 
 // ANSI color codes for syntax highlighting. ansiReset and ansiBold are
 // declared in lg_ansi.go; the rest are repl-only.
@@ -135,7 +90,7 @@ func repl(ctx *compiler.Context) {
 	config := &readline.Config{
 		Prompt:          prompt,
 		EOFPrompt:       "exit",
-		AutoComplete:    &completer{ctx: ctx},
+		AutoComplete:    &complete.Completer{Ctx: ctx},
 		InterruptPrompt: "^C",
 		HistoryFile:     historyFile(),
 		Painter:         &syntaxHighlighter{},

--- a/lg_repl_test.go
+++ b/lg_repl_test.go
@@ -1,0 +1,65 @@
+//go:build !plan9 && !js && !wasip1
+
+/*
+ * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func testCompleter(t *testing.T) *completer {
+	t.Helper()
+	ns := rt.NS("user")
+	if ns == nil {
+		t.Fatal("user namespace not found")
+	}
+	return &completer{ctx: compiler.NewCompiler(vm.NewConsts(), ns)}
+}
+
+// Tab completion walks the refer graph, which is cyclic (clojure.core requires
+// let-go.types, RegisterNS refers clojure.core back into it). Completing at all
+// is the assertion here — before the visited set this overflowed the stack.
+func TestCompleterDoReturnsUntypedRemainder(t *testing.T) {
+	c := testCompleter(t)
+
+	line := []rune("(ns-unm")
+	candidates, length := c.Do(line, len(line))
+	if len(candidates) == 0 {
+		t.Fatal("no candidates for ns-unm")
+	}
+	if length != len("ns-unm") {
+		t.Fatalf("length = %d, want %d", length, len("ns-unm"))
+	}
+
+	// readline inserts the candidate at the cursor, so each one must be only the
+	// part not typed yet — a whole symbol here would render as "ns-unmns-unmap".
+	found := false
+	for _, cand := range candidates {
+		if strings.HasPrefix(string(cand), "ns-unm") {
+			t.Fatalf("candidate %q repeats the typed prefix", string(cand))
+		}
+		if string(cand) == "ap " {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ns-unmap missing from candidates: %q", candidates)
+	}
+}
+
+func TestCompleterDoUnknownNamespace(t *testing.T) {
+	c := testCompleter(t)
+	line := []rune("nosuchns/x")
+	if candidates, _ := c.Do(line, len(line)); len(candidates) != 0 {
+		t.Fatalf("want no candidates for an unknown namespace, got %q", candidates)
+	}
+}

--- a/pkg/compiler/reader.go
+++ b/pkg/compiler/reader.go
@@ -1557,6 +1557,17 @@ func isTerminatingMacro(r rune) bool {
 	return r != '#' && r != '\'' && r != '%' && isMacro(r)
 }
 
+// IsTokenBoundary reports whether r ends a symbol token the way the reader's
+// tokenizer does everywhere it scans one (readSymbol, readString escapes,
+// readRegex, etc.): whitespace (isWhitespace treats ',' as whitespace too)
+// or a terminating macro character. Exported so pkg/complete's REPL
+// completer can backscan a line for a completion prefix using the exact same
+// boundary rule as the reader, instead of a hand-rolled approximation that
+// can drift from it.
+func IsTokenBoundary(r rune) bool {
+	return isWhitespace(r) || isTerminatingMacro(r)
+}
+
 func isMacro(r rune) bool {
 	_, ok := macros[r]
 	return ok

--- a/pkg/complete/complete.go
+++ b/pkg/complete/complete.go
@@ -9,20 +9,11 @@ package complete
 
 import (
 	"strings"
-	"unicode"
 
 	"github.com/nooga/let-go/pkg/compiler"
 	"github.com/nooga/let-go/pkg/rt"
 	"github.com/nooga/let-go/pkg/vm"
 )
-
-func isTerminator(r rune) bool {
-	switch r {
-	case '(', ')', '[', ']', '{', '}', '"', '\\', '\'', '@', '`', '~', ';', '#':
-		return true
-	}
-	return unicode.IsSpace(r)
-}
 
 // Completer implements readline's AutoCompleter interface.
 // readline passes line as []rune and pos as a rune index; we stay in runes
@@ -38,23 +29,23 @@ func (c *Completer) Do(line []rune, pos int) (newLine [][]rune, length int) {
 	head := line[:pos]
 
 	start := pos
-	for start > 0 && !isTerminator(head[start-1]) {
+	for start > 0 && !compiler.IsTokenBoundary(head[start-1]) {
 		start--
 	}
 	prefix := string(head[start:])
 
-	symbols := rt.FuzzyNamespacedSymbolLookup(c.Ctx.CurrentNS(), vm.Symbol(prefix))
+	symbols, namePrefix := rt.FuzzyNamespacedSymbolLookup(c.Ctx.CurrentNS(), vm.Symbol(prefix))
 
 	// readline INSERTS the candidate at the cursor, so a candidate has to be the
 	// part not typed yet — returning whole symbols turns "ns-unm<tab>" into
 	// "ns-unmns-unmap". Candidates come back unqualified, because the lookup
 	// resolves the ns segment of the prefix and matches on the name, so the typed
-	// part to strip is the name segment. length is that segment's rune count:
-	// readline echoes that many runes ahead of each candidate when it lists them.
-	_, namePrefix, _ := vm.Symbol(prefix).NamespacedRaw()
+	// part to strip is namePrefix, the same name segment the lookup itself
+	// matched against. length is that segment's rune count: readline echoes
+	// that many runes ahead of each candidate when it lists them.
 	for _, s := range symbols {
 		newLine = append(newLine, []rune(strings.TrimPrefix(string(s), string(namePrefix))+" "))
 	}
-	length = len([]rune(string(namePrefix)))
+	length = len([]rune(namePrefix))
 	return
 }

--- a/pkg/complete/complete.go
+++ b/pkg/complete/complete.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+// Package complete supplies REPL symbol completion. It lives outside package
+// main so it can be tested — the repo keeps test files out of the repo root.
+package complete
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+func isTerminator(r rune) bool {
+	switch r {
+	case '(', ')', '[', ']', '{', '}', '"', '\\', '\'', '@', '`', '~', ';', '#':
+		return true
+	}
+	return unicode.IsSpace(r)
+}
+
+// Completer implements readline's AutoCompleter interface.
+// readline passes line as []rune and pos as a rune index; we stay in runes
+// throughout so non-ASCII input and mid-line cursors are handled correctly.
+type Completer struct {
+	Ctx *compiler.Context
+}
+
+func (c *Completer) Do(line []rune, pos int) (newLine [][]rune, length int) {
+	if pos > len(line) {
+		pos = len(line)
+	}
+	head := line[:pos]
+
+	start := pos
+	for start > 0 && !isTerminator(head[start-1]) {
+		start--
+	}
+	prefix := string(head[start:])
+
+	symbols := rt.FuzzyNamespacedSymbolLookup(c.Ctx.CurrentNS(), vm.Symbol(prefix))
+
+	// readline INSERTS the candidate at the cursor, so a candidate has to be the
+	// part not typed yet — returning whole symbols turns "ns-unm<tab>" into
+	// "ns-unmns-unmap". Candidates come back unqualified, because the lookup
+	// resolves the ns segment of the prefix and matches on the name, so the typed
+	// part to strip is the name segment. length is that segment's rune count:
+	// readline echoes that many runes ahead of each candidate when it lists them.
+	_, namePrefix, _ := vm.Symbol(prefix).NamespacedRaw()
+	for _, s := range symbols {
+		newLine = append(newLine, []rune(strings.TrimPrefix(string(s), string(namePrefix))+" "))
+	}
+	length = len([]rune(string(namePrefix)))
+	return
+}

--- a/pkg/complete/complete.go
+++ b/pkg/complete/complete.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
  * SPDX-License-Identifier: MIT
  */
 

--- a/pkg/complete/complete_test.go
+++ b/pkg/complete/complete_test.go
@@ -1,11 +1,9 @@
-//go:build !plan9 && !js && !wasip1
-
 /*
  * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>
  * SPDX-License-Identifier: MIT
  */
 
-package main
+package complete
 
 import (
 	"strings"
@@ -16,19 +14,19 @@ import (
 	"github.com/nooga/let-go/pkg/vm"
 )
 
-func testCompleter(t *testing.T) *completer {
+func testCompleter(t *testing.T) *Completer {
 	t.Helper()
 	ns := rt.NS("user")
 	if ns == nil {
 		t.Fatal("user namespace not found")
 	}
-	return &completer{ctx: compiler.NewCompiler(vm.NewConsts(), ns)}
+	return &Completer{Ctx: compiler.NewCompiler(vm.NewConsts(), ns)}
 }
 
 // Tab completion walks the refer graph, which is cyclic (clojure.core requires
 // let-go.types, RegisterNS refers clojure.core back into it). Completing at all
 // is the assertion here — before the visited set this overflowed the stack.
-func TestCompleterDoReturnsUntypedRemainder(t *testing.T) {
+func TestDoReturnsUntypedRemainder(t *testing.T) {
 	c := testCompleter(t)
 
 	line := []rune("(ns-unm")
@@ -56,7 +54,7 @@ func TestCompleterDoReturnsUntypedRemainder(t *testing.T) {
 	}
 }
 
-func TestCompleterDoUnknownNamespace(t *testing.T) {
+func TestDoUnknownNamespace(t *testing.T) {
 	c := testCompleter(t)
 	line := []rune("nosuchns/x")
 	if candidates, _ := c.Do(line, len(line)); len(candidates) != 0 {

--- a/pkg/complete/complete_test.go
+++ b/pkg/complete/complete_test.go
@@ -61,3 +61,20 @@ func TestDoUnknownNamespace(t *testing.T) {
 		t.Fatalf("want no candidates for an unknown namespace, got %q", candidates)
 	}
 }
+
+// The reader treats ',' as whitespace (isWhitespace), so it terminates a
+// symbol token there just like on a space. The completer's backscan must
+// stop at the comma too, or "(foo,ns-unm<TAB>" would use "foo,ns-unm" as
+// the prefix instead of "ns-unm".
+func TestDoStopsAtComma(t *testing.T) {
+	c := testCompleter(t)
+
+	line := []rune("(foo,ns-unm")
+	candidates, length := c.Do(line, len(line))
+	if len(candidates) == 0 {
+		t.Fatal("no candidates for ns-unm after a comma")
+	}
+	if length != len("ns-unm") {
+		t.Fatalf("length = %d, want %d (comma should terminate the prefix scan)", length, len("ns-unm"))
+	}
+}

--- a/pkg/complete/complete_test.go
+++ b/pkg/complete/complete_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Marcin Gasperowicz <xnooga@gmail.com>
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
  * SPDX-License-Identifier: MIT
  */
 

--- a/pkg/nrepl/server.go
+++ b/pkg/nrepl/server.go
@@ -345,7 +345,7 @@ func (n *NreplServer) handleCompletions(conn net.Conn, msg map[string]any) {
 	var completions []any
 	if prefix != "" {
 		sym := vm.Symbol(prefix)
-		matches := rt.FuzzyNamespacedSymbolLookup(n.ctx.CurrentNS(), sym)
+		matches, _ := rt.FuzzyNamespacedSymbolLookup(n.ctx.CurrentNS(), sym)
 		for _, m := range matches {
 			completions = append(completions, map[string]any{
 				"candidate": string(m),

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -479,18 +479,24 @@ func RemoveNS(name string) {
 	nsMu.Unlock()
 }
 
-func FuzzyNamespacedSymbolLookup(currentNS *vm.Namespace, s vm.Symbol) []vm.Symbol {
-	sns := s.Namespace()
+// FuzzyNamespacedSymbolLookup fuzzy-matches s (which may be ns-qualified) as
+// a symbol prefix, resolving any ns segment against currentNS. Alongside the
+// matches it returns namePrefix, the unqualified name segment of s that was
+// actually matched against — callers that need to strip the typed prefix
+// from a candidate (e.g. pkg/complete's REPL completer) should use this
+// instead of independently re-splitting s, so the two derivations can't
+// drift apart.
+func FuzzyNamespacedSymbolLookup(currentNS *vm.Namespace, s vm.Symbol) (matches []vm.Symbol, namePrefix vm.Symbol) {
+	sns, name, hasNS := s.NamespacedRaw()
 	var ns *vm.Namespace
-	if sns != vm.NIL {
+	if hasNS {
 		nsMu.RLock()
-		ns = nsRegistry[string(sns.(vm.String))]
+		ns = nsRegistry[string(sns)]
 		nsMu.RUnlock()
 	} else {
 		ns = currentNS
 	}
-	name := s.Name()
-	return vm.FuzzySymbolLookup(ns, vm.Symbol(name.(vm.String)), true)
+	return vm.FuzzySymbolLookup(ns, name, true), name
 }
 
 func NS(name string) *vm.Namespace {

--- a/pkg/vm/namespace.go
+++ b/pkg/vm/namespace.go
@@ -641,10 +641,23 @@ func (n *Namespace) Unmap(name Symbol) {
 	n.mu.Unlock()
 }
 
+// FuzzySymbolLookup collects every symbol visible from ns whose name starts
+// with s, walking refers transitively. The refer graph is cyclic — clojure.core
+// requires let-go.types for array?/bigint?, and RegisterNS auto-refers
+// clojure.core back into it — so the walk needs a visited set; without one the
+// core<->let-go.types edge recurses until the stack blows.
 func FuzzySymbolLookup(ns *Namespace, s Symbol, lookupPrivate bool) []Symbol {
+	return fuzzySymbolLookup(ns, s, lookupPrivate, map[*Namespace]bool{})
+}
+
+func fuzzySymbolLookup(ns *Namespace, s Symbol, lookupPrivate bool, seen map[*Namespace]bool) []Symbol {
 	ret := []Symbol{}
+	if ns == nil || seen[ns] {
+		return ret
+	}
+	seen[ns] = true
 	for _, r := range ns.refersSnapshot() {
-		ret = append(ret, FuzzySymbolLookup(r.ns, s, false)...)
+		ret = append(ret, fuzzySymbolLookup(r.ns, s, false, seen)...)
 	}
 	for k, v := range ns.registrySnapshot() {
 		if strings.HasPrefix(string(k), string(s)) {

--- a/pkg/vm/namespace.go
+++ b/pkg/vm/namespace.go
@@ -519,14 +519,21 @@ func (n *Namespace) String() string {
 	return fmt.Sprintf("<ns %s>", n.Name())
 }
 
-// registrySnapshot copies the registry so FuzzySymbolLookup can scan it (and
-// recurse into refers) without holding the lock across other-namespace reads.
-func (n *Namespace) registrySnapshot() map[Symbol]*Var {
+// registryPrefixSymbols returns the registry's symbols whose name starts with
+// prefix, filtering under the read lock so FuzzySymbolLookup doesn't have to
+// copy (and then mostly discard) the entire registry on every call.
+func (n *Namespace) registryPrefixSymbols(prefix Symbol, includePrivate bool) []Symbol {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
-	out := make(map[Symbol]*Var, len(n.registry))
+	var out []Symbol
 	for k, v := range n.registry {
-		out[k] = v
+		if !strings.HasPrefix(string(k), string(prefix)) {
+			continue
+		}
+		if v.isPrivate && !includePrivate {
+			continue
+		}
+		out = append(out, k)
 	}
 	return out
 }
@@ -646,6 +653,11 @@ func (n *Namespace) Unmap(name Symbol) {
 // requires let-go.types for array?/bigint?, and RegisterNS auto-refers
 // clojure.core back into it — so the walk needs a visited set; without one the
 // core<->let-go.types edge recurses until the stack blows.
+//
+// Two visibility rules mirror lookupViaRefers/ReferredVars: a `:refer [only]`
+// refer only contributes the listed names (not the whole referred namespace),
+// and any symbol ns has explicitly ns-unmap'd is excluded even if a refer
+// would otherwise bring it into scope.
 func FuzzySymbolLookup(ns *Namespace, s Symbol, lookupPrivate bool) []Symbol {
 	return fuzzySymbolLookup(ns, s, lookupPrivate, map[*Namespace]bool{})
 }
@@ -657,15 +669,25 @@ func fuzzySymbolLookup(ns *Namespace, s Symbol, lookupPrivate bool, seen map[*Na
 	}
 	seen[ns] = true
 	for _, r := range ns.refersSnapshot() {
-		ret = append(ret, fuzzySymbolLookup(r.ns, s, false, seen)...)
-	}
-	for k, v := range ns.registrySnapshot() {
-		if strings.HasPrefix(string(k), string(s)) {
-			if v.isPrivate && !lookupPrivate {
+		if r.all {
+			ret = append(ret, fuzzySymbolLookup(r.ns, s, false, seen)...)
+			continue
+		}
+		for sym := range r.only {
+			if !strings.HasPrefix(string(sym), string(s)) {
 				continue
 			}
-			ret = append(ret, k)
+			if v := r.ns.localVar(sym); v != nil && !v.isPrivate {
+				ret = append(ret, sym)
+			}
 		}
 	}
-	return ret
+	ret = append(ret, ns.registryPrefixSymbols(s, lookupPrivate)...)
+	filtered := ret[:0]
+	for _, sym := range ret {
+		if !ns.unmappedLocked(sym) {
+			filtered = append(filtered, sym)
+		}
+	}
+	return filtered
 }

--- a/pkg/vm/namespace_test.go
+++ b/pkg/vm/namespace_test.go
@@ -63,3 +63,24 @@ func TestLookup_QualifiedAliasFollowsTargetRefers(t *testing.T) {
 		t.Fatalf("resolved var value = %v, want TRUE", got)
 	}
 }
+
+func TestFuzzySymbolLookup_CyclicRefersTerminate(t *testing.T) {
+	// The real refer graph is cyclic: clojure.core requires let-go.types, and
+	// RegisterNS auto-refers clojure.core back into it. REPL/nREPL tab
+	// completion walks that graph, so the walk must not recurse forever.
+	a := NewNamespace("cyc-a")
+	b := NewNamespace("cyc-b")
+	a.Refer(b, "", true)
+	b.Refer(a, "", true)
+	a.Def("defer-me", TRUE)
+	b.Def("defcmd", TRUE)
+
+	got := FuzzySymbolLookup(a, Symbol("def"), true)
+	names := map[Symbol]int{}
+	for _, s := range got {
+		names[s]++
+	}
+	if names["defer-me"] != 1 || names["defcmd"] != 1 {
+		t.Fatalf("want each symbol once across the cycle, got %v", got)
+	}
+}

--- a/pkg/vm/namespace_test.go
+++ b/pkg/vm/namespace_test.go
@@ -84,3 +84,45 @@ func TestFuzzySymbolLookup_CyclicRefersTerminate(t *testing.T) {
 		t.Fatalf("want each symbol once across the cycle, got %v", got)
 	}
 }
+
+func TestFuzzySymbolLookup_HonorsReferOnly(t *testing.T) {
+	// (:require [lib :refer [foo]]) should only bring foo into scope, not
+	// every other public symbol lib happens to define.
+	lib := NewNamespace("only-lib")
+	lib.Def("foo", TRUE)
+	lib.Def("fred", TRUE)
+	lib.Def("flip", TRUE)
+
+	user := NewNamespace("only-user")
+	user.ReferList(lib, []Symbol{"foo"})
+
+	got := FuzzySymbolLookup(user, Symbol("f"), true)
+	names := map[Symbol]bool{}
+	for _, s := range got {
+		names[s] = true
+	}
+	if !names["foo"] {
+		t.Fatalf("want foo (explicitly referred) in results, got %v", got)
+	}
+	if names["fred"] || names["flip"] {
+		t.Fatalf("want fred/flip excluded (not in :refer list), got %v", got)
+	}
+}
+
+func TestFuzzySymbolLookup_HonorsUnmap(t *testing.T) {
+	// After (ns-unmap *ns* 'foo), foo should no longer resolve in this
+	// namespace even though it's still referred from lib.
+	lib := NewNamespace("unmap-lib")
+	lib.Def("foo", TRUE)
+
+	user := NewNamespace("unmap-user")
+	user.Refer(lib, "", true) // :refer :all
+	user.Unmap("foo")
+
+	got := FuzzySymbolLookup(user, Symbol("f"), true)
+	for _, s := range got {
+		if s == "foo" {
+			t.Fatalf("want foo excluded after ns-unmap, got %v", got)
+		}
+	}
+}


### PR DESCRIPTION
Pressing Tab in the REPL kills the process:

```
lg 1.12.2 (9c9a3d6)
user=> de<Tab>
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
```

`FuzzySymbolLookup` walks refers recursively with no visited set, and the refer graph is cyclic. `clojure.core` requires `let-go.types` for `array?`/`bigint?`, and `RegisterNS` auto-refers `clojure.core` back into it, so the walk ping-pongs between those two namespaces until the stack is exhausted:

```
core         -> [let-go.types]
let-go.core  -> [core let-go.types]
let-go.types -> [core let-go.core]
user         -> [core let-go.core let-go.types]
```

Both edges are intended, so the walk has to tolerate them. The recursion is old, but it was harmless until the cycle existed — `v1.11.1` completes fine, and the first tag carrying the `clojure.core` -> `let-go.types` edge from #410 is `v1.12.0`. nREPL completion calls the same function, so editors on `lg` 1.12.x hit it too.

Two smaller bugs sit on the same path:

- A prefix naming an unregistered namespace (`nosuchns/x<Tab>`) passes a nil `*Namespace` into the walk and segfaults. The visited-set rewrite skips nil targets.
- readline *inserts* a candidate at the cursor, so a candidate has to be the part not typed yet. The completer returned whole symbols, so `ns-unm<Tab>` produced `ns-unmns-unmap`. Candidates come back unqualified, because the lookup resolves the namespace segment of the prefix and matches on the name; the segment to strip is therefore the name, which is also what readline echoes ahead of each candidate when it lists them. This one predates 1.12 and makes completion useless rather than fatal, which is how it stayed hidden behind the crash.

Still not handled, and out of scope here: `FuzzyNamespacedSymbolLookup` resolves a qualified prefix against the namespace registry directly, so an alias (`str/rep<Tab>` after `[clojure.string :as str]`) still yields nothing.

## Verification

New tests, each confirmed to fail against the unpatched code:

- `pkg/vm`: a two-namespace refer cycle terminates and yields each symbol once (stack overflow before).
- `pkg/complete`: `Do` returns the untyped remainder and never repeats the typed prefix; an unknown-namespace prefix returns no candidates instead of crashing. The completer moved out of package `main` to get there — test files are not allowed at the repo root, and it depends only on `rt` and `vm` (readline's `AutoCompleter` is satisfied structurally, so `pkg/complete` does not import readline).

Driven manually in a pty at 1.12.2 and at this branch: `de<Tab>`, `defre<Tab>` -> `defrecord`, `ns-unm<Tab>` -> `ns-unmap`, `nosuchns/x<Tab>` -> no candidates, no crash.
