### PR TITLE
ci(perf): paginate sticky-comment lookup in both lanes

### DIFF
--- a/.github/workflows/perf-pr-repeat.yml
+++ b/.github/workflows/perf-pr-repeat.yml
@@ -221,7 +221,9 @@ jobs:
             // Resolved in the refs step so it works for both pull_request and
             // workflow_dispatch (where there's no pull_request in the payload).
             const issue_number = Number(process.env.PR);
-            const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number});
+            // paginate: the default page is 30, and a sticky upsert past that
+            // silently duplicates. Same call in perf-pr.yml.
+            const comments = await github.paginate(github.rest.issues.listComments, {owner, repo, issue_number});
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -204,7 +204,9 @@ jobs:
             // Resolved in the refs step so it works for both pull_request and
             // workflow_dispatch (where there's no pull_request in the payload).
             const issue_number = Number(process.env.PR);
-            const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number});
+            // paginate: the default page is 30, and a sticky upsert past that
+            // silently duplicates. Same call in perf-pr-repeat.yml.
+            const comments = await github.paginate(github.rest.issues.listComments, {owner, repo, issue_number});
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});


### PR DESCRIPTION
## Summary

- Stacked on #708. Fixes the pagination nit from the review there in **both** sticky-comment lanes (`perf-pr.yml` and `perf-pr-repeat.yml`), not just the new one.
- `github.rest.issues.listComments` returns one page (30 by default). Past that the marker is missed and every run posts a fresh comment instead of updating the sticky one.
- Switch both upserts to `github.paginate(...)` so the marker search covers the full comment list.

## Test plan

- [ ] Confirm the net diff vs #708 is only the two `listComments` → `paginate` swaps
- [ ] After #708 merges and this retargets to `main`, label a long-lived PR with `perf` / `perf-repeat` twice and confirm the sticky updates in place (no duplicate)
- [ ] `actionlint` still clean on both workflows


Made with [Cursor](https://cursor.com)