### PR TITLE
docs: document os namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ lens, with no known failures, compile skips, panic skips, or runtime skips.
 Core namespaces cover `clojure.core` (macros, lazy seqs, transducers, protocols,
 records, multimethods, BigInt/BigDecimal) plus `string`, `set`, `walk`, `edn`,
 `pprint`, `test`, and `core.async`, alongside let-go's own `io`, `http`, `json`,
-`transit`, `os`, `System`, `syscall`, and `pods`. See
+`transit`, [`os`](docs/guide/os.md), `System`, `syscall`, and `pods`. See
 [docs/guide/clojure-compatibility.md](docs/guide/clojure-compatibility.md) for
 the full per-namespace status table and the Clojure differences.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@ status: active
 last-verified: 2026-08-11
 authoritative-for:
   - docs-index
-human-verified: 2026-06-20
+human-verified: 2026-08-11
 ---
 
 # let-go docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-06-30
+last-verified: 2026-08-11
 authoritative-for:
   - docs-index
 human-verified: 2026-06-20
@@ -63,6 +63,7 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | let-go under TinyGo (status: not currently supported) | `guide/tinygo.md` |
 | nREPL server + editor setup | `guide/nrepl.md` |
 | TCP client + bencode framing (`net`, `bencode`) | `guide/net.md` |
+| Processes, environment, filesystem and paths (`os`) | `guide/os.md` |
 | Clojure compatibility: namespace table + differences | `guide/clojure-compatibility.md` |
 | Running, compiling, WASM, project mgmt (lgx) | `guide/usage.md` |
 | IR pipeline dynamic vars (knobs + per-compile state) | `design/ir-dynamic-vars.md` |

--- a/docs/guide/clojure-compatibility.md
+++ b/docs/guide/clojure-compatibility.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-07-13
+last-verified: 2026-08-11
 human-verified:
 ---
 
@@ -30,7 +30,7 @@ with no known failures, compile skips, panic skips, or runtime skips.
 | `http`               | Ring-style server + client, streaming responses                                                                                                                                               |
 | `json`               | `read-json`, `write-json` (float-preserving, record-aware)                                                                                                                                    |
 | `transit`            | transit+json codec with rolling cache                                                                                                                                                         |
-| `os`                 | `sh`, `stat`, `ls`, `cwd`, `getenv`/`setenv`, `exit`, `os-name`, `arch`, `user-name`, `hostname`, separators                                                                                  |
+| `os`                 | process execution, environment/args, filesystem and path operations, host information; see the [`os` guide](os.md)                                                                            |
 | `System`             | JVM-shaped: `getProperty`, `getProperties`, `getenv`, `exit`, `currentTimeMillis`, `nanoTime`. Exposes `let-go.version`, `let-go.commit`, `user.home`, `user.dir`, `os.name`, `os.arch`, etc. |
 | `syscall`            | direct Linux syscalls (mount, unshare, mknod, prctl, capset, seccomp, AppArmor)                                                                                                               |
 | `pods`               | Babashka pods over JSON / EDN / transit                                                                                                                                                       |

--- a/docs/guide/clojure-compatibility.md
+++ b/docs/guide/clojure-compatibility.md
@@ -1,7 +1,7 @@
 ---
 status: active
 last-verified: 2026-08-11
-human-verified:
+human-verified: 2026-08-11
 ---
 
 # Clojure compatibility and differences

--- a/docs/guide/os.md
+++ b/docs/guide/os.md
@@ -1,0 +1,76 @@
+---
+status: active
+last-verified: 2026-08-11
+human-verified:
+---
+
+# OS and filesystem operations
+
+The built-in `os` namespace covers process execution, environment and host
+information, and common filesystem work. This page calls out the contracts that
+matter for correctness; straightforward getters are grouped at the end.
+
+## Files and paths
+
+| Form | Result and behavior |
+|---|---|
+| `(os/cwd)` | Current working directory. |
+| `(os/temp-dir)` | Host temporary-directory path. |
+| `(os/ls path)` | Vector of entry names directly beneath `path`. |
+| `(os/stat path)` | `os/FileStat` with `:name`, `:size`, `:dir?`, and `:mod-time`, or `nil` when absent. |
+| `(os/unzip zip-path dest-dir)` | Safely extracts regular files under `dest-dir` and returns it. Entries cannot escape the destination; symlinks and other special entries are skipped. |
+| `(os/rename old-path new-path)` | Renames and returns `new-path`. On Unix a same-filesystem rename is atomic; there is no copy/delete fallback when the host cannot rename directly. Go does not guarantee atomicity on non-Unix hosts. |
+| `(os/delete-tree path)` | Recursively removes `path` and returns `nil`. An absent path succeeds; an empty path, `.`, or filesystem root is refused. Symlinks are unlinked, never followed. |
+
+Use the two path forms according to whether the named entry already exists:
+
+| Form | Must exist? | Resolves symlinks? | Typical use |
+|---|---:|---:|---|
+| `(os/absolute-path path)` | No | No | Name a file that may be created later. |
+| `(os/canonical-path path)` | Yes | Yes | Compare identities or construct a cache key. |
+
+Both return an absolute, cleaned path and reject an empty string. In particular,
+`canonical-path` errors on a missing entry rather than returning a lexical
+guess.
+
+A same-directory staging file plus `rename` is the usual Unix pattern for
+publishing a complete file without exposing a partial write:
+
+```clojure
+(spit "result.edn.tmp" rendered)
+(os/rename "result.edn.tmp" "result.edn")
+```
+
+## Processes and environment
+
+- `(os/sh command & args)` buffers a child process and returns
+  `{:exit code :out stdout :err stderr}`.
+- `(os/exec* command & args)` streams through the current `*out*` and `*err*`
+  bindings, keeps stdin interactive, and returns the exit code.
+- `os/exec` and `os/with-stdin` expose the lower-level Go command value when a
+  caller needs to configure a process before running it.
+- `os/args` is the full process argv vector. Prefer `*command-line-args*` for
+  just the arguments after a script name.
+- `os/getenv`, `os/setenv`, and `os/exit` read configuration, update the process
+  environment, and terminate with an integer status.
+
+`os/free-port` asks the host for an unused loopback TCP port and releases it
+before returning. The result is a hint, not a reservation: another process can
+bind the port before the caller does.
+
+Host information is available through `os-name`, `arch`, `user-name`, and
+`hostname`, plus the `file-separator`, `path-separator`, and `line-separator`
+values.
+
+## Platform availability
+
+These functions expose host effects, so unsupported operations return the
+underlying platform error. Two reduced environments are worth calling out:
+
+- In browser `js/wasm`, Go's host shim does not provide a working cwd or
+  filesystem lookup. `absolute-path` therefore fails for relative input, while
+  `canonical-path` fails for every input; subprocess and other filesystem calls
+  are similarly host-limited.
+- TinyGo builds register only `os/exit`, `os/getenv`, and `os/args`; `os/args`
+  is currently an empty vector. Use a standard-Go build for the rest of this
+  namespace.

--- a/docs/guide/os.md
+++ b/docs/guide/os.md
@@ -1,7 +1,7 @@
 ---
 status: active
 last-verified: 2026-08-11
-human-verified:
+human-verified: 2026-08-11
 ---
 
 # OS and filesystem operations

--- a/docs/guide/tinygo.md
+++ b/docs/guide/tinygo.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-07-15
+last-verified: 2026-08-11
 human-verified:
 ---
 
@@ -36,6 +36,10 @@ wasmtime on every PR, so the target can't silently regress.
 
 ## Limitations
 
+- **The `os` namespace is minimal.** Only `os/exit`, `os/getenv`, and `os/args`
+  are registered; `os/args` is currently an empty vector. Process execution,
+  filesystem and path operations, and host-information functions require a
+  standard-Go build.
 - **Reflect is partial.** TinyGo does not implement `reflect.Type.Method` or
   `reflect.Value.Call`, which let-go's Go-interop boxing uses. The affected paths
   are shimmed: boxed-method dispatch hand-registers the methods programs reach

--- a/docs/guide/tinygo.md
+++ b/docs/guide/tinygo.md
@@ -1,7 +1,7 @@
 ---
 status: active
 last-verified: 2026-08-11
-human-verified:
+human-verified: 2026-08-11
 ---
 
 # let-go under TinyGo

--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -145,7 +145,7 @@ pkg/rt/core_compiled.lgb pkg/rt/native_prims.go generator eb0246a1c8565285c8b3fb
 pkg/rt/core_compiled.lgb pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_compiled.lgb pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_compiled.lgb pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/core_compiled.lgb pkg/rt/os.go generator 444077d3727b8a18f5c78672883953d090c4b56d381064158e27aae370dec71d
+pkg/rt/core_compiled.lgb pkg/rt/os.go generator c0524458dab45d8cbef2d43464f23b6e27cf4526a7046b54540c8ef26d07e03f
 pkg/rt/core_compiled.lgb pkg/rt/os_tinygo.go generator 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/core_compiled.lgb pkg/rt/parallel.go generator 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/core_compiled.lgb pkg/rt/pods.go generator 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3
@@ -459,7 +459,7 @@ pkg/rt/core_go_lowered/ pkg/rt/native_prims.go generator eb0246a1c8565285c8b3fb3
 pkg/rt/core_go_lowered/ pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_go_lowered/ pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_go_lowered/ pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/core_go_lowered/ pkg/rt/os.go generator 444077d3727b8a18f5c78672883953d090c4b56d381064158e27aae370dec71d
+pkg/rt/core_go_lowered/ pkg/rt/os.go generator c0524458dab45d8cbef2d43464f23b6e27cf4526a7046b54540c8ef26d07e03f
 pkg/rt/core_go_lowered/ pkg/rt/os_tinygo.go generator 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/core_go_lowered/ pkg/rt/parallel.go generator 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/core_go_lowered/ pkg/rt/pods.go generator 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3
@@ -704,7 +704,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/native_prims.go input eb0246a1c8565285c
 pkg/rt/zz_primitives_generated.go pkg/rt/native_prims_lifecycle.go input 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/zz_primitives_generated.go pkg/rt/net.go input 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/zz_primitives_generated.go pkg/rt/net_wasm.go input e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
-pkg/rt/zz_primitives_generated.go pkg/rt/os.go input 444077d3727b8a18f5c78672883953d090c4b56d381064158e27aae370dec71d
+pkg/rt/zz_primitives_generated.go pkg/rt/os.go input c0524458dab45d8cbef2d43464f23b6e27cf4526a7046b54540c8ef26d07e03f
 pkg/rt/zz_primitives_generated.go pkg/rt/os_tinygo.go input 9edb8783e742feb2645643e9a07114caf0f5c11ca775f7c1cb994a8983e7ede9
 pkg/rt/zz_primitives_generated.go pkg/rt/parallel.go input 520cd217f93da579ee05d3419d980505baa8d45a5e068fc1e54f61f8a90744b8
 pkg/rt/zz_primitives_generated.go pkg/rt/pods.go input 2945d0fe60eedba514418518782746bbbe84a1859b3c7baf13d3ef46062d38b3

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-9a9f67ede417733eafe258455cf9f4e16df7e594d5d5d400b55244caadd7df61
+1c9c90e6de6a4f88481ad3579a2b36e1a619e81e0b58cf58c3caf737b8a7124b

--- a/pkg/rt/os.go
+++ b/pkg/rt/os.go
@@ -289,10 +289,11 @@ func installOsNS() {
 
 	// os/rename — (os/rename old-path new-path) → new-path
 	//
-	// Renames old-path to new-path through rename(2), which is atomic within
-	// a filesystem: a concurrent reader sees either the old state or the new
-	// one, never a half-written file. Writing to a temporary name and
-	// renaming into place is the usual way to publish a file safely.
+	// Renames old-path to new-path. On Unix, a rename within one filesystem
+	// is atomic: a concurrent reader sees either the old state or the new one,
+	// never a half-written file. Go does not guarantee that property on
+	// non-Unix hosts. Writing to a temporary name in the destination directory
+	// and renaming into place is the usual Unix way to publish a file safely.
 	//
 	// A rename across filesystems fails rather than falling back to
 	// copy-then-delete. The fallback is what callers reach for this instead


### PR DESCRIPTION
Stacked on #699, which is stacked on #698.

**Do not merge this PR yet.** Merge #698 and then #699 first. After both are on `main`, retarget this PR from `wt/os-paths` to `main` and recheck the resulting one-commit diff before merging.

## What changed

- add a compact `docs/guide/os.md` covering the public `os` surface and the contracts users can otherwise get wrong
- distinguish lexical `absolute-path` from filesystem-backed `canonical-path`
- document rename, recursive deletion, unzip, process execution, environment access, and host information without turning the root README into an API catalog
- link the guide from the root README, docs index, and compatibility table
- record the browser `js/wasm` and TinyGo reductions
- correct the inherited `os/rename` comment: same-filesystem rename is atomic on Unix, while Go does not promise atomicity on non-Unix hosts

## Why

#698 and #699 add four user-facing filesystem/path functions, but their important behavior currently lives only in PR prose and Go comments. The existing compatibility row also omits several already-shipped `os` functions. A focused guide captures the real surface while keeping the README change to a single link.

## Verification

- `python3 scripts/docs_frontmatter_hook.py --check docs/README.md docs/guide/clojure-compatibility.md docs/guide/tinygo.md docs/guide/os.md`
- `python3 scripts/docs_status.py` (reports two unrelated pre-existing findings)
- `go test ./pkg/rt -run '^TestOs(Rename|DeleteTree|AbsolutePath|CanonicalPath|Unzip)'`
- `go test -short ./...`
