### PR TITLE
perf(vm): keep defer scaffolding out of the dispatch hot path

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -801,36 +801,76 @@ func releasePanickedFrames(state *frameRunState) {
 func (f *Frame) Run() (result Value, resultErr error) {
 	f.parent = nil
 	state := frameRunState{root: f, current: f}
-	entering := true
+	// A defer statement in this function would cost deferreturn scaffolding on
+	// every host->VM entry even when never registered (the compiler emits the
+	// return-path walk unconditionally), so the panic-cleanup defer lives in a
+	// separate wrapper taken only when allocation attribution is on. Without
+	// attribution, a Go panic leaks the chain's pooled frames to GC — exactly
+	// what pre-#645 did when a panic skipped runBytecodeCallTarget's
+	// ReleaseFrame; the panic itself is preserved either way.
+	if allocAttrEnabled {
+		return runChainProtected(&state)
+	}
+	return runChain(&state)
+}
+
+// runChainProtected owns the panic-path cleanup that keeps allocation
+// attribution balanced and pooled frames released. Kept out of Run and
+// runChain so their fast paths carry no defer scaffolding.
+func runChainProtected(state *frameRunState) (result Value, resultErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			// runLoop's defer already left the current frame. Balance and release
-			// every suspended child-owned frame before preserving the panic.
-			releasePanickedFrames(&state)
+			// runLoop's attr wrapper already left the current frame. Balance and
+			// release every suspended child-owned frame before preserving the panic.
+			releasePanickedFrames(state)
 			panic(r)
 		}
 	}()
+	return runChain(state)
+}
+
+// runChain drives the dispatch loop and the error-resume protocol for the
+// frame chain rooted at state.root.
+func runChain(state *frameRunState) (result Value, resultErr error) {
+	entering := true
 	for {
-		result, resultErr = state.current.runLoop(&state, entering)
+		result, resultErr = state.current.runLoop(state, entering)
 		entering = false
 		if resultErr == nil {
 			return result, nil
 		}
 		var resumed *Frame
-		resumed, resultErr = releaseFailedFrames(&state, resultErr)
+		resumed, resultErr = releaseFailedFrames(state, resultErr)
 		if resumed == nil {
 			return NIL, resultErr
 		}
 	}
 }
 
+// runLoop dispatches to the attr-tracking wrapper or the bare loop. leaveFrame
+// is a no-op unless allocation attribution is on, and a defer statement inside
+// the dispatch loop itself would cost deferreturn scaffolding on every VM
+// entry, so the deferring variant is a separate function.
 func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
+	if allocAttrEnabled {
+		return f.runLoopAttr(state, entering)
+	}
+	return f.runLoopInner(state, entering)
+}
+
+// runLoopAttr balances attrPopFrame for whichever logical frame is current
+// when the loop unwinds; suspended parents remain active. leaveFrame ignores
+// its argument (attribution keeps its own frame stack), so the wrapper can
+// leave on behalf of the loop without tracking its final frame.
+func (f *Frame) runLoopAttr(state *frameRunState, entering bool) (Value, error) {
+	defer func() { leaveFrame(state.current) }()
+	return f.runLoopInner(state, entering)
+}
+
+func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error) {
 	if entering {
 		enterFrame(f)
 	}
-	// f changes as the loop descends and returns. On a final return or error,
-	// leave whichever logical frame is current; suspended parents remain active.
-	defer func() { leaveFrame(f) }()
 	for {
 		inst := f.code.code[f.ip]
 		if f.debug {


### PR DESCRIPTION
Since Go 1.21, `deferreturn` walks the same `_panic.nextDefer` machinery the panic path uses, so a function that merely *contains* a defer statement pays return-path scaffolding on every call — even when the defer is never registered at runtime. CPU profiles of the #700 workload show `runtime.(*_panic).nextDefer` and `runtime.(*_panic).start` attributed to `Frame.Run`'s normal returns, on both current main and a #645 revert build.

#645 put two such defers on every host-to-VM entry: `Run`'s panic-cleanup defer and `runLoop`'s `leaveFrame` defer. Both exist only to keep allocation-attribution balance and frame-pool hygiene when a Go panic unwinds through the VM; the panic itself is re-raised either way. Native functions that invoke a bytecode callback per element (`some`, `reduce` with a closure) pay the entry cost once per element, which is where most of #700's consumer-visible regression comes from.

This change hoists both defers into wrappers that are entered only when allocation attribution is on (`runChainProtected`, `runLoopAttr`), leaving `Run`, `runChain`, and `runLoopInner` with no defer statements at all. `leaveFrame` ignores its argument (attribution keeps its own frame stack), so the wrapper can leave on the loop's behalf without tracking which frame the loop ends on.

Behavior note: without attribution enabled, a Go panic now leaks the chain's pooled frames to GC instead of returning them to the pool. That matches pre-#645 behavior exactly — a panic skipped `runBytecodeCallTarget`'s `ReleaseFrame` the same way. The attribution tests and #645's frame-lifecycle tests cover the gated path.

Measured on the #700 shape, `(some (fn [x] (< 9999999 x)) (range 1000000))`, darwin/arm64, interleaved runs: main 89.9 ms → this branch 72.4 ms, against v1.12.2's 60.1 ms — about 59% of the gap on that workload.

Draft on purpose: the local box could not adjudicate the micro families. `FuncInvoke/Direct` and `Closure` improved consistently across runs, but `FrameDispatch`/`SeqIteration` swung both ways inside local noise, and the #706 investigation showed `runLoop` restructures can shift register allocation in either direction. The `perf-repeat` label is the point of this draft — if those families hold, this is ready for review.

Verified: `pkg/vm`, `pkg/rt`, and `test/` suites; linux, js/wasm, and plan9 builds.
