### PR TITLE
perf(vm): move cold error arms out of the dispatch loop

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -266,7 +266,7 @@ pkg/rt/core_compiled.lgb pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2
 pkg/rt/core_compiled.lgb pkg/vm/value.go generator 9c00df4c29b70dc9fea057628152cf139bdc73abc75d8666877fb7bf94be8c96
 pkg/rt/core_compiled.lgb pkg/vm/var.go generator 816e670512bc08f78a6d8a39bd8280dea82b171454ac99a54be2595942aee39d
 pkg/rt/core_compiled.lgb pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_compiled.lgb pkg/vm/vm.go generator c9eac4f6738ae3267a18e771575da28531cceff76afa7e89ef31e95534612df6
+pkg/rt/core_compiled.lgb pkg/vm/vm.go generator 9dd0383eeabc14f34f3cea1e1bb40e5525bebf11b64aff0b56a98bd6664b4cc6
 pkg/rt/core_compiled.lgb pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_compiled.lgb pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_compiled.lgb pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a
@@ -580,7 +580,7 @@ pkg/rt/core_go_lowered/ pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2a
 pkg/rt/core_go_lowered/ pkg/vm/value.go generator 9c00df4c29b70dc9fea057628152cf139bdc73abc75d8666877fb7bf94be8c96
 pkg/rt/core_go_lowered/ pkg/vm/var.go generator 816e670512bc08f78a6d8a39bd8280dea82b171454ac99a54be2595942aee39d
 pkg/rt/core_go_lowered/ pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_go_lowered/ pkg/vm/vm.go generator c9eac4f6738ae3267a18e771575da28531cceff76afa7e89ef31e95534612df6
+pkg/rt/core_go_lowered/ pkg/vm/vm.go generator 9dd0383eeabc14f34f3cea1e1bb40e5525bebf11b64aff0b56a98bd6664b4cc6
 pkg/rt/core_go_lowered/ pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_go_lowered/ pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_go_lowered/ pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-7eb6880f3306ddc72a42e6da970c3871fbe8084a2a172ab2827c5d0f45ba493f
+a90b27cc2b0de87d7919dbe644cc6b7238d005ed2b0dcfe6703c8904c49696da

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -914,6 +914,16 @@ func errBitOpType(name string) error {
 	return fmt.Errorf("%s expected Int", name)
 }
 
+// debugTraceInst prints the per-instruction trace when frame tracing is on.
+// Kept out of line so the fmt varargs boxing does not sit at the top of the
+// dispatch loop's hottest block.
+//
+//go:noinline
+func debugTraceInst(f *Frame, inst int32) {
+	f.stackDbg()
+	fmt.Println("#", f.ip, OpcodeToString(inst))
+}
+
 func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error) {
 	if entering {
 		enterFrame(f)
@@ -921,8 +931,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 	for {
 		inst := f.code.code[f.ip]
 		if f.debug {
-			f.stackDbg()
-			fmt.Println("#", f.ip, OpcodeToString(inst))
+			debugTraceInst(f, inst)
 		}
 		if f.profileOn {
 			currOp := uint8(inst & 0xff)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -867,6 +867,53 @@ func (f *Frame) runLoopAttr(state *frameRunState, entering bool) (Value, error) 
 	return f.runLoopInner(state, entering)
 }
 
+// Cold-path error constructors, kept out of runLoopInner. Error construction
+// only runs on failure, but when the constructor bodies (fmt varargs setup,
+// struct literals, source-map lookups) are inlined into the ~25KB dispatch
+// function they enlarge it and degrade its register allocation (the #706/#719
+// FrameDispatch fragility). //go:noinline keeps each body a plain call so the
+// hot function stays small.
+
+//go:noinline
+func execErr(msg string) error {
+	return NewExecutionError(msg)
+}
+
+//go:noinline
+func execWrap(msg string, err error) error {
+	return NewExecutionError(msg).Wrap(err)
+}
+
+//go:noinline
+func errNotAFunction(v Value) error {
+	return NewTypeError(v, "is not a function", nil)
+}
+
+// wrapCallErr attributes err to the call at f.ip, naming the callee. Same
+// message shape as wrapCallSite, but for the in-arm sites where the callee fn
+// is already in hand.
+//
+//go:noinline
+func wrapCallErr(f *Frame, fn Fn, err error) error {
+	srcInfo := f.code.LookupSource(f.ip)
+	return NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
+}
+
+//go:noinline
+func errIntOverflow() error {
+	return NewExecutionError("integer overflow")
+}
+
+//go:noinline
+func errDivByZero() error {
+	return NewExecutionError("integer division by zero")
+}
+
+//go:noinline
+func errBitOpType(name string) error {
+	return fmt.Errorf("%s expected Int", name)
+}
+
 func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error) {
 	if entering {
 		enterFrame(f)
@@ -889,29 +936,29 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 		case OP_LOAD_CONST:
 			idx := f.code.code[f.ip+1]
 			if int(idx) >= f.constsc {
-				return NIL, NewExecutionError("const lookup out of bounds")
+				return NIL, execErr("const lookup out of bounds")
 			}
 			err := f.push(f.consts.get(int(idx)))
 			if err != nil {
-				return NIL, NewExecutionError("const push failed").Wrap(err)
+				return NIL, execWrap("const push failed", err)
 			}
 			f.ip += 2
 
 		case OP_LOAD_ARG:
 			idx := f.code.code[f.ip+1]
 			if int(idx) >= f.argc {
-				return NIL, NewExecutionError("argument lookup out of bounds")
+				return NIL, execErr("argument lookup out of bounds")
 			}
 			err := f.push(f.args[idx])
 			if err != nil {
-				return NIL, NewExecutionError("argument push failed").Wrap(err)
+				return NIL, execWrap("argument push failed", err)
 			}
 			f.ip += 2
 
 		case OP_RETURN:
 			v, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("return failed").Wrap(err)
+				return NIL, execWrap("return failed", err)
 			}
 			if f.parent == nil {
 				return v, nil
@@ -931,10 +978,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 				return NIL, callErr
 			}
 			if e := f.drop(callArity + 1); e != nil {
-				return NIL, NewExecutionError("cleaning stack after call").Wrap(e)
+				return NIL, execWrap("cleaning stack after call", e)
 			}
 			if e := f.push(v); e != nil {
-				return NIL, NewExecutionError("pushing return value failed").Wrap(e)
+				return NIL, execWrap("pushing return value failed", e)
 			}
 			f.ip += 2
 
@@ -944,20 +991,19 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			if arity > 0 {
 				fraw, err := f.nth(int(arity))
 				if err != nil {
-					return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
+					return NIL, execWrap("invoke instruction failed", err)
 				}
 				fn, ok := AsFn(fraw)
 				if !ok {
-					return NIL, NewTypeError(fraw, "is not a function", nil)
+					return NIL, errNotAFunction(fraw)
 				}
 				a, err := f.mult(0, int(arity))
 				if err != nil {
-					return NIL, NewExecutionError("popping arguments failed").Wrap(err)
+					return NIL, execWrap("popping arguments failed", err)
 				}
 				target, direct, cerr := resolveBytecodeCall(fn, a)
 				if cerr != nil {
-					srcInfo := f.code.LookupSource(f.ip)
-					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(cerr)
+					wrapped := wrapCallErr(f, fn, cerr)
 					if f.handleError(wrapped) {
 						continue
 					}
@@ -973,8 +1019,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 				}
 				out, err = f.ec.Invoke(fn, a)
 				if err != nil {
-					srcInfo := f.code.LookupSource(f.ip)
-					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
+					wrapped := wrapCallErr(f, fn, err)
 					if f.handleError(wrapped) {
 						continue
 					}
@@ -982,23 +1027,22 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 				}
 				err = f.drop(int(arity) + 1)
 				if err != nil {
-					return NIL, NewExecutionError("cleaning stack after call").Wrap(err)
+					return NIL, execWrap("cleaning stack after call", err)
 				}
 			} else {
 				// Peek rather than pop, so the callee slot remains for the
 				// uniform drop(arity+1) when a descended child returns.
 				fraw, err := f.nth(0)
 				if err != nil {
-					return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
+					return NIL, execWrap("invoke instruction failed", err)
 				}
 				fn, ok := AsFn(fraw)
 				if !ok {
-					return NIL, NewTypeError(fraw, "is not a function", nil)
+					return NIL, errNotAFunction(fraw)
 				}
 				target, direct, cerr := resolveBytecodeCall(fn, nil)
 				if cerr != nil {
-					srcInfo := f.code.LookupSource(f.ip)
-					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(cerr)
+					wrapped := wrapCallErr(f, fn, cerr)
 					if f.handleError(wrapped) {
 						continue
 					}
@@ -1013,12 +1057,11 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 					continue
 				}
 				if _, perr := f.pop(); perr != nil {
-					return NIL, NewExecutionError("invoke instruction failed").Wrap(perr)
+					return NIL, execWrap("invoke instruction failed", perr)
 				}
 				out, err = f.ec.Invoke(fn, nil)
 				if err != nil {
-					srcInfo := f.code.LookupSource(f.ip)
-					wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
+					wrapped := wrapCallErr(f, fn, err)
 					if f.handleError(wrapped) {
 						continue
 					}
@@ -1027,7 +1070,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			}
 			err := f.push(out)
 			if err != nil {
-				return NIL, NewExecutionError("pushing return value failed").Wrap(err)
+				return NIL, execWrap("pushing return value failed", err)
 			}
 			f.ip += 2
 
@@ -1037,24 +1080,23 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			// return path can use one drop(arity+1) protocol for every arity.
 			fraw, err := f.nth(int(arity))
 			if err != nil {
-				return NIL, NewExecutionError("invoke instruction failed").Wrap(err)
+				return NIL, execWrap("invoke instruction failed", err)
 			}
 			fn, ok := AsFn(fraw)
 			if !ok {
-				return NIL, NewTypeError(fraw, "is not a function", nil)
+				return NIL, errNotAFunction(fraw)
 			}
 			var a []Value
 			if arity > 0 {
 				a, err = f.mult(0, int(arity))
 				if err != nil {
-					return NIL, NewExecutionError("popping arguments failed").Wrap(err)
+					return NIL, execWrap("popping arguments failed", err)
 				}
 			}
 
 			target, direct, resolveErr := resolveBytecodeCall(fn, a)
 			if resolveErr != nil {
-				srcInfo := f.code.LookupSource(f.ip)
-				wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(resolveErr)
+				wrapped := wrapCallErr(f, fn, resolveErr)
 				if f.handleError(wrapped) {
 					continue
 				}
@@ -1078,8 +1120,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 
 			out, err := f.ec.Invoke(fn, a)
 			if err != nil {
-				srcInfo := f.code.LookupSource(f.ip)
-				wrapped := NewExecutionError(fmt.Sprintf("calling %s", fnName(fn))).WithSource(srcInfo).Wrap(err)
+				wrapped := wrapCallErr(f, fn, err)
 				if f.handleError(wrapped) {
 					continue
 				}
@@ -1089,10 +1130,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			// on the compiler-emitted RETURN so frame-chain unwind remains
 			// centralized in OP_RETURN.
 			if e := f.drop(int(arity) + 1); e != nil {
-				return NIL, NewExecutionError("cleaning stack after call").Wrap(e)
+				return NIL, execWrap("cleaning stack after call", e)
 			}
 			if e := f.push(out); e != nil {
-				return NIL, NewExecutionError("pushing return value failed").Wrap(e)
+				return NIL, execWrap("pushing return value failed", e)
 			}
 			f.ip += 2
 			continue
@@ -1101,7 +1142,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			offset := f.code.code[f.ip+1]
 			v, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("BRANCH_TRUE pop condition").Wrap(err)
+				return NIL, execWrap("BRANCH_TRUE pop condition", err)
 			}
 			if !IsTruthy(v) {
 				f.ip += 2
@@ -1113,7 +1154,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			offset := f.code.code[f.ip+1]
 			v, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("BRANCH_FALSE pop condition").Wrap(err)
+				return NIL, execWrap("BRANCH_FALSE pop condition", err)
 			}
 			if IsTruthy(v) {
 				f.ip += 2
@@ -1128,23 +1169,23 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 		case OP_POP:
 			_, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("POP failed").Wrap(err)
+				return NIL, execWrap("POP failed", err)
 			}
 			f.ip++
 
 		case OP_POP_N:
 			v, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("POP_N top value").Wrap(err)
+				return NIL, execWrap("POP_N top value", err)
 			}
 			num := f.code.code[f.ip+1]
 			err = f.drop(int(num))
 			if err != nil {
-				return NIL, NewExecutionError("POP_N drop").Wrap(err)
+				return NIL, execWrap("POP_N drop", err)
 			}
 			err = f.push(v)
 			if err != nil {
-				return NIL, NewExecutionError("POP_N push").Wrap(err)
+				return NIL, execWrap("POP_N push", err)
 			}
 			f.ip += 2
 
@@ -1152,26 +1193,26 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			num := f.code.code[f.ip+1]
 			val, err := f.nth(int(num))
 			if err != nil {
-				return NIL, NewExecutionError("DUP_NTH get nth").Wrap(err)
+				return NIL, execWrap("DUP_NTH get nth", err)
 			}
 			err = f.push(val)
 			if err != nil {
-				return NIL, NewExecutionError("DUP_NTH push").Wrap(err)
+				return NIL, execWrap("DUP_NTH push", err)
 			}
 			f.ip += 2
 
 		case OP_SET_VAR:
 			val, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("SET_VAR pop value failed").Wrap(err)
+				return NIL, execWrap("SET_VAR pop value failed", err)
 			}
 			varr, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("SET_VAR pop var failed").Wrap(err)
+				return NIL, execWrap("SET_VAR pop var failed", err)
 			}
 			varrd, ok := varr.(*Var)
 			if !ok {
-				return NIL, NewExecutionError("SET_VAR invalid Var").Wrap(err)
+				return NIL, execWrap("SET_VAR invalid Var", err)
 			}
 			// (set! *v* val) mutates the current execution's top dynamic
 			// binding (thread-local, matching Clojure) when one is active.
@@ -1188,32 +1229,32 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			armTraceIfTruthy(varrd, val)
 			err = f.push(varr)
 			if err != nil {
-				return NIL, NewExecutionError("SET_VAR push var failed").Wrap(err)
+				return NIL, execWrap("SET_VAR push var failed", err)
 			}
 			f.ip++
 
 		case OP_LOAD_VAR:
 			idx := f.code.code[f.ip+1]
 			if int(idx) >= f.constsc {
-				return NIL, NewExecutionError("const lookup out of bounds")
+				return NIL, execErr("const lookup out of bounds")
 			}
 			err := f.push(f.ec.deref(f.consts.get(int(idx)).(*Var)))
 			if err != nil {
-				return NIL, NewExecutionError("const push failed").Wrap(err)
+				return NIL, execWrap("const push failed", err)
 			}
 			f.ip += 2
 
 		case OP_MAKE_CLOSURE:
 			idx := f.sp - 1
 			if idx < 0 {
-				return NIL, NewExecutionError("MAKE_CLOSURE stack underflow")
+				return NIL, execErr("MAKE_CLOSURE stack underflow")
 			}
 			type closureCreator interface {
 				MakeClosure() Fn
 			}
 			fn, ok := f.stack[idx].(closureCreator)
 			if !ok {
-				return NIL, NewExecutionError("MAKE_CLOSURE invalid func on stack")
+				return NIL, execErr("MAKE_CLOSURE invalid func on stack")
 			}
 			f.stack[idx] = fn.MakeClosure()
 			f.ip++
@@ -1221,30 +1262,30 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 		case OP_LOAD_CLOSEDOVER:
 			idx := f.code.code[f.ip+1]
 			if int(idx) >= len(f.closedOvers) {
-				return NIL, NewExecutionError("closed over lookup out of bounds")
+				return NIL, execErr("closed over lookup out of bounds")
 			}
 			err := f.push(f.closedOvers[idx])
 			if err != nil {
-				return NIL, NewExecutionError("closed over push failed").Wrap(err)
+				return NIL, execWrap("closed over push failed", err)
 			}
 			f.ip += 2
 
 		case OP_PUSH_CLOSEDOVER:
 			val, err := f.pop()
 			if err != nil {
-				return NIL, NewExecutionError("popping closed over value failed").Wrap(err)
+				return NIL, execWrap("popping closed over value failed", err)
 			}
 			idx := f.sp - 1
 			if idx < 0 {
-				return NIL, NewExecutionError("PUSH_CLOSEDOVER stack overflow").Wrap(err)
+				return NIL, execWrap("PUSH_CLOSEDOVER stack overflow", err)
 			}
 			cls := f.stack[idx]
 			if cls.Type() != FuncType {
-				return NIL, NewExecutionError("PUSH_CLOSEDOVER expected a Fn")
+				return NIL, execErr("PUSH_CLOSEDOVER expected a Fn")
 			}
 			fun, ok := cls.(*Closure)
 			if !ok {
-				return NIL, NewExecutionError("PUSH_CLOSEDOVER invalid closure on stack")
+				return NIL, execErr("PUSH_CLOSEDOVER invalid closure on stack")
 			}
 			fun.closedOvers = append(fun.closedOvers, val)
 			f.ip++
@@ -1253,7 +1294,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			arity := f.code.code[f.ip+1]
 			a, err := f.mult(0, int(arity))
 			if err != nil {
-				return NIL, NewExecutionError("popping arguments failed").Wrap(err)
+				return NIL, execWrap("popping arguments failed", err)
 			}
 			copy(f.args, a)
 			f.argc = int(arity)
@@ -1266,15 +1307,15 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			ignore := f.code.code[f.ip+3]
 			a, err := f.mult(0, int(argc))
 			if err != nil {
-				return NIL, NewExecutionError("RECUR popping arguments failed").Wrap(err)
+				return NIL, execWrap("RECUR popping arguments failed", err)
 			}
 			err = f.drop(int(argc)*2 + int(ignore))
 			if err != nil {
-				return NIL, NewExecutionError("RECUR popping old locals").Wrap(err)
+				return NIL, execWrap("RECUR popping old locals", err)
 			}
 			err = f.pushMult(a)
 			if err != nil {
-				return NIL, NewExecutionError("RECUR pushing new locals").Wrap(err)
+				return NIL, execWrap("RECUR pushing new locals", err)
 			}
 
 			f.ip -= int(offset)
@@ -1284,18 +1325,18 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			n := int(nfns)
 			fns, err := f.mult(0, n)
 			if err != nil {
-				return NIL, NewExecutionError("MAKE_MULTI_ARITY popping arguments failed").Wrap(err)
+				return NIL, execWrap("MAKE_MULTI_ARITY popping arguments failed", err)
 			}
 			f.sp -= n
 
 			fn, err := MakeMultiArity(fns)
 			if err != nil {
-				return NIL, NewExecutionError("MAKE_MULTI_ARITY failed").Wrap(err)
+				return NIL, execWrap("MAKE_MULTI_ARITY failed", err)
 			}
 
 			err = f.push(fn)
 			if err != nil {
-				return NIL, NewExecutionError("MAKE_MULTI_ARITY push failed").Wrap(err)
+				return NIL, execWrap("MAKE_MULTI_ARITY push failed", err)
 			}
 
 			f.ip += 2
@@ -1365,10 +1406,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 				if bi, ok := b.(Int); ok {
 					r, ok := checkedAddInt(ai, bi)
 					if !ok {
-						if f.handleError(NewExecutionError("integer overflow")) {
+						if f.handleError(errIntOverflow()) {
 							continue
 						}
-						return NIL, NewExecutionError("integer overflow")
+						return NIL, errIntOverflow()
 					}
 					f.stack[f.sp-2] = r
 					f.sp--
@@ -1394,10 +1435,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 				if bi, ok := b.(Int); ok {
 					r, ok := checkedSubInt(ai, bi)
 					if !ok {
-						if f.handleError(NewExecutionError("integer overflow")) {
+						if f.handleError(errIntOverflow()) {
 							continue
 						}
-						return NIL, NewExecutionError("integer overflow")
+						return NIL, errIntOverflow()
 					}
 					f.stack[f.sp-2] = r
 					f.sp--
@@ -1423,10 +1464,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 				if bi, ok := b.(Int); ok {
 					r, ok := checkedMulInt(ai, bi)
 					if !ok {
-						if f.handleError(NewExecutionError("integer overflow")) {
+						if f.handleError(errIntOverflow()) {
 							continue
 						}
-						return NIL, NewExecutionError("integer overflow")
+						return NIL, errIntOverflow()
 					}
 					f.stack[f.sp-2] = r
 					f.sp--
@@ -1450,17 +1491,17 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-2]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-and expected Int")) {
+				if f.handleError(errBitOpType("bit-and")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-and expected Int")
+				return NIL, errBitOpType("bit-and")
 			}
 			bi, ok := b.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-and expected Int")) {
+				if f.handleError(errBitOpType("bit-and")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-and expected Int")
+				return NIL, errBitOpType("bit-and")
 			}
 			f.stack[f.sp-2] = MakeInt(int(ai) & int(bi))
 			f.sp--
@@ -1471,17 +1512,17 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-2]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-or expected Int")) {
+				if f.handleError(errBitOpType("bit-or")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-or expected Int")
+				return NIL, errBitOpType("bit-or")
 			}
 			bi, ok := b.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-or expected Int")) {
+				if f.handleError(errBitOpType("bit-or")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-or expected Int")
+				return NIL, errBitOpType("bit-or")
 			}
 			f.stack[f.sp-2] = MakeInt(int(ai) | int(bi))
 			f.sp--
@@ -1492,17 +1533,17 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-2]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-xor expected Int")) {
+				if f.handleError(errBitOpType("bit-xor")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-xor expected Int")
+				return NIL, errBitOpType("bit-xor")
 			}
 			bi, ok := b.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-xor expected Int")) {
+				if f.handleError(errBitOpType("bit-xor")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-xor expected Int")
+				return NIL, errBitOpType("bit-xor")
 			}
 			f.stack[f.sp-2] = MakeInt(int(ai) ^ int(bi))
 			f.sp--
@@ -1513,17 +1554,17 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-2]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-and-not expected Int")) {
+				if f.handleError(errBitOpType("bit-and-not")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-and-not expected Int")
+				return NIL, errBitOpType("bit-and-not")
 			}
 			bi, ok := b.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-and-not expected Int")) {
+				if f.handleError(errBitOpType("bit-and-not")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-and-not expected Int")
+				return NIL, errBitOpType("bit-and-not")
 			}
 			f.stack[f.sp-2] = MakeInt(int(ai) &^ int(bi))
 			f.sp--
@@ -1534,17 +1575,17 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-2]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-shift-left expected Int")) {
+				if f.handleError(errBitOpType("bit-shift-left")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-shift-left expected Int")
+				return NIL, errBitOpType("bit-shift-left")
 			}
 			bi, ok := b.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-shift-left expected Int")) {
+				if f.handleError(errBitOpType("bit-shift-left")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-shift-left expected Int")
+				return NIL, errBitOpType("bit-shift-left")
 			}
 			f.stack[f.sp-2] = MakeInt(int(ai) << uint(bi))
 			f.sp--
@@ -1555,17 +1596,17 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-2]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-shift-right expected Int")) {
+				if f.handleError(errBitOpType("bit-shift-right")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-shift-right expected Int")
+				return NIL, errBitOpType("bit-shift-right")
 			}
 			bi, ok := b.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-shift-right expected Int")) {
+				if f.handleError(errBitOpType("bit-shift-right")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-shift-right expected Int")
+				return NIL, errBitOpType("bit-shift-right")
 			}
 			f.stack[f.sp-2] = MakeInt(int(ai) >> uint(bi))
 			f.sp--
@@ -1576,17 +1617,17 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-2]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("unsigned-bit-shift-right expected Int")) {
+				if f.handleError(errBitOpType("unsigned-bit-shift-right")) {
 					continue
 				}
-				return NIL, fmt.Errorf("unsigned-bit-shift-right expected Int")
+				return NIL, errBitOpType("unsigned-bit-shift-right")
 			}
 			bi, ok := b.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("unsigned-bit-shift-right expected Int")) {
+				if f.handleError(errBitOpType("unsigned-bit-shift-right")) {
 					continue
 				}
-				return NIL, fmt.Errorf("unsigned-bit-shift-right expected Int")
+				return NIL, errBitOpType("unsigned-bit-shift-right")
 			}
 			f.stack[f.sp-2] = MakeInt(int(uint(ai) >> uint(bi)))
 			f.sp--
@@ -1598,10 +1639,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			if ai, ok := a.(Int); ok {
 				if bi, ok := b.(Int); ok {
 					if bi == 0 {
-						if f.handleError(NewExecutionError("integer division by zero")) {
+						if f.handleError(errDivByZero()) {
 							continue
 						}
-						return NIL, NewExecutionError("integer division by zero")
+						return NIL, errDivByZero()
 					}
 					// Int quot is truncated toward zero — Go's / on
 					// signed ints matches Clojure's quot semantics.
@@ -1644,10 +1685,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			a := f.stack[f.sp-1]
 			ai, ok := a.(Int)
 			if !ok {
-				if f.handleError(fmt.Errorf("bit-not expected Int")) {
+				if f.handleError(errBitOpType("bit-not")) {
 					continue
 				}
-				return NIL, fmt.Errorf("bit-not expected Int")
+				return NIL, errBitOpType("bit-not")
 			}
 			f.stack[f.sp-1] = MakeInt(^int(ai))
 			f.ip++
@@ -1770,10 +1811,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			if ai, ok := a.(Int); ok {
 				r, ok := checkedAddInt(ai, 1)
 				if !ok {
-					if f.handleError(NewExecutionError("integer overflow")) {
+					if f.handleError(errIntOverflow()) {
 						continue
 					}
-					return NIL, NewExecutionError("integer overflow")
+					return NIL, errIntOverflow()
 				}
 				f.stack[f.sp-1] = r
 				f.ip++
@@ -1794,10 +1835,10 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			if ai, ok := a.(Int); ok {
 				r, ok := checkedSubInt(ai, 1)
 				if !ok {
-					if f.handleError(NewExecutionError("integer overflow")) {
+					if f.handleError(errIntOverflow()) {
 						continue
 					}
-					return NIL, NewExecutionError("integer overflow")
+					return NIL, errIntOverflow()
 				}
 				f.stack[f.sp-1] = r
 				f.ip++
@@ -1814,7 +1855,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			f.ip++
 
 		default:
-			return NIL, NewExecutionError("unknown instruction")
+			return NIL, execErr("unknown instruction")
 		}
 	}
 }


### PR DESCRIPTION
Stacked on #719. The repeat A/B there found one real cost: `FrameDispatch` +5.8% median, the register-allocation sensitivity of restructuring the large dispatch function (#706's mechanism notes). This change shrinks that function's hot text so the allocator has a smaller region to solve: eight `//go:noinline` helpers absorb the cold arms — error construction and wrapping (`execErr`/`execWrap`/`wrapCallErr`), the not-a-function, integer overflow, divide-by-zero, and bit-op type errors — across 98 sites, plus one hoist of the per-instruction debug print. `runLoopInner` text drops from 25,872 to 20,384 bytes (−21%). Error output is byte-identical; behavior is unchanged.

Draft, `perf-repeat` label, because the claim needs the amd64 lane to decide it: on darwin/arm64 the +5.8% `FrameDispatch` regression does not reproduce at all — the base branch already runs the dispatch loop at parity with main there — so local measurement can only establish no harm, which it does (dispatch and `some` flat vs base across interleaved batches; the base branch's invoke-family wins survive intact at 1.22–1.26× vs main). If the repeat A/B shows `FrameDispatch` reclaimed, this erases the one cost on #719's trade; if flat, it is a hot-function shrink with no perf claim and can be judged on maintainability alone.

The two commits are separately bisectable (helpers, then the debug-print hoist).

Verified: `pkg/vm`, `pkg/rt`, and `test/` suites; linux, js/wasm, and plan9 builds; error-message byte-parity checked against the base branch.
