### PR TITLE
perf(vm): remove the runLoop hop; make leaveFrame parameter-free

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -266,7 +266,7 @@ pkg/rt/core_compiled.lgb pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2
 pkg/rt/core_compiled.lgb pkg/vm/value.go generator 9c00df4c29b70dc9fea057628152cf139bdc73abc75d8666877fb7bf94be8c96
 pkg/rt/core_compiled.lgb pkg/vm/var.go generator 816e670512bc08f78a6d8a39bd8280dea82b171454ac99a54be2595942aee39d
 pkg/rt/core_compiled.lgb pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_compiled.lgb pkg/vm/vm.go generator 9dd0383eeabc14f34f3cea1e1bb40e5525bebf11b64aff0b56a98bd6664b4cc6
+pkg/rt/core_compiled.lgb pkg/vm/vm.go generator 74440788fc7cbe3cf1b81d8e0cb713d6a2841b205eafc0c58472e084c6d2d4c9
 pkg/rt/core_compiled.lgb pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_compiled.lgb pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_compiled.lgb pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a
@@ -580,7 +580,7 @@ pkg/rt/core_go_lowered/ pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2a
 pkg/rt/core_go_lowered/ pkg/vm/value.go generator 9c00df4c29b70dc9fea057628152cf139bdc73abc75d8666877fb7bf94be8c96
 pkg/rt/core_go_lowered/ pkg/vm/var.go generator 816e670512bc08f78a6d8a39bd8280dea82b171454ac99a54be2595942aee39d
 pkg/rt/core_go_lowered/ pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_go_lowered/ pkg/vm/vm.go generator 9dd0383eeabc14f34f3cea1e1bb40e5525bebf11b64aff0b56a98bd6664b4cc6
+pkg/rt/core_go_lowered/ pkg/vm/vm.go generator 74440788fc7cbe3cf1b81d8e0cb713d6a2841b205eafc0c58472e084c6d2d4c9
 pkg/rt/core_go_lowered/ pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_go_lowered/ pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_go_lowered/ pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-a90b27cc2b0de87d7919dbe644cc6b7238d005ed2b0dcfe6703c8904c49696da
+0f6482760f75b9a77c650e0f14b5346770a1ba56e3e87a8011209fd24387d246

--- a/pkg/vm/explicit_frame_test.go
+++ b/pkg/vm/explicit_frame_test.go
@@ -381,3 +381,85 @@ func TestDescendedErrorReleasesChildFrame(t *testing.T) {
 	}
 	ReleaseFrame(root)
 }
+
+// rawPanicFn panics with a plain Go value when invoked. It deliberately does
+// NOT wrap itself in RecoverPanic the way NativeFn does: ec.Invoke's default
+// arm calls it bare, so the panic unwinds through the live dispatch loop —
+// the path releasePanickedFrames (attribution on) and the documented
+// leak-to-GC trade (attribution off) exist for.
+type rawPanicFn struct{ payload string }
+
+func (p *rawPanicFn) String() string                { return "<raw-panic-fn>" }
+func (p *rawPanicFn) Type() ValueType               { return NativeFnType }
+func (p *rawPanicFn) Unbox() any                    { return p }
+func (p *rawPanicFn) Arity() int                    { return 0 }
+func (p *rawPanicFn) Invoke([]Value) (Value, error) { panic(p.payload) }
+
+// A Go panic escaping a native while the chain is mid-descent must be
+// preserved as-is, and the pool must see the currently-intended behavior in
+// BOTH configurations: with attribution on, runChainProtected releases the
+// suspended chain's pooled frames; with attribution off (the default), Run is
+// deliberately defer-free and the frames leak to GC — pre-#645 parity, per
+// Run's doc comment. A future change that reintroduces a must-release-on-panic
+// invariant on the default path has to update this test consciously.
+func TestPanicUnwindingDescendedFramePinsPoolBehavior(t *testing.T) {
+	framePoolMu.Lock()
+	oldPool := framePoolStack
+	framePoolStack = nil
+	framePoolMu.Unlock()
+	t.Cleanup(func() {
+		framePoolMu.Lock()
+		clear(framePoolStack)
+		framePoolStack = oldPool
+		framePoolMu.Unlock()
+	})
+
+	// child (bytecode, arity 1): invoke its argument — the raw-panicking fn.
+	consts := NewConsts()
+	childChunk := NewCodeChunk(consts)
+	childChunk.Append(OP_LOAD_ARG)
+	childChunk.Append32(0)
+	childChunk.Append(OP_INVOKE)
+	childChunk.Append32(0)
+	childChunk.Append(OP_RETURN)
+	childChunk.SetMaxStack(4)
+	child := MakeFunc(1, false, childChunk)
+
+	// root: descend into child with the panicking fn as the argument, so the
+	// panic fires while root is a suspended parent of a live pooled frame.
+	rootChunk := NewCodeChunk(consts)
+	rootChunk.Append(OP_LOAD_CONST)
+	rootChunk.Append32(consts.Intern(child))
+	rootChunk.Append(OP_LOAD_ARG)
+	rootChunk.Append32(0)
+	rootChunk.Append(OP_INVOKE)
+	rootChunk.Append32(1)
+	rootChunk.Append(OP_RETURN)
+	rootChunk.SetMaxStack(4)
+
+	root := NewFrame(rootChunk, []Value{&rawPanicFn{payload: "raw-panic-719"}})
+	root.ec = RootExecContext
+
+	recovered := func() (r any) {
+		defer func() { r = recover() }()
+		_, _ = root.Run()
+		return nil
+	}()
+	if recovered != "raw-panic-719" {
+		t.Fatalf("panic was not preserved through the dispatch loop: got %v", recovered)
+	}
+
+	framePoolMu.Lock()
+	pooled := append([]*Frame(nil), framePoolStack...)
+	framePoolMu.Unlock()
+	if allocAttrEnabled {
+		if len(pooled) != 1 {
+			t.Fatalf("attribution on: panicked child not released exactly once: pool has %d frames", len(pooled))
+		}
+	} else {
+		if len(pooled) != 0 {
+			t.Fatalf("default config: panic path released %d frame(s); the intended behavior is leak-to-GC (update this test if that changed on purpose)", len(pooled))
+		}
+	}
+	ReleaseFrame(root)
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -744,7 +744,11 @@ func enterFrame(f *Frame) {
 	f.profileOn = ProfilingEnabled.Load()
 }
 
-func leaveFrame(_ *Frame) {
+// leaveFrame takes no frame on purpose: attribution keeps its own shadow
+// stack, and a parameter here invites passing a frame that may already be
+// back in the pool (OP_RETURN releases the child before state.current is
+// rebound). No parameter, no use-after-release to reason about.
+func leaveFrame() {
 	if allocAttrEnabled {
 		attrPopFrame()
 	}
@@ -767,7 +771,7 @@ func releaseFailedFrames(state *frameRunState, err error) (*Frame, error) {
 			state.current = parent
 			return parent, err
 		}
-		leaveFrame(parent)
+		leaveFrame()
 		parent.parent = nil
 		if parent != state.root {
 			ReleaseFrame(parent)
@@ -786,7 +790,7 @@ func releasePanickedFrames(state *frameRunState) {
 	}
 	for parent != nil {
 		next := parent.parent
-		leaveFrame(parent)
+		leaveFrame()
 		parent.parent = nil
 		if parent != state.root {
 			ReleaseFrame(parent)
@@ -795,7 +799,7 @@ func releasePanickedFrames(state *frameRunState) {
 	}
 }
 
-// Run executes this frame to completion. runLoop descends into bytecode
+// Run executes this frame to completion. The dispatch loop descends into bytecode
 // callees within one dispatch loop, keeping the Go stack flat. A parent link
 // on each live frame carries the suspended call chain without a retained slice.
 func (f *Frame) Run() (result Value, resultErr error) {
@@ -820,7 +824,7 @@ func (f *Frame) Run() (result Value, resultErr error) {
 func runChainProtected(state *frameRunState) (result Value, resultErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			// runLoop's attr wrapper already left the current frame. Balance and
+			// runLoopAttr already left the current frame. Balance and
 			// release every suspended child-owned frame before preserving the panic.
 			releasePanickedFrames(state)
 			panic(r)
@@ -830,11 +834,22 @@ func runChainProtected(state *frameRunState) (result Value, resultErr error) {
 }
 
 // runChain drives the dispatch loop and the error-resume protocol for the
-// frame chain rooted at state.root.
+// frame chain rooted at state.root. The attribution gate lives here, hoisted
+// out of the loop: a dispatcher function between runChain and the loop would
+// be too big to inline (runLoopInner far exceeds the inlining budget), so it
+// would cost a real call on every host->VM entry and every error-resume
+// iteration. A defer statement inside the bare loop itself would cost
+// deferreturn scaffolding on every VM entry, so the deferring variant stays
+// a separate function.
 func runChain(state *frameRunState) (result Value, resultErr error) {
 	entering := true
+	attr := allocAttrEnabled
 	for {
-		result, resultErr = state.current.runLoop(state, entering)
+		if attr {
+			result, resultErr = state.current.runLoopAttr(state, entering)
+		} else {
+			result, resultErr = state.current.runLoopInner(state, entering)
+		}
 		entering = false
 		if resultErr == nil {
 			return result, nil
@@ -847,23 +862,12 @@ func runChain(state *frameRunState) (result Value, resultErr error) {
 	}
 }
 
-// runLoop dispatches to the attr-tracking wrapper or the bare loop. leaveFrame
-// is a no-op unless allocation attribution is on, and a defer statement inside
-// the dispatch loop itself would cost deferreturn scaffolding on every VM
-// entry, so the deferring variant is a separate function.
-func (f *Frame) runLoop(state *frameRunState, entering bool) (Value, error) {
-	if allocAttrEnabled {
-		return f.runLoopAttr(state, entering)
-	}
-	return f.runLoopInner(state, entering)
-}
-
 // runLoopAttr balances attrPopFrame for whichever logical frame is current
-// when the loop unwinds; suspended parents remain active. leaveFrame ignores
-// its argument (attribution keeps its own frame stack), so the wrapper can
-// leave on behalf of the loop without tracking its final frame.
+// when the loop unwinds; suspended parents remain active. Attribution keeps
+// its own frame stack, so the wrapper can leave on behalf of the loop without
+// tracking its final frame.
 func (f *Frame) runLoopAttr(state *frameRunState, entering bool) (Value, error) {
-	defer func() { leaveFrame(state.current) }()
+	defer leaveFrame()
 	return f.runLoopInner(state, entering)
 }
 
@@ -975,7 +979,7 @@ func (f *Frame) runLoopInner(state *frameRunState, entering bool) (Value, error)
 			child := f
 			parent := child.parent
 			child.parent = nil
-			leaveFrame(child)
+			leaveFrame()
 			ReleaseFrame(child)
 			f = parent
 			state.current = f


### PR DESCRIPTION
Draft until the stack ahead of it settles; I'll add `perf-repeat` for an EPYC adjudication once the queue is quiet.

Carries the three low-severity notes from #719's review as a stacked PR, so #719 merges as reviewed and its perf-repeat baseline stays put.

- **Fold the attribution gate into `runChain`.** `runLoop` was a dispatcher too big to inline (`cost 144 exceeds budget 80`), so the entry path paid `Run → runChain → runLoop → runLoopInner` — one non-inlined call more than needed on every host→VM entry and every error-resume iteration. The gate is now hoisted out of `runChain`'s loop and calls `runLoopAttr`/`runLoopInner` directly; `runLoop` is gone.
- **Drop `leaveFrame`'s parameter.** It took a `*Frame` it never read, and in `OP_RETURN` there is a window after `ReleaseFrame(child)` where `state.current` still points at the pooled frame — the first real use of the parameter would have been a use-after-release. With no parameter the invariant is structural, and `runLoopAttr`'s defer sheds its closure.
- **Pin the default-config panic path.** With `LG_ALLOC_ATTR` unset, `Run` is deliberately defer-free and a Go panic leaks the chain's pooled frames to GC (pre-#645 parity) — previously documented but untested. The new test panics a raw (unwrapped) callable inside a descended frame and asserts the panic value survives and the pool sees the intended behavior in both configurations: leak-to-GC with attribution off, exactly-once release via `runChainProtected` with it on.

Measured (interleaved go-bench medians, N=6, vs #719's head): `FrameDispatch` 0.94×, `FuncInvoke/Closure` 0.97×, `Direct` 1.00× — flat to slightly better, matching the review's own bench of the fold. 

Verified: `pkg/vm`, `pkg/rt`, `pkg/genmanifest`, `test/` suites; `go test -race ./pkg/vm`; both suites again with `LG_ALLOC_ATTR=1`; the new test passes in both configurations; linux, plan9, js/wasm builds.
