### PR TITLE
build: gate binaries by directory, and run the binary check on push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,12 +172,23 @@ AGENTS.md
 # Local goreleaser / cross-build artifacts
 /dist/
 
+# Build outputs. `build/` is where generated binaries land; `bin/` holds the
+# promoted current copy of lg and the tooling. Both are directory-scoped so a
+# new binary needs no new ignore entry — the per-binary list below exists for
+# outputs that still land at the repo root, and shrinks as they move.
+/build/
+/bin/
+
 # AOT codegen tool — built ad-hoc, not checked in
 /lgbgen
 /lginterop
 /lgprimgen
 /bench-ratchet
 /perf-page
+# `go build -o check-generated` output. Named after the make target, which is
+# how it evaded this list: every sibling binary above was added by hand when
+# someone noticed it, and this one was not noticed until it was staged.
+/check-generated
 
 # bench-ratchet streams per-bench results here on capture; the
 # aggregated baseline is in docs/perf/baseline.json (committed).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,12 +31,16 @@ repos:
       # `go build` output). Magic-byte based (Mach-O / ELF / PE), so it ignores
       # the repo's legitimate binary assets — the LGB core bundle and images.
       # No type filter: it must inspect every staged file's leading bytes.
+      # stages includes pre-push because a jj working copy is snapshotted by jj
+      # itself: `git commit` never runs, so the pre-commit stage never fires for
+      # a jj-based workflow. pre-push is the only gate those commits pass
+      # through, and it is where prek runs under jj-pre-push.
       - id: forbid-compiled-binaries
         name: forbid committing compiled executables
         description: Reject staged Mach-O / ELF / PE binaries before they bloat history
         entry: python3 scripts/reject_compiled_binaries.py
         language: system
-        stages: [pre-commit]
+        stages: [pre-commit, pre-push]
 
       # Auto-fix formatting before linters run. gofmt ships with Go.
       # goimports is fetched on demand via `go run ...@latest` so contributors


### PR DESCRIPTION
## Summary

Two changes, both about keeping compiled binaries out of the repository. No behaviour change to the build itself; moving the build outputs into `build/` and `bin/` is a separate change that this one prepares for.

## Why

Every generated binary needed its own `.gitignore` line — `/lgbgen`, `/lginterop`, `/lgprimgen`, `/bench-ratchet`, `/perf-page`, `/let-go`, `*.test` — and the list was maintained by noticing. `check-generated`, a `go build -o check-generated` output named after the make target, was never noticed. It is a 3.1 MB Mach-O arm64 executable and it was not ignored.

The only thing that had been keeping it out of a commit was jj's `snapshot.max-new-file-size` refusal at 1 MiB. That guard is content-addressed: once the same bytes exist in the store, an identical file is snapshotted without complaint. It failed exactly that way this week.

## Changes

**Directory-scoped ignores.** `/build/` for generated binaries, `/bin/` for the promoted current copy of `lg` and the tooling. A new binary then needs no new ignore entry, because the rule is a location rather than a name. The per-binary entries stay until those outputs move, and `/check-generated` joins them in the meantime.

**`forbid-compiled-binaries` now runs at pre-push as well as pre-commit.** A jj working copy is snapshotted by jj itself, so `git commit` never runs and the pre-commit stage never fires for a jj-based workflow. pre-push is the only gate those commits pass through, and it is where prek runs under `jj-pre-push`.

## Evidence

A/B in a scratch git repository with a staged Mach-O:

```
stages: [pre-commit, pre-push]
  forbid committing compiled executables ... Failed
    refusing to commit compiled executable binaries:
      stray-binary  (Mach-O executable (64-bit, LE))

stages: [pre-commit]        (control)
  (no output — the hook does not run at pre-push)
```

With the new ignore rules in place, `check-generated`, `build/lg` and `bin/lg` are all invisible to `jj status`, and `scripts/reject_compiled_binaries.py` still exits 1 on a staged one.

Gated push through `jj-pre-push` ran the full hook set on this commit, including `forbid committing compiled executables ... Passed`.

## Follow-up

Moving `$(LG)`, `$(LG-PROFILE)`, `.selfhost-lgbgen` and the `go test -c` outputs into `build/` and `bin/`, and shrinking the per-binary ignore list to nothing, is the next change. Live-tree consumers are `Makefile` (16 references), `scripts/*.lg` (~17), `test/language_test.go`, `test/benches/ysbench.sh`, `test/namespace_shadow_warning_test/run.sh`, `pkg/rt/wasm/browserinspector_test.go`, `cmd/lginterop/main.go` and a few `examples/`. `.github/workflows/` has no direct references — CI goes through `make`.