### PR TITLE
refactor(build): extract the generated-module scaffolding into pkg/gomod

### DIFF
--- a/pkg/gomod/gomod.go
+++ b/pkg/gomod/gomod.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
+ * SPDX-License-Identifier: MIT
+ */
+
+// Package gomod scaffolds the throwaway Go module that `lg` generates around
+// emitted Go sources before handing them to `go build`.
+//
+// It was extracted from the WASM build path, which was its only caller and had
+// the module name baked in. The AOT native path (nooga/let-go#596) needs the
+// same three behaviors — pin a released binary's require to its own version,
+// prefer a local source tree in dev builds, fall back to the module proxy — so
+// this exists to keep one implementation rather than two.
+package gomod
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ModulePath is the let-go module the generated module requires.
+const ModulePath = "github.com/nooga/let-go"
+
+// Files is a generated module's go.mod text and go.sum bytes. Sum is empty when
+// the local-source path supplied no go.sum.
+type Files struct {
+	Mod string
+	Sum []byte
+}
+
+// Generate produces go.mod/go.sum for a module named moduleName, to be written
+// in dir.
+//
+// version is the lg binary's own version string ("dev" for an unreleased
+// build). A released binary pins the require to its exact version so the
+// generated program builds against the runtime it was emitted by; a dev build
+// prefers the local source tree, and falls back to the module proxy at @latest
+// when there isn't one.
+func Generate(dir, moduleName, version string) (Files, error) {
+	if ref, ok := ReleaseRef(version); ok {
+		// Released binary: pin the require to this exact version. We can't
+		// return a nil go.sum (go build rejects a module with unresolved
+		// sums), so resolve it from the proxy the same way the no-source path
+		// below does. `go get` on the single require writes go.sum without the
+		// `go mod tidy` that the build step deliberately avoids.
+		return resolveFiles(dir, moduleName, ref)
+	}
+	// Dev build — try local source first
+	srcDir, err := FindLetGoSourceDir()
+	if err == nil {
+		return localFiles(srcDir, moduleName)
+	}
+	// No local source — resolve latest version from module proxy
+	return resolveFiles(dir, moduleName, ModulePath+"@latest")
+}
+
+// ReleaseRef reports the module ref a released binary should pin to, and
+// whether this version is a release at all. A version is a release when it
+// starts with a digit: "dev" and "" are not, so they fall through to the
+// local-source and proxy paths.
+func ReleaseRef(version string) (string, bool) {
+	if version == "dev" || version == "" || version[0] < '0' || version[0] > '9' {
+		return "", false
+	}
+	return ModulePath + "@v" + version, true
+}
+
+// resolveFiles scaffolds a minimal module in dir and resolves the let-go
+// require named by modRef via `go get`, returning the resulting go.mod and
+// go.sum. Used for both released binaries (pinned version) and dev builds with
+// no local source tree (@latest).
+func resolveFiles(dir, moduleName, modRef string) (Files, error) {
+	goMod := "module " + moduleName + "\n\ngo 1.26\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0644); err != nil {
+		return Files{}, err
+	}
+	get := exec.Command(GoToolPath(), "get", modRef)
+	get.Dir = dir
+	get.Stderr = os.Stderr
+	if err := get.Run(); err != nil {
+		return Files{}, fmt.Errorf("resolving let-go module: %w (set LETGO_SRC for local source)", err)
+	}
+	// go get wrote the go.mod with the resolved version — read it back
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return Files{}, err
+	}
+	sum, _ := os.ReadFile(filepath.Join(dir, "go.sum"))
+	return Files{Mod: string(data), Sum: sum}, nil
+}
+
+// localFiles rewrites the let-go checkout's own go.mod into one for moduleName
+// that requires let-go through a replace pointing back at srcDir, so a dev
+// build compiles against the working tree rather than a published version.
+func localFiles(srcDir, moduleName string) (Files, error) {
+	modData, err := os.ReadFile(filepath.Join(srcDir, "go.mod"))
+	if err != nil {
+		return Files{}, err
+	}
+	modText := strings.Replace(string(modData), "module "+ModulePath, "module "+moduleName, 1)
+	modText = strings.TrimRight(modText, "\n") + "\n\nrequire " + ModulePath + " v0.0.0\n"
+	modText = strings.TrimRight(modText, "\n") + fmt.Sprintf("\n\nreplace %s => %s\n", ModulePath, srcDir)
+	sumData, err := os.ReadFile(filepath.Join(srcDir, "go.sum"))
+	if err != nil && !os.IsNotExist(err) {
+		return Files{}, err
+	}
+	return Files{Mod: modText, Sum: sumData}, nil
+}
+
+// FindLetGoSourceDir locates a let-go checkout to build against: LETGO_SRC if
+// set, else the module root above the current directory, else the one above the
+// running executable.
+func FindLetGoSourceDir() (string, error) {
+	if src := os.Getenv("LETGO_SRC"); src != "" {
+		return src, nil
+	}
+	if dir := findModuleRoot(mustGetwd()); dir != "" {
+		return dir, nil
+	}
+	if exe, err := os.Executable(); err == nil {
+		if dir := findModuleRoot(filepath.Dir(exe)); dir != "" {
+			return dir, nil
+		}
+	}
+	return "", fmt.Errorf("cannot find let-go source tree (dev build); set LETGO_SRC or run from source directory")
+}
+
+func findModuleRoot(start string) string {
+	for d := start; d != "/" && d != "."; d = filepath.Dir(d) {
+		data, err := os.ReadFile(filepath.Join(d, "go.mod"))
+		if err == nil && strings.Contains(string(data), "module "+ModulePath) {
+			return d
+		}
+	}
+	return ""
+}
+
+func mustGetwd() string {
+	d, _ := os.Getwd()
+	return d
+}
+
+// GoToolPath returns the `go` binary to invoke, preferring the one under the
+// GOROOT this binary was built with so a build doesn't silently pick a
+// different toolchain off PATH.
+func GoToolPath() string {
+	if goroot := runtime.GOROOT(); goroot != "" {
+		if path := filepath.Join(goroot, "bin", "go"); fileExists(path) {
+			return path
+		}
+	}
+	return "go"
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/pkg/gomod/gomod_test.go
+++ b/pkg/gomod/gomod_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
+ * SPDX-License-Identifier: MIT
+ */
+
+package gomod
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestReleaseRef pins the released-vs-dev decision that routes Generate. A
+// released binary must pin its require to its own version (nooga/let-go#594:
+// an unpinned require made released `lg -w` builds resolve a go.sum that did
+// not match the runtime they were emitted by); "dev" and an empty version must
+// not, so they reach the local-source path instead.
+func TestReleaseRef(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		wantRef string
+		wantOK  bool
+	}{
+		{"1.12.2", "github.com/nooga/let-go@v1.12.2", true},
+		{"0.1.0", "github.com/nooga/let-go@v0.1.0", true},
+		{"dev", "", false},
+		{"", "", false},
+	} {
+		ref, ok := ReleaseRef(tc.version)
+		if ok != tc.wantOK || ref != tc.wantRef {
+			t.Errorf("ReleaseRef(%q) = (%q, %v), want (%q, %v)", tc.version, ref, ok, tc.wantRef, tc.wantOK)
+		}
+	}
+}
+
+// writeFakeCheckout lays down the minimum that reads as a let-go source tree:
+// a go.mod naming the module, plus a go.sum to be carried across.
+func writeFakeCheckout(t *testing.T, goSum string) string {
+	t.Helper()
+	dir := t.TempDir()
+	mod := "module " + ModulePath + "\n\ngo 1.26\n\nrequire example.com/dep v1.2.3\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(mod), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if goSum != "" {
+		if err := os.WriteFile(filepath.Join(dir, "go.sum"), []byte(goSum), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// TestGenerateLocalSource covers the dev-build path end to end through
+// Generate: LETGO_SRC points at a checkout, so no network or `go get` is
+// involved. It asserts the two properties the generated module must have —
+// the caller's module name (not let-go's, and not a baked-in one), and a
+// replace pointing back at the checkout.
+func TestGenerateLocalSource(t *testing.T) {
+	src := writeFakeCheckout(t, "example.com/dep v1.2.3 h1:abc=\n")
+	t.Setenv("LETGO_SRC", src)
+
+	files, err := Generate(t.TempDir(), "some-app", "dev")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if !strings.HasPrefix(files.Mod, "module some-app\n") {
+		t.Errorf("module name not substituted; go.mod starts:\n%s", firstLine(files.Mod))
+	}
+	if strings.Contains(files.Mod, "module "+ModulePath) {
+		t.Errorf("let-go's own module line survived into the generated go.mod:\n%s", files.Mod)
+	}
+	if want := "replace " + ModulePath + " => " + src; !strings.Contains(files.Mod, want) {
+		t.Errorf("missing %q in:\n%s", want, files.Mod)
+	}
+	if !strings.Contains(files.Mod, "require "+ModulePath+" v0.0.0") {
+		t.Errorf("missing require of let-go in:\n%s", files.Mod)
+	}
+	if string(files.Sum) != "example.com/dep v1.2.3 h1:abc=\n" {
+		t.Errorf("go.sum not carried across, got %q", files.Sum)
+	}
+}
+
+// TestGenerateModuleNameIsCallerSupplied is the point of the extraction: the
+// module name was baked in when the WASM build was the only caller, so two
+// callers must be able to get two different names from one implementation.
+func TestGenerateModuleNameIsCallerSupplied(t *testing.T) {
+	src := writeFakeCheckout(t, "")
+	t.Setenv("LETGO_SRC", src)
+
+	for _, name := range []string{"lg-wasm-app", "aotmod", "example.com/native/prog"} {
+		files, err := Generate(t.TempDir(), name, "dev")
+		if err != nil {
+			t.Fatalf("Generate(%q): %v", name, err)
+		}
+		if !strings.HasPrefix(files.Mod, "module "+name+"\n") {
+			t.Errorf("module %q not honored; go.mod starts:\n%s", name, firstLine(files.Mod))
+		}
+	}
+}
+
+// TestFindLetGoSourceDirPrefersEnv pins LETGO_SRC as the override: it wins over
+// the walk-up, which matters because the walk-up finds whatever checkout the
+// process happens to be running inside.
+func TestFindLetGoSourceDirPrefersEnv(t *testing.T) {
+	src := writeFakeCheckout(t, "")
+	t.Setenv("LETGO_SRC", src)
+
+	got, err := FindLetGoSourceDir()
+	if err != nil {
+		t.Fatalf("FindLetGoSourceDir: %v", err)
+	}
+	if got != src {
+		t.Errorf("FindLetGoSourceDir() = %q, want %q", got, src)
+	}
+}
+
+// TestGoToolPath checks the returned tool is usable: either an existing path
+// under GOROOT, or the bare "go" fallback for PATH lookup.
+func TestGoToolPath(t *testing.T) {
+	got := GoToolPath()
+	if got == "go" {
+		return
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Errorf("GoToolPath() = %q, which does not exist: %v", got, err)
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/wasm.go
+++ b/wasm.go
@@ -20,10 +20,16 @@ import (
 
 	"github.com/nooga/let-go/pkg/bytecode"
 	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/gomod"
 	"github.com/nooga/let-go/pkg/resolver"
 	wasmassets "github.com/nooga/let-go/pkg/rt/wasm"
 	"github.com/nooga/let-go/pkg/vm"
 )
+
+// wasmModuleName is the module name of the throwaway Go module the WASM build
+// scaffolds around its generated sources. It used to be baked into the module
+// scaffolder; it is passed in now that the AOT native path shares that code.
+const wasmModuleName = "lg-wasm-app"
 
 // tinyGoStackSizeRe matches a tinygo -stack-size value (a byte count or a
 // K/M/G-suffixed size, e.g. 1MB, 64KB, 16384). Used only to warn on a typo in
@@ -100,7 +106,7 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		return err
 	}
 	goEnv := wasmBuildEnv(tmpDir)
-	goTool := goToolPath()
+	goTool := gomod.GoToolPath()
 	buildTags := strings.TrimSpace(os.Getenv("LG_WASM_BUILD_TAGS"))
 
 	// 3. Write generated source files
@@ -111,7 +117,7 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		return err
 	}
 	if wasmassets.HasBuildTag(buildTags, "gogen_ir") {
-		srcDir, err := findLetGoModuleDir()
+		srcDir, err := gomod.FindLetGoSourceDir()
 		if err != nil {
 			return fmt.Errorf("gogen_ir wasm build requires local let-go source for wireup: %w", err)
 		}
@@ -121,15 +127,15 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 	}
 
 	// 4. Write go.mod
-	goMod, goSum, err := generateWasmModuleFiles(tmpDir)
+	mod, err := gomod.Generate(tmpDir, wasmModuleName, version)
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goMod), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(mod.Mod), 0644); err != nil {
 		return err
 	}
-	if len(goSum) > 0 {
-		if err := os.WriteFile(filepath.Join(tmpDir, "go.sum"), goSum, 0644); err != nil {
+	if len(mod.Sum) > 0 {
+		if err := os.WriteFile(filepath.Join(tmpDir, "go.sum"), mod.Sum, 0644); err != nil {
 			return err
 		}
 	}
@@ -284,114 +290,6 @@ func wasmBuildEnv(tmpDir string) []string {
 	)
 }
 
-func goToolPath() string {
-	if goroot := runtime.GOROOT(); goroot != "" {
-		if path := filepath.Join(goroot, "bin", "go"); fileExists(path) {
-			return path
-		}
-	}
-	return "go"
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-func generateWasmModuleFiles(tmpDir string) (string, []byte, error) {
-	v := version
-	if v != "dev" && v != "" && v[0] >= '0' && v[0] <= '9' {
-		// Released binary: pin the require to this exact version. We can't
-		// return a nil go.sum (go build rejects a module with unresolved
-		// sums), so resolve it from the proxy the same way the no-source path
-		// below does. `go get` on the single require writes go.sum without the
-		// `go mod tidy` that the build step deliberately avoids.
-		return resolveWasmModuleFiles(tmpDir, "github.com/nooga/let-go@v"+v)
-	}
-	// Dev build — try local source first
-	srcDir, err := findLetGoModuleDir()
-	if err == nil {
-		goMod, goSum, err := localWasmModuleFiles(srcDir)
-		if err != nil {
-			return "", nil, err
-		}
-		return goMod, goSum, nil
-	}
-	// No local source — resolve latest version from module proxy
-	return resolveWasmModuleFiles(tmpDir, "github.com/nooga/let-go@latest")
-}
-
-// resolveWasmModuleFiles scaffolds a minimal module in tmpDir and resolves the
-// let-go require named by modRef via `go get`, returning the resulting go.mod
-// and go.sum. Used for both released binaries (pinned version) and dev builds
-// with no local source tree (@latest).
-func resolveWasmModuleFiles(tmpDir, modRef string) (string, []byte, error) {
-	goMod := "module lg-wasm-app\n\ngo 1.26\n"
-	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goMod), 0644); err != nil {
-		return "", nil, err
-	}
-	get := exec.Command(goToolPath(), "get", modRef)
-	get.Dir = tmpDir
-	get.Stderr = os.Stderr
-	if err := get.Run(); err != nil {
-		return "", nil, fmt.Errorf("resolving let-go module: %w (set LETGO_SRC for local source)", err)
-	}
-	// go get wrote the go.mod with the resolved version — read it back
-	data, err := os.ReadFile(filepath.Join(tmpDir, "go.mod"))
-	if err != nil {
-		return "", nil, err
-	}
-	sum, _ := os.ReadFile(filepath.Join(tmpDir, "go.sum"))
-	return string(data), sum, nil
-}
-
-func localWasmModuleFiles(srcDir string) (string, []byte, error) {
-	modPath := filepath.Join(srcDir, "go.mod")
-	modData, err := os.ReadFile(modPath)
-	if err != nil {
-		return "", nil, err
-	}
-	modText := string(modData)
-	modText = strings.Replace(modText, "module github.com/nooga/let-go", "module lg-wasm-app", 1)
-	modText = strings.TrimRight(modText, "\n") + "\n\nrequire github.com/nooga/let-go v0.0.0\n"
-	modText = strings.TrimRight(modText, "\n") + fmt.Sprintf("\n\nreplace github.com/nooga/let-go => %s\n", srcDir)
-	sumData, err := os.ReadFile(filepath.Join(srcDir, "go.sum"))
-	if err != nil && !os.IsNotExist(err) {
-		return "", nil, err
-	}
-	return modText, sumData, nil
-}
-
-func findLetGoModuleDir() (string, error) {
-	if src := os.Getenv("LETGO_SRC"); src != "" {
-		return src, nil
-	}
-	if dir := findModuleRoot(mustGetwd()); dir != "" {
-		return dir, nil
-	}
-	if exe, err := os.Executable(); err == nil {
-		if dir := findModuleRoot(filepath.Dir(exe)); dir != "" {
-			return dir, nil
-		}
-	}
-	return "", fmt.Errorf("cannot find let-go source tree (dev build); set LETGO_SRC or run from source directory")
-}
-
-func findModuleRoot(start string) string {
-	for d := start; d != "/" && d != "."; d = filepath.Dir(d) {
-		data, err := os.ReadFile(filepath.Join(d, "go.mod"))
-		if err == nil && strings.Contains(string(data), "module github.com/nooga/let-go") {
-			return d
-		}
-	}
-	return ""
-}
-
-func mustGetwd() string {
-	d, _ := os.Getwd()
-	return d
-}
-
 // tinygoFdWriteRe matches TinyGo's WASI fd_write import in its wasm_exec.js.
 // TinyGo routes os.Stdout through this (NOT through globalThis.fs), and it
 // line-buffers into logLine, emitting to console.log only on LF — so under our
@@ -449,7 +347,7 @@ func readWasmExecJS() ([]byte, error) {
 		goroot = runtime.GOROOT()
 	}
 	if goroot == "" {
-		out, err := exec.Command(goToolPath(), "env", "GOROOT").Output()
+		out, err := exec.Command(gomod.GoToolPath(), "env", "GOROOT").Output()
 		if err != nil {
 			return nil, fmt.Errorf("cannot find GOROOT: %w", err)
 		}


### PR DESCRIPTION
`lg -w` privately owns the logic that scaffolds a throwaway Go module around generated sources before `go build`: pin a released binary's require to its own version (#594), prefer a local checkout in dev builds, fall back to the module proxy when there's neither. The AOT native path (#596) needs exactly those three behaviors, and the module name was baked in — so adding a second caller would have meant a second copy of all of it.

#97 sets the principle for the generator work — avoid two independent generators, factor the internals into reusable pieces first. This applies it before the second copy exists rather than after.

## What changed

The scaffolding moves to `pkg/gomod` with the module name passed in rather than hardcoded. `lg -w` now calls `gomod.Generate(tmpDir, wasmModuleName, version)` and takes the same path it always did — `wasm.go` loses 115 lines and gains 13.

The released-vs-dev decision is split out as `gomod.ReleaseRef`, a pure function, so the branch that #594 fixed can be tested without a network round trip.

Nothing else changes. This is preparation, and it stands alone: one implementation of the module scaffolding is the right shape whether or not the native path lands.

## Why pkg/ and not package main

The helpers could have stayed in `package main` beside their caller. They moved because CI rejects test files at the repo root, so anything in the root package can't carry direct coverage — and this had none. `pkg/gomod` is testable, and the tests below are new.

## Verification

- New `pkg/gomod` tests: the released/dev routing (`ReleaseRef`), the local-source path end to end through `Generate` (module name substituted, `replace` pointing at the checkout, `go.sum` carried across), that the module name is honored for several distinct callers, and that `LETGO_SRC` beats the walk-up.
- `lg -w` end to end on a hello-world `.lg`: builds and emits a 7.7 MB `index.html`, same as before.
- `go vet` clean; builds for `linux/amd64`, `js/wasm`, `plan9/amd64`, `wasip1/wasm`, plus the `bootstrap` tag.
- `generated.sums` untouched; `check-generated` clean.

Groundwork for #596, under #258.
