### PR TITLE
fix(rt): wake Plan 9 key reads on terminal resize

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ A subdir is earned when a cluster of related docs justifies one; one-off cross-c
 | IR fixup / link pass | `design/els2023-ir-fixup-audit.md` |
 | Parallel IR lowering + determinism | `design/parallel-lowering-and-type-cache.md` |
 | Runtime I/O, host decoupling | `design/runtime-io-host-decoupling.md` |
+| Terminal resize wake contract | `design/terminal-resize-wake.md` |
 | Off-goroutine execution context threading | `design/exec-context-threading.md` |
 
 ## Reading order if starting cold

--- a/docs/design/terminal-resize-wake.md
+++ b/docs/design/terminal-resize-wake.md
@@ -1,0 +1,126 @@
+---
+status: active
+last-verified: 2026-08-14
+authoritative-for:
+  - terminal-resize-wake
+human-verified: 2026-08-14
+---
+
+# Terminal resize wake contract
+
+**Status:** active design for making Plan 9 terminal resizes wake a blocked
+`term/read-key` while preserving the existing native contract.
+
+**Decision:** terminal backends may interrupt a blocked key read with the
+synthetic BEL key (`\x07`). The notification source is platform-specific, but
+the observable `read-key` / `key-pending?` behavior is shared.
+
+## 1. Problem
+
+Interactive applications commonly block in `term/read-key` and check
+`term/size` once per event-loop iteration. Native Unix already wakes that read
+on `SIGWINCH`, but Plan 9's queued stdin source previously woke only for input
+or EOF. Plan 9 terminals could update `/env/COLS` and `/env/LINES` immediately
+while a Letgo application remained parked until the next keypress.
+
+This is a runtime terminal concern, not an application-specific workaround:
+any Letgo TUI needs a chance to observe new geometry without waiting for user
+input.
+
+## 2. Shared contract
+
+The native contract introduced in #165 remains authoritative:
+
+- a terminal resize may make `key-pending?` true;
+- `read-key` consumes the wake as synthetic BEL (`\x07`);
+- real keyboard input takes priority when input and resize are both pending;
+- resize storms may coalesce into one wake; and
+- EOF and reader errors take priority over a synthetic wake.
+
+The application does not interpret BEL as geometry. It handles the event as it
+normally would, then reads `term/size`; a size change triggers its ordinary
+redraw path.
+
+## 3. Platform mechanisms
+
+### Native Unix
+
+The existing backend receives `SIGWINCH`, writes a BEL byte to a self-pipe, and
+polls that pipe alongside stdin. No behavior changes on Linux or macOS.
+
+### Plan 9
+
+The Plan 9 root key source wraps `queuedKeySource` and lazily watches the live
+`/env/WINCH` generation. Terminals publish `COLS` and `LINES` before advancing
+`WINCH`, so a changed generation is the commit signal that new dimensions are
+ready. The watcher then queues an internal wake on the source.
+
+The watcher uses a 100 ms ticker. It is event polling, not a busy loop: the
+goroutine sleeps between reads and reads one small environment file per tick.
+Notifications coalesce in the queued source, so resize drags cannot create an
+unbounded backlog.
+
+If `WINCH` is absent, the watcher quietly waits for it to appear. Input, EOF,
+and `term/size` retain their previous behavior.
+
+## 4. API boundary
+
+`KeySource` remains the public two-method interface: `ReadKey` and
+`KeyPending`. Adding a public `Wake` method would break existing embedders and
+would mix this focused terminal fix with the separate source-lifecycle work in
+#498.
+
+Instead, `queuedKeySource` owns an unexported, coalesced wake flag and method.
+The Plan 9 adapter can use that implementation detail without exposing a new
+host API. WASM's SharedArrayBuffer wake protocol remains separate future work.
+
+## 5. Lifecycle
+
+The Plan 9 source remains the single process-lifetime root over `os.Stdin`, the
+same lifecycle accepted in #461. It captures the current `WINCH` generation
+when the term namespace constructs the root, before application code performs
+its first `term/size` read. Its reader and resize watcher still start lazily on
+the first `ReadKey` or `KeyPending` call. This split closes a startup race: a
+host correction arriving between the first frame and first key read differs
+from the construction-time baseline and therefore wakes that read. If an
+embedder replaces `*keys*`, the root source is never consulted and neither
+goroutine starts.
+
+This does not attempt to solve repeated embedder-source teardown. That broader
+ownership and `Close` question is tracked in #498.
+
+## 6. Alternatives considered
+
+- **Add `Wake` to `KeySource`.** Rejected for this change because it is a
+  breaking public-interface expansion and is unnecessary for the Plan 9 root.
+- **Inject BEL into stdin.** Rejected because concurrent byte injection can
+  interleave with escape or UTF-8 sequences. Wake state belongs beside, not
+  inside, the byte queue.
+- **Start a new blocking read goroutine per call and select on resize.**
+  Rejected because the losing read cannot be cancelled and leaks goroutines.
+- **Use Plan 9 interrupt notes through `/dev/consctl winchon`.** Useful for
+  terminals that expose that protocol, but not universal across Drawterm and
+  redirected console namespaces. `/env/WINCH` is the portable host-published
+  contract used here; note-driven wake can be a later optimization.
+- **Teach the application to poll size.** Rejected because every TUI would
+  need its own timer and wake loop even though the blocking primitive lives in
+  the runtime.
+
+## 7. Verification
+
+The platform-neutral queued-source tests prove that:
+
+- a wake interrupts a parked `ReadKey`;
+- `KeyPending` observes it;
+- wake bursts coalesce;
+- real input is returned before a simultaneous wake; and
+- the wake remains pending after that real input is consumed.
+
+A Plan 9-only test also moves the `WINCH` generation after root-source
+construction but before the first `ReadKey`, proving that the startup
+correction is not lost.
+
+CI runs the ordinary runtime suite and race detector on supported native
+hosts, while a Plan 9 cross-build covers the build-tagged adapter. Interactive
+acceptance testing resizes a Drawterm-backed terminal while `read-key` is
+blocked and confirms that a Letgo TUI redraws without a keypress.

--- a/docs/design/terminal-resize-wake.md
+++ b/docs/design/terminal-resize-wake.md
@@ -51,9 +51,13 @@ polls that pipe alongside stdin. No behavior changes on Linux or macOS.
 ### Plan 9
 
 The Plan 9 root key source wraps `queuedKeySource` and lazily watches the live
-`/env/WINCH` generation. Terminals publish `COLS` and `LINES` before advancing
-`WINCH`, so a changed generation is the commit signal that new dimensions are
-ready. The watcher then queues an internal wake on the source.
+`/env/WINCH` generation. `WINCH` is an optional producer contract rather than
+a universal Plan 9 terminal facility. The behavior is verified with the
+[Windows `-G` console path in the `dharmatech/drawterm` fork][drawterm-winch]:
+it publishes `COLS` and `LINES` first, then increments `WINCH` as the commit
+signal, and exposes those live files to the guest through `/mnt/term/env`.
+Other terminal integrations interoperate when they provide the same ordering.
+The watcher queues an internal wake after observing a changed generation.
 
 The watcher uses a 100 ms ticker. It is event polling, not a busy loop: the
 goroutine sleeps between reads and reads one small environment file per tick.
@@ -62,6 +66,8 @@ unbounded backlog.
 
 If `WINCH` is absent, the watcher quietly waits for it to appear. Input, EOF,
 and `term/size` retain their previous behavior.
+
+[drawterm-winch]: https://github.com/dharmatech/drawterm/commit/f445a501730a9340bff812f60cc9bf53cb932da2
 
 ## 4. API boundary
 

--- a/docs/design/terminal-resize-wake.md
+++ b/docs/design/terminal-resize-wake.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last-verified: 2026-08-14
+last-verified: 2026-08-16
 authoritative-for:
   - terminal-resize-wake
 human-verified: 2026-08-14
@@ -121,6 +121,7 @@ construction but before the first `ReadKey`, proving that the startup
 correction is not lost.
 
 CI runs the ordinary runtime suite and race detector on supported native
-hosts, while a Plan 9 cross-build covers the build-tagged adapter. Interactive
-acceptance testing resizes a Drawterm-backed terminal while `read-key` is
-blocked and confirms that a Letgo TUI redraws without a keypress.
+hosts. For this change, the Let Go executable and `pkg/rt` test binary were
+manually cross-compiled for `plan9/amd64`. Interactive acceptance testing
+resizes a Drawterm-backed terminal while `read-key` is blocked and confirms
+that a Let Go TUI redraws without a keypress.

--- a/pkg/rt/keysource.go
+++ b/pkg/rt/keysource.go
@@ -14,14 +14,20 @@
  * an embedder or test can feed synthetic keys.
  *
  * Scope: ReadKey + KeyPending only. Terminal geometry (size / set-size) stays
- * a separate term op, and wake — unblocking a parked ReadKey without a real
- * key — is deferred (see the note in pkg/rt/wasm/lg-host.js); it needs a
- * SAB-level protocol this seam leaves room for but doesn't introduce.
+ * a separate term op. Platform sources may surface an external terminal event
+ * as terminalWakeKey, but wake remains an implementation detail rather than a
+ * method on the public seam; WASM still needs a SAB-level wake protocol.
  */
 
 package rt
 
 import "github.com/nooga/let-go/pkg/vm"
+
+// terminalWakeKey is the synthetic key returned when an external terminal
+// event interrupts a blocked ReadKey. BEL preserves the native SIGWINCH
+// contract introduced in #165: callers treat it as an unknown key, then run
+// their ordinary term/size check on the next loop iteration.
+const terminalWakeKey = "\x07"
 
 // KeySource is a source of keypresses for term/read-key and key-pending?.
 type KeySource interface {

--- a/pkg/rt/keysource_queued.go
+++ b/pkg/rt/keysource_queued.go
@@ -28,14 +28,15 @@ import (
 // source's ReadKey/KeyPending are never called and the reader never starts — no
 // bytes stolen from the source that replaced it.
 type queuedKeySource struct {
-	mu      sync.Mutex
-	r       io.Reader
-	buf     []byte        // read but not yet tokenized out
-	err     error         // sticky reader error; nil for a clean EOF
-	done    bool          // reader finished (EOF or error) — no more bytes coming
-	started bool          // reader goroutine launched
-	notify  chan struct{} // buffered(1) wakeup; reader signals on append/done
-	grace   time.Duration // inter-byte wait for stitching a split escape sequence
+	mu          sync.Mutex
+	r           io.Reader
+	buf         []byte        // read but not yet tokenized out
+	err         error         // sticky reader error; nil for a clean EOF
+	done        bool          // reader finished (EOF or error) — no more bytes coming
+	started     bool          // reader goroutine launched
+	wakePending bool          // coalesced external terminal wake, consumed by ReadKey
+	notify      chan struct{} // buffered(1) condition signal for data/done/wake
+	grace       time.Duration // inter-byte wait for stitching a split escape sequence
 }
 
 // escGrace is the default bound on how long ReadKey waits for the rest of an
@@ -72,6 +73,13 @@ func resolveGrace() time.Duration {
 // first ReadKey/KeyPending, so binding this at *keys* without ever consulting it
 // (e.g. when api.WithKeySource overrides it) reads nothing.
 func NewQueuedKeySource(r io.Reader) KeySource {
+	return newQueuedKeySource(r)
+}
+
+// newQueuedKeySource is the concrete constructor used by platform adapters
+// that need queuedKeySource implementation details without widening the public
+// KeySource interface.
+func newQueuedKeySource(r io.Reader) *queuedKeySource {
 	return &queuedKeySource{r: r, notify: make(chan struct{}, 1), grace: resolveGrace()}
 }
 
@@ -100,6 +108,21 @@ func (s *queuedKeySource) signal() {
 	case s.notify <- struct{}{}:
 	default:
 	}
+}
+
+// wake interrupts a blocked ReadKey without adding bytes to the input queue.
+// A boolean is enough: terminal resize storms may coalesce, and the caller only
+// needs one opportunity to re-read term/size. Reader completion wins over a
+// wake, matching native's EOF/error precedence.
+func (s *queuedKeySource) wake() {
+	s.mu.Lock()
+	if s.done {
+		s.mu.Unlock()
+		return
+	}
+	s.wakePending = true
+	s.mu.Unlock()
+	s.signal()
 }
 
 // readLoop blocks on r.Read WITHOUT holding the lock, then locks only to append
@@ -131,21 +154,24 @@ func (s *queuedKeySource) readLoop() {
 	}
 }
 
-// ReadKey blocks until a whole key token is available (or the reader ends),
-// tokenizing one key per call off the shared buffer via scanKey. It returns ""
-// with a nil error at a clean EOF (the read-key nil contract), or "" with the
-// retained error if the reader failed. Blocking here matches native (which
-// blocks in poll); callers stay responsive by gating on KeyPending first.
+// ReadKey blocks until a whole key token, an external terminal wake, or reader
+// completion is available. It tokenizes one key per call off the shared buffer
+// via scanKey, returns terminalWakeKey for a wake, "" with a nil error at clean
+// EOF, or "" with the retained reader error. Blocking here matches native.
 func (s *queuedKeySource) ReadKey() (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.start()
 
-	for len(s.buf) == 0 && !s.done {
+	for len(s.buf) == 0 && !s.wakePending && !s.done {
 		s.condWait(0) // no deadline: block until data or reader end
 	}
 	if len(s.buf) == 0 {
-		return "", s.err // clean EOF (err nil) or a real reader failure
+		if s.done {
+			return "", s.err // clean EOF (err nil) or a real reader failure
+		}
+		s.wakePending = false
+		return terminalWakeKey, nil
 	}
 
 	var deadline time.Time // set on the first incomplete front token
@@ -208,13 +234,13 @@ func (s *queuedKeySource) condWait(timeout time.Duration) {
 	s.mu.Lock()
 }
 
-// KeyPending reports whether a key is buffered and ready, without consuming it.
-// Non-blocking and eof-blind (false once the queue drains at end-of-input),
-// mirroring native's FIONREAD-based rawPending so a per-tick input poll doesn't
-// busy-drain end-of-input forever.
+// KeyPending reports whether a key or external terminal wake is buffered and
+// ready, without consuming it. It is non-blocking and eof-blind (false once the
+// queue drains at end-of-input), mirroring native's rawPending behavior so a
+// per-tick input poll doesn't busy-drain end-of-input forever.
 func (s *queuedKeySource) KeyPending() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.start()
-	return len(s.buf) > 0
+	return len(s.buf) > 0 || (!s.done && s.wakePending)
 }

--- a/pkg/rt/keysource_queued_test.go
+++ b/pkg/rt/keysource_queued_test.go
@@ -244,6 +244,88 @@ func TestQueuedKeySourceKeyPending(t *testing.T) {
 	}
 }
 
+// TestQueuedKeySourceWake verifies the platform-adapter wake contract: a wake
+// interrupts a parked read, surfaces through KeyPending, and is consumed as the
+// same synthetic BEL used by native SIGWINCH handling.
+func TestQueuedKeySourceWake(t *testing.T) {
+	ch := make(chan []byte)
+	ks := newSource(&chunkReader{ch: ch})
+
+	result := make(chan string, 1)
+	go func() {
+		k, _ := ks.ReadKey()
+		result <- k
+	}()
+	ks.wake()
+
+	select {
+	case got := <-result:
+		if got != terminalWakeKey {
+			t.Fatalf("wake key = %q, want %q", got, terminalWakeKey)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("wake did not interrupt blocked ReadKey")
+	}
+	close(ch)
+}
+
+func TestQueuedKeySourceWakePendingAndCoalescing(t *testing.T) {
+	ch := make(chan []byte)
+	ks := newSource(&chunkReader{ch: ch})
+
+	ks.wake()
+	ks.wake()
+	ks.wake()
+	if !ks.KeyPending() {
+		t.Fatal("KeyPending false with a queued wake")
+	}
+	if k, err := ks.ReadKey(); k != terminalWakeKey || err != nil {
+		t.Fatalf("ReadKey wake = (%q, %v), want (%q, nil)", k, err, terminalWakeKey)
+	}
+	if ks.KeyPending() {
+		t.Fatal("resize wake burst did not coalesce")
+	}
+	close(ch)
+}
+
+func TestQueuedKeySourcePrefersInputOverWake(t *testing.T) {
+	ch := make(chan []byte, 1)
+	ks := newSource(&chunkReader{ch: ch})
+	ch <- []byte("x")
+	if !eventually(func() bool { return ks.KeyPending() }) {
+		t.Fatal("input never reached queued source")
+	}
+	ks.wake()
+
+	if k, err := ks.ReadKey(); k != "x" || err != nil {
+		t.Fatalf("first ReadKey = (%q, %v), want real input", k, err)
+	}
+	if !ks.KeyPending() {
+		t.Fatal("wake was lost after real input took priority")
+	}
+	if k, err := ks.ReadKey(); k != terminalWakeKey || err != nil {
+		t.Fatalf("second ReadKey = (%q, %v), want pending wake", k, err)
+	}
+	close(ch)
+}
+
+func TestQueuedKeySourceEOFPrecedesWake(t *testing.T) {
+	ch := make(chan []byte)
+	close(ch)
+	ks := newSource(&chunkReader{ch: ch})
+
+	if k, err := ks.ReadKey(); k != "" || err != nil {
+		t.Fatalf("initial EOF = (%q, %v), want (\"\", nil)", k, err)
+	}
+	ks.wake()
+	if ks.KeyPending() {
+		t.Fatal("wake became pending after reader EOF")
+	}
+	if k, err := ks.ReadKey(); k != "" || err != nil {
+		t.Fatalf("EOF after wake = (%q, %v), want (\"\", nil)", k, err)
+	}
+}
+
 func eventually(cond func() bool) bool {
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {

--- a/pkg/rt/term.go
+++ b/pkg/rt/term.go
@@ -57,7 +57,7 @@ func setupWinch() {
 			for range sigCh {
 				// One BEL per SIGWINCH. Storms collapse — the read side
 				// drains whatever's pending in a single Read regardless.
-				_, _ = w.Write([]byte{0x07})
+				_, _ = w.Write([]byte{terminalWakeKey[0]})
 			}
 		}()
 	})
@@ -128,7 +128,7 @@ func (s nativeKeySource) ReadKey() (string, error) {
 				return "", nil // EOF / nil contract
 			}
 			if isWinchWake(chunk) {
-				return "\x07", nil // SIGWINCH wake — synthetic, not tokenized
+				return terminalWakeKey, nil // SIGWINCH wake — synthetic, not tokenized
 			}
 			keyBuf = chunk
 		}
@@ -158,7 +158,7 @@ func (s nativeKeySource) ReadKey() (string, error) {
 }
 
 func isWinchWake(b []byte) bool {
-	return len(b) == 1 && b[0] == '\x07'
+	return len(b) == 1 && b[0] == terminalWakeKey[0]
 }
 
 // readRaw does one blocking poll+read, returning raw stdin bytes, nil on EOF,
@@ -236,7 +236,7 @@ func (nativeKeySource) readRaw() ([]byte, error) {
 	}
 
 	// Only the wake fired — return BEL so the loop's term/size diff runs.
-	return []byte{'\x07'}, nil
+	return []byte{terminalWakeKey[0]}, nil
 }
 
 func (s nativeKeySource) KeyPending() bool {

--- a/pkg/rt/term_plan9.go
+++ b/pkg/rt/term_plan9.go
@@ -10,11 +10,13 @@ package rt
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 	"unicode/utf8"
 
 	"github.com/nooga/let-go/pkg/vm"
@@ -24,10 +26,11 @@ import (
 // "rawon" (Plan 9 has no termios; consctl controls the console), and read-key /
 // key-pending? read through a queuedKeySource (keysource_queued.go) — a
 // background goroutine feeding a byte queue, because Plan 9 lacks the Unix
-// poll(2)/FIONREAD non-blocking peek. The ANSI output functions route through
-// *out* (WriteToOut) like native. size reads $COLS/$LINES (fallback 80x24); real
-// window geometry (/dev/wctl pixels) is a deferred follow-up. open-pty/set-size
-// stay unsupported. mouse decoding is native-only.
+// poll(2)/FIONREAD non-blocking peek. A lazy /env/WINCH watcher wakes that queue
+// on resize. The ANSI output functions route through *out* (WriteToOut) like
+// native. size reads $COLS/$LINES (fallback 80x24); real window geometry
+// (/dev/wctl pixels) is a deferred follow-up. open-pty/set-size stay unsupported.
+// mouse decoding is native-only.
 
 // consctl holds /dev/consctl open while the terminal is in raw mode. Plan 9
 // reverts to cooked mode as soon as this fd closes, so raw-mode! keeps it open
@@ -37,6 +40,86 @@ var (
 	consctlMu sync.Mutex
 )
 
+// plan9KeySource adds resize wakes to the platform-neutral queued source. It
+// remains the process-lifetime root over os.Stdin; embedders that replace
+// *keys* never call it, so neither its reader nor its watcher starts.
+type plan9KeySource struct {
+	*queuedKeySource
+	winchOnce     sync.Once
+	readWinch     func() (string, bool)
+	winchInterval time.Duration
+	initialWinch  string
+	haveInitial   bool
+}
+
+const plan9WinchPollInterval = 100 * time.Millisecond
+
+func newPlan9KeySource(r io.Reader) *plan9KeySource {
+	return newPlan9KeySourceWithWinch(r, func() (string, bool) {
+		return readEnvValue("WINCH")
+	}, plan9WinchPollInterval)
+}
+
+// newPlan9KeySourceWithWinch keeps the generation reader and interval
+// injectable for the Plan 9 startup-race test. Capturing the baseline here —
+// when the term namespace installs the root source — closes the window between
+// the application's first term/size read and its first blocking ReadKey. The
+// reader and watcher goroutines remain lazy.
+func newPlan9KeySourceWithWinch(r io.Reader, readWinch func() (string, bool), interval time.Duration) *plan9KeySource {
+	initial, haveInitial := readWinch()
+	return &plan9KeySource{
+		queuedKeySource: newQueuedKeySource(r),
+		readWinch:       readWinch,
+		winchInterval:   interval,
+		initialWinch:    initial,
+		haveInitial:     haveInitial,
+	}
+}
+
+func (s *plan9KeySource) startWinchWatcher() {
+	s.winchOnce.Do(func() {
+		go s.watchWinch(s.initialWinch, s.haveInitial)
+	})
+}
+
+func (s *plan9KeySource) watchWinch(last string, haveLast bool) {
+	ticker := time.NewTicker(s.winchInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		next, ok := s.readWinch()
+		if !ok {
+			haveLast = false
+			continue
+		}
+		if !haveLast || next != last {
+			last, haveLast = next, true
+			s.wake()
+		}
+	}
+}
+
+func (s *plan9KeySource) ReadKey() (string, error) {
+	s.startWinchWatcher()
+	return s.queuedKeySource.ReadKey()
+}
+
+func (s *plan9KeySource) KeyPending() bool {
+	s.startWinchWatcher()
+	return s.queuedKeySource.KeyPending()
+}
+
+// readEnvValue reads a live Plan 9 environment file and normalizes its value.
+// The bool is false for a missing or empty value, which lets the WINCH watcher
+// establish a fresh baseline if the file appears later.
+func readEnvValue(name string) (string, bool) {
+	b, err := os.ReadFile("/env/" + name)
+	if err != nil {
+		return "", false
+	}
+	v := strings.TrimRight(string(b), "\x00\n\r\t ")
+	return v, v != ""
+}
+
 // readEnvInt reads /env/<name> as a live file and parses it as an int, returning
 // def when the file is missing or unparseable. Plan 9's environment is a
 // filesystem, so reading the file each call picks up updates that os.Getenv's
@@ -44,13 +127,11 @@ var (
 // /env/LINES on every window resize, so the live read is what lets term/size
 // track the real terminal size instead of a stale startup value.
 func readEnvInt(name string, def int) int {
-	b, err := os.ReadFile("/env/" + name)
-	if err != nil {
+	v, ok := readEnvValue(name)
+	if !ok {
 		return def
 	}
-	// /env values can carry a trailing NUL (Plan 9 stores them NUL-terminated)
-	// and/or a newline; trim before parsing.
-	if n, err := strconv.Atoi(strings.TrimRight(string(b), "\x00\n\r\t ")); err == nil {
+	if n, err := strconv.Atoi(v); err == nil {
 		return n
 	}
 	return def
@@ -96,7 +177,7 @@ func installTermNS() {
 	// root — the input dual of the os.Stdout *out* default in iort.go. read-key
 	// and key-pending? consult the bound source, so api.WithKeySource / (binding
 	// [*keys* …]) transparently overrides it for tests and embedders.
-	CoreNS.Lookup("*keys*").(*vm.Var).SetRoot(vm.NewBoxed(NewQueuedKeySource(os.Stdin)))
+	CoreNS.Lookup("*keys*").(*vm.Var).SetRoot(vm.NewBoxed(newPlan9KeySource(os.Stdin)))
 
 	// raw-mode! — enter raw mode by opening /dev/consctl and writing "rawon",
 	// holding the fd (Plan 9 reverts to cooked mode when it closes). Only the

--- a/pkg/rt/term_plan9_test.go
+++ b/pkg/rt/term_plan9_test.go
@@ -1,0 +1,51 @@
+//go:build plan9
+
+/*
+ * Copyright (c) 2026 let-go contributors; see CONTRIBUTORS.
+ * SPDX-License-Identifier: MIT
+ */
+
+package rt
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestPlan9KeySourceCatchesResizeBeforeFirstRead covers the startup window
+// where a terminal publishes corrected geometry after the root key source is
+// constructed but before an application reaches its first blocking read-key.
+// The constructor's generation baseline must make that change observable.
+func TestPlan9KeySourceCatchesResizeBeforeFirstRead(t *testing.T) {
+	var generation atomic.Value
+	generation.Store("1")
+	readWinch := func() (string, bool) {
+		return generation.Load().(string), true
+	}
+
+	ch := make(chan []byte)
+	ks := newPlan9KeySourceWithWinch(
+		&chunkReader{ch: ch},
+		readWinch,
+		time.Millisecond,
+	)
+
+	// The correction lands after construction but before ReadKey starts.
+	generation.Store("2")
+	result := make(chan string, 1)
+	go func() {
+		k, _ := ks.ReadKey()
+		result <- k
+	}()
+
+	select {
+	case got := <-result:
+		if got != terminalWakeKey {
+			t.Fatalf("startup resize key = %q, want %q", got, terminalWakeKey)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resize before first ReadKey was missed")
+	}
+	close(ch)
+}


### PR DESCRIPTION
## Summary

- add an internal, coalesced wake path to `queuedKeySource` without changing the public `KeySource` interface
- make the Plan 9 terminal source watch the live `/env/WINCH` generation and wake blocked `term/read-key` calls after a resize
- preserve the existing native BEL wake contract, including real-input priority and EOF/error precedence
- document the cross-platform contract and add shared plus Plan 9-specific regression tests

## Root cause

Plan 9 terminals can publish updated `/env/COLS` and `/env/LINES`, but Letgo's queued stdin source previously woke only for keyboard input or EOF. A TUI blocked in `term/read-key` therefore could not observe the new geometry until the user pressed a key.

The Plan 9 adapter now treats a changed `/env/WINCH` generation as the commit signal for updated geometry and queues the same synthetic BEL wake already used by the native `SIGWINCH` path.

## Impact

Letgo TUIs on Plan 9 can redraw while idle immediately after a terminal resize. Resize storms coalesce, a missing `WINCH` environment file remains harmless, and Linux/macOS behavior is unchanged.

## Validation

- `go test -short -count=1 -timeout 300s ./... -skip TestClojureTestSuite`
- `go test -race -short -count=1 -timeout 300s ./pkg/vm/... ./pkg/rt/...`
- `go vet ./pkg/rt/...`
- Plan 9 `amd64` cross-build of both Letgo and the `pkg/rt` test binary
- Plan 9-specific startup-resize test and queued-wake tests, including 100-iteration stress runs
- manual Drawterm/Windows Terminal acceptance with LegMacs: idle resize, maximize/restore, split windows, ordinary input, and clean exit

The complete Plan 9 `pkg/rt` test binary still encounters existing platform failures in loopback-listener and namespace-fixture tests; the resize-specific Plan 9 tests pass.
