### PR TITLE
fix(vscode): enable Git integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,5 @@
   ],
   "files.associations": {
     "*.lg": "clojure"
-  },
-  "git.enabled": false
+  }
 }


### PR DESCRIPTION
## Summary

- Remove the workspace-level `git.enabled: false` setting.
- Preserve the project-specific Calva connection and `*.lg` file association.

## Why

The checked-in setting disables VS Code's built-in Git integration for every contributor who opens the repository. Because it is a workspace setting, it overrides contributors' user-level Git preferences and makes the Source Control view report that Git must be enabled.

The setting was introduced alongside unrelated IR changes and has no documented project requirement, so it appears to be an unintended local preference. Removing it restores VS Code's default behavior while still respecting users who have disabled Git in their own settings.

## Validation

- `jq empty .vscode/settings.json`
- `git diff --check upstream/main...HEAD`
- No runtime tests were run because this only changes VS Code workspace configuration.
