### PR TITLE
build: gate pushes on generated-artifact manifest freshness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,6 +149,24 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      # Generated-artifact provenance gate (#641). ~1.3s: a pure hash
+      # comparison of the manifest's declared inputs against the tree, with no
+      # regeneration and no build. Editing any declared input restages the
+      # outputs, and no server-side operation can refresh the manifest for you
+      # — not a rebase, not a merge driver, not the stack UI — so this has to
+      # run on a developer machine. always_run: a declared input can be a .go
+      # or a .lg file, so it must run on every push rather than on a types
+      # filter.
+      # NOTE: jj does not run git hooks — jj users gate with `make
+      # check-generated-manifest` (the same check) before pushing.
+      - id: check-generated-manifest
+        name: generated-artifact manifest freshness (#641)
+        description: Fail if a declared generator input changed without `make generate`
+        entry: go run ./cmd/check-generated
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
   - repo: https://github.com/checkmake/checkmake.git
     rev: v0.2.2
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ install-hooks:
 # pkg/rt/generated.sums. This catches the exact drift that a prior go generate
 # or lgbgen invocation would otherwise mask in CI.
 check-generated-manifest: $(GO)
-	@go run ./cmd/check-generated -stale || { \
+	@go run ./cmd/check-generated || { \
 		echo "ERROR: dependency manifest stale or check errored — run 'make generate'."; \
 		exit 1; \
 	}


### PR DESCRIPTION
## Problem

#641 made `pkg/rt/generated.manifest` record a SHA-256 per declared generator input. Editing any of those inputs restages `core_compiled.lgb`, `core_go_lowered/` and `zz_primitives_generated.go`, whether or not the generated content moves. `pkg/rt/os.go` is an ordinary source file, and nothing about editing it signals that a regeneration is now owed.

Nothing local catches the omission. No hook ran `check-generated` at any stage: the config has twelve hooks — nine at pre-commit, three at pre-push, with `forbid-compiled-binaries` at both — and none of them is this one. `make install-hooks` registers only the two merge drivers.

And no server-side operation can supply it, because none of them has a generator. A rebase moves a base. A merge driver resolves a file. The stack UI does both and force-pushes the result. None recomputes a hash.

The cost so far:

- `main` went red twice in three hours on 2026-08-16. #749 and #750 are the same commit written by hand twice: a regenerated manifest and its digest.
- The #698/#699/#717 stack stayed red through two full rounds of restacking. Each member needed its own `make generate`, and each one restaled the members above it, so the chore scaled with stack depth rather than with the size of the change.

There is also no backstop above it: per #751 the `main` ruleset has no `required_status_checks`, so a red branch reads as merely unreviewed.

## Change

Add `check-generated` as a pre-push hook.

It is a hash comparison of the manifest's declared inputs against the tree, with no regeneration and no build, so it costs about 1.3 seconds. That makes it the cheapest hook in the file — the three already at pre-push are `go test`, the vendored Clojure compat suite, and the ir-stress ratchet.

`always_run` is set rather than a `types` filter, because a declared input can be a `.go` or a `.lg` file and a filter on either would miss half the sources.

## Verification

With `prek`, the hook passes on a clean tree, and a committed edit to `pkg/rt/os.go` fails it:

```
generated-artifact manifest freshness (#641).............................Failed
  check-generated: dependency manifest stale for 3 output(s): pkg/rt/core_compiled.lgb, pkg/rt/core_go_lowered/, pkg/rt/zz_primitives_generated.go
  Run `make generate` to regenerate the bundle + lowered Go tree and refresh the manifest.
```

The failure only reproduces when the edit is committed. `prek` stashes unstaged changes before running hooks, so probing with a dirty working tree passes vacuously.

## What this does not cover

This is the local layer only, and it is worth being clear about the two it leaves open.

It would not have prevented either `main` outage. Those were stale-green *merges* — #743's checks ran 19 minutes before #641 landed, and GitHub does not recompute a merge ref when the base moves. That is #751's missing `required_status_checks`, and it needs a ruleset change rather than a hook.

It also does not settle the `merge=manifest` question in #747. My read is that this check weakens the case for a driver rather than complementing it: the sharp edge you identified there is a manifest that merges *cleanly* into a wrong state, since the file is sorted and one record per line, and a hash comparison against the tree catches exactly that. #747 already notes the risk that a regenerating driver "could assert outputs are ready when they have not been rebuilt". I would rather land this, see whether the driver still has a job, and decide that separately. You run these workflows locally more than I do, so if there is a conflict pattern this check misses, that changes the answer.

Refs #641, #747, #751.
