### PR TITLE
feat(vm): reflect proxy boxes multi-return funcs as vectors

### DIFF
--- a/docs/guide/go-interop.md
+++ b/docs/guide/go-interop.md
@@ -115,6 +115,31 @@ So the core of the wrapper is nearly free:
 `database/sql` is standard library, so the wrapper adds **no new go.mod
 dependency**. Only drivers are external, and they stay host-side (see below).
 
+### How Go return values arrive
+
+A boxed Go function's results map to let-go like this:
+
+| Go signature | let-go result |
+|---|---|
+| `func(…)` | `nil` |
+| `func(…) T` | the boxed `T` |
+| `func(…) error` | the boxed error **as a value** — does not throw |
+| `func(…) (T, error)` | boxed `T`, throwing when the error is non-nil |
+| `func(…) (A, B)` | vector `[a b]` |
+| `func(…) (A, B, …, error)` | vector `[a b …]`, throwing when the error is non-nil |
+
+A trailing `error` becomes a throw only when some other result remains to
+return. `func() error` — `Close`, `Flush`, and friends — hands the error back
+as an ordinary value, so `(if (.Close f) ...)` keeps working.
+
+The type test is on the *declared* result type, so a function returning a
+concrete `*MyError` is returning a value, not signalling failure. An `error` in
+any position but last is likewise an ordinary value.
+
+Known limitation: Go **array** results (`[N]T`, as opposed to slices) are not
+boxable and surface as an error. This is not specific to multi-return —
+`func() [1]int` has always behaved this way.
+
 ### The one seam: `Scan`'s out-parameters
 
 The interop layer already does the pointer work you'd expect: boxed values

--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -229,7 +229,7 @@ pkg/rt/core_compiled.lgb pkg/vm/meta_value.go generator 457b232d744935a2be249ab6
 pkg/rt/core_compiled.lgb pkg/vm/multifn.go generator faabb5b0a048d17c744e7e8bed33087f7d671063f8b5e2142252674bf7576efe
 pkg/rt/core_compiled.lgb pkg/vm/namespace.go generator b847271519c2b7eeba5bee173e31b7d4dd4c49361476ded23baf4a6d2cd5942b
 pkg/rt/core_compiled.lgb pkg/vm/native_func.go generator cc7a41a8836351b960838c36aac9eed51c6aa50520b699268bbfd7c8b274dec3
-pkg/rt/core_compiled.lgb pkg/vm/native_func_reflect.go generator d82a428b5956591759c70b004c94ae438a2ffffb72f07c34c7dc713dc06a0f4b
+pkg/rt/core_compiled.lgb pkg/vm/native_func_reflect.go generator e0b61c24da76fc1eed120ed9735d59469c99060f7539a8d6340faed8a6cda83b
 pkg/rt/core_compiled.lgb pkg/vm/native_func_tinygo.go generator c03c3ec4a5656b532ccb03aade7c9416e31413837c603d9ca75e3555ae850b29
 pkg/rt/core_compiled.lgb pkg/vm/nil.go generator 6bde1028333ea2286660e67121034d02e730c9d06db271b1ef93ebae5c09f177
 pkg/rt/core_compiled.lgb pkg/vm/numbers.go generator 27161e860e3114e1b344f6de904c565997d5b62c6106defc7df1f8804e975310
@@ -547,7 +547,7 @@ pkg/rt/core_go_lowered/ pkg/vm/meta_value.go generator 457b232d744935a2be249ab6d
 pkg/rt/core_go_lowered/ pkg/vm/multifn.go generator faabb5b0a048d17c744e7e8bed33087f7d671063f8b5e2142252674bf7576efe
 pkg/rt/core_go_lowered/ pkg/vm/namespace.go generator b847271519c2b7eeba5bee173e31b7d4dd4c49361476ded23baf4a6d2cd5942b
 pkg/rt/core_go_lowered/ pkg/vm/native_func.go generator cc7a41a8836351b960838c36aac9eed51c6aa50520b699268bbfd7c8b274dec3
-pkg/rt/core_go_lowered/ pkg/vm/native_func_reflect.go generator d82a428b5956591759c70b004c94ae438a2ffffb72f07c34c7dc713dc06a0f4b
+pkg/rt/core_go_lowered/ pkg/vm/native_func_reflect.go generator e0b61c24da76fc1eed120ed9735d59469c99060f7539a8d6340faed8a6cda83b
 pkg/rt/core_go_lowered/ pkg/vm/native_func_tinygo.go generator c03c3ec4a5656b532ccb03aade7c9416e31413837c603d9ca75e3555ae850b29
 pkg/rt/core_go_lowered/ pkg/vm/nil.go generator 6bde1028333ea2286660e67121034d02e730c9d06db271b1ef93ebae5c09f177
 pkg/rt/core_go_lowered/ pkg/vm/numbers.go generator 27161e860e3114e1b344f6de904c565997d5b62c6106defc7df1f8804e975310

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-2c725207920e5317a2a57b08fd50dda35854c05109ea4bd168c2a083415df097
+9f371b256c1ee41420e5851a319ca78984ba71e0f30a5b74c80732d1560015e5

--- a/pkg/vm/native_func_reflect.go
+++ b/pkg/vm/native_func_reflect.go
@@ -65,27 +65,49 @@ func boxReflectFunc(t *theNativeFnType, fn any, ty reflect.Type) (Value, error) 
 			}
 		}
 		res := v.Call(rawArgs)
-		lr := len(res)
-		if lr == 0 {
-			return NIL, nil
+
+		// A trailing `error` is Go's failure channel, so surface it as a throw
+		// rather than as a value — but only when a non-error result remains to
+		// return. `func() error` (Close, Write, …) keeps handing the error back
+		// as an ordinary value, which is what existing let-go code expects; the
+		// peel applies from (T, error) upward, exactly as it always has.
+		//
+		// The type test is against the `error` interface rather than the
+		// implemented-by relation: res carries DECLARED result types, so a
+		// function returning a concrete *MyError is returning a value, not
+		// signalling failure.
+		var callErr error
+		if n := len(res); n >= 2 && res[n-1].Type() == reflect.TypeFor[error]() {
+			if e := res[n-1].Interface(); e != nil {
+				callErr = e.(error)
+			}
+			res = res[:n-1]
 		}
-		if lr == 1 {
+
+		switch len(res) {
+		case 0:
+			return NIL, callErr
+		case 1:
 			wv, err := BoxValue(res[0])
 			if err != nil {
 				return NIL, err
 			}
-			return wv, nil
+			return wv, callErr
 		}
-		// assume lr == 2 && res[1] is error
-		wv, err := BoxValue(res[0])
-		if err != nil {
-			return NIL, err
+
+		// Two or more results: box them into a vector. Previously everything
+		// past the second was dropped here, on the Go side and before boxing,
+		// so a .lg veneer could never recover it. (a, b, ok) and (a, b, err)
+		// are ordinary modern Go — strings.Cut returns three.
+		vals := make([]Value, len(res))
+		for i := range res {
+			wv, err := BoxValue(res[i])
+			if err != nil {
+				return NIL, err
+			}
+			vals[i] = wv
 		}
-		errorInterface := reflect.TypeFor[error]()
-		if res[1].Type() == errorInterface && res[1].Interface() != nil {
-			return wv, res[1].Interface().(error)
-		}
-		return wv, nil
+		return ArrayVector(vals), callErr
 	}
 
 	f := &NativeFn{

--- a/pkg/vm/native_func_reflect_test.go
+++ b/pkg/vm/native_func_reflect_test.go
@@ -1,0 +1,175 @@
+//go:build !tinygo
+
+/*
+ * Copyright (c) 2026 let-go contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+package vm
+
+import (
+	"errors"
+	"testing"
+)
+
+// The reflect proxy assumed a Go function returns at most two values, and
+// silently dropped anything past the second. That drop happens on the Go side,
+// before boxing, so no amount of .lg veneer can recover the lost values — and a
+// wrapper library has no Go of its own to shim with. (a, b, ok) and
+// (a, b, err) are ordinary modern Go: strings.Cut returns three.
+func TestBoxReflectFuncMultiReturn(t *testing.T) {
+	boom := errors.New("boom")
+
+	tests := []struct {
+		name    string
+		fn      any
+		want    string
+		wantErr error
+	}{
+		// Existing shapes must not move.
+		{name: "no results", fn: func() {}, want: "nil"},
+		{name: "one result", fn: func() int { return 7 }, want: "7"},
+		{name: "value and nil error", fn: func() (int, error) { return 7, nil }, want: "7"},
+		{
+			name:    "value and non-nil error throws",
+			fn:      func() (int, error) { return 0, boom },
+			want:    "0",
+			wantErr: boom,
+		},
+
+		// Previously dropped.
+		{name: "two non-error results", fn: func() (int, string) { return 1, "a" }, want: `[1 "a"]`},
+		{name: "three non-error results", fn: func() (int, string, bool) { return 1, "a", true }, want: `[1 "a" true]`},
+		{
+			name: "strings.Cut shape: two values and a bool",
+			fn:   func() (string, string, bool) { return "k", "v", true },
+			want: `["k" "v" true]`,
+		},
+		{
+			name: "two values and a nil error",
+			fn:   func() (int, string, error) { return 1, "a", nil },
+			want: `[1 "a"]`,
+		},
+		{
+			name:    "two values and a non-nil error throws",
+			fn:      func() (int, string, error) { return 1, "a", boom },
+			want:    `[1 "a"]`,
+			wantErr: boom,
+		},
+		{
+			name: "four values",
+			fn:   func() (int, int, int, int) { return 1, 2, 3, 4 },
+			want: "[1 2 3 4]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			boxed, err := NativeFnType.Box(tt.fn)
+			if err != nil {
+				t.Fatalf("Box: %v", err)
+			}
+			fn, ok := boxed.(*NativeFn)
+			if !ok {
+				t.Fatalf("Box returned %T, want *NativeFn", boxed)
+			}
+			got, err := fn.proxy(nil)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("proxy err = %v, want %v", err, tt.wantErr)
+			}
+			rendered, rerr := SafeString(got)
+			if rerr != nil {
+				t.Fatalf("SafeString: %v", rerr)
+			}
+			if rendered != tt.want {
+				t.Errorf("proxy() = %s, want %s", rendered, tt.want)
+			}
+		})
+	}
+}
+
+// func() error must keep returning the error as a VALUE rather than throwing.
+// Every reflect-boxed Close/Write/Flush has this shape, so peeling here would
+// silently change how a large amount of existing interop behaves. The peel
+// starts at (T, error), exactly where it always did.
+func TestBoxReflectFuncSoleErrorStaysAValue(t *testing.T) {
+	boom := errors.New("boom")
+	for _, tt := range []struct {
+		name string
+		fn   any
+		want string
+	}{
+		{name: "non-nil error", fn: func() error { return boom }, want: "<go.*errors.errorString boom>"},
+		{name: "nil error", fn: func() error { return nil }, want: "nil"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			boxed, err := NativeFnType.Box(tt.fn)
+			if err != nil {
+				t.Fatalf("Box: %v", err)
+			}
+			got, err := boxed.(*NativeFn).proxy(nil)
+			if err != nil {
+				t.Fatalf("func() error must not throw, got %v", err)
+			}
+			rendered, rerr := SafeString(got)
+			if rerr != nil {
+				t.Fatalf("SafeString: %v", rerr)
+			}
+			if rendered != tt.want {
+				t.Errorf("proxy() = %s, want %s", rendered, tt.want)
+			}
+		})
+	}
+}
+
+// Known limitation, pinned so a future fix is deliberate rather than
+// accidental: BoxValue does not support Go ARRAY values. Its
+// `case reflect.Slice, reflect.Array` calls IsNil — invalid for arrays — and
+// the branches under it assert []int64 / call Bytes(), neither of which holds
+// for [N]T. This predates multi-return: func() [1]int panics the same way and
+// always has. NativeFn.Invoke recovers it into an error, so callers see a
+// failure rather than a crash.
+//
+// Multi-return makes the existing hole reachable through one more shape. That
+// is a visible error instead of the silent wrong answer it used to give (the
+// array result was simply dropped), so it is not a regression — but it is not
+// a fix either, and fixing BoxValue is out of scope here.
+func TestBoxReflectFuncArrayResultIsAKnownLimitation(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		fn   any
+	}{
+		{name: "sole array result (pre-existing)", fn: func() [1]int { return [1]int{9} }},
+		{name: "array among several results", fn: func() (int, [1]int) { return 1, [1]int{9} }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			boxed, err := NativeFnType.Box(tt.fn)
+			if err != nil {
+				t.Fatalf("Box: %v", err)
+			}
+			// Invoke, not proxy: Invoke is what recovers the panic into an error.
+			if _, err := boxed.(*NativeFn).Invoke(nil); err == nil {
+				t.Errorf("expected an error for an array result; if BoxValue " +
+					"learned to box arrays, update this test to assert the value")
+			}
+		})
+	}
+}
+
+// A trailing error is peeled off as a throw only when it is actually the last
+// result. An error in any other position is an ordinary value.
+func TestBoxReflectFuncErrorOnlyPeeledWhenTrailing(t *testing.T) {
+	boom := errors.New("boom")
+	boxed, err := NativeFnType.Box(func() (error, int) { return boom, 3 })
+	if err != nil {
+		t.Fatalf("Box: %v", err)
+	}
+	got, err := boxed.(*NativeFn).proxy(nil)
+	if err != nil {
+		t.Fatalf("a non-trailing error must not throw, got %v", err)
+	}
+	v, ok := got.(ArrayVector)
+	if !ok || len(v) != 2 {
+		t.Fatalf("got %#v, want a 2-element vector", got)
+	}
+}


### PR DESCRIPTION
Resolves: #775 

Same goal as #773: letting lgx projects depend on Go libraries. That only pays off if calling those libraries works, and the reflect proxy assumed at most two results, silently dropping the rest. Any `(a, b, ok)` or `(a, b, err)` function came back wrong, and `strings.Cut` returns three. The values were dropped on the Go side before boxing, so no `.lg` wrapper could recover them.

Independent of #773 and can land in any order.