### PR TITLE
fix(ir): preserve capture-free closure identity

### DIFF
--- a/pkg/ir/lisp_closure_template_test.go
+++ b/pkg/ir/lisp_closure_template_test.go
@@ -57,3 +57,33 @@ func TestNestedMultiFnTemplateStillExecutesViaBytecodeLowering(t *testing.T) {
 		t.Fatalf("expected captured one-arity branch to produce 3, got %T %v", result, result)
 	}
 }
+
+func TestIRBytecodePreservesCaptureFreeClosureIdentity(t *testing.T) {
+	ensureLoader()
+
+	runLispExpr(t, `(binding [*ir-compile* true]
+		(eval (quote
+			(defn ir-closure-identity-regression [eq]
+				(let* [f (fn* [x] (+ x 1))
+				       f-again f]
+				  (eq f f-again))))))`)
+	runLispExpr(t, `(binding [*ir-compile* true]
+		(eval (quote
+			(defn ir-closure-identity-variadic-regression [eq]
+				(let* [f (fn* [x] (+ x 1))]
+				  (eq f f f))))))`)
+	runLispExpr(t, `(binding [*ir-compile* true]
+		(eval (quote
+			(defn ir-distinct-closure-sites-regression [identical?]
+				(not (identical? (fn* [x] x) (fn* [x] x)))))))`)
+
+	for _, call := range []string{
+		`(ir-closure-identity-regression =)`,
+		`(ir-closure-identity-variadic-regression =)`,
+		`(ir-distinct-closure-sites-regression identical?)`,
+	} {
+		if result := runLispExpr(t, call); result != vm.TRUE {
+			t.Fatalf("%s = %v, want true", call, result)
+		}
+	}
+}

--- a/pkg/rt/core/ir/lower.lg
+++ b/pkg/rt/core/ir/lower.lg
@@ -30,9 +30,17 @@
 
 (declare lower)
 
+(defn- fn-template-aux? [aux]
+  (and (map? aux)
+       (contains? #{:fn-template :multi-fn-template} (:kind aux))))
+
+(defn- fn-template-const? [f nid]
+  (and (= :const (ir/op nid f))
+       (fn-template-aux? (ir/aux nid f))))
+
 (defn- template-value [aux]
   (cond
-    (and (map? aux) (= (:kind aux) :fn-template))
+    (and (fn-template-aux? aux) (= (:kind aux) :fn-template))
     (let [inner (:fn aux)
           arity (:arity aux)
           variadic? (:variadic? aux)
@@ -216,7 +224,9 @@
         (when-not (ir/uses-empty? us)
           (let [def-block (ir/block-of i f)
                 def-op    (ir/op i f)]
-            (when-not (and (ir/op-cheap-load? def-op) (not= def-op :load-var))
+            (when-not (and (ir/op-cheap-load? def-op)
+                           (not= def-op :load-var)
+                           (not (fn-template-const? f i)))
               (ir/uses-for-each us
                 (fn [user-id]
                   (let [user-block (ir/block-of user-id f)]
@@ -422,6 +432,11 @@
   (let [uc (use-count-of l nid)]
     (cond
       (zero? uc) false
+      ;; A function literal is an allocation with observable identity, not a
+      ;; replayable scalar constant. Materialize it once per lowering site and
+      ;; DUP_NTH every local reuse; re-running template-value would manufacture
+      ;; a distinct *vm.Func for each reference.
+      (fn-template-const? (f-of l) nid) true
       (> uc 1) false
       :else
       ;; uc == 1 already → bitset has exactly one user-id. Pull it via

--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -64,7 +64,7 @@ pkg/rt/core_compiled.lgb pkg/rt/core/ir/dominance.lg generator 628f963434f65c2d9
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/dump.lg generator 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/form_heads.lg generator 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lattice.lg generator a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg generator c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
+pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg generator 3f5b4c402609370c3f308922e685c8dd205150d5d8c06bc537f5ac2506bf1ea3
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower_go.lg generator 1966bea7ee7fdb40a1f1deaa33477ced1ed6772844e9c13e297649cd9ba511ce
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/ops.lg generator 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/passes.lg generator ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169
@@ -290,7 +290,7 @@ pkg/rt/core_compiled.lgb pkg/rt/core/ir/dominance.lg input 628f963434f65c2d93827
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/dump.lg input 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/form_heads.lg input 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lattice.lg input a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg input c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
+pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower.lg input 3f5b4c402609370c3f308922e685c8dd205150d5d8c06bc537f5ac2506bf1ea3
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/lower_go.lg input 1966bea7ee7fdb40a1f1deaa33477ced1ed6772844e9c13e297649cd9ba511ce
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/ops.lg input 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_compiled.lgb pkg/rt/core/ir/passes.lg input ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169
@@ -381,7 +381,7 @@ pkg/rt/core_go_lowered/ pkg/rt/core/ir/dominance.lg generator 628f963434f65c2d93
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/dump.lg generator 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/form_heads.lg generator 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lattice.lg generator a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg generator c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
+pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg generator 3f5b4c402609370c3f308922e685c8dd205150d5d8c06bc537f5ac2506bf1ea3
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower_go.lg generator 1966bea7ee7fdb40a1f1deaa33477ced1ed6772844e9c13e297649cd9ba511ce
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/ops.lg generator 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/passes.lg generator ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169
@@ -607,7 +607,7 @@ pkg/rt/core_go_lowered/ pkg/rt/core/ir/dominance.lg input 628f963434f65c2d938273
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/dump.lg input 37931f132b103329225590cc8451988991eb0fffbcf9b00a9a087c7532f5d3a1
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/form_heads.lg input 257c0c97c0b0321a3bd439f67d908c5f9f7dfe8f3b0f0a8e66a3068f9677beaf
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lattice.lg input a22cca8585c949e1466e047c2d343bbfe2a1fd3501139cb189e24b3716e63586
-pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg input c92aef96318f133f6be5411acf4aca264d05ee9bf91f1a1f8a7247901ac39e7c
+pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower.lg input 3f5b4c402609370c3f308922e685c8dd205150d5d8c06bc537f5ac2506bf1ea3
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/lower_go.lg input 1966bea7ee7fdb40a1f1deaa33477ced1ed6772844e9c13e297649cd9ba511ce
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/ops.lg input 86f2e25640809fb91000caa687e242dcff7fbe9011725a49cfa574def24c7836
 pkg/rt/core_go_lowered/ pkg/rt/core/ir/passes.lg input ac86c005541910dca8564b5f537139d1e76e2581b51eaf3ed50b54e8c3065169

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-ea5f425c41d0638c421bc3bdff14967ec557ee01f63020cd6537dc24d52726d5
+1805fd81f7ae15b4f41e6491ac03d53cb2762525ae0f5e609fa5d40b4732bee8


### PR DESCRIPTION
## Why

Under `*ir-compile*`, a capture-free `fn*` literal is a `:const` node carrying a `:fn-template` aux. The lowering treated it like any other cheap replayable constant: multiple local references re-ran `template-value` at each use site, manufacturing a distinct `*vm.Func` per reference.

Observable damage: closure identity breaks. `(let* [f (fn* [x] ...) g f] (identical? f g))` is false under IR compilation and true under the direct compiler; `=` on the rebound closure fails the same way.

## What changed

`pkg/rt/core/ir/lower.lg`:

- `fn-template-const?` recognizes `:fn-template`/`:multi-fn-template` const nodes.
- The cheap-load rematerialization path excludes them, so a function literal is materialized once per lowering site and every local reuse goes through `DUP_NTH` of that one value.
- The use-count sink rule treats a fn-template const as always worth a slot: it is an allocation with observable identity, not a replayable scalar.

Distinct textual `fn*` literals still produce distinct closures (`(identical? (fn* [x] x) (fn* [x] x))` stays false).

`pkg/rt/generated.manifest` / `generated.sums` are refreshed because `lower.lg` is a declared generator input.

## Verification

New `TestIRBytecodePreservesCaptureFreeClosureIdentity` in `pkg/ir/lisp_closure_template_test.go` pins rebinding identity, multi-reference identity, and the distinct-sites negative case under `*ir-compile*`.

`make generate` twice is deterministic, `make check-generated` passes, and `go test ./...` including the e2e suite passes on this head.

Complementary to #767: that fixes capturing closures at disagreeing joins in `lower_go.lg`; this fixes capture-free closure identity in bytecode `lower.lg`. No file overlap.
