### PR TITLE
build: gate untagged builds against the optional heavy subsystems

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -159,6 +159,28 @@ jobs:
   # Keeps the lg_no_http lane from rotting. Nothing in the default build
   # exercises pkg/rt/http_stub.go, so without this a change to http.go's
   # signatures breaks the tagged build silently.
+  # Default-build dependency gate. The optional heavy subsystems (glplat's GL
+  # and Ebitengine backends, and the font stack they use) are meant to be
+  # reachable only behind a build tag. A single untagged file in their import
+  # closure puts the whole closure in every binary we ship, and nothing else
+  # here would notice: the build still succeeds and the tests still pass.
+  # Measured on the glplat branch, an untagged pkg/rt/interop_glplat.go cost
+  # the default binary +718,208 bytes (+3.60%) and hit ./cmd/lg-runtime too,
+  # which is the binary #658 spent effort shrinking. Same lane as #652/#658.
+  default-deps:
+    name: default-deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Assert untagged builds link no tag-gated subsystems
+        run: make check-default-deps
+
   no-http-build:
     name: no-http-build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -447,6 +447,13 @@ check-generated-manifest: $(GO)
 #     parity job, any -tags gogen_ir build) regenerate it first; the untagged
 #     build and the shipped bytecode binary never need it.
 #
+# Default-build dependency gate: an untagged build must not link the optional
+# heavy subsystems. See scripts/check-default-deps.sh for why the patterns are
+# anchored — the stdlib's vendored x/text copies would otherwise trip it.
+.PHONY: check-default-deps
+check-default-deps: $(GO)
+	@scripts/check-default-deps.sh
+
 # This is the gate CI runs. After a merge/rebase touching pkg/rt/core/**, run
 # `make check-generated` (or `make generate` to refresh, then commit).
 check-generated: check-generated-manifest $(GO)

--- a/scripts/check-default-deps.sh
+++ b/scripts/check-default-deps.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Default-build dependency gate.
+#
+# Asserts that a plain, untagged build of the shipping binaries links none of
+# the optional heavy subsystems. Those subsystems are meant to be reachable
+# only behind a build tag; a single untagged file anywhere in their import
+# closure silently puts them in every binary we ship.
+#
+# This exists because that is not hypothetical. On the glplat branch,
+# pkg/rt/interop_glplat.go — generated, in package rt, and therefore in every
+# binary — carried no build tag, so the default `lg` build linked
+# golang.org/x/image and golang.org/x/text through pkg/glplat/font.go. Cost:
+# +718,208 bytes, +3.60% (19,958,434 -> 20,676,642, darwin/arm64, measured
+# 2026-09-02). The GL and Ebitengine backends themselves were correctly gated;
+# it was the untagged font path that leaked. Nothing catches that today, which
+# is the gap this closes — and it runs against the same binary-footprint work
+# as #652/#658.
+#
+# ANCHORING IS LOAD-BEARING. `go list -deps` reports the standard library's
+# vendored copies under a `vendor/` prefix, so main already lists
+# vendor/golang.org/x/text/{transform,unicode/bidi,secure/bidirule,unicode/norm}
+# by way of net/http's IDNA handling. Those are stdlib, not the module, and
+# must not trip the gate. Every pattern below is anchored with ^ so the
+# vendored copies do not match; drop the anchor and this fails on main.
+set -euo pipefail
+
+# Import-path prefixes that must not appear in an untagged build. Extend this
+# list when a new optional subsystem lands, not when one trips the gate.
+DENY='^golang\.org/x/image/|^golang\.org/x/text/|^github\.com/go-gl/|^github\.com/hajimehoshi/|^github\.com/ebitengine/'
+
+TARGETS=("." "./cmd/lg-runtime")
+
+status=0
+for target in "${TARGETS[@]}"; do
+    if ! deps="$(go list -deps "$target" 2>/dev/null)"; then
+        echo "check-default-deps: go list -deps $target failed" >&2
+        exit 2
+    fi
+    if found="$(printf '%s\n' "$deps" | grep -E "$DENY")"; then
+        status=1
+        echo "check-default-deps: $target links tag-gated dependencies in an untagged build:" >&2
+        printf '  %s\n' $found >&2
+    fi
+done
+
+if [ "$status" -ne 0 ]; then
+    cat >&2 <<'MSG'
+
+Every package above should be reachable only behind a build tag. The usual
+cause is one untagged file in the subsystem's import closure — check for a
+file with no //go:build line, including generated ones, since a generated
+file in package rt puts the whole closure in every binary.
+MSG
+    exit 1
+fi
+
+echo "check-default-deps: OK — untagged builds link no tag-gated subsystems."


### PR DESCRIPTION
The GL and Ebitengine backends and the font stack they use are meant to be reachable only behind a build tag. One untagged file anywhere in their import closure defeats that, and nothing in CI notices, because the build still succeeds and the tests still pass while every shipped binary grows.

`scripts/check-default-deps.sh` runs `go list -deps` over both shipping targets, `.` and `./cmd/lg-runtime`, and fails if either links a tag-gated subsystem. It is wired up as `make check-default-deps` and as a `default-deps` CI job.

Motivating case and the measurement: #788.
