### PR TITLE
perf(vm): make PrepareCall allocation-free for native fold loops

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -143,7 +143,7 @@ pkg/rt/core_compiled.lgb pkg/rt/lg_bind_marker.go generator e9732750420945f868e1
 pkg/rt/core_compiled.lgb pkg/rt/math.go generator d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/core_compiled.lgb pkg/rt/native_direct.go generator db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a
 pkg/rt/core_compiled.lgb pkg/rt/native_direct_install.go generator 674bede5ceee03bb0d2af8b88f3290cfe15d1826768abcfeeb0aaf63e081cabe
-pkg/rt/core_compiled.lgb pkg/rt/native_prims.go generator df4e87fb76a3378156ff19a37b39c4317fb8f6399efedee180d34f430917ccec
+pkg/rt/core_compiled.lgb pkg/rt/native_prims.go generator f5c6734ede69cb6a3e01f9501c34a79faa685a7d83b3cb5b150d7e5232db242b
 pkg/rt/core_compiled.lgb pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_compiled.lgb pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_compiled.lgb pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
@@ -211,7 +211,7 @@ pkg/rt/core_compiled.lgb pkg/vm/exception_class.go generator 05ae249d3b954d46791
 pkg/rt/core_compiled.lgb pkg/vm/exec_context.go generator d29c0a58bcf9a1826a01cb907856740aca9be30ca3556cb5a59a1931f6c9dfd7
 pkg/rt/core_compiled.lgb pkg/vm/exinfo.go generator 40b4c132683e364747033ec44e8a2301eddec1aafca872e55000611bd737dcae
 pkg/rt/core_compiled.lgb pkg/vm/float.go generator 264fd7adbcc359d8fcab67330b3f37a3a68192260183b9356de36c53f2c7d41b
-pkg/rt/core_compiled.lgb pkg/vm/func.go generator 265f957c72f9958d446259de178c36792995a9147f639ad110f60579e95127ff
+pkg/rt/core_compiled.lgb pkg/vm/func.go generator 1863e6df3e00709af60100cef4653c5af0735e6015a13b1ba16d5df9eb2e0db5
 pkg/rt/core_compiled.lgb pkg/vm/hash.go generator 64a27b187fd9a9b46842bb881986b088f1fa24dae8a53d5e3dc0b3be2772990f
 pkg/rt/core_compiled.lgb pkg/vm/instant.go generator 990c7d2e5060db4e6f59dae4dd0e216d4b5b4a5c850df906ef235aba538e4ec4
 pkg/rt/core_compiled.lgb pkg/vm/int.go generator d69e7093cc3a7f83d583653f9460d9e6312028a1186bdfd6658a179e0883fb91
@@ -238,7 +238,7 @@ pkg/rt/core_compiled.lgb pkg/vm/persistent_queue.go generator ff8a6e5b89dc696861
 pkg/rt/core_compiled.lgb pkg/vm/persistent_set.go generator 29ca3f88a849d6ce3fec5fdc55a70fb2f2129fc35c836efa905936b87ca2ce99
 pkg/rt/core_compiled.lgb pkg/vm/persistent_vector.go generator 8d23146ecfa0a8bdf0392ce955e8563cfbcb6e0890a800a21948ca51fcb981f2
 pkg/rt/core_compiled.lgb pkg/vm/persistent_vector_chunked.go generator 02eccfe961b615f1db95f19f53ffb5da0e60cc3bf6c52005328a8e70129fcfe1
-pkg/rt/core_compiled.lgb pkg/vm/prepared_call.go generator c1a7e9c7ab150e8ab660068a6a290c725c57be5f0dce56c236f0484a27b6af44
+pkg/rt/core_compiled.lgb pkg/vm/prepared_call.go generator ada0b57187db626cbe2cd7096e980c7ab60947ce0c52142ed236a78d01ddb9a3
 pkg/rt/core_compiled.lgb pkg/vm/profile.go generator 0ae176ffc3bff446d8c8366d2dc6e1f156da15b2648295ef0b1bbc921e31e69a
 pkg/rt/core_compiled.lgb pkg/vm/promise.go generator 52b22d987ab77e71cb306ef9007fa97c4daf04ae9cc5a425917486de381ae4cc
 pkg/rt/core_compiled.lgb pkg/vm/protocol.go generator 92d5591408555a267fed43ecc6eb0d02d6ccde2d3e9a1706cdf02e53792678ec
@@ -268,7 +268,7 @@ pkg/rt/core_compiled.lgb pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2
 pkg/rt/core_compiled.lgb pkg/vm/value.go generator 9c00df4c29b70dc9fea057628152cf139bdc73abc75d8666877fb7bf94be8c96
 pkg/rt/core_compiled.lgb pkg/vm/var.go generator 816e670512bc08f78a6d8a39bd8280dea82b171454ac99a54be2595942aee39d
 pkg/rt/core_compiled.lgb pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_compiled.lgb pkg/vm/vm.go generator 74440788fc7cbe3cf1b81d8e0cb713d6a2841b205eafc0c58472e084c6d2d4c9
+pkg/rt/core_compiled.lgb pkg/vm/vm.go generator 1f948756f500ef17291c2eb250051a192571b78547034d8ed04fd56a073ab4f1
 pkg/rt/core_compiled.lgb pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_compiled.lgb pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_compiled.lgb pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a
@@ -459,7 +459,7 @@ pkg/rt/core_go_lowered/ pkg/rt/lg_bind_marker.go generator e9732750420945f868e16
 pkg/rt/core_go_lowered/ pkg/rt/math.go generator d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/core_go_lowered/ pkg/rt/native_direct.go generator db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a
 pkg/rt/core_go_lowered/ pkg/rt/native_direct_install.go generator 674bede5ceee03bb0d2af8b88f3290cfe15d1826768abcfeeb0aaf63e081cabe
-pkg/rt/core_go_lowered/ pkg/rt/native_prims.go generator df4e87fb76a3378156ff19a37b39c4317fb8f6399efedee180d34f430917ccec
+pkg/rt/core_go_lowered/ pkg/rt/native_prims.go generator f5c6734ede69cb6a3e01f9501c34a79faa685a7d83b3cb5b150d7e5232db242b
 pkg/rt/core_go_lowered/ pkg/rt/native_prims_lifecycle.go generator 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/core_go_lowered/ pkg/rt/net.go generator 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/core_go_lowered/ pkg/rt/net_wasm.go generator e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42
@@ -527,7 +527,7 @@ pkg/rt/core_go_lowered/ pkg/vm/exception_class.go generator 05ae249d3b954d467911
 pkg/rt/core_go_lowered/ pkg/vm/exec_context.go generator d29c0a58bcf9a1826a01cb907856740aca9be30ca3556cb5a59a1931f6c9dfd7
 pkg/rt/core_go_lowered/ pkg/vm/exinfo.go generator 40b4c132683e364747033ec44e8a2301eddec1aafca872e55000611bd737dcae
 pkg/rt/core_go_lowered/ pkg/vm/float.go generator 264fd7adbcc359d8fcab67330b3f37a3a68192260183b9356de36c53f2c7d41b
-pkg/rt/core_go_lowered/ pkg/vm/func.go generator 265f957c72f9958d446259de178c36792995a9147f639ad110f60579e95127ff
+pkg/rt/core_go_lowered/ pkg/vm/func.go generator 1863e6df3e00709af60100cef4653c5af0735e6015a13b1ba16d5df9eb2e0db5
 pkg/rt/core_go_lowered/ pkg/vm/hash.go generator 64a27b187fd9a9b46842bb881986b088f1fa24dae8a53d5e3dc0b3be2772990f
 pkg/rt/core_go_lowered/ pkg/vm/instant.go generator 990c7d2e5060db4e6f59dae4dd0e216d4b5b4a5c850df906ef235aba538e4ec4
 pkg/rt/core_go_lowered/ pkg/vm/int.go generator d69e7093cc3a7f83d583653f9460d9e6312028a1186bdfd6658a179e0883fb91
@@ -554,7 +554,7 @@ pkg/rt/core_go_lowered/ pkg/vm/persistent_queue.go generator ff8a6e5b89dc6968615
 pkg/rt/core_go_lowered/ pkg/vm/persistent_set.go generator 29ca3f88a849d6ce3fec5fdc55a70fb2f2129fc35c836efa905936b87ca2ce99
 pkg/rt/core_go_lowered/ pkg/vm/persistent_vector.go generator 8d23146ecfa0a8bdf0392ce955e8563cfbcb6e0890a800a21948ca51fcb981f2
 pkg/rt/core_go_lowered/ pkg/vm/persistent_vector_chunked.go generator 02eccfe961b615f1db95f19f53ffb5da0e60cc3bf6c52005328a8e70129fcfe1
-pkg/rt/core_go_lowered/ pkg/vm/prepared_call.go generator c1a7e9c7ab150e8ab660068a6a290c725c57be5f0dce56c236f0484a27b6af44
+pkg/rt/core_go_lowered/ pkg/vm/prepared_call.go generator ada0b57187db626cbe2cd7096e980c7ab60947ce0c52142ed236a78d01ddb9a3
 pkg/rt/core_go_lowered/ pkg/vm/profile.go generator 0ae176ffc3bff446d8c8366d2dc6e1f156da15b2648295ef0b1bbc921e31e69a
 pkg/rt/core_go_lowered/ pkg/vm/promise.go generator 52b22d987ab77e71cb306ef9007fa97c4daf04ae9cc5a425917486de381ae4cc
 pkg/rt/core_go_lowered/ pkg/vm/protocol.go generator 92d5591408555a267fed43ecc6eb0d02d6ccde2d3e9a1706cdf02e53792678ec
@@ -584,7 +584,7 @@ pkg/rt/core_go_lowered/ pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2a
 pkg/rt/core_go_lowered/ pkg/vm/value.go generator 9c00df4c29b70dc9fea057628152cf139bdc73abc75d8666877fb7bf94be8c96
 pkg/rt/core_go_lowered/ pkg/vm/var.go generator 816e670512bc08f78a6d8a39bd8280dea82b171454ac99a54be2595942aee39d
 pkg/rt/core_go_lowered/ pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_go_lowered/ pkg/vm/vm.go generator 74440788fc7cbe3cf1b81d8e0cb713d6a2841b205eafc0c58472e084c6d2d4c9
+pkg/rt/core_go_lowered/ pkg/vm/vm.go generator 1f948756f500ef17291c2eb250051a192571b78547034d8ed04fd56a073ab4f1
 pkg/rt/core_go_lowered/ pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_go_lowered/ pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_go_lowered/ pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a
@@ -704,7 +704,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/lg_bind_marker.go input e9732750420945f
 pkg/rt/zz_primitives_generated.go pkg/rt/math.go input d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/zz_primitives_generated.go pkg/rt/native_direct.go input db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a
 pkg/rt/zz_primitives_generated.go pkg/rt/native_direct_install.go input 674bede5ceee03bb0d2af8b88f3290cfe15d1826768abcfeeb0aaf63e081cabe
-pkg/rt/zz_primitives_generated.go pkg/rt/native_prims.go input df4e87fb76a3378156ff19a37b39c4317fb8f6399efedee180d34f430917ccec
+pkg/rt/zz_primitives_generated.go pkg/rt/native_prims.go input f5c6734ede69cb6a3e01f9501c34a79faa685a7d83b3cb5b150d7e5232db242b
 pkg/rt/zz_primitives_generated.go pkg/rt/native_prims_lifecycle.go input 62e02df9b4ca29ed1c65a82d500f83b6a89eb2a69c741f95bbc35693a85f60e6
 pkg/rt/zz_primitives_generated.go pkg/rt/net.go input 6b117f6b365173941f01996d3813113bf58604c975a2f8ec2776ca538f987452
 pkg/rt/zz_primitives_generated.go pkg/rt/net_wasm.go input e7780099c634a41c9a4a26792bb3a86710a2148431af8c6853e5d034682bbe42

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-c740d0c0e3f707c8baaa96f0ed07c9780c5af1d518411fa162bf16d9883117c8
+1fa0851b236088a7cf9017075e7bfd19f530e2743176979111901970c56cf5ec

--- a/pkg/rt/native_prims.go
+++ b/pkg/rt/native_prims.go
@@ -386,8 +386,12 @@ func reduceColl(ec *vm.ExecContext, mfn vm.Fn, coll vm.Value, hasInit bool, init
 	// fold; per-element ec.Invoke pays resolution, frame-pool traffic, and
 	// frame init on every element. Non-bytecode/variadic reducers fall back
 	// to the generic invoke below.
-	pc := ec.PrepareCall(mfn, 2)
-	if pc != nil {
+	// The PreparedCall lives on this stack frame and its argument slots in
+	// the pooled VM frame, so a short reduce (the IR compiler does thousands
+	// per compile) pays no heap allocation for the preparation itself.
+	var pc vm.PreparedCall
+	prepared := ec.PrepareCallInto(&pc, mfn, 2)
+	if prepared {
 		defer pc.Release()
 	}
 	// Reused two-arg buffer, shared by every path below: ec.Invoke does not
@@ -408,7 +412,7 @@ func reduceColl(ec *vm.ExecContext, mfn vm.Fn, coll vm.Value, hasInit bool, init
 		for ; i < len(av); i++ {
 			var res vm.Value
 			var err error
-			if pc != nil {
+			if prepared {
 				res, err = pc.Call2(acc, av[i])
 			} else {
 				fargs[0] = acc
@@ -441,7 +445,7 @@ func reduceColl(ec *vm.ExecContext, mfn vm.Fn, coll vm.Value, hasInit bool, init
 		for (step > 0 && i < end) || (step < 0 && i > end) {
 			var res vm.Value
 			var err error
-			if pc != nil {
+			if prepared {
 				res, err = pc.Call2(acc, vm.Int(i))
 			} else {
 				fargs[0] = acc
@@ -492,7 +496,7 @@ func reduceColl(ec *vm.ExecContext, mfn vm.Fn, coll vm.Value, hasInit bool, init
 			c := cs.ChunkedFirst()
 			n := c.ChunkCount()
 			for i := 0; i < n; i++ {
-				if pc != nil {
+				if prepared {
 					acc, err = pc.Call2(acc, c.Nth(i))
 				} else {
 					fargs[0] = acc
@@ -509,7 +513,7 @@ func reduceColl(ec *vm.ExecContext, mfn vm.Fn, coll vm.Value, hasInit bool, init
 			seq = cs.ChunkedNext()
 			continue
 		}
-		if pc != nil {
+		if prepared {
 			acc, err = pc.Call2(acc, seq.First())
 		} else {
 			fargs[0] = acc
@@ -619,8 +623,9 @@ func Some(ec *vm.ExecContext, pred vm.Value, coll vm.Value) (vm.Value, error) {
 	// walk: per-element ec.Invoke would pay resolution, frame-pool traffic,
 	// and frame init on every element. Non-bytecode/variadic predicates fall
 	// back to the generic invoke below.
-	pc := ec.PrepareCall(f, 1)
-	if pc != nil {
+	var pc vm.PreparedCall
+	prepared := ec.PrepareCallInto(&pc, f, 1)
+	if prepared {
 		defer pc.Release()
 	}
 	fargs := []vm.Value{nil}
@@ -633,7 +638,7 @@ func Some(ec *vm.ExecContext, pred vm.Value, coll vm.Value) (vm.Value, error) {
 			for i := 0; i < n; i++ {
 				var v vm.Value
 				var err error
-				if pc != nil {
+				if prepared {
 					v, err = pc.Call1(c.Nth(i))
 				} else {
 					fargs[0] = c.Nth(i)
@@ -651,7 +656,7 @@ func Some(ec *vm.ExecContext, pred vm.Value, coll vm.Value) (vm.Value, error) {
 		}
 		var v vm.Value
 		var err error
-		if pc != nil {
+		if prepared {
 			v, err = pc.Call1(seq.First())
 		} else {
 			fargs[0] = seq.First()

--- a/pkg/vm/func.go
+++ b/pkg/vm/func.go
@@ -115,47 +115,60 @@ type bytecodeCallTarget struct {
 // that reuses that same frame must copy them into frame-owned storage before
 // resetting the operand stack. Variadic packing always returns a fresh slice.
 func resolveBytecodeCall(fn Fn, args []Value) (bytecodeCallTarget, bool, error) {
-	display := fn
-	var closedOvers []Value
+	t, closedOvers, display, ok, err := unwrapBytecodeFn(fn, len(args))
+	if err != nil || !ok {
+		return bytecodeCallTarget{}, false, err
+	}
+	prepared := args
+	if t.isVariadric {
+		if len(prepared) < t.arity-1 {
+			return bytecodeCallTarget{}, false, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", display, t.arity-1, len(prepared)))
+		}
+		restlist, boxErr := boxRest(prepared[t.arity-1:])
+		if boxErr != nil {
+			return bytecodeCallTarget{}, false, boxErr
+		}
+		// Never append into prepared: it may be a window into the
+		// caller's operand stack or a host-owned argument slice.
+		packed := make([]Value, t.arity)
+		copy(packed, prepared[:t.arity-1])
+		packed[t.arity-1] = restlist
+		prepared = packed
+	} else if len(prepared) != t.arity {
+		return bytecodeCallTarget{}, false, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", display, t.arity, len(prepared)))
+	}
+	return bytecodeCallTarget{
+		fn:          t,
+		args:        prepared,
+		closedOvers: closedOvers,
+	}, true, nil
+}
+
+// unwrapBytecodeFn walks the MetaFn / MultiArityFn / Closure wrappers around
+// fn to the *Func that an argc-argument call would run, carrying the closure
+// captures along. ok is false for callables that are not bytecode (native,
+// protocol, ...). It allocates nothing, so callers that only need to inspect
+// the target — PrepareCallInto rejecting variadic or wrong-arity fns — can
+// decide before any argument packing happens.
+func unwrapBytecodeFn(fn Fn, argc int) (target *Func, closedOvers []Value, display Fn, ok bool, err error) {
+	display = fn
 	for {
 		switch t := fn.(type) {
 		case *MetaFn:
 			fn = t.Wrapped()
 		case *MultiArityFn:
-			variant, err := t.variantFor(display, len(args))
-			if err != nil {
-				return bytecodeCallTarget{}, false, err
+			variant, verr := t.variantFor(display, argc)
+			if verr != nil {
+				return nil, nil, display, false, verr
 			}
 			fn = variant
 		case *Closure:
 			closedOvers = t.closedOvers
 			fn = t.fn
 		case *Func:
-			prepared := args
-			if t.isVariadric {
-				if len(prepared) < t.arity-1 {
-					return bytecodeCallTarget{}, false, NewExecutionError(fmt.Sprintf("function %s expected at least %d args, got %d", display, t.arity-1, len(prepared)))
-				}
-				restlist, boxErr := boxRest(prepared[t.arity-1:])
-				if boxErr != nil {
-					return bytecodeCallTarget{}, false, boxErr
-				}
-				// Never append into prepared: it may be a window into the
-				// caller's operand stack or a host-owned argument slice.
-				packed := make([]Value, t.arity)
-				copy(packed, prepared[:t.arity-1])
-				packed[t.arity-1] = restlist
-				prepared = packed
-			} else if len(prepared) != t.arity {
-				return bytecodeCallTarget{}, false, NewExecutionError(fmt.Sprintf("function %s expected %d args, got %d", display, t.arity, len(prepared)))
-			}
-			return bytecodeCallTarget{
-				fn:          t,
-				args:        prepared,
-				closedOvers: closedOvers,
-			}, true, nil
+			return t, closedOvers, display, true, nil
 		default:
-			return bytecodeCallTarget{}, false, nil
+			return nil, nil, display, false, nil
 		}
 	}
 }

--- a/pkg/vm/prepared_call.go
+++ b/pkg/vm/prepared_call.go
@@ -27,34 +27,65 @@ type PreparedCall struct {
 	stackLen    int
 }
 
-// PrepareCall resolves fn for repeated arity-n invocation. It returns nil for
-// targets that are not plain fixed-arity bytecode callables (variadic, native,
-// protocol, ...), and for arities without a matching CallN method; callers
-// fall back to ec.Invoke.
-func (ec *ExecContext) PrepareCall(fn Fn, arity int) *PreparedCall {
-	// Only arities a CallN entry point can fully populate are prepared —
-	// Call1 and Call2 today. Widen this as CallN methods land.
-	if arity < 1 || arity > 2 {
-		return nil
+// maxPreparedArity is the widest arity a CallN entry point can fully
+// populate — Call1 and Call2 today. Widen this as CallN methods land.
+const maxPreparedArity = 2
+
+// PrepareCallInto resolves fn for repeated arity-n invocation into p, which
+// the caller owns — typically a stack variable in a native loop. It reports
+// false, leaving p unusable, for targets that are not plain fixed-arity
+// bytecode callables (variadic, native, protocol, ...) and for arities
+// without a matching CallN method; callers fall back to ec.Invoke.
+//
+// Nothing here allocates once the frame pool is warm: p is the caller's,
+// the frame comes from the pool, and the argument slots live in the frame's
+// prepArgs, which survives pool reuse. They deliberately do not alias
+// argbuf, which installBytecodeCall overwrites on a same-frame tail call.
+func (ec *ExecContext) PrepareCallInto(p *PreparedCall, fn Fn, arity int) bool {
+	if arity < 1 || arity > maxPreparedArity {
+		return false
 	}
-	args := make([]Value, arity)
-	target, direct, err := resolveBytecodeCall(fn, args)
-	if err != nil || !direct || target.fn.isVariadric {
-		return nil
+	// Inspect the target without resolveBytecodeCall: that path retains the
+	// argument slice it is given (so a stack probe would escape) and packs a
+	// rest list for variadic fns before we could reject them. unwrapBytecodeFn
+	// answers "which *Func, is it fixed-arity n" without allocating.
+	target, closedOvers, _, ok, err := unwrapBytecodeFn(fn, arity)
+	if err != nil || !ok || target.isVariadric || target.arity != arity {
+		return false
 	}
 	ec = ec.orRoot()
-	f := NewFrame(target.fn.chunk, nil)
-	f.closedOvers = target.closedOvers
+	f := NewFrame(target.chunk, nil)
+	f.closedOvers = closedOvers
 	f.ec = ec
-	return &PreparedCall{
-		fn:          target.fn,
-		closedOvers: target.closedOvers,
+	// The argument slots live in the pooled frame and survive pool reuse, so
+	// they cost nothing after the first use of each frame. They deliberately
+	// do not alias argbuf, which installBytecodeCall overwrites on a
+	// same-frame tail call.
+	if cap(f.prepArgs) < arity {
+		f.prepArgs = make([]Value, maxPreparedArity)
+	}
+	args := f.prepArgs[:arity]
+	*p = PreparedCall{
+		fn:          target,
+		closedOvers: closedOvers,
 		ec:          ec,
 		frame:       f,
 		args:        args,
-		constsc:     target.fn.chunk.consts.count(),
-		stackLen:    max(target.fn.chunk.maxStack, 4),
+		constsc:     target.chunk.consts.count(),
+		stackLen:    max(target.chunk.maxStack, 4),
 	}
+	return true
+}
+
+// PrepareCall is the heap-allocating form of PrepareCallInto: it returns a
+// new PreparedCall, or nil when fn cannot be prepared. Hot loops should
+// prefer PrepareCallInto with a stack variable.
+func (ec *ExecContext) PrepareCall(fn Fn, arity int) *PreparedCall {
+	p := new(PreparedCall)
+	if !ec.PrepareCallInto(p, fn, arity) {
+		return nil
+	}
+	return p
 }
 
 // Call1 invokes the prepared unary callable. Calling it on a preparation of
@@ -112,4 +143,5 @@ func (p *PreparedCall) Release() {
 		ReleaseFrame(p.frame)
 		p.frame = nil
 	}
+	p.args = nil // the slots belong to the frame, which the pool may hand elsewhere
 }

--- a/pkg/vm/prepared_call_test.go
+++ b/pkg/vm/prepared_call_test.go
@@ -203,6 +203,47 @@ func TestPreparedCallArityMismatchErrors(t *testing.T) {
 	}
 }
 
+// PrepareCallInto is the allocation-free entry point for hot native loops
+// (reduce, some, ...): the PreparedCall lives on the caller's stack and the
+// argument slots live in the pooled frame, so preparing and calling a
+// bytecode fn allocates nothing once the frame pool is warm. This is what
+// keeps a compile made of many short reductions from paying two heap
+// allocations per reduce.
+func TestPrepareCallIntoDoesNotAllocate(t *testing.T) {
+	consts := NewConsts()
+	identity := testBytecodeFnReturningArg(consts, 1)
+	second := testBytecodeFnReturningArg(consts, 2)
+	// Warm the frame pool so the measurement sees steady state.
+	{
+		var pc PreparedCall
+		if !RootExecContext.PrepareCallInto(&pc, identity, 1) {
+			t.Fatal("PrepareCallInto rejected a plain unary Func")
+		}
+		pc.Release()
+	}
+	allocs := testing.AllocsPerRun(200, func() {
+		var pc PreparedCall
+		if !RootExecContext.PrepareCallInto(&pc, identity, 1) {
+			t.Fatal("PrepareCallInto rejected a plain unary Func")
+		}
+		if v, err := pc.Call1(Int(3)); err != nil || v != Int(3) {
+			t.Fatalf("Call1 returned %v, %v", v, err)
+		}
+		pc.Release()
+		var pc2 PreparedCall
+		if !RootExecContext.PrepareCallInto(&pc2, second, 2) {
+			t.Fatal("PrepareCallInto rejected a plain binary Func")
+		}
+		if v, err := pc2.Call2(Int(1), Int(2)); err != nil || v != Int(1) { // the helper returns its first arg
+			t.Fatalf("Call2 returned %v, %v", v, err)
+		}
+		pc2.Release()
+	})
+	if allocs != 0 {
+		t.Fatalf("PrepareCallInto + CallN allocated %.0f times per run; want 0", allocs)
+	}
+}
+
 func TestPreparedCallCall2RepeatedInvocation(t *testing.T) {
 	consts := NewConsts()
 	chunk := NewCodeChunk(consts)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -376,6 +376,7 @@ type Frame struct {
 	stack       []Value
 	args        []Value
 	argbuf      []Value // frame-owned arguments used by same-frame tail replacement
+	prepArgs    []Value // argument slots owned by a PreparedCall; kept across pool reuse so preparing allocates nothing once warm
 	closedOvers []Value
 	argc        int
 	consts      *Consts
@@ -435,7 +436,14 @@ func releaseFrame(f *Frame) {
 }
 
 func NewFrame(code *CodeChunk, args []Value) *Frame {
-	f := acquireFrame()
+	return initFrame(acquireFrame(), code, args)
+}
+
+// initFrame prepares an acquired frame to run code with args. Split from
+// NewFrame so a caller that must hold a frame before it knows the code (see
+// PrepareCallInto, which resolves the callee using the frame's own argument
+// slots) can acquire first and initialize afterwards.
+func initFrame(f *Frame, code *CodeChunk, args []Value) *Frame {
 	needed := max(code.maxStack, 4)
 	if cap(f.stack) >= needed {
 		f.stack = f.stack[:needed]
@@ -469,6 +477,7 @@ func ReleaseFrame(f *Frame) {
 	f.args = nil
 	clear(f.argbuf)
 	f.argbuf = nil
+	clear(f.prepArgs) // drop the values, keep the capacity for the next PrepareCallInto
 	f.closedOvers = nil
 	f.consts = nil
 	f.code = nil


### PR DESCRIPTION
Fixes the allocation regression from #727 and restores a green `make bench-ratchet` on `main`. Bisect and numbers in #791.

#727 routed `reduce` and `some` through `PrepareCall`, which heap-allocated a `PreparedCall` and an argument slice per invocation and resolved the target through `resolveBytecodeCall`, which packs a rest list for variadic fns before the preparation could reject them. The IR compiler performs thousands of short reductions per compile, so `BenchmarkIRCompile` gained ~1,900 allocs/op, over the ratchet's 2% deterministic bar.

- `PrepareCallInto(p, fn, arity)` fills a caller-owned `PreparedCall`, so the hot loops keep it on their stack.
- Argument slots live in a new `Frame.prepArgs` that survives pool reuse and does not alias `argbuf`, which `installBytecodeCall` overwrites on a same-frame tail call.
- `unwrapBytecodeFn`, split out of `resolveBytecodeCall`, inspects the target without allocating, so variadic and wrong-arity fns are rejected before any packing. `PrepareCall` remains as the allocating form.
- `TestPrepareCallIntoDoesNotAllocate` pins the zero-allocation contract; the existing PreparedCall tests (tail-call rebind, error reuse, arity mismatch) still pass.

On an Apple M3, plugged in, `BenchmarkIRCompile [bytecode]`:

| | allocs/op | bytes/op | ns/op |
|---|---|---|---|
| #780 baseline | 114,255 | 4,963,229 | 15.05M |
| main (bdd8268) | 116,149 | 5,080,290 | 17.01M |
| this PR | 113,722 | 4,935,179 | 15.48M |

`make bench-ratchet` on this tree: deterministic OK, anchor +0.7%, IRCompile [bytecode] +2.0% ok, InitFromLGB -2.4%, IRCompile [gogen_ir] -10.2%, 0 regressions. `go test ./... -skip TestClojureTestSuite` and `go test ./test/e2e` pass; `make check-generated` clean (manifest and sums refreshed).