### PR TITLE
fix(examples): ys-lower-report calls the public compile-form

### DIFF
--- a/examples/aot/yamlstar/ys-lower-report.lg
+++ b/examples/aot/yamlstar/ys-lower-report.lg
@@ -1,6 +1,6 @@
 ;; ys-lower-report — actually ATTEMPT to lower each single-arity defn in a file
 ;; and report :lowered vs fallback (with the error). Loads the file form-by-form
-;; first (so refers resolve), then runs compile-form* per lowerable form under
+;; first (so refers resolve), then runs compile-form per lowerable form under
 ;; *target* :go, catching failures.
 ;;
 ;;   ./lg scripts/ys-lower-report.lg <file.lg>   (one ns per invocation)
@@ -42,7 +42,7 @@
     (let [r (reduce
               (fn [acc f]
                 (let [nm  (form-name f)
-                      res (try (ir.passes.pipeline/compile-form* f)
+                      res (try (ir.passes.pipeline/compile-form f)
                                (catch e {:status :threw :err (str e)}))
                       st  (:status res)]
                   (cond


### PR DESCRIPTION
`examples/aot/yamlstar/ys-lower-report.lg` has been unable to run since
`compile-form*` became private. Every invocation dies at load:

```
error: compiling let body
caused by: Can't resolve ir.passes.pipeline/compile-form* in this context
  --> examples/aot/yamlstar/ys-lower-report.lg:45:32
```

It never reports on a single form, so the per-fn lower/fallback report described
in `examples/aot/README.md` is currently unavailable.

## Why the public wrapper, beyond it resolving

`compile-form` normalises a `:multi-fn-template` result to `:status :lowered`.
Its own comment gives the reason: public callers key off `:status`, and without
the normalisation "a form that lowered via lambda-lift reads as unlowered".
`ys-lower-report` is one of those callers — it branches on `:status` and prints
anything other than `:lowered` as a fallback. So the wrapper is the correct
entry point here, not just the reachable one.

## Verification

Ran the tool over five in-repo namespaces, which exercises the whole of its
contract:

| File | Result |
|---|---|
| `examples/aot/native-entry/fib.lg` | `ok=2 fallback=0 threw=0` |
| `examples/aot/cross-package/src/lib.lg` | `ok=2 fallback=0 threw=0` |
| `test/native-entry/closure_capture.lg` | `ok=2 fallback=0 threw=0` |
| `test/native-entry/loop_carried_closure.lg` | `ok=3 fallback=0 threw=0` |
| `test/native-entry/conditional_closure.lg` | `ok=4 fallback=0 threw=0` |

`fib.lg`'s `ok=2` agrees with the `2 fns lowered` that `lg-compile` reports for
the same file.

The three closure fixtures are the lambda-lift shapes, and they only show that
the fixed tool reports them lowered. There is no before-and-after to compare,
because nothing ran before.

## Scope

Two lines: the call site and the header comment that describes it. Other
references to `compile-form*` in the tree describe the private function itself
and are left alone.

Found while using the tool to survey a demo's lowerability against tip, which
also produced #796 and the comments on #551, #562, #660 and #358.
