### PR TITLE
docs(tinygo): correct the xxh3 limitation and point to murmur3

### DIFF
--- a/docs/guide/tinygo.md
+++ b/docs/guide/tinygo.md
@@ -52,9 +52,16 @@ wasmtime on every PR, so the target can't silently regress.
   arithmetic overflows or wraps on the WASM target. Native TinyGo (arm64/amd64)
   is 64-bit and unaffected. Use the standard-Go WASI build when 64-bit fidelity
   matters.
-- **`xxh3` is not bit-compatible.** The `xxh3` dependency is assembly-only on
-  arm64/amd64, so TinyGo links a pure-Go substitute hash. It is deterministic but
-  produces different digests, making a TinyGo build its own determinism domain.
+- **There is no `xxh3` namespace.** The `xxh3` dependency is assembly-only on
+  arm64/amd64 with no purego mode, and its bindings are reflect-boxed, so
+  `interop_xxh3.go` is gated `!tinygo`. Nothing is substituted in its place: a
+  program that calls `xxh3/*` on a TinyGo build gets nil and fails at the call
+  site. Use the `murmur3` namespace instead. It is registered on every build,
+  mirrors the same `Hash` / `HashSeed` / `HashString` / `HashStringSeed`
+  surface, and masks its results to 31 bits so a value is identical on 64-bit
+  native and 32-bit wasm — including across the `int`-width boundary above.
+  Porting a hash-dependent program is a namespace swap, not an acceptance of a
+  separate determinism domain.
 - **No Unix domain sockets or full `os.ProcessState`**, so the nREPL Unix-socket
   transport and some process introspection are unavailable on native builds.
 - **Native macOS does not link** (tinygo-org/tinygo#4794 — Darwin syscalls route


### PR DESCRIPTION
## What this changes

The TinyGo guide's `xxh3` bullet describes a substitution that does not happen. It currently reads:

> **`xxh3` is not bit-compatible.** The `xxh3` dependency is assembly-only on
> arm64/amd64, so TinyGo links a pure-Go substitute hash. It is deterministic
> but produces different digests, making a TinyGo build its own determinism
> domain.

Two claims there send a reader the wrong way.

**No substitute is linked.** `pkg/rt/interop_xxh3.go` carries `//go:build !tinygo`, so a TinyGo build has no `xxh3` namespace. A program calling `xxh3/*` does not get different digests; it gets nil and fails at the call site.

**`murmur3` is the portable hash, not a divergent one.** `pkg/rt/hash_murmur3.go` is untagged and registered on every build, and it masks results to 31 bits so a value is identical on 64-bit native and 32-bit wasm. Its own header states this intent. The current text points at a determinism domain to avoid, when the available hash is the one that removes the divergence.

The replacement bullet says the namespace is absent, names `murmur3` as the call to make instead, notes that the surface matches (`Hash`, `HashSeed`, `HashString`, `HashStringSeed`), and gives the 31-bit masking so the reader can see how it composes with the `int`-width limitation directly above it.

## How this surfaced

Building a real program: a game whose determinism layer is keyed on a seed fold. Under TinyGo it builds and reaches its title screen, then dies:

```
FATAL ERROR: TypeError: nil is not a function
  new-game <- show-title-screen <- generate-title <- pick <- int-in <- xxh3-64
```

The guide sends you looking for a digest mismatch. The failure is a missing namespace, and the fix is a one-token swap to `murmur3`. After that swap the game runs, and its generated world is byte-identical between the TinyGo wasm build (32-bit `int`) and the stock-Go wasm build (64-bit `int`): same sha256 over the rendered dungeon at a fixed seed. That is the masking doing what its implementation comment describes.

## Verification

- The `!tinygo` tag on `interop_xxh3.go` and the absence of a tag on `hash_murmur3.go` both read off `origin/main`.
- `murmur3/HashSeed` exercised on a native build; results land inside 31 bits.
- The crash above reproduced from a clean `origin/main` TinyGo wasm build.
- Cross-width determinism checked by diffing the rendered world from both builds at one fixed seed. One seed, not a sweep.

Docs only. No code changes, nothing to regenerate, no CI surface touched.
