### PR TITLE
feat(lg): extend -strip to -w bundles

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -403,7 +403,7 @@ func registerFlags() {
 	flag.StringVar(&bundleOutput, "b", "", "bundle .lg file into a standalone executable (specify output path)")
 	flag.BoolVar(&compressBundle, "z", false, "with -c/-b: DEFLATE-compress the bundle body (smaller .lgb / standalone binary; transparently inflated at load)")
 	flag.StringVar(&bundleBase, "bundle-base", "", "path to target-platform lg binary for cross-OS bundling (defaults to current executable)")
-	flag.BoolVar(&stripDebug, "strip", false, "split source maps and local-variable tables into a digest-bound .debug companion (with -c/-b)")
+	flag.BoolVar(&stripDebug, "strip", false, "split source maps and local-variable tables into a digest-bound .debug companion (with -c/-b/-w)")
 	flag.StringVar(&debugOutput, "debug-output", "", "path for the -strip debug companion (defaults to <output>.debug)")
 	flag.StringVar(&wasmOutput, "w", "", "build .lg file into a WASM web app (specify output directory)")
 	flag.StringVar(&wasmShell, "w-shell", "xterm", "shell for -w: 'xterm' (default), 'none' (emit core only; client supplies its own shell via window.LetGoHost), or a path to a custom HTML template containing __LG_HOST_JS_BODY_PLACEHOLDER__")
@@ -561,8 +561,8 @@ func runMain() int {
 		fmt.Fprintln(os.Stderr, "error: -z requires -c or -b")
 		return 2
 	}
-	if stripDebug && compileOutput == "" && bundleOutput == "" {
-		fmt.Fprintln(os.Stderr, "error: -strip requires -c or -b")
+	if stripDebug && compileOutput == "" && bundleOutput == "" && wasmOutput == "" {
+		fmt.Fprintln(os.Stderr, "error: -strip requires -c, -b or -w")
 		return 2
 	}
 	if debugOutput != "" && !stripDebug {

--- a/pkg/cli/wasm.go
+++ b/pkg/cli/wasm.go
@@ -198,6 +198,23 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		}
 	}
 
+	// -strip splits source maps and local-variable tables out of the embedded
+	// program before it is baked into the wasm binary. The companion is written
+	// beside the bundle directory rather than inside it: everything in outDir is
+	// served, and a debug sidecar is build output, not something to ship to every
+	// visitor.
+	var debugData []byte
+	var debugPath string
+	if stripDebug {
+		stripped, companion, path, err := wasmassets.SplitProgramDebug(lgbBuf.Bytes(), outDir, debugOutput)
+		if err != nil {
+			return err
+		}
+		lgbBuf.Reset()
+		lgbBuf.Write(stripped)
+		debugData, debugPath = companion, path
+	}
+
 	// 2. Create temp build directory
 	tmpDir, err := os.MkdirTemp("", "lg-wasm-*")
 	if err != nil {
@@ -380,8 +397,19 @@ func buildWasm(ctx *compiler.Context, nsRes *resolver.NSResolver, src string, ou
 		return err
 	}
 
+	// The debug companion lands last, so a failed build leaves no sidecar
+	// claiming to describe a bundle that was never written.
+	if debugData != nil {
+		if err := os.WriteFile(debugPath, debugData, 0644); err != nil {
+			return fmt.Errorf("writing debug companion: %w", err)
+		}
+	}
+
 	fi, _ := os.Stat(outPath)
 	fmt.Printf("output: %s (%.1f MB)\n", outPath, float64(fi.Size())/(1024*1024))
+	if debugData != nil {
+		fmt.Printf("debug companion: %s (%d bytes)\n", debugPath, len(debugData))
+	}
 	return nil
 }
 

--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -749,6 +749,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/user.go input 1c159c6064e56b865095e0ba8
 pkg/rt/zz_primitives_generated.go pkg/rt/user_js.go input 6ebaaff45c660f105dbca1a9c372c7a69f342069990c222612f7cb36b8bf2edf
 pkg/rt/zz_primitives_generated.go pkg/rt/warnings.go input dd55d06ef229020042cd38e4b5c83e8cdc4987da8e933b5a179fbbcbc499a933
 pkg/rt/zz_primitives_generated.go pkg/rt/wasm/build.go input 0358ab3fd85dece3f25a769a1436bfb127de9f8f0e0ad1d25abb756fdf60534a
+pkg/rt/zz_primitives_generated.go pkg/rt/wasm/debugcompanion.go input 76314598920838b76a334a9415cc357b67043329988c0a1f6e1bac5dedf701d2
 pkg/rt/zz_primitives_generated.go pkg/rt/wasm/embed.go input 8b9cf8fca20f7bfbbe476eea4565e18e8a4e686aadff7d506e14645fde5420ed
 pkg/rt/zz_primitives_generated.go pkg/rt/wasm/rendermain.go input f583f723cd62c939969027ba03d671faf890be401c72a8baea561bb6dcc928a2
 pkg/rt/zz_primitives_generated.go pkg/rt/wasm/shell.go input 0eb9f9970c8cb19d568adca4ae5fff5eaa18dc95c2068790712c32f7a6e7a164

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-062191fdb46c1e0616088a201c2c39a841d287ee2f6cf01c3b99c2110ec94185
+c8a8ef8e43a8e6b426ed9954055429a7392440056f444d588c849bb260a37b53

--- a/pkg/rt/wasm/debugcompanion.go
+++ b/pkg/rt/wasm/debugcompanion.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Matt Parrett <matt.parrett@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package wasm
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/nooga/let-go/pkg/bytecode"
+)
+
+// SplitProgramDebug strips a wasm bundle's program of its debug sections and
+// returns the companion together with the path to write it to.
+//
+// The path is derived from the bundle directory rather than a file inside it:
+// every file in the output directory is served, and a debug sidecar is build
+// output rather than something to hand to each visitor. outDir is canonicalized
+// first, so `dist/`, `dist/.` and `.` all name the directory itself and never
+// degrade the companion into a dotfile inside it.
+//
+// override, when non-empty, selects the companion path explicitly. It is
+// rejected when it names the bundle directory or anything under it: an
+// override such as dist/index.html would pass a same-path check and then
+// replace a generated asset with binary debug data.
+func SplitProgramDebug(lgb []byte, outDir, override string) (stripped, companion []byte, path string, err error) {
+	stripped, companion, err = bytecode.SplitDebug(lgb)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("splitting debug sections: %w", err)
+	}
+	base, err := canonicalBundleDir(outDir)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	path = override
+	if path == "" {
+		path = base + bytecode.DebugCompanionSuffix
+	}
+	if err := rejectInsideBundle(base, path); err != nil {
+		return nil, nil, "", err
+	}
+	return stripped, companion, path, nil
+}
+
+// canonicalBundleDir cleans outDir into a form whose last element is the
+// bundle directory's own name. Spellings that clean to "." or ".." carry no
+// name to derive a sibling from, so those are resolved to an absolute path;
+// a filesystem root has no sibling at all and is refused.
+func canonicalBundleDir(outDir string) (string, error) {
+	if strings.TrimSpace(outDir) == "" {
+		return "", fmt.Errorf("cannot derive a debug companion path from output directory %q", outDir)
+	}
+	base := filepath.Clean(outDir)
+	if name := filepath.Base(base); name == "." || name == ".." {
+		abs, err := filepath.Abs(base)
+		if err != nil {
+			return "", fmt.Errorf("resolving output directory %q: %w", outDir, err)
+		}
+		base = abs
+	}
+	if filepath.Dir(base) == base {
+		return "", fmt.Errorf("cannot derive a debug companion path from filesystem root %q", outDir)
+	}
+	return base, nil
+}
+
+// rejectInsideBundle fails when path names the bundle directory or any entry
+// under it, comparing canonical absolute forms so that relative and absolute
+// spellings of the same location agree. Every file under the bundle directory
+// is served, and the generated outputs (index.html, coi-serviceworker.js,
+// main.wasm in external mode) all live there, so "inside" is the invariant
+// rather than a list of filenames.
+func rejectInsideBundle(base, path string) error {
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return fmt.Errorf("resolving bundle directory %q: %w", base, err)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolving debug output %q: %w", path, err)
+	}
+	rel, err := filepath.Rel(absBase, absPath)
+	if err != nil {
+		return nil // different volumes: cannot be inside
+	}
+	if rel == "." {
+		return fmt.Errorf("debug output must differ from bundle output %s", base)
+	}
+	if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("debug output %s is inside the bundle directory %s, where every file is served", path, base)
+	}
+	return nil
+}

--- a/pkg/rt/wasm/debugcompanion_test.go
+++ b/pkg/rt/wasm/debugcompanion_test.go
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 Matt Parrett <matt.parrett@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package wasm
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nooga/let-go/pkg/bytecode"
+	"github.com/nooga/let-go/pkg/compiler"
+	"github.com/nooga/let-go/pkg/rt"
+	"github.com/nooga/let-go/pkg/vm"
+)
+
+// programLGB compiles a small program so the tests run against a real bundle
+// carrying debug sections rather than a hand-built fixture.
+func programLGB(t *testing.T) []byte {
+	t.Helper()
+	ctx := compiler.NewCompiler(vm.NewConsts(), rt.NS("user"))
+	chunk, _, err := ctx.CompileMultiple(strings.NewReader(
+		`(defn add [a b] (+ a b))
+(defn twice [n] (add n n))
+(twice 21)`))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := bytecode.EncodeCompilation(&buf, ctx.Consts(), chunk); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// The companion must land beside the bundle directory, never inside it: every
+// file in the output directory is served.
+func TestSplitProgramDebugWritesCompanionOutsideBundle(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "dist")
+	lgb := programLGB(t)
+
+	stripped, companion, path, err := SplitProgramDebug(lgb, outDir, "")
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if len(companion) == 0 {
+		t.Fatal("companion is empty; nothing was split out")
+	}
+	if len(stripped) >= len(lgb) {
+		t.Fatalf("stripped bundle did not shrink: %d >= %d", len(stripped), len(lgb))
+	}
+	if !bytecode.HasSplitDebug(stripped) {
+		t.Error("stripped bundle is not marked as split-debug")
+	}
+	if want := outDir + bytecode.DebugCompanionSuffix; path != want {
+		t.Errorf("companion path = %q, want %q", path, want)
+	}
+	if rel, err := filepath.Rel(outDir, path); err == nil && !strings.HasPrefix(rel, "..") {
+		t.Errorf("companion %q is inside the served bundle directory %q", path, outDir)
+	}
+}
+
+// A trailing separator must not degrade the companion into a dotfile inside the
+// bundle — `-w dist/` is an ordinary way to spell the same directory.
+func TestSplitProgramDebugTrailingSeparator(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "dist")
+	_, _, path, err := SplitProgramDebug(programLGB(t), outDir+string(os.PathSeparator), "")
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if want := outDir + bytecode.DebugCompanionSuffix; path != want {
+		t.Errorf("companion path = %q, want %q", path, want)
+	}
+}
+
+func TestSplitProgramDebugHonorsOverride(t *testing.T) {
+	dir := t.TempDir()
+	override := filepath.Join(dir, "symbols", "app.debug")
+	_, _, path, err := SplitProgramDebug(programLGB(t), filepath.Join(dir, "dist"), override)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if path != override {
+		t.Errorf("companion path = %q, want %q", path, override)
+	}
+}
+
+// An override equal to the bundle directory would have the build overwrite its
+// own output directory with a companion file.
+func TestSplitProgramDebugRejectsOverrideEqualToBundle(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "dist")
+	if _, _, _, err := SplitProgramDebug(programLGB(t), outDir, outDir); err == nil {
+		t.Error("expected an error when the override equals the bundle directory")
+	}
+}
+
+// Every spelling of the same directory must derive the same sibling. Before
+// canonicalization `-w dist/.` produced `dist/..debug` and `-w .` produced
+// `..debug`, both dotfiles inside the served directory.
+func TestSplitProgramDebugCanonicalizesOutDir(t *testing.T) {
+	root := t.TempDir()
+	outDir := filepath.Join(root, "dist")
+	want := outDir + bytecode.DebugCompanionSuffix
+	for _, spelling := range []string{
+		outDir,
+		outDir + string(os.PathSeparator),
+		filepath.Join(outDir, "."),
+		outDir + string(os.PathSeparator) + "." + string(os.PathSeparator),
+		filepath.Join(outDir, "sub", ".."),
+	} {
+		_, _, path, err := SplitProgramDebug(programLGB(t), spelling, "")
+		if err != nil {
+			t.Errorf("%q: %v", spelling, err)
+			continue
+		}
+		if path != want {
+			t.Errorf("%q: companion path = %q, want %q", spelling, path, want)
+		}
+	}
+}
+
+// `-w .` names the current directory; the companion goes beside it, under its
+// real name, never as `..debug` inside it.
+func TestSplitProgramDebugDotResolvesToCwdSibling(t *testing.T) {
+	root := t.TempDir()
+	outDir := filepath.Join(root, "dist")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(outDir)
+	_, _, path, err := SplitProgramDebug(programLGB(t), ".", "")
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	// TempDir may sit behind a symlink (macOS /var -> /private/var), so compare
+	// the resolved forms.
+	got, _ := filepath.EvalSymlinks(filepath.Dir(path))
+	wantDir, _ := filepath.EvalSymlinks(root)
+	if got != wantDir || filepath.Base(path) != "dist"+bytecode.DebugCompanionSuffix {
+		t.Errorf("companion path = %q, want dist%s beside %q", path, bytecode.DebugCompanionSuffix, root)
+	}
+}
+
+// An override inside the bundle directory would be served, and one that names
+// a generated asset would silently replace it with binary debug data after the
+// same-path check passed.
+func TestSplitProgramDebugRejectsOverrideInsideBundle(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "dist")
+	for _, override := range []string{
+		filepath.Join(outDir, "index.html"),
+		filepath.Join(outDir, "coi-serviceworker.js"),
+		filepath.Join(outDir, "main.wasm"),
+		filepath.Join(outDir, "symbols", "app.debug"),
+		filepath.Join(outDir, "sub", "..", "app.debug"),
+		outDir + string(os.PathSeparator),
+	} {
+		if _, _, _, err := SplitProgramDebug(programLGB(t), outDir, override); err == nil {
+			t.Errorf("%q: expected an error for a companion inside the bundle directory", override)
+		}
+	}
+}
+
+// Siblings and unrelated locations stay allowed, including ones whose name
+// merely starts with the bundle directory's name.
+func TestSplitProgramDebugAllowsOverrideOutsideBundle(t *testing.T) {
+	root := t.TempDir()
+	outDir := filepath.Join(root, "dist")
+	for _, override := range []string{
+		outDir + bytecode.DebugCompanionSuffix,
+		filepath.Join(root, "dist-symbols", "app.debug"),
+		filepath.Join(root, "app.debug"),
+	} {
+		if _, _, _, err := SplitProgramDebug(programLGB(t), outDir, override); err != nil {
+			t.Errorf("%q: unexpected error: %v", override, err)
+		}
+	}
+}
+
+// A filesystem root has no sibling to write beside.
+func TestSplitProgramDebugRejectsRoot(t *testing.T) {
+	if _, _, _, err := SplitProgramDebug(programLGB(t), string(os.PathSeparator), ""); err == nil {
+		t.Error("expected an error for a filesystem-root output directory")
+	}
+}
+
+// The split must round-trip: the companion has to reattach to the artifact it
+// was cut from, or a stripped deployment cannot be symbolicated at all.
+func TestSplitProgramDebugRoundTrips(t *testing.T) {
+	stripped, companion, _, err := SplitProgramDebug(programLGB(t), filepath.Join(t.TempDir(), "dist"), "")
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if _, err := bytecode.DecodeToExecUnitBytesWithDebug(stripped, companion, nil); err != nil {
+		t.Fatalf("stripped bundle + companion failed to decode: %v", err)
+	}
+}


### PR DESCRIPTION
## What changes

`-strip` split debug info out of `-c` and `-b` artifacts in #624, but rejected `-w`. A wasm bundle therefore had no way to ship without its source maps and local-variable tables. This makes the flag compose with `-w`, closing half of #631.

## Where the companion goes

Beside the bundle directory, not inside it. Every file in the output directory is served; a debug sidecar is build output, not something to hand to each visitor. `-debug-output` overrides the path.

Three details that are easy to get wrong:

- The output directory is canonicalized before the sibling is derived, so `dist/`, `dist/.`, and `.` all name the directory itself. Without that, a trailing separator gives a companion named `.debug` inside the bundle, and `dist/.` gives `dist/..debug`.
- An override is refused when it names the bundle directory or anything under it. A same-path check alone lets `-debug-output dist/index.html` through, and the build then replaces a generated asset with binary debug data while still reporting success. The same holds for `coi-serviceworker.js` and, in external mode, `main.wasm`, so the check is "inside the served directory" rather than a list of filenames.
- The companion is written last, after the bundle succeeds. These artifacts are digest-bound, so a sidecar left behind by a failed build would claim to describe something that was never produced, which is worse than having none.

## Sizes, not oversold

On a real program bundle, xsofy's `main.lg` compiled to `.lgb`:

| | raw | gzip -9 |
|---|---:|---:|
| plain | 709,129 | 232,854 |
| stripped | 583,963 | 164,882 |
| saving | 125,166 (17.7%) | **67,972 (29.2%)** |

The compressed saving is the larger percentage because source maps and local-variable tables are structured numeric data that compresses worse than bytecode and strings, so removing them takes a disproportionate share of the shipped bytes.

Against a whole wasm bundle, though, the program is a small term. A three-line app shrank by 48 bytes on an 8.1 MB bundle, and xsofy's saving is roughly 1.5% of its bundle. This is worth having and nearly free, but the footprint argument in #631 rests on the embedded core and on `.lgb` artifacts shipped directly, not on the wasm bundle. The embedded-core half is a separate change, the way #501 and #502 were split.

## Tests

The strip step lives in `pkg/rt/wasm` so its tests run without a full wasm build, which would have put minutes and a module fetch into the suite. They cover: the companion landing outside the served directory; every spelling of the directory deriving the same sibling; `-w .` resolving to the current directory's sibling under its real name; overrides inside the bundle, including the generated asset names, being rejected while siblings and unrelated paths are allowed; a filesystem root being refused; and a stripped bundle plus its companion still decoding together.

Each rejection was checked against the reintroduced bug: with canonicalization disabled the `-w .` case fails, and with only the same-path check the inside-bundle case fails.

`gofmt`, `go vet`, the `pkg/rt/wasm`, `pkg/cli`, and `pkg/bytecode` suites, `make check-generated`, and cross-builds for linux/amd64, js/wasm, plan9/amd64, and wasip1/wasm are clean.
