### PR TITLE
fix(json): preserve string map keys

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -134,7 +134,7 @@ pkg/rt/core_compiled.lgb pkg/rt/ions.go generator bc46c36ed70a734ed6323f95157883
 pkg/rt/core_compiled.lgb pkg/rt/iort.go generator d56aae517e4680a3aed6eaaf1fd12541494999d73918a5528448f037d4095a87
 pkg/rt/core_compiled.lgb pkg/rt/ir_bridge_generated.go generator e9147537efd6da82ca9023b8fe7ef249cecaae89bae5893a51db4113d95aa2d9
 pkg/rt/core_compiled.lgb pkg/rt/js.go generator 0009511f66420745103c8c17881ad52a5f31227172557dc539b2a4b171dd4738
-pkg/rt/core_compiled.lgb pkg/rt/json.go generator 1a47708464ebcd2958f804ba4723f59f9394fee26b8e725ece03088851902397
+pkg/rt/core_compiled.lgb pkg/rt/json.go generator cde0a6755b094b1e187a2615e82cc578d871245fa80757ee82bf8be8c5212d6c
 pkg/rt/core_compiled.lgb pkg/rt/key_tokenizer.go generator 197eba584a6f0a33fc02b429e4dd45c8f3a63e0b86d0c4d3ba7c3700dcf81d9e
 pkg/rt/core_compiled.lgb pkg/rt/keysource.go generator f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/core_compiled.lgb pkg/rt/keysource_js_wasm.go generator d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
@@ -452,7 +452,7 @@ pkg/rt/core_go_lowered/ pkg/rt/ions.go generator bc46c36ed70a734ed6323f951578834
 pkg/rt/core_go_lowered/ pkg/rt/iort.go generator d56aae517e4680a3aed6eaaf1fd12541494999d73918a5528448f037d4095a87
 pkg/rt/core_go_lowered/ pkg/rt/ir_bridge_generated.go generator e9147537efd6da82ca9023b8fe7ef249cecaae89bae5893a51db4113d95aa2d9
 pkg/rt/core_go_lowered/ pkg/rt/js.go generator 0009511f66420745103c8c17881ad52a5f31227172557dc539b2a4b171dd4738
-pkg/rt/core_go_lowered/ pkg/rt/json.go generator 1a47708464ebcd2958f804ba4723f59f9394fee26b8e725ece03088851902397
+pkg/rt/core_go_lowered/ pkg/rt/json.go generator cde0a6755b094b1e187a2615e82cc578d871245fa80757ee82bf8be8c5212d6c
 pkg/rt/core_go_lowered/ pkg/rt/key_tokenizer.go generator 197eba584a6f0a33fc02b429e4dd45c8f3a63e0b86d0c4d3ba7c3700dcf81d9e
 pkg/rt/core_go_lowered/ pkg/rt/keysource.go generator f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/core_go_lowered/ pkg/rt/keysource_js_wasm.go generator d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
@@ -699,7 +699,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/installers.go input 5aba80526feae8d3cef
 pkg/rt/zz_primitives_generated.go pkg/rt/ions.go input bc46c36ed70a734ed6323f9515788345f354255c0e581640f16c5e65ff4cf072
 pkg/rt/zz_primitives_generated.go pkg/rt/iort.go input d56aae517e4680a3aed6eaaf1fd12541494999d73918a5528448f037d4095a87
 pkg/rt/zz_primitives_generated.go pkg/rt/js.go input 0009511f66420745103c8c17881ad52a5f31227172557dc539b2a4b171dd4738
-pkg/rt/zz_primitives_generated.go pkg/rt/json.go input 1a47708464ebcd2958f804ba4723f59f9394fee26b8e725ece03088851902397
+pkg/rt/zz_primitives_generated.go pkg/rt/json.go input cde0a6755b094b1e187a2615e82cc578d871245fa80757ee82bf8be8c5212d6c
 pkg/rt/zz_primitives_generated.go pkg/rt/key_tokenizer.go input 197eba584a6f0a33fc02b429e4dd45c8f3a63e0b86d0c4d3ba7c3700dcf81d9e
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource.go input f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource_js_wasm.go input d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-c774c0ded555af88679076c9a86347ae597dc01354f727fbf2fed3421dce0315
+be7d26ed270ad0f1a43c5a77e3eeb1c6160a23c8d8bdaed9cff91db1dc1e52f9

--- a/pkg/rt/json.go
+++ b/pkg/rt/json.go
@@ -72,9 +72,14 @@ func fromMapValue(v vm.Value) (any, error) {
 			if e != nil {
 				return vm.NIL, vm.NewExecutionError("invalid VM value")
 			}
-			nk := k.String()
-			if k.Type() == vm.KeywordType {
-				nk = nk[1:]
+			var nk string
+			switch k := k.(type) {
+			case vm.String:
+				nk = string(k)
+			case vm.Keyword:
+				nk = string(k)
+			default:
+				nk = k.String()
 			}
 			r[nk] = vv
 		}

--- a/test/json_test.lg
+++ b/test/json_test.lg
@@ -64,6 +64,24 @@
       (is (includes? s "\"items\""))
       (is (includes? s "2.5")))))
 
+(deftest json-write-string-map-keys
+  (testing "string keys are encoded as JSON object keys, not quoted strings"
+    (is (= "{\"key\":\"value\"}"
+           (write-json {"key" "value"}))))
+
+  (testing "nested string-key maps round-trip"
+    (let [original {"outer" {"inner" 1}}]
+      (is (= original (read-json (write-json original))))))
+
+  (testing "empty, escaped, Unicode, and slash keys round-trip"
+    (doseq [key ["" "a\"b" "snowman-☃" "a/b"]]
+      (let [original {key "value"}]
+        (is (= original (read-json (write-json original)))))))
+
+  (testing "keyword keys retain their existing JSON spelling"
+    (is (= "{\"key\":\"value\"}"
+           (write-json {:key "value"})))))
+
 (deftest json-roundtrip
   (testing "roundtrip preserves floats"
     (let [original {:price 9.99 :qty 3}


### PR DESCRIPTION
## Summary

Fix `json/write-json` corrupting VM string map keys by serializing their underlying text instead of their readable EDN representation.

- preserve raw string keys at every nesting level
- retain existing keyword-key spelling and fallback behavior for other key types
- cover plain, nested, empty, quote-escaped, Unicode, and slash-containing keys

Closes #817.

## Reproduction

Before:

```clojure
(json/write-json {"key" "value"})
;; => {"\"key\"":"value"}
```

After:

```clojure
(json/write-json {"key" "value"})
;; => {"key":"value"}
```

## Validation

- `go test ./test -run 'TestRunner/json_test\.lg$' -count=1`
- `go test -race ./test -run 'TestRunner/json_test\.lg$' -count=1`
- `go test ./pkg/rt -count=1`
- `go vet ./pkg/rt ./test`
- `make generate`
- `make check-generated`
- `git diff --check`
- independent code review: PASS, no findings

A broader `go test ./pkg/rt ./test -count=1` pass before the final mechanical restack had `pkg/rt` green; the `test` package was blocked only by this sandbox denying the suite's existing literal `/tmp` writes. The focused JSON suite is green before and after the restack; CI remains the unrestricted full-suite gate.
