### PR TITLE
fix(wasm): resolve wasm_exec from active Go toolchain

### DIFF
--- a/docs/contribution-policy.md
+++ b/docs/contribution-policy.md
@@ -212,6 +212,10 @@ explicit rules:
 - If the default binary grows to carry deps/generator machinery,
   verify the wasm build does not pay for authoring-only code unless
   the user opted into it.
+- `lg -w` resolves Go support assets such as `wasm_exec.js` from the
+  same selected Go toolchain used for the build (while honoring an
+  explicit `GOROOT`). A cached or relocated `lg` binary must not retain
+  its build-time GOROOT as a permanent runtime dependency.
 
 ## 8. Distribution UX target
 

--- a/pkg/cli/wasm.go
+++ b/pkg/cli/wasm.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	runtimeDebug "runtime/debug"
 	"strings"
 
@@ -484,17 +483,31 @@ func readWasmExecJS() ([]byte, error) {
 		}
 		return patchTinyGoStdout(data), nil
 	}
-	goroot := os.Getenv("GOROOT")
-	if goroot == "" {
-		goroot = runtime.GOROOT()
+	goroot, err := resolveGoRoot(os.Getenv("GOROOT"), func() ([]byte, error) {
+		return exec.Command(gomod.GoToolPath(), "env", "GOROOT").Output()
+	})
+	if err != nil {
+		return nil, err
 	}
-	if goroot == "" {
-		out, err := exec.Command(gomod.GoToolPath(), "env", "GOROOT").Output()
-		if err != nil {
-			return nil, fmt.Errorf("cannot find GOROOT: %w", err)
-		}
-		goroot = strings.TrimSpace(string(out))
+	return readGoWasmExecJS(goroot)
+}
+
+// resolveGoRoot asks the same Go executable selected for the WASM build where
+// its tree lives. GoToolPath still prefers the toolchain that built let-go when
+// it exists, but can fall back to PATH after a cached binary outlives that
+// toolchain; runtime.GOROOT would remain stuck on the vanished build-time path.
+func resolveGoRoot(configured string, query func() ([]byte, error)) (string, error) {
+	if configured != "" {
+		return configured, nil
 	}
+	out, err := query()
+	if err != nil {
+		return "", fmt.Errorf("cannot find GOROOT: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func readGoWasmExecJS(goroot string) ([]byte, error) {
 	candidates := []string{
 		filepath.Join(goroot, "lib", "wasm", "wasm_exec.js"),
 		filepath.Join(goroot, "misc", "wasm", "wasm_exec.js"),

--- a/pkg/cli/wasm_test.go
+++ b/pkg/cli/wasm_test.go
@@ -6,12 +6,70 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	runtimeDebug "runtime/debug"
 	"strings"
 	"testing"
 
 	"github.com/nooga/let-go/pkg/gomod"
 )
+
+func TestResolveGoRootUsesActiveToolchain(t *testing.T) {
+	called := false
+	got, err := resolveGoRoot("", func() ([]byte, error) {
+		called = true
+		return []byte("/active/go\n"), nil
+	})
+	if err != nil {
+		t.Fatalf("resolveGoRoot: %v", err)
+	}
+	if !called {
+		t.Fatal("resolveGoRoot did not query the active Go toolchain")
+	}
+	if got != "/active/go" {
+		t.Errorf("resolveGoRoot = %q, want %q", got, "/active/go")
+	}
+}
+
+func TestResolveGoRootHonorsEnvironment(t *testing.T) {
+	got, err := resolveGoRoot("/configured/go", func() ([]byte, error) {
+		return nil, errors.New("query should not run")
+	})
+	if err != nil {
+		t.Fatalf("resolveGoRoot: %v", err)
+	}
+	if got != "/configured/go" {
+		t.Errorf("resolveGoRoot = %q, want %q", got, "/configured/go")
+	}
+}
+
+func TestReadGoWasmExecJSLayouts(t *testing.T) {
+	for _, rel := range []string{
+		filepath.Join("lib", "wasm", "wasm_exec.js"),
+		filepath.Join("misc", "wasm", "wasm_exec.js"),
+	} {
+		t.Run(rel, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, rel)
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				t.Fatal(err)
+			}
+			const want = "// active toolchain wasm_exec.js\n"
+			if err := os.WriteFile(path, []byte(want), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := readGoWasmExecJS(root)
+			if err != nil {
+				t.Fatalf("readGoWasmExecJS: %v", err)
+			}
+			if string(got) != want {
+				t.Errorf("readGoWasmExecJS = %q, want %q", got, want)
+			}
+		})
+	}
+}
 
 // The version handed to gomod.Generate must describe let-go, not the binary.
 // For a custom lg the ldflags-stamped version is the HOST module's, and using


### PR DESCRIPTION
## Summary

- resolve the Go root by asking the same `go` executable selected for the WASM build
- preserve the existing preference for let-go's build-time toolchain while it is still installed
- fall back cleanly to the PATH toolchain when a cached let-go binary outlives its original Go installation
- cover active-toolchain resolution plus both current and legacy `wasm_exec.js` layouts

## Why

[xsofy#191](https://github.com/nooga/xsofy/pull/191) exposed this after GitHub Actions restored a cached let-go binary built with Go 1.26.7 onto a runner using Go 1.26.8. `runtime.GOROOT()` remained `/opt/hostedtoolcache/go/1.26.7/x64`, which no longer existed, so `lg -w` failed with:

```
error: wasm_exec.js not found in GOROOT (/opt/hostedtoolcache/go/1.26.7/x64)
```

`gomod.GoToolPath()` already handles this lifecycle correctly: it uses the build-time Go executable if that path still exists and otherwise falls back to `go` on PATH. Asking that selected executable for `go env GOROOT` makes the runtime asset lookup follow the toolchain that will actually perform the WASM build.

This preserves the toolchain-consistency intent introduced in #379 rather than always preferring an unrelated PATH toolchain.

## Related

- Cache behavior that created the stale-binary scenario: [nooga/xsofy#163](https://github.com/nooga/xsofy/pull/163)
- Failure that exposed the stale build-time GOROOT: [nooga/xsofy#191](https://github.com/nooga/xsofy/pull/191)
- Companion cache-identity fix: [nooga/xsofy#193](https://github.com/nooga/xsofy/pull/193)
- Post-merge documentation refresh: [nnunley/let-go-wiki#20](https://github.com/nnunley/let-go-wiki/issues/20)

## Verification

- `go test ./pkg/cli ./pkg/gomod`
- `go test -short -timeout 60s ./... -skip TestClojureTestSuite`
