### PR TITLE
feat(rt): add scope-cancelled? (#830)

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -141,7 +141,7 @@ pkg/rt/core_compiled.lgb pkg/rt/key_tokenizer.go generator 197eba584a6f0a33fc02b
 pkg/rt/core_compiled.lgb pkg/rt/keysource.go generator f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/core_compiled.lgb pkg/rt/keysource_js_wasm.go generator d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
 pkg/rt/core_compiled.lgb pkg/rt/keysource_queued.go generator 16e6acbefe44cd071ab3102fef172ff6887770899656b3b595d05955442fbde9
-pkg/rt/core_compiled.lgb pkg/rt/lang.go generator 120947cec62fb42699ea31708119dccc2985b1464f7ca9756329338956d4f47a
+pkg/rt/core_compiled.lgb pkg/rt/lang.go generator 4527edd5543ff25b5f747904e884bf6eea6f1ac5721a0d9e2ae77bdf4a9a98a8
 pkg/rt/core_compiled.lgb pkg/rt/lg_bind_marker.go generator e9732750420945f868e1653f0ee827a3de55530183df970ac87df931ec795ed0
 pkg/rt/core_compiled.lgb pkg/rt/math.go generator d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/core_compiled.lgb pkg/rt/native_direct.go generator db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a
@@ -462,7 +462,7 @@ pkg/rt/core_go_lowered/ pkg/rt/key_tokenizer.go generator 197eba584a6f0a33fc02b4
 pkg/rt/core_go_lowered/ pkg/rt/keysource.go generator f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/core_go_lowered/ pkg/rt/keysource_js_wasm.go generator d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
 pkg/rt/core_go_lowered/ pkg/rt/keysource_queued.go generator 16e6acbefe44cd071ab3102fef172ff6887770899656b3b595d05955442fbde9
-pkg/rt/core_go_lowered/ pkg/rt/lang.go generator 120947cec62fb42699ea31708119dccc2985b1464f7ca9756329338956d4f47a
+pkg/rt/core_go_lowered/ pkg/rt/lang.go generator 4527edd5543ff25b5f747904e884bf6eea6f1ac5721a0d9e2ae77bdf4a9a98a8
 pkg/rt/core_go_lowered/ pkg/rt/lg_bind_marker.go generator e9732750420945f868e1653f0ee827a3de55530183df970ac87df931ec795ed0
 pkg/rt/core_go_lowered/ pkg/rt/math.go generator d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/core_go_lowered/ pkg/rt/native_direct.go generator db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a
@@ -710,7 +710,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/key_tokenizer.go input 197eba584a6f0a33
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource.go input f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource_js_wasm.go input d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource_queued.go input 16e6acbefe44cd071ab3102fef172ff6887770899656b3b595d05955442fbde9
-pkg/rt/zz_primitives_generated.go pkg/rt/lang.go input 120947cec62fb42699ea31708119dccc2985b1464f7ca9756329338956d4f47a
+pkg/rt/zz_primitives_generated.go pkg/rt/lang.go input 4527edd5543ff25b5f747904e884bf6eea6f1ac5721a0d9e2ae77bdf4a9a98a8
 pkg/rt/zz_primitives_generated.go pkg/rt/lg_bind_marker.go input e9732750420945f868e1653f0ee827a3de55530183df970ac87df931ec795ed0
 pkg/rt/zz_primitives_generated.go pkg/rt/math.go input d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/zz_primitives_generated.go pkg/rt/native_direct.go input db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-69877c2e8b3cd31ef8b6ee79557211c1c270e3aca695fca931d02464caf8436a
+a58c28e03f31f8d27958a0863d77208cd096fff2ffac86aa3c1e0636b2ad3377

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -2710,6 +2710,32 @@ func installLangNS() {
 		return vm.OpenChildEC(ec), nil
 	})
 
+	// scope-cancelled? reports whether a scope's cancellation context is done.
+	// With no argument it inspects the calling execution's current scope. Lisp
+	// code cannot otherwise observe cancellation: blocking natives such as
+	// sleep return early and silently when their scope is cancelled, so a
+	// coordinator loop parked on sleep has no way to tell "woke up" from
+	// "was cancelled" without this predicate.
+	scopeCancelled := vm.NewCtxNativeFn("scope-cancelled?", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
+		var s *vm.Scope
+		switch len(vs) {
+		case 0:
+			s = ec.Scope()
+		case 1:
+			var ok bool
+			s, ok = vs[0].(*vm.Scope)
+			if !ok {
+				return vm.NIL, fmt.Errorf("scope-cancelled? expected a scope")
+			}
+		default:
+			return vm.NIL, fmt.Errorf("scope-cancelled? expects 0 or 1 arguments")
+		}
+		if s.Context().Err() != nil {
+			return vm.TRUE, nil
+		}
+		return vm.FALSE, nil
+	})
+
 	chanput := vm.NewCtxNativeFn(">!", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 2 {
 			return vm.NIL, fmt.Errorf("wrong number of arguments %d", len(vs))
@@ -3836,6 +3862,7 @@ func installLangNS() {
 	ns.Def(">!!", chanput)
 	ns.Def("<!!", changet)
 	ns.Def("scope-open", scopeOpen)
+	ns.Def("scope-cancelled?", scopeCancelled)
 
 	ns.Def("int", intf)
 	ns.Def("byte", intf)

--- a/test/e2e/scope_cancelled_test.go
+++ b/test/e2e/scope_cancelled_test.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestScopeCancelledPredicate: scope-cancelled? is false for a live scope,
+// true for an explicit scope after it is closed, and true from inside a
+// future whose parent scope was closed — sleep returns early and silently on
+// cancellation, so this predicate is the only way Lisp code can observe it.
+func TestScopeCancelledPredicate(t *testing.T) {
+	bin := buildLG(t)
+	src := `(def parent (scope-open)) ` +
+		`(def before (scope-cancelled? parent)) ` +
+		`(def seen (promise)) ` +
+		`(def child-before (promise)) ` +
+		`(future (deliver child-before (scope-cancelled?)) (sleep 10000) (deliver seen (scope-cancelled?))) ` +
+		`(deref child-before) ` +
+		`(scope-close! parent 5000) ` +
+		`(println [before @child-before (scope-cancelled? parent) (deref seen 1000 :timeout)])`
+	start := time.Now()
+	out, err := exec.Command(bin, "-e", src).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "[false false true true]") {
+		t.Fatalf("expected [false false true true], got: %q", out)
+	}
+	if d := time.Since(start); d > 9*time.Second {
+		t.Fatalf("sleep was not interrupted by teardown: %v", d)
+	}
+}


### PR DESCRIPTION
Fixes #830.

Blocking natives such as `sleep` return early and silently when their scope is cancelled, so Lisp code cannot tell "woke up" from "was cancelled". This adds a predicate:

- `(scope-cancelled?)` reports whether the calling execution's current scope is done.
- `(scope-cancelled? s)` inspects a given scope.

A coordinator loop parked on `sleep` can now check after waking and unwind instead of carrying on after its owner has gone.

## Tests

- `test/e2e/scope_cancelled_test.go`: false for a live scope; true for an explicit scope after `scope-close!`; true from inside a future whose parent scope was closed, with the future's `sleep` interrupted. It fails on `main` without the change.

## Notes

- One of the PRs split out of #847; independent of the others.
- Generated artifacts are refreshed with `make generate` in their own commit. If another PR from the split merges first, re-run `make generate`; only the generated files should conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9MhEtBehQ7Yz2sgMTLW6s
