### PR TITLE
fix(rt): bound-fn* calls run under the invoking scope (#832)

### DIFF
--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -141,7 +141,7 @@ pkg/rt/core_compiled.lgb pkg/rt/key_tokenizer.go generator 197eba584a6f0a33fc02b
 pkg/rt/core_compiled.lgb pkg/rt/keysource.go generator f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/core_compiled.lgb pkg/rt/keysource_js_wasm.go generator d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
 pkg/rt/core_compiled.lgb pkg/rt/keysource_queued.go generator 16e6acbefe44cd071ab3102fef172ff6887770899656b3b595d05955442fbde9
-pkg/rt/core_compiled.lgb pkg/rt/lang.go generator 4527edd5543ff25b5f747904e884bf6eea6f1ac5721a0d9e2ae77bdf4a9a98a8
+pkg/rt/core_compiled.lgb pkg/rt/lang.go generator fdb1d0c2587950206390d01c70b19b5a6ae0de7c87833e7cd0a0869b3f0e08e9
 pkg/rt/core_compiled.lgb pkg/rt/lg_bind_marker.go generator e9732750420945f868e1653f0ee827a3de55530183df970ac87df931ec795ed0
 pkg/rt/core_compiled.lgb pkg/rt/math.go generator d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/core_compiled.lgb pkg/rt/native_direct.go generator db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a
@@ -462,7 +462,7 @@ pkg/rt/core_go_lowered/ pkg/rt/key_tokenizer.go generator 197eba584a6f0a33fc02b4
 pkg/rt/core_go_lowered/ pkg/rt/keysource.go generator f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/core_go_lowered/ pkg/rt/keysource_js_wasm.go generator d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
 pkg/rt/core_go_lowered/ pkg/rt/keysource_queued.go generator 16e6acbefe44cd071ab3102fef172ff6887770899656b3b595d05955442fbde9
-pkg/rt/core_go_lowered/ pkg/rt/lang.go generator 4527edd5543ff25b5f747904e884bf6eea6f1ac5721a0d9e2ae77bdf4a9a98a8
+pkg/rt/core_go_lowered/ pkg/rt/lang.go generator fdb1d0c2587950206390d01c70b19b5a6ae0de7c87833e7cd0a0869b3f0e08e9
 pkg/rt/core_go_lowered/ pkg/rt/lg_bind_marker.go generator e9732750420945f868e1653f0ee827a3de55530183df970ac87df931ec795ed0
 pkg/rt/core_go_lowered/ pkg/rt/math.go generator d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/core_go_lowered/ pkg/rt/native_direct.go generator db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a
@@ -710,7 +710,7 @@ pkg/rt/zz_primitives_generated.go pkg/rt/key_tokenizer.go input 197eba584a6f0a33
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource.go input f7331de29ceb2055b3be9b1a9f4aee6d07b16b01a336306014dff76d86f5f2cd
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource_js_wasm.go input d790cddc0c77a3993b668d205cf38264db312d3cff314f48b92a81d82e08073c
 pkg/rt/zz_primitives_generated.go pkg/rt/keysource_queued.go input 16e6acbefe44cd071ab3102fef172ff6887770899656b3b595d05955442fbde9
-pkg/rt/zz_primitives_generated.go pkg/rt/lang.go input 4527edd5543ff25b5f747904e884bf6eea6f1ac5721a0d9e2ae77bdf4a9a98a8
+pkg/rt/zz_primitives_generated.go pkg/rt/lang.go input fdb1d0c2587950206390d01c70b19b5a6ae0de7c87833e7cd0a0869b3f0e08e9
 pkg/rt/zz_primitives_generated.go pkg/rt/lg_bind_marker.go input e9732750420945f868e1653f0ee827a3de55530183df970ac87df931ec795ed0
 pkg/rt/zz_primitives_generated.go pkg/rt/math.go input d5860fe3242df6e2afd6a6b69b0e5224e60ce94041a47d823d98225f878d5ed2
 pkg/rt/zz_primitives_generated.go pkg/rt/native_direct.go input db57f47b71f19c1be0bf941797a8a0b065ba9575de22201a3abeab1dff0fc83a

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-ac4f22f5e3f56f969748a27d047d180fadea42ef137dacc3073e3bed3d1fe7d4
+650dde47dd462b485d923994c80c205a1457761a3f7bfad76f74ca65e486a024

--- a/pkg/rt/lang.go
+++ b/pkg/rt/lang.go
@@ -3370,13 +3370,18 @@ func installLangNS() {
 		if len(snap) == 0 {
 			return fn, nil
 		}
-		wrapped, _ := vm.NativeFnType.Wrap(func(args []vm.Value) (vm.Value, error) {
-			// Re-establish the captured bindings in a fresh context on every
-			// call, so invocations (possibly on different goroutines) stay
-			// isolated from one another and from the global stack.
-			return vm.NewExecContextFrom(snap).Invoke(fn, args)
-		})
-		return wrapped, nil
+		// Re-establish the captured bindings in a fresh context on every
+		// call, so invocations (possibly on different goroutines) stay
+		// isolated from one another and from the global stack. Only the
+		// binding stack is conveyed: the call runs under the *invoking*
+		// execution's structured-concurrency scope, so work spawned inside a
+		// bound fn stays owned (and cancellable) by whoever called it rather
+		// than silently escaping to the root scope.
+		return vm.NewCtxNativeFn("bound-fn", func(callEC *vm.ExecContext, args []vm.Value) (vm.Value, error) {
+			c := vm.NewExecContextFrom(snap)
+			c.SetScope(callEC.Scope())
+			return c.Invoke(fn, args)
+		}), nil
 	})
 
 	metaf, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {

--- a/test/e2e/bound_fn_scope_test.go
+++ b/test/e2e/bound_fn_scope_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBoundFnKeepsInvokingScope: bound-fn* conveys dynamic bindings but must
+// not detach the call from the invoking execution's scope. A sleep inside a
+// bound fn called from a scoped future is interrupted when that scope closes
+// (sleep returns early on cancellation), and the captured binding is still
+// visible inside the call. A bound fn detached from the scope sleeps its full
+// ten seconds, so the deref times out instead.
+func TestBoundFnKeepsInvokingScope(t *testing.T) {
+	bin := buildLG(t)
+	src := `(def ^:dynamic *x* :root) ` +
+		`(def f (binding [*x* :caller] (bound-fn* (fn [] (sleep 10000) [*x* :woke])))) ` +
+		`(def parent (scope-open)) ` +
+		`(def seen (promise)) ` +
+		`(future (deliver seen (f))) ` +
+		`(sleep 50) ` +
+		`(scope-close! parent 5000) ` +
+		`(println (deref seen 1000 :timeout))`
+	start := time.Now()
+	out, err := exec.Command(bin, "-e", src).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "[:caller :woke]") {
+		t.Fatalf("expected [:caller :woke], got: %q", out)
+	}
+	if d := time.Since(start); d > 9*time.Second {
+		t.Fatalf("bound fn escaped its invoking scope: %v", d)
+	}
+}


### PR DESCRIPTION
Fixes #832.

`bound-fn*` re-established the captured bindings in a fresh execution context rooted at the root scope, so work done inside a bound fn escaped the caller's structured-concurrency scope: a `sleep` or child task inside it kept running after the caller's scope was cancelled. The wrapper now conveys only the binding stack, and each call runs under the invoking execution's scope.

## Tests

- `test/e2e/bound_fn_scope_test.go`: a bound fn called from a future inside a scope sleeps for ten seconds; closing the scope must interrupt the sleep while the captured binding stays visible, giving `[:caller :woke]`. Detached from the scope, the sleep runs to completion and the deref times out. It fails on `main` without the change.

## Notes

- One of the PRs split out of #847; independent of the others.
- Generated artifacts are refreshed with `make generate` in their own commit. If another PR from the split merges first, re-run `make generate`; only the generated files should conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9MhEtBehQ7Yz2sgMTLW6s
