### PR TITLE
fix(compiler): eval runs in the caller's execution context (#833)

### DIFF
--- a/pkg/compiler/eval.go
+++ b/pkg/compiler/eval.go
@@ -284,8 +284,12 @@ func postCoreInit() {
 	lsVar := coreNS.LookupOrAdd(vm.Symbol("load-string"))
 	lsVar.(*vm.Var).SetRoot(loadStringFn)
 
-	// eval: compile and evaluate a single already-read form in the current namespace.
-	evalFn, _ := vm.NativeFnType.Wrap(func(vs []vm.Value) (vm.Value, error) {
+	// eval: compile and evaluate a single already-read form in the current
+	// namespace. The compiled form runs in the CALLER's execution context, so
+	// dynamic bindings active around eval (with-out-str, binding) and the
+	// caller's structured-concurrency scope apply to the evaluated code, as
+	// thread bindings do around Clojure's eval.
+	evalFn := vm.NewCtxNativeFn("eval", func(ec *vm.ExecContext, vs []vm.Value) (vm.Value, error) {
 		if len(vs) != 1 {
 			return vm.NIL, nil
 		}
@@ -301,7 +305,7 @@ func postCoreInit() {
 		}
 		c.chunk.SetMaxStack(c.spMax)
 		c.emit(vm.OP_RETURN)
-		f := vm.NewFrame(c.chunk, nil)
+		f := vm.NewFrameIn(c.chunk, nil, ec)
 		out, err := f.RunProtected()
 		vm.ReleaseFrame(f)
 		if err != nil {

--- a/pkg/rt/generated.manifest
+++ b/pkg/rt/generated.manifest
@@ -23,7 +23,7 @@ pkg/rt/core_compiled.lgb pkg/bytecode/tags.go generator 266aea717d2e56da6373deda
 pkg/rt/core_compiled.lgb pkg/compiler/cell.go generator 48e204420afb4c410d41764275616df57abef33ee601a03921bf6a8e7469087a
 pkg/rt/core_compiled.lgb pkg/compiler/compiler.go generator d78220296893882025d2f516cd6b13ebf84eb526e919d8a4d1b160fe0a1851db
 pkg/rt/core_compiled.lgb pkg/compiler/errors.go generator ede6ac1bcb90b3ab0c5fe1fa9d19e2fbc08ab807e6dbd6af8dcffdfe895948f8
-pkg/rt/core_compiled.lgb pkg/compiler/eval.go generator 69615c5b203ec2c8984e85ecaea14057a5f21b6f0ec4f4f56e3cc901c37e61f4
+pkg/rt/core_compiled.lgb pkg/compiler/eval.go generator 4115f565c2d094848a3c89d6723532996088a24f56335f47f9cbb32fc7c47a2b
 pkg/rt/core_compiled.lgb pkg/compiler/forms.go generator b4fb78bb40daadecc135e56ac4db858c9e37861a3291bd67118e5ec2f3a4131b
 pkg/rt/core_compiled.lgb pkg/compiler/init.go generator f2d212196585fed4c367469ba3d97d08e58fec2b48a9bcf4e3f4cb304dedcfa3
 pkg/rt/core_compiled.lgb pkg/compiler/reader.go generator ac181c6161af390bdf49eca477338ad6b2b8f9c24fd6f6d82009e7de444c1fc8
@@ -272,7 +272,7 @@ pkg/rt/core_compiled.lgb pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2
 pkg/rt/core_compiled.lgb pkg/vm/value.go generator 359212bb2a8c766471c9739996b0c1e1666769b2acfe096bcc1f06a138faf101
 pkg/rt/core_compiled.lgb pkg/vm/var.go generator acb1c2e09d393a4a07d36b03ffe1b3945bee5046721a3765960661cd5795ad36
 pkg/rt/core_compiled.lgb pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_compiled.lgb pkg/vm/vm.go generator 49378003901727dfc973e86f4c12d51b73ea9728f2de7321bfb57e50062ed52a
+pkg/rt/core_compiled.lgb pkg/vm/vm.go generator 4ae58cf726bf9bc0e38fde85ec4b720b4612e6723ed8e0912e06b221141cc84a
 pkg/rt/core_compiled.lgb pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_compiled.lgb pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_compiled.lgb pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a
@@ -344,7 +344,7 @@ pkg/rt/core_go_lowered/ pkg/bytecode/tags.go generator 266aea717d2e56da6373dedaa
 pkg/rt/core_go_lowered/ pkg/compiler/cell.go generator 48e204420afb4c410d41764275616df57abef33ee601a03921bf6a8e7469087a
 pkg/rt/core_go_lowered/ pkg/compiler/compiler.go generator d78220296893882025d2f516cd6b13ebf84eb526e919d8a4d1b160fe0a1851db
 pkg/rt/core_go_lowered/ pkg/compiler/errors.go generator ede6ac1bcb90b3ab0c5fe1fa9d19e2fbc08ab807e6dbd6af8dcffdfe895948f8
-pkg/rt/core_go_lowered/ pkg/compiler/eval.go generator 69615c5b203ec2c8984e85ecaea14057a5f21b6f0ec4f4f56e3cc901c37e61f4
+pkg/rt/core_go_lowered/ pkg/compiler/eval.go generator 4115f565c2d094848a3c89d6723532996088a24f56335f47f9cbb32fc7c47a2b
 pkg/rt/core_go_lowered/ pkg/compiler/forms.go generator b4fb78bb40daadecc135e56ac4db858c9e37861a3291bd67118e5ec2f3a4131b
 pkg/rt/core_go_lowered/ pkg/compiler/init.go generator f2d212196585fed4c367469ba3d97d08e58fec2b48a9bcf4e3f4cb304dedcfa3
 pkg/rt/core_go_lowered/ pkg/compiler/reader.go generator ac181c6161af390bdf49eca477338ad6b2b8f9c24fd6f6d82009e7de444c1fc8
@@ -593,7 +593,7 @@ pkg/rt/core_go_lowered/ pkg/vm/uuid.go generator 249cc824c4af570c1693f968fdbab2a
 pkg/rt/core_go_lowered/ pkg/vm/value.go generator 359212bb2a8c766471c9739996b0c1e1666769b2acfe096bcc1f06a138faf101
 pkg/rt/core_go_lowered/ pkg/vm/var.go generator acb1c2e09d393a4a07d36b03ffe1b3945bee5046721a3765960661cd5795ad36
 pkg/rt/core_go_lowered/ pkg/vm/vector.go generator 3695aa8424bbc2f34ae3b100331af59925fbf35ce6875c950c92e562f47bbc10
-pkg/rt/core_go_lowered/ pkg/vm/vm.go generator 49378003901727dfc973e86f4c12d51b73ea9728f2de7321bfb57e50062ed52a
+pkg/rt/core_go_lowered/ pkg/vm/vm.go generator 4ae58cf726bf9bc0e38fde85ec4b720b4612e6723ed8e0912e06b221141cc84a
 pkg/rt/core_go_lowered/ pkg/vm/void.go generator bea0103c574dad2dd702302b7611a9947ac917e73fb8eba82e28c57768b71627
 pkg/rt/core_go_lowered/ pkg/vm/volatile.go generator dd18155eda1c0fb376f9934fea08a1a4389c9efbbc1d56685f04839a99f280ef
 pkg/rt/core_go_lowered/ pkg/rt/core/async.lg input f1ae4c5801422270587d811529d1735f9882945b0a380e7cc0b783ecca15795a

--- a/pkg/rt/generated.sums
+++ b/pkg/rt/generated.sums
@@ -2,4 +2,4 @@
 # Digest of generated.manifest: generator input provenance plus declared
 # file-output readiness records. Input checks and output-readiness queries
 # interpret those record kinds separately.
-650dde47dd462b485d923994c80c205a1457761a3f7bfad76f74ca65e486a024
+f8a9d0ad41f4c3d30e323562ecefc3285fe80fa0fc8301c885e9fb0dab34d9ad

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -441,6 +441,16 @@ func releaseFrame(f *Frame) {
 	framePoolMu.Unlock()
 }
 
+// NewFrameIn is NewFrame with the given execution context installed, so the
+// frame resolves dynamic bindings and its structured-concurrency scope against
+// the caller rather than the root. Used by eval-style natives that compile a
+// form and must run it where the caller is.
+func NewFrameIn(code *CodeChunk, args []Value, ec *ExecContext) *Frame {
+	f := NewFrame(code, args)
+	f.ec = ec.orRoot()
+	return f
+}
+
 func NewFrame(code *CodeChunk, args []Value) *Frame {
 	return initFrame(acquireFrame(), code, args)
 }

--- a/test/e2e/eval_context_test.go
+++ b/test/e2e/eval_context_test.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Norman Nunley, Jr <nnunley@gmail.com>
+ * Part of the let-go project; see CONTRIBUTORS for full list of authors.
+ * SPDX-License-Identifier: MIT
+ */
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestEvalRunsInCallerContext: a form passed to eval runs under the caller's
+// dynamic bindings, so with-out-str around eval captures what the evaluated
+// code prints, including from inside a future.
+func TestEvalRunsInCallerContext(t *testing.T) {
+	bin := buildLG(t)
+	src := `(println (pr-str @(future (with-out-str (eval (read-string "(println :captured)"))))))`
+	out, err := exec.Command(bin, "-e", src).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), `":captured\n"`) {
+		t.Fatalf("expected captured output, got: %q", out)
+	}
+}


### PR DESCRIPTION
Fixes #833.

`eval` compiled a form and ran it in a frame bound to the root execution context, so dynamic bindings active around `eval` (`with-out-str`, `binding`) and the caller's scope did not apply to the evaluated code. This adds `vm.NewFrameIn(code, args, ec)`, which builds a frame with a given execution context installed, and `eval` now runs its frame in the caller's context, as thread bindings apply around Clojure's `eval`.

## Tests

- `test/e2e/eval_context_test.go`: `with-out-str` around `eval` inside a future captures what the evaluated form prints. It fails on `main` without the change.

## Notes

- One of the PRs split out of #847; independent of the others.
- Generated artifacts are refreshed with `make generate` in their own commit. If another PR from the split merges first, re-run `make generate`; only the generated files should conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9MhEtBehQ7Yz2sgMTLW6s
